### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Build steps:
 5. Switch into the build directory: `cd build`
 6. Open the index.html with your favorite browser (tested: Firefox and Chrome). Running Tutanota locally with Chrome requires starting Chrome with the argument `--allow-file-access-from-files`.
 
+## Server templates
+Server templates contains working installation instructions. Allows to create a temporary server to test, deploy production servers and fork configurations for customization.
+ - [Debian Wheezy] (https://manageacloud.com/cookbook/tutanota_email_client_debian_wheezy_70)
+ - [Ubuntu 14.04] (https://manageacloud.com/cookbook/tutanota_email_client_ubuntu_trusty_tahr_1404)
+ - [Amazon Linux] (https://manageacloud.com/cookbook/tutanota_email_client_amazon_2014032)
+ - [CentOS 6.5] (https://manageacloud.com/cookbook/tutanota_email_client)
+ - [CentOS 7] (https://manageacloud.com/cookbook/tutanota_email_client_centos_7)
+
 ## Tests
 
 We use the following tools for testing:


### PR DESCRIPTION
Added a server template in the documentation for Debian 7 / Ubuntu 14.04 / CentOS 6.5 / CentOS 7 and Amazon Linux. This allows users to:
- Have working instructions to install the application from scratch 
- Create a temporarily server with a working version of tutanota to play around
- Deploy a production server with tutanota

I think this is a great add-on for the documentation. Novice users will be able to run the application with no problem and advanced users has templates that they just need to customise.

Feedback is appreciated!
