### PR TITLE
implemented "Display the email address in the 'TO:' section"

### DIFF
--- a/web/js/ctrl/ComposingMail.js
+++ b/web/js/ctrl/ComposingMail.js
@@ -668,7 +668,7 @@ tutao.tutanota.ctrl.ComposingMail.prototype._createBubbleFromRecipientInfo = fun
             return "displayRecipient";
         }
     }, this);
-	return new tutao.tutanota.ctrl.bubbleinput.Bubble(recipientInfo, ko.observable(recipientInfo.getDisplayText()), ko.observable(recipientInfo.getMailAddress()), state, true);
+	return new tutao.tutanota.ctrl.bubbleinput.Bubble(recipientInfo, ko.observable(recipientInfo.getDisplayText()+" <"+recipientInfo.getMailAddress()+">"), ko.observable(recipientInfo.getMailAddress()), state, true);
 };
 
 /**


### PR DESCRIPTION
as described in request https://tutanota.uservoice.com/forums/237921-general/suggestions/7188451-display-the-email-address-not-the-person-s-name, this pull replaces the previous `Name` format with the requested `Name <email>` format.