### PR TITLE
Fixed repeated random numbers

### DIFF
--- a/web/js/crypto/SecureRandom.js
+++ b/web/js/crypto/SecureRandom.js
@@ -31,5 +31,4 @@ SecureRandom.prototype.nextBytes = function(array) {
  */
 SecureRandom.setNextRandomBytes = function(bytes) {
     SecureRandom._nextBytes = SecureRandom._nextBytes.concat(bytes);
-    this._nextBytes = this._nextBytes.concat(bytes);
 };


### PR DESCRIPTION
Note this might cause the "SecureRandom does not have random numbers." exception to be thrown.

I think this is only currently used for generating RSA private keys. You might want to force everyone to generate new ones. I haven't tested, but I think it's rare that someone will generate a bad RSA key.