### PR TITLE
All job is done in current thread. Release wakelock

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
@@ -255,7 +255,7 @@ public final class PushNotificationService extends JobService {
     public boolean onStartJob(JobParameters params) {
         Log.d(TAG, "onStartJob");
         restartConnectionIfNeeded(null);
-        return true;
+        return false; // All job is done in this thread. Release wakelock
     }
 
     @Override


### PR DESCRIPTION
https://medium.com/google-developers/scheduling-jobs-like-a-pro-with-jobscheduler-286ef8510129

onStartJob() is called by the system when it is time for your job to execute. If your task is short and simple, feel free to implement the logic directly in onStartJob() and return false when you are finished, to let the system know that all work has been completed. But if you need to do a more complicated task, like connecting to the network, you’ll want to kick off a background thread and return true, letting the system know that you have a thread still running and it should hold on to your wakelock for a while longer.