### PR TITLE
Native file network fixes

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/FileUtil.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/FileUtil.java
@@ -205,8 +205,6 @@ public class FileUtil {
             response.put("statusCode", con.getResponseCode());
             response.put("statusMessage", con.getResponseMessage());
             return response;
-        } catch (Exception e) {
-            throw e;
         } finally {
             con.disconnect();
         }

--- a/app-android/app/src/main/java/de/tutao/tutanota/FileUtil.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/FileUtil.java
@@ -187,8 +187,8 @@ public class FileUtil {
         return Utils.getFileInfo(activity, Uri.parse(fileUri)).name;
     }
 
-    int upload(final String fileUri, final String targetUrl, final JSONObject headers) throws IOException, JSONException {
-        InputStream inputStream = activity.getContentResolver().openInputStream(Uri.parse(fileUri));
+    JSONObject upload(final String absolutePath, final String targetUrl, final JSONObject headers) throws IOException, JSONException {
+        File file = Utils.uriToFile(activity, absolutePath);
         HttpURLConnection con = (HttpURLConnection) (new URL(targetUrl)).openConnection();
         try {
             con.setConnectTimeout(HTTP_TIMEOUT);
@@ -200,44 +200,51 @@ public class FileUtil {
             con.setChunkedStreamingMode(4096); // mitigates OOM for large files (start uploading before the complete file is buffered)
             addHeadersToRequest(con, headers);
             con.connect();
-            IOUtils.copy(inputStream, con.getOutputStream());
-            return con.getResponseCode();
+            IOUtils.copy(new FileInputStream(file), con.getOutputStream());
+            JSONObject response = new JSONObject();
+            response.put("statusCode", con.getResponseCode());
+            response.put("statusMessage", con.getResponseMessage());
+            return response;
+        } catch (Exception e) {
+            throw e;
         } finally {
             con.disconnect();
         }
     }
 
-    Promise<String, Exception, Void> download(final String sourceUrl, final String filename, final JSONObject headers) {
-        DeferredObject<String, Exception, Void> result = new DeferredObject<>();
-        backgroundTasksExecutor.execute(() -> {
-            HttpURLConnection con = null;
-            try {
-                con = (HttpURLConnection) (new URL(sourceUrl)).openConnection();
-                con.setConnectTimeout(HTTP_TIMEOUT);
-                con.setReadTimeout(HTTP_TIMEOUT);
-                con.setRequestMethod("GET");
-                con.setDoInput(true);
-                con.setUseCaches(false);
-                addHeadersToRequest(con, headers);
-                con.connect();
+    JSONObject download(final String sourceUrl, final String filename, final JSONObject headers) throws IOException, JSONException {
+        HttpURLConnection con = null;
+        try {
+            con = (HttpURLConnection) (new URL(sourceUrl)).openConnection();
+            con.setConnectTimeout(HTTP_TIMEOUT);
+            con.setReadTimeout(HTTP_TIMEOUT);
+            con.setRequestMethod("GET");
+            con.setDoInput(true);
+            con.setUseCaches(false);
+            addHeadersToRequest(con, headers);
+            con.connect();
+
+            File encryptedFile = null;
+            if (con.getResponseCode() == 200) {
 
                 File encryptedDir = new File(Utils.getDir(activity), Crypto.TEMP_DIR_ENCRYPTED);
                 encryptedDir.mkdirs();
-                File encryptedFile = new File(encryptedDir, filename);
+                encryptedFile = new File(encryptedDir, filename);
 
                 IOUtils.copyLarge(con.getInputStream(), new FileOutputStream(encryptedFile),
                         new byte[1024 * 1000]);
-
-                result.resolve(Utils.fileToUri(encryptedFile));
-            } catch (IOException | JSONException e) {
-                result.reject(e);
-            } finally {
-                if (con != null) {
-                    con.disconnect();
-                }
             }
-        });
-        return result;
+
+            JSONObject result = new JSONObject();
+            result.put("statusCode", con.getResponseCode());
+            result.put("statusMessage", con.getResponseMessage());
+            result.put("encryptedFileUri", encryptedFile != null ? Utils.fileToUri(encryptedFile) : JSONObject.NULL);
+            return result;
+        } finally {
+            if (con != null) {
+                con.disconnect();
+            }
+        }
     }
 
     Promise<String, Exception, Void> saveBlob(final String name, final String base64blob) {

--- a/app-android/app/src/main/java/de/tutao/tutanota/Native.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/Native.java
@@ -203,7 +203,8 @@ public final class Native {
                     promise.resolve(files.upload(args.getString(0), args.getString(1), args.getJSONObject(2)));
                     break;
                 case "download":
-                    return files.download(args.getString(0), args.getString(1), args.getJSONObject(2));
+                    promise.resolve(files.download(args.getString(0), args.getString(1), args.getJSONObject(2)));
+                    break;
                 case "clearFileData":
                     files.clearFileData();
                     promise.resolve(null);

--- a/app-ios/tutanota/Sources/Files/TUTFileUtil.h
+++ b/app-ios/tutanota/Sources/Files/TUTFileUtil.h
@@ -30,12 +30,12 @@
 - (void)uploadFileAtPath:(NSString * _Nonnull)filePath
 				   toUrl:(NSString * _Nonnull)urlString
 			 withHeaders:(NSDictionary<NSString *, NSString *> * _Nonnull)headers
-			  completion:(void (^ _Nonnull)(NSNumber * _Nullable responseCode, NSError * _Nullable error))completion;
+			  completion:(void (^ _Nonnull)(NSDictionary<NSString *, id> * _Nullable response, NSError * _Nullable error))completion;
 
 - (void)downloadFileFromUrl:(NSString * _Nonnull)urlString
 					forName:(NSString * _Nonnull)fileName
 				withHeaders:(NSDictionary<NSString *, NSString *> * _Nonnull)headers
-				 completion:(void (^ _Nonnull)(NSString * _Nullable filePath, NSError * _Nullableerror))completion;
+				 completion:(void (^ _Nonnull)(NSDictionary<NSString *, id> * _Nullable response, NSError * _Nullable error))completion;
 
 - (void)clearFileData;
 

--- a/src/api/worker/facades/FileFacade.js
+++ b/src/api/worker/facades/FileFacade.js
@@ -41,18 +41,21 @@ export class FileFacade {
 				if (env.mode === Mode.App) {
 					let queryParams = {'_body': encodeURIComponent(body)}
 					let url = addParamsToUrl(getHttpOrigin() + "/rest/tutanota/filedataservice", queryParams)
-					return fileApp.download(url, file.name, headers).then(fileLocation => {
-						return aesDecryptFile(neverNull(sessionKey), fileLocation).then(decryptedFileUrl => {
-							return {
-								_type: 'FileReference',
-								name: file.name,
-								mimeType: file.mimeType,
-								location: decryptedFileUrl,
-								size: file.size
-							}
-						}).finally(() =>
-							fileApp.deleteFile(fileLocation)
-							       .catch(() => console.log("Failed to delete encrypted file", fileLocation)))
+
+					return fileApp.download(url, file.name, headers).then(({statusCode, statusMessage, encryptedFileUri}) => {
+						return ((statusCode === 200 && encryptedFileUri != null)
+							? aesDecryptFile(neverNull(sessionKey), encryptedFileUri).then(decryptedFileUrl => {
+								return {
+									_type: 'FileReference',
+									name: file.name,
+									mimeType: file.mimeType,
+									location: decryptedFileUrl,
+									size: file.size
+								}
+							})
+							: Promise.reject(handleRestError(statusCode, `${statusMessage} | GET ${url} failed to natively download attachment`)))
+							.finally(() => encryptedFileUri != null && fileApp.deleteFile(encryptedFileUri)
+							                                                  .catch(() => console.log("Failed to delete encrypted file", encryptedFileUri)))
 					})
 				} else {
 					return restClient.request("/rest/tutanota/filedataservice", HttpMethod.GET, {}, headers, body, MediaType.Binary)
@@ -96,11 +99,12 @@ export class FileFacade {
 						let headers = this._login.createAuthHeaders()
 						headers['v'] = FileDataDataReturnTypeModel.version
 						let url = addParamsToUrl(getHttpOrigin() + "/rest/tutanota/filedataservice", {fileDataId})
-						return fileApp.upload(encryptedFileLocation, url, headers).then(responseCode => {
-							if (responseCode === 200) {
+						return fileApp.upload(encryptedFileLocation, url, headers).then(({statusCode, statusMessage}) => {
+							if (statusCode === 200) {
 								return fileDataId;
 							} else {
-								throw handleRestError(responseCode, "failed to natively upload attachment");
+								throw handleRestError(statusCode,
+									`${statusMessage} | PUT ${url} failed to natively upload attachment`)
 							}
 						})
 					})

--- a/src/native/FileApp.js
+++ b/src/native/FileApp.js
@@ -105,7 +105,7 @@ function saveBlob(data: DataFile): Promise<FileReference> {
 /**
  * Uploads the binary data of a file to tutadb
  */
-function upload(fileUrl: string, targetUrl: string, headers: Object): Promise<number> {
+function upload(fileUrl: string, targetUrl: string, headers: Object): Promise<{statusCode: number, statusMessage: string}> {
 	return nativeApp.invokeNative(new Request("upload", [fileUrl, targetUrl, headers]))
 }
 
@@ -113,7 +113,7 @@ function upload(fileUrl: string, targetUrl: string, headers: Object): Promise<nu
  * Downloads the binary data of a file from tutadb and stores it in the internal memory.
  * @returns Resolves to the URI of the downloaded file
  */
-function download(sourceUrl: string, filename: string, headers: Object): Promise<string> {
+function download(sourceUrl: string, filename: string, headers: Object): Promise<{statusCode: number, statusMessage: string, encryptedFileUri: ?string}> {
 	return nativeApp.invokeNative(new Request("download", [sourceUrl, filename, headers]))
 }
 


### PR DESCRIPTION
Pass status code/error ID from native network requests to be able to send useful bug reports.
Required server change to pass error id in a header because iOS doesn't let you get status message.
When we switch to header everywhere, it should help with #823