### PR TITLE
Fixed "Ordered list" button title

### DIFF
--- a/src/gui/base/RichTextToolbar.js
+++ b/src/gui/base/RichTextToolbar.js
@@ -73,7 +73,7 @@ export class RichTextToolbar {
 			}
 		}, {
 			label: "emptyString_msg",
-			title: () => lang.get("formatTextUl_msg") + " (Ctrl + Shift + 9)",
+			title: () => lang.get("formatTextOl_msg") + " (Ctrl + Shift + 9)",
 			click: () => {
 				if (editor.styles.listing === 'ol') {
 					editor._squire.removeList()


### PR DESCRIPTION
If you hover on the "Ordered list" button in Formatting tools, a tooltip for "Unordered list" will appear. This simple commit fixes this typo.