### PR TITLE
Add conditional for mobile in dropdown show

### DIFF
--- a/src/gui/base/Dropdown.js
+++ b/src/gui/base/Dropdown.js
@@ -322,7 +322,7 @@ export class Dropdown {
 						this._domContents.style.maxHeight = px(this.maxHeight - this._getFilterHeight())
 						this._domContents.style.overflowY = client.overflowAuto
 					}
-					if (this._domInput) {
+					if (this._domInput && !client.isMobileDevice()) {
 						this._domInput.focus()
 					}
 				})

--- a/src/gui/base/DropdownN.js
+++ b/src/gui/base/DropdownN.js
@@ -256,7 +256,7 @@ export class DropdownN {
 					this._domContents.style.maxHeight = px(this.maxHeight - this._getFilterHeight())
 					this._domContents.style.overflowY = client.overflowAuto
 				}
-				if (this._domInput) {
+				if (this._domInput && !client.isMobileDevice()) {
 					this._domInput.focus()
 				}
 			})


### PR DESCRIPTION
Type fields in dropdowns are not automatically focused for mobile devices

Fixes #955