### PR TITLE
Allow pressing the return key to accept dialogues

### DIFF
--- a/src/gui/base/Dialog.js
+++ b/src/gui/base/Dialog.js
@@ -469,6 +469,14 @@ export class Dialog {
 				help: "cancel_action"
 			})
 		}
+		if (okAction) {
+			dialog.addShortcut({
+				key: Keys.RETURN,
+				shift: false
+				exec: doAction,
+				help: "ok_action"
+			})
+		}
 
 		return dialog.show()
 	}


### PR DESCRIPTION
When seeing dialogues with an 'OK' button, you can now press the return key. It should then behave as if the 'OK' button is pressed.
This is particularly useful for dialogues with a text entry such as the 2FA dialogue. You can then press the return key to accept this dialogue.

I'm unsure of what happens with this when there are dialogues with multi-line text fields where the return key is pressed by the user to type a newline. Are there any such dialogues? If so, we should maybe only add this for the 2FA dialogue.