### PR TITLE
Address #1408, improve readability of am/pm in TimePicker. Make parseTime() more flexible and test new behavior.

### DIFF
--- a/src/calendar/CalendarUtils.js
+++ b/src/calendar/CalendarUtils.js
@@ -39,18 +39,18 @@ export function generateUid(event: CalendarEvent, timestamp: number): string {
  * Accepts 2, 2:30, 2:5, 02:05, 02:30, 24:30, 2430, 12:30pm, 12:30 p.m.
  */
 export function parseTime(timeString: string): ?{hours: number, minutes: number} {
-	var suffix = null
-	var hours = NaN
-	var minutes = NaN
+	let suffix  // am/pm indicator or undefined
+	let hours   // numeric hours
+	let minutes // numeric minutes
 	// See if the time includes a colon separating hh:mm
-	var mt = timeString.match(/^(\d{1,2}):(\d{1,2})\s*(am|pm|a.m.|p.m.)?$/i)
+	let mt = timeString.match(/^(\d{1,2}):(\d{1,2})\s*(am|pm|a\.m\.|p\.m\.)?$/i)
 	if (mt != null) {
 		suffix = mt[3]
 		hours = parseInt(mt[1], 10)
 		minutes = parseInt(mt[2], 10)
 	} else {
 		// Interpret 127am as 1:27am or 2311 as 11:11pm, e.g.
-		mt = timeString.match(/^(\d{1,4})\s*(am|pm|a.m.|p.m.)?$/i)
+		mt = timeString.match(/^(\d{1,4})\s*(am|pm|a\.m\.|p\.m\.)?$/i)
 		if (mt != null) {
 			suffix = mt[2]
 			const digits = mt[1]

--- a/src/calendar/CalendarUtils.js
+++ b/src/calendar/CalendarUtils.js
@@ -36,26 +36,45 @@ export function generateUid(event: CalendarEvent, timestamp: number): string {
 }
 
 /**
- * Accepts 2, 2:30, 2:5, 02:05, 02:30, 24:30
+ * Accepts 2, 2:30, 2:5, 02:05, 02:30, 24:30, 2430, 12:30pm, 12:30 p.m.
  */
 export function parseTime(timeString: string): ?{hours: number, minutes: number} {
-	const suffix = timeString.substr(-2).toUpperCase()
-	if (suffix === "AM" || suffix === "PM") {
-		timeString = timeString.slice(0, -2)
-	}
-	const parts = timeString.split(":")
-	let hours = filterInt(parts[0])
-	let minutes = 0
-	if (parts.length === 2) {
-		minutes = filterInt(parts[1])
+	var suffix = null
+	var hours = NaN
+	var minutes = NaN
+	// See if the time includes a colon separating hh:mm
+	var mt = timeString.match(/^(\d{1,2}):(\d{1,2})\s*(am|pm|a.m.|p.m.)?$/i)
+	if (mt != null) {
+		suffix = mt[3]
+		hours = parseInt(mt[1], 10)
+		minutes = parseInt(mt[2], 10)
+	} else {
+		// Interpret 127am as 1:27am or 2311 as 11:11pm, e.g.
+		mt = timeString.match(/^(\d{1,4})\s*(am|pm|a.m.|p.m.)?$/i)
+		if (mt != null) {
+			suffix = mt[2]
+			const digits = mt[1]
+			// Hours only?
+			if (digits.length <= 2) {
+				hours = parseInt(digits, 10)
+				minutes = 0
+			} else {
+				hours = parseInt(digits.substr(0, digits.length - 2), 10)
+				minutes = parseInt(digits.substr(-2, 2), 10)
+	                }
+		} else {
+			return null
+                }
 	}
 	if (isNaN(hours) || isNaN(minutes) || minutes > 59) {
 		return null
 	}
-	if (suffix === "PM") {
+	if (suffix)
+		suffix = suffix.toUpperCase()
+	if (suffix === "PM" || suffix == "P.M.") {
 		if (hours > 12) return null
 		if (hours !== 12) hours = hours + 12
-	} else if (suffix === "AM") {
+	} else if (suffix === "AM" || suffix == "A.M.") {
 		if (hours > 12) return null
 		if (hours === 12) hours = 0
 	} else if (hours > 23) {
@@ -81,13 +100,13 @@ export function timeStringFromParts(hours: number, minutes: number, amPm: boolea
 	let minutesString = pad(minutes, 2)
 	if (amPm) {
 		if (hours === 0) {
-			return `12:${minutesString}AM`
+			return `12:${minutesString} am`
 		} else if (hours === 12) {
-			return `12:${minutesString}PM`
+			return `12:${minutesString} pm`
 		} else if (hours > 12) {
-			return `${hours - 12}:${minutesString}PM`
+			return `${hours - 12}:${minutesString} pm`
 		} else {
-			return `${hours}:${minutesString}AM`
+			return `${hours}:${minutesString} am`
 		}
 	} else {
 		let hoursString = pad(hours, 2)

--- a/test/client/calendar/CalendarUtilsTest.js
+++ b/test/client/calendar/CalendarUtilsTest.js
@@ -1,7 +1,7 @@
 // @flow
 import o from "ospec/ospec.js"
 import type {CalendarMonth} from "../../../src/calendar/CalendarUtils"
-import {getCalendarMonth, getStartOfWeek, getWeekNumber, parseTime} from "../../../src/calendar/CalendarUtils"
+import {getCalendarMonth, getStartOfWeek, getWeekNumber, parseTime, timeStringFromParts} from "../../../src/calendar/CalendarUtils"
 import {lang} from "../../../src/misc/LanguageViewModel"
 
 o.spec("calendar utils tests", function () {
@@ -133,11 +133,22 @@ o.spec("calendar utils tests", function () {
 	o.spec("parseTimeTo", function () {
 		o("parses full 24H time", function () {
 			o(parseTime("12:45")).deepEquals({hours: 12, minutes: 45})
+			o(parseTime("1245")).deepEquals({hours: 12, minutes: 45})
+			o(parseTime("2359")).deepEquals({hours: 23, minutes: 59})
+			o(parseTime("0000")).deepEquals({hours: 0, minutes: 0})
+			o(parseTime("0623")).deepEquals({hours: 6, minutes: 23})
+			o(parseTime("08:09")).deepEquals({hours: 8, minutes: 9})
 		})
 
 		o("parses partial 24H time", function () {
 			o(parseTime("12")).deepEquals({hours: 12, minutes: 0})
+			o(parseTime("1:2")).deepEquals({hours: 1, minutes: 2})
+			o(parseTime("102")).deepEquals({hours: 1, minutes: 2})
+			o(parseTime("17")).deepEquals({hours: 17, minutes: 0})
+			o(parseTime("6")).deepEquals({hours: 6, minutes: 0})
+			o(parseTime("955")).deepEquals({hours: 9, minutes: 55})
 			o(parseTime("12:3")).deepEquals({hours: 12, minutes: 3})
+			o(parseTime("809")).deepEquals({hours: 8, minutes: 9})
 		})
 
 		o("not parses incorrect time", function () {
@@ -147,9 +158,15 @@ o.spec("calendar utils tests", function () {
 			o(parseTime(":2")).deepEquals(null)
 			o(parseTime("25:03")).deepEquals(null)
 			o(parseTime("22:93")).deepEquals(null)
+			o(parseTime("24")).deepEquals(null)
+			o(parseTime("13pm")).deepEquals(null)
+			o(parseTime("263PM")).deepEquals(null)
+			o(parseTime("1403PM")).deepEquals(null)
+			o(parseTime("14:03:33PM")).deepEquals(null)
 		})
 
 		o("parses AM/PM time", function () {
+			o(parseTime("7PM")).deepEquals({hours: 19, minutes: 0})
 			o(parseTime("11PM")).deepEquals({hours: 23, minutes: 0})
 			o(parseTime("12PM")).deepEquals({hours: 12, minutes: 0})
 			o(parseTime("11:30PM")).deepEquals({hours: 23, minutes: 30})
@@ -157,9 +174,31 @@ o.spec("calendar utils tests", function () {
 			o(parseTime("12:30AM")).deepEquals({hours: 0, minutes: 30})
 			o(parseTime("3:30AM")).deepEquals({hours: 3, minutes: 30})
 			o(parseTime("3:30PM")).deepEquals({hours: 15, minutes: 30})
+			o(parseTime("9:37am")).deepEquals({hours: 9, minutes: 37})
+			o(parseTime("1:59pm")).deepEquals({hours: 13, minutes: 59})
+			o(parseTime("3:30 AM")).deepEquals({hours: 3, minutes: 30})
+			o(parseTime("3:30 PM")).deepEquals({hours: 15, minutes: 30})
+			o(parseTime("9:37 am")).deepEquals({hours: 9, minutes: 37})
+			o(parseTime("1:59 pm")).deepEquals({hours: 13, minutes: 59})
+			o(parseTime("9:37 a.m.")).deepEquals({hours: 9, minutes: 37})
+			o(parseTime("1:59 p.m.")).deepEquals({hours: 13, minutes: 59})
+			o(parseTime("1052 P.M.")).deepEquals({hours: 22, minutes: 52})
+			o(parseTime("1052 A.M.")).deepEquals({hours: 10, minutes: 52})
+			o(parseTime("948 P.M.")).deepEquals({hours: 21, minutes: 48})
+			o(parseTime("948 A.M.")).deepEquals({hours: 9, minutes: 48})
 		})
 	})
 
+	o.spec("timeStringFromParts", function () {
+		o("works", function () {
+			o(timeStringFromParts(0, 0, true)).equals("12:00 am")
+			o(timeStringFromParts(12, 0, true)).equals("12:00 pm")
+			o(timeStringFromParts(10, 55, true)).equals("10:55 am")
+			o(timeStringFromParts(10, 55, false)).equals("10:55")
+			o(timeStringFromParts(22, 55, true)).equals("10:55 pm")
+			o(timeStringFromParts(22, 55, false)).equals("22:55")
+		})
+	})
 	o.spec("getStartOfWeek", function () {
 		o("works", function () {
 			o(getStartOfWeek(new Date(2019, 6, 7), 0).toISOString()).equals(new Date(2019, 6, 7).toISOString())

--- a/test/client/calendar/CalendarUtilsTest.js
+++ b/test/client/calendar/CalendarUtilsTest.js
@@ -163,6 +163,7 @@ o.spec("calendar utils tests", function () {
 			o(parseTime("263PM")).deepEquals(null)
 			o(parseTime("1403PM")).deepEquals(null)
 			o(parseTime("14:03:33PM")).deepEquals(null)
+			o(parseTime("9:37 acme")).deepEquals(null)
 		})
 
 		o("parses AM/PM time", function () {


### PR DESCRIPTION
This commit improves calendar time parsing to permit use of lower-case characters and periods in the am/pm indicators in TimePicker. It also allows omission of the colon separating hours and minutes, and the addition of spaces between the minutes and am/pm indicator. This mimics some of the behavior in other popular calendars. For example 13:14, 1314, 1:14pm, 114pm, 1:14 p.m., and 1:14 PM are all now equivalent. This can now handle the formats produced by most locales (it cannot handle some languages with non-Latin characters).

The timeStringFromParts() function has been modified to append a space and lower case "am" or "pm" when appropriate.

I added tests to the CalendarUtilsTest to verify these changes.