### PR TITLE
Fix #1511, use company name as fallback in contact list

### DIFF
--- a/src/contacts/ContactListView.js
+++ b/src/contacts/ContactListView.js
@@ -5,7 +5,7 @@ import {load, loadAll} from "../api/main/Entity"
 import {ContactTypeRef} from "../api/entities/tutanota/Contact"
 import {ContactView} from "./ContactView"
 import {GENERATED_MAX_ID} from "../api/common/EntityFunctions"
-import {compareContacts, LazyContactListId} from "./ContactUtils"
+import {compareContacts, LazyContactListId, getContactListName} from "./ContactUtils"
 import {assertMainOrNode} from "../api/Env"
 import {lang} from "../misc/LanguageViewModel"
 import {NotFoundError} from "../api/common/error/RestError"
@@ -95,7 +95,7 @@ export class ContactRow {
 			this.domElement.classList.remove("row-selected")
 		}
 
-		this._domName.textContent = contact.firstName + " " + contact.lastName
+		this._domName.textContent = getContactListName(contact)
 		this._domAddress.textContent = (contact.mailAddresses && contact.mailAddresses.length > 0) ?
 			contact.mailAddresses[0].address : ""
 	}

--- a/src/contacts/ContactUtils.js
+++ b/src/contacts/ContactUtils.js
@@ -182,7 +182,7 @@ export function getContactDisplayName(contact: Contact): string {
 
 export function getContactListName(contact: Contact): string {
 	let name = `${contact.firstName} ${contact.lastName}`.trim()
-	if (name.length == 0) {
+	if (name.length === 0) {
 		name = contact.company.trim()
 	}
 	return name

--- a/src/contacts/ContactUtils.js
+++ b/src/contacts/ContactUtils.js
@@ -93,27 +93,16 @@ export function getContactSocialTypeLabel(type: ContactSocialTypeEnum, custom: s
  * Missing fields are sorted below existing fields
  */
 export function compareContacts(contact1: Contact, contact2: Contact) {
-	let c1First = contact1.firstName.trim()
-	let c2First = contact2.firstName.trim()
-	let c1Last = contact1.lastName.trim()
-	let c2Last = contact2.lastName.trim()
+	let c1Name = getContactListName(contact1)
+	let c2Name = getContactListName(contact2)
 	let c1MailLength = contact1.mailAddresses.length
 	let c2MailLength = contact2.mailAddresses.length
-	if (c1First && !c2First) {
+	if (c1Name && !c2Name) {
 		return -1
-	} else if (c2First && !c1First) {
+	} else if (c2Name && !c1Name) {
 		return 1
 	} else {
-		let result = (c1First).localeCompare(c2First)
-		if (result === 0) {
-			if (c1Last && !c2Last) {
-				return -1
-			} else if (c2Last && !c1Last) {
-				return 1
-			} else {
-				result = (c1Last).localeCompare(c2Last)
-			}
-		}
+		let result = (c1Name).localeCompare(c2Name)
 		if (result === 0) {// names are equal or no names in contact
 			if (c1MailLength > 0 && c2MailLength === 0) {
 				return -1
@@ -189,6 +178,14 @@ export function getContactDisplayName(contact: Contact): string {
 	} else {
 		return `${contact.firstName} ${contact.lastName}`.trim()
 	}
+}
+
+export function getContactListName(contact: Contact): string {
+	let name = `${contact.firstName} ${contact.lastName}`.trim()
+	if (name.length == 0) {
+		name = contact.company.trim()
+	}
+	return name
 }
 
 export function formatBirthdayNumeric(birthday: Birthday): string {

--- a/src/mail/MailEditor.js
+++ b/src/mail/MailEditor.js
@@ -74,7 +74,7 @@ import {showProgressDialog} from "../gui/base/ProgressDialog"
 import type {MailboxDetail} from "./MailModel"
 import {mailModel} from "./MailModel"
 import {locator} from "../api/main/MainLocator"
-import {LazyContactListId, searchForContacts} from "../contacts/ContactUtils"
+import {LazyContactListId, searchForContacts, getContactListName} from "../contacts/ContactUtils"
 import {RecipientNotResolvedError} from "../api/common/error/RecipientNotResolvedError"
 import stream from "mithril/stream/stream.js"
 import {checkApprovalStatus} from "../misc/ErrorHandlerImpl"
@@ -1215,7 +1215,7 @@ class MailBubbleHandler implements BubbleHandler<RecipientInfo, ContactSuggestio
 
 		return contactsPromise
 			.map(contact => {
-				let name = `${contact.firstName} ${contact.lastName}`.trim()
+				let name = getContactListName(contact)
 				let mailAddresses = []
 				if (name.toLowerCase().indexOf(query) !== -1) {
 					mailAddresses = contact.mailAddresses.filter(ma => isMailAddress(ma.address.trim(), false))

--- a/src/search/SearchBarOverlay.js
+++ b/src/search/SearchBarOverlay.js
@@ -22,7 +22,7 @@ import {WhitelabelChildTypeRef} from "../api/entities/sys/WhitelabelChild"
 import {client} from "../misc/ClientDetector"
 import m from "mithril"
 import {theme} from "../gui/theme"
-
+import {getContactListName} from "../contacts/ContactUtils.js"
 
 type SearchBarOverlayAttrs = {
 	state: SearchBarState,
@@ -180,7 +180,7 @@ export class SearchBarOverlay implements MComponent<SearchBarOverlayAttrs> {
 			let contact = ((result: any): Contact)
 			return [
 				m(".top.flex-space-between",
-					m(".name", contact.firstName + " " + contact.lastName),
+					m(".name", getContactListName(contact)),
 				),
 				m(".bottom.flex-space-between",
 					m("small.mail-address", (contact.mailAddresses && contact.mailAddresses.length


### PR DESCRIPTION
Uses company name if if first and last name missing. Updates the search and sorting displays accordingly.