### PR TITLE
Provide a button to launch openstreetmap for event locations.

### DIFF
--- a/src/calendar/CalendarEventDialog.js
+++ b/src/calendar/CalendarEventDialog.js
@@ -373,7 +373,15 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 			}: DropDownSelectorAttrs<CalendarInfo>)),
 			m(TextFieldN, {
 				label: "location_label",
-				value: locationValue
+				value: locationValue,
+				injectionsRight: () => m(ButtonN, {
+					label: 'showAddress_alt',
+					icon: () => Icons.Pin,
+					click: () => {
+						let address = encodeURIComponent(locationValue())
+						window.open(`https://www.openstreetmap.org/search?query=${address}`, '_blank')
+					}
+				})
 			}),
 			m(TextFieldN, {
 				label: "description_label",


### PR DESCRIPTION
I think this feature is useful in the Calendar. I'm not thrilled with the call to window.open() instead of just having an appropriate <a> tag in the HTML, but this seemed like the simplest implementation.