### PR TITLE
Add menu item to show headers in the dropdown menu

### DIFF
--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -313,7 +313,7 @@ export class MailViewer {
 				}
 				moreButtons.push(new Button("showHeaders_action", () => this._showHeaders(), () => Icons.ListUnordered).setType(ButtonType.Dropdown))
 				return moreButtons
-			}))
+			}, 350))
 		}
 
 		this._inlineFileIds = this._loadMailBody(mail)

--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -311,6 +311,7 @@ export class MailViewer {
 						}
 					}, () => Icons.Cancel).setType(ButtonType.Dropdown))
 				}
+				moreButtons.push(new Button("showHeaders_action", () => this._showHeaders(), () => Icons.ListUnordered).setType(ButtonType.Dropdown))
 				return moreButtons
 			}))
 		}


### PR DESCRIPTION
This adds a menu item in the drop down menu when viewing an email that will display the email headers. This allows users on mobile to view headers, and provides an alternative for desktop and browser users (instead of using the keyboard shortcut)