### PR TITLE
Fix falsely removing/not removing attachments for inline image, fix #1515

### DIFF
--- a/src/mail/MailEditor.js
+++ b/src/mail/MailEditor.js
@@ -51,7 +51,7 @@ import {
 	resolveRecipientInfo
 } from "./MailUtils"
 import {fileController} from "../file/FileController"
-import {contains, remove, replace} from "../api/common/utils/ArrayUtils"
+import {contains, findAllAndRemove, remove, replace} from "../api/common/utils/ArrayUtils"
 import {FileTypeRef} from "../api/entities/tutanota/File"
 import {ConversationEntryTypeRef} from "../api/entities/tutanota/ConversationEntry"
 import {MailTypeRef} from "../api/entities/tutanota/Mail"
@@ -1149,16 +1149,19 @@ export class MailEditor {
 		// Doing this check instead of relying on mutations also helps with the case when node is removed but inserted again
 		// briefly, e.g. if some text is inserted before/after the element, Squire would put it into another diff and this
 		// means removal + insertion.
+		const elementsToRemove = []
 		this._inlineImageElements.forEach((inlineImage) => {
 			if (this._domElement && !this._domElement.contains(inlineImage)) {
 				const cid = inlineImage.getAttribute("cid")
 				const attachmentIndex = this._attachments.findIndex((a) => a.cid === cid)
 				if (attachmentIndex !== -1) {
 					this._attachments.splice(attachmentIndex, 1)
+					elementsToRemove.push(inlineImage)
 					m.redraw()
 				}
 			}
 		})
+		findAllAndRemove(this._inlineImageElements, (imageElement) => elementsToRemove.includes(imageElement))
 	})
 
 	_observeEditorMutations() {

--- a/src/mail/MailUtils.js
+++ b/src/mail/MailUtils.js
@@ -471,14 +471,16 @@ export function insertInlineImageB64ClickHandler(ev: Event, handler: ImageHandle
 
 
 export function replaceCidsWithInlineImages(dom: HTMLElement, inlineImages: InlineImages,
-                                            onContext: (TutanotaFile, Event, HTMLElement) => mixed) {
+                                            onContext: (TutanotaFile, Event, HTMLElement) => mixed): Array<HTMLElement> {
 	// all image tags which have cid attribute. The cid attribute has been set by the sanitizer for adding a default image.
 	const imageElements: Array<HTMLElement> = Array.from(dom.querySelectorAll("img[cid]"))
+	const elementsWithCid = []
 	imageElements.forEach((imageElement) => {
 		const cid = imageElement.getAttribute("cid")
 		if (cid) {
 			const inlineImage = inlineImages[cid]
 			if (inlineImage) {
+				elementsWithCid.push(imageElement)
 				imageElement.setAttribute("src", inlineImages[cid].url)
 				imageElement.classList.remove("tutanota-placeholder")
 
@@ -501,7 +503,7 @@ export function replaceCidsWithInlineImages(dom: HTMLElement, inlineImages: Inli
 						}
 					})
 
-					imageElement.addEventListener("touchend", (e: TouchEvent) => {
+					imageElement.addEventListener("touchend", () => {
 						timeoutId && clearTimeout(timeoutId)
 					})
 				}
@@ -515,6 +517,7 @@ export function replaceCidsWithInlineImages(dom: HTMLElement, inlineImages: Inli
 			}
 		}
 	})
+	return elementsWithCid
 }
 
 export function replaceInlineImagesWithCids(dom: HTMLElement): HTMLElement {


### PR DESCRIPTION
In case of inserting lines before/after the image we've been removing
attachment when we shouldn't have (Squire would insert it back right
away).

Another case is removing the attachment itself. We've been not removing
corresponding image element.