### PR TITLE
Fix recurring all-day events from another timezone, fix #1809

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/Native.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/Native.java
@@ -230,8 +230,6 @@ public final class Native {
 
 					String pushIdentifierId = args.getString(3);
 					String pushIdentifierSessionKeyB64 = args.getString(4);
-
-					Log.d("XXXXX", "session from web: " + pushIdentifierSessionKeyB64 + " for push identifier: " + pushIdentifierId);
 					sseStorage.storePushIdentifierSessionKey(userId, pushIdentifierId, pushIdentifierSessionKeyB64);
 					promise.resolve(true);
 					break;

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotificationsManager.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotificationsManager.java
@@ -209,7 +209,6 @@ public class AlarmNotificationsManager {
 				return resolved;
 			} else {
 				byte[] pushIdentifierSessionKey = sseStorage.getPushIdentifierSessionKey(pushIdentifierId);
-				Log.d("XXXXX", "session from ssestorage: " + Utils.bytesToBase64(pushIdentifierSessionKey) + " for push identifier: " + pushIdentifierId);
 				if (pushIdentifierSessionKey == null) {
 					return null;
 				}

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/TutanotaNotificationsHandler.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/TutanotaNotificationsHandler.java
@@ -112,7 +112,7 @@ public class TutanotaNotificationsHandler {
 
 			try (InputStream inputStream = urlConnection.getInputStream()) {
 				String responseString = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
-				Log.d(TAG, "Missed notifications response:\n" + responseString);
+				Log.d(TAG, "Loaded Missed notifications response");
 				return MissedNotification.fromJson(new JSONObject(responseString));
 			}
 		} catch (MalformedURLException | JSONException e) {

--- a/src/api/worker/EventBusClient.js
+++ b/src/api/worker/EventBusClient.js
@@ -418,7 +418,6 @@ export class EventBusClient {
 				           if (!isTest() && !isAdminClient()) {
 					           this._executeIfNotTerminated(() => {
 						           this._indexer.addBatchesToQueue([{groupId, batchId, events: filteredEvents}])
-						           console.log("_indexer.startProcessing from EventBusClient")
 						           this._indexer.startProcessing()
 					           })
 				           }

--- a/src/api/worker/facades/LoginFacade.js
+++ b/src/api/worker/facades/LoginFacade.js
@@ -125,7 +125,6 @@ export class LoginFacade {
 			// do not reset here because the event bus client needs to be kept if the same user is logged in as before
 			// check if it is the same user in _initSession()
 		}
-		console.log("createSession worker")
 		return this._loadUserPassphraseKey(mailAddress, passphrase).then(userPassphraseKey => {
 			// the verifier is always sent as url parameter, so it must be url encoded
 			let authVerifier = createAuthVerifierAsBase64Url(userPassphraseKey)
@@ -282,7 +281,6 @@ export class LoginFacade {
 	 * Resume a session of stored credentials.
 	 */
 	resumeSession(credentials: Credentials, externalUserSalt: ?Uint8Array): Promise<{user: User, userGroupInfo: GroupInfo, sessionId: IdTuple}> {
-		console.log("resumeSession worker")
 		return this._loadSessionData(credentials.accessToken).then(sessionData => {
 			let passphrase = utf8Uint8ArrayToString(aes128Decrypt(sessionData.accessKey, base64ToUint8Array(neverNull(credentials.encryptedPassword))))
 			let passphraseKeyPromise: Promise<Aes128Key>
@@ -523,7 +521,6 @@ export class LoginFacade {
 
 	storeEntropy(): Promise<void> {
 		if (!this._accessToken) return Promise.resolve()
-		console.log("updating stored entropy")
 		return loadRoot(TutanotaPropertiesTypeRef, this.getUserGroupId()).then(tutanotaProperties => {
 			tutanotaProperties.groupEncEntropy = encryptBytes(this.getUserGroupKey(), random.generateRandomData(32))
 			return update(tutanotaProperties)

--- a/src/api/worker/search/Indexer.js
+++ b/src/api/worker/search/Indexer.js
@@ -6,14 +6,22 @@ import {NotAuthorizedError} from "../../common/error/RestError"
 import {EntityEventBatchTypeRef} from "../../entities/sys/EntityEventBatch"
 import type {DbTransaction} from "./DbFacade"
 import {DbFacade, GroupDataOS, MetaDataOS} from "./DbFacade"
-import {firstBiggerThanSecond, GENERATED_MAX_ID, getElementId, isSameId, isSameTypeRef, isSameTypeRefByAttr, TypeRef} from "../../common/EntityFunctions"
+import {
+	firstBiggerThanSecond,
+	GENERATED_MAX_ID,
+	getElementId,
+	isSameId,
+	isSameTypeRef,
+	isSameTypeRefByAttr,
+	TypeRef
+} from "../../common/EntityFunctions"
 import type {DeferredObject} from "../../common/utils/Utils"
 import {defer, downcast, neverNull, noOp} from "../../common/utils/Utils"
 import {hash} from "../crypto/Sha256"
 import {generatedIdToTimestamp, stringToUtf8Uint8Array, timestampToGeneratedId, uint8ArrayToBase64} from "../../common/utils/Encoding"
 import {aes256Decrypt, aes256Encrypt, aes256RandomKey, IV_BYTE_LENGTH} from "../crypto/Aes"
 import {decrypt256Key, encrypt256Key} from "../crypto/CryptoFacade"
-import {_createNewIndexUpdate, filterIndexMemberships, markEnd, markStart, printMeasure, typeRefToTypeInfo} from "./IndexUtils"
+import {_createNewIndexUpdate, filterIndexMemberships, markEnd, markStart, typeRefToTypeInfo} from "./IndexUtils"
 import type {Db, GroupData} from "./SearchTypes"
 import type {WorkerImpl} from "../WorkerImpl"
 import {ContactIndexer} from "./ContactIndexer"
@@ -405,7 +413,6 @@ export class Indexer {
 			.then(() => {
 				// add all batches of all groups in one step to avoid that just some groups are added when a ServiceUnavailableError occurs
 				this.addBatchesToQueue(batchesOfAllGroups)
-				console.log("_indexer.startProcessing from Indexer")
 				this.startProcessing()
 			})
 	}
@@ -501,11 +508,11 @@ export class Indexer {
 					}).then(() => {
 						markEnd("writeIndexUpdate")
 						markEnd("processEntityEvents")
-						if (!env.dist && env.mode !== "Test") {
-							printMeasure("Update of " + key.type + " " + batch.events.map(e => operationTypeKeys[e.operation]).join(","), [
-								"processEntityEvents", "processEvent", "writeIndexUpdate"
-							])
-						}
+						// if (!env.dist && env.mode !== "Test") {
+						// 	printMeasure("Update of " + key.type + " " + batch.events.map(e => operationTypeKeys[e.operation]).join(","), [
+						// 		"processEntityEvents", "processEvent", "writeIndexUpdate"
+						// 	])
+						// }
 					})
 				})
 			})

--- a/src/api/worker/search/IndexerCore.js
+++ b/src/api/worker/search/IndexerCore.js
@@ -239,7 +239,6 @@ export class IndexerCore {
 	}
 
 	_writeIndexUpdate(indexUpdate: IndexUpdate, updateGroupData: (t: DbTransaction) => $Promisable<void>): Promise<void> {
-		console.log("writeIndexUpdate")
 		return this._executeOperation({
 			transaction: null,
 			transactionFactory: () => this.db.dbFacade.createTransaction(false, [

--- a/src/app.js
+++ b/src/app.js
@@ -286,3 +286,30 @@ function setupExceptionHandling() {
 		}
 	})
 }
+
+env.dist && setTimeout(() => {
+	console.log(`
+
+''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''''''''''''''''''
+''''''''''''''''''''''''',:,''''''''''''    
+''''''''''''';:llllcccccccc,''''''''''''    Do you care about privacy?
+'''''''''''':kXWXkoc::;,,''''''''''''''' 
+'''''''''''',cdk0KKK00kxdolc;,''''''''''    Work at Tutanota! Fight for our rights!
+'''''''''''''''';coxOKNMMWWNK0kdl:,'''''    
+'''''''''''''''''''',;oKMMMMMMMMWX0dc,''    https://tutanota.com/jobs
+'''''''''''''''''''''';kWMMMMMMMMMMWXk:'
+'''''''''''''''''''',:xXMMMMMMMMMMMMMWKl
+''''''''''''''''';lk0KWMMMMMMMMMMMMMMMWK
+''''''''''''';cdOKWMMMMMMMMMMMMMMMMMMMMM
+'''''''',:ldOKNWMMMMMMMMMMMMMMMMMMMMMMMM
+''',:ldk0XWMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+ldk0XWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+WWMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+
+`)
+}, 5000)

--- a/src/calendar/CalendarAgendaView.js
+++ b/src/calendar/CalendarAgendaView.js
@@ -12,6 +12,7 @@ import {
 	getEventColor,
 	getEventText,
 	getStartOfDayWithZone,
+	getTimeZone,
 	hasAlarmsForTheUser
 } from "./CalendarUtils"
 import {isAllDayEvent} from "../api/common/utils/CommonCalendarUtils"
@@ -33,8 +34,9 @@ type Attrs = {
 export class CalendarAgendaView implements MComponent<Attrs> {
 	view({attrs}: Vnode<Attrs>) {
 		const now = new Date()
+		const zone = getTimeZone()
 
-		const today = getStartOfDayWithZone(now)
+		const today = getStartOfDayWithZone(now, zone)
 		const tomorrow = incrementDate(new Date(today), 1)
 		const days = getNextFourteenDays(today)
 		const lastDay = lastThrow(days)
@@ -88,8 +90,8 @@ export class CalendarAgendaView implements MComponent<Attrs> {
 							}, events.length === 0
 								? m(".mb-s", lang.get("noEntries_msg"))
 								: events.map((ev) => {
-									const startsBefore = eventStartsBefore(day, ev)
-									const endsAfter = eventEndsAfterDay(day, ev)
+									const startsBefore = eventStartsBefore(day, zone, ev)
+									const endsAfter = eventEndsAfterDay(day, zone, ev)
 									let textOption
 									if (isAllDayEvent(ev) || (startsBefore && endsAfter)) {
 										textOption = EventTextTimeOption.ALL_DAY

--- a/src/calendar/CalendarAgendaView.js
+++ b/src/calendar/CalendarAgendaView.js
@@ -2,11 +2,18 @@
 import m from "mithril"
 import {CalendarEventBubble} from "./CalendarEventBubble"
 import {EventTextTimeOption} from "../api/common/TutanotaConstants"
-import {getStartOfDay, incrementDate} from "../api/common/utils/DateUtils"
+import {incrementDate} from "../api/common/utils/DateUtils"
 import {styles} from "../gui/styles"
 import {lang} from "../misc/LanguageViewModel"
 import {formatDate, formatDateWithWeekday} from "../misc/Formatter"
-import {eventEndsAfterDay, eventStartsBefore, getEventColor, getEventText, hasAlarmsForTheUser} from "./CalendarUtils"
+import {
+	eventEndsAfterDay,
+	eventStartsBefore,
+	getEventColor,
+	getEventText,
+	getStartOfDayWithZone,
+	hasAlarmsForTheUser
+} from "./CalendarUtils"
 import {isAllDayEvent} from "../api/common/utils/CommonCalendarUtils"
 import {neverNull} from "../api/common/utils/Utils"
 import {px, size} from "../gui/size"
@@ -27,7 +34,7 @@ export class CalendarAgendaView implements MComponent<Attrs> {
 	view({attrs}: Vnode<Attrs>) {
 		const now = new Date()
 
-		const today = getStartOfDay(now)
+		const today = getStartOfDayWithZone(now)
 		const tomorrow = incrementDate(new Date(today), 1)
 		const days = getNextFourteenDays(today)
 		const lastDay = lastThrow(days)

--- a/src/calendar/CalendarDayEventsView.js
+++ b/src/calendar/CalendarDayEventsView.js
@@ -5,7 +5,7 @@ import {theme} from "../gui/theme"
 import {px, size} from "../gui/size"
 import {DAY_IN_MILLIS} from "../api/common/utils/DateUtils"
 import {numberRange} from "../api/common/utils/ArrayUtils"
-import {expandEvent, getEventColor, getEventText, hasAlarmsForTheUser, layOutEvents} from "./CalendarUtils"
+import {expandEvent, getEventColor, getEventText, getTimeZone, hasAlarmsForTheUser, layOutEvents} from "./CalendarUtils"
 import {CalendarEventBubble} from "./CalendarEventBubble"
 import {EventTextTimeOption} from "../api/common/TutanotaConstants"
 import {neverNull} from "../api/common/utils/Utils"
@@ -92,7 +92,7 @@ export class CalendarDayEventsView implements MComponent<Attrs> {
 
 
 	_renderEvents(attrs: Attrs, events: Array<CalendarEvent>): Children {
-		return layOutEvents(events, (columns) => this._renderColumns(attrs, columns), false)
+		return layOutEvents(events, getTimeZone(), (columns) => this._renderColumns(attrs, columns), false)
 	}
 
 

--- a/src/calendar/CalendarDayView.js
+++ b/src/calendar/CalendarDayView.js
@@ -7,7 +7,7 @@ import {incrementDate, isSameDay} from "../api/common/utils/DateUtils"
 import {EventTextTimeOption} from "../api/common/TutanotaConstants"
 import {ContinuingCalendarEventBubble} from "./ContinuingCalendarEventBubble"
 import {isAllDayEvent} from "../api/common/utils/CommonCalendarUtils"
-import {CALENDAR_EVENT_HEIGHT, eventEndsAfterDay, eventStartsBefore, getEventColor} from "./CalendarUtils"
+import {CALENDAR_EVENT_HEIGHT, eventEndsAfterDay, eventStartsBefore, getEventColor, getTimeZone} from "./CalendarUtils"
 import {neverNull} from "../api/common/utils/Utils"
 import {CalendarDayEventsView, calendarDayTimes} from "./CalendarDayEventsView"
 import {theme} from "../gui/theme"
@@ -69,13 +69,14 @@ export class CalendarDayView implements MComponent<CalendarDayViewAttrs> {
 		const shortEvents = []
 		const longEvents = []
 		const allDayEvents = []
+		const zone = getTimeZone()
 		events.forEach((e) => {
 			if (attrs.hiddenCalendars.has(neverNull(e._ownerGroup))) {
 				return
 			}
 			if (isAllDayEvent(e)) {
 				allDayEvents.push(e)
-			} else if (eventStartsBefore(date, e) || eventEndsAfterDay(date, e)) {
+			} else if (eventStartsBefore(date, zone, e) || eventEndsAfterDay(date, zone, e)) {
 				longEvents.push(e)
 			} else {
 				shortEvents.push(e)
@@ -87,6 +88,7 @@ export class CalendarDayView implements MComponent<CalendarDayViewAttrs> {
 	_renderDay(vnode: Vnode<CalendarDayViewAttrs>, date: Date, thisPageEvents: PageEvents, mainPageEvents: PageEvents) {
 		const {shortEvents, longEvents, allDayEvents} = thisPageEvents
 		const mainPageEventsCount = mainPageEvents.allDayEvents.length + mainPageEvents.longEvents.length
+		const zone = getTimeZone()
 		return m(".fill-absolute.flex.col.calendar-column-border.margin-are-inset-lr", {
 			oncreate: () => {
 				this._redrawIntervalId = setInterval(m.redraw, 1000 * 60)
@@ -112,6 +114,7 @@ export class CalendarDayView implements MComponent<CalendarDayViewAttrs> {
 						color: getEventColor(e, vnode.attrs.groupColors),
 						onEventClicked: () => vnode.attrs.onEventClicked(e),
 						showTime: EventTextTimeOption.NO_TIME,
+						zone,
 					})
 				})),
 				m(".calendar-hour-margin.pr-l", longEvents.map(e => m(ContinuingCalendarEventBubble, {
@@ -121,6 +124,7 @@ export class CalendarDayView implements MComponent<CalendarDayViewAttrs> {
 					color: getEventColor(e, vnode.attrs.groupColors),
 					onEventClicked: () => vnode.attrs.onEventClicked(e),
 					showTime: EventTextTimeOption.START_TIME,
+					zone,
 				}))),
 				mainPageEvents.allDayEvents.length > 0 || mainPageEvents.longEvents.length > 0
 					? m(".mt-s")

--- a/src/calendar/CalendarEventDialog.js
+++ b/src/calendar/CalendarEventDialog.js
@@ -33,7 +33,7 @@ import {
 	getCalendarName,
 	getDiffInDays,
 	getEventEnd,
-	getEventStart,
+	getEventStart, getStartOfDayWithZone, getStartOfNextDayWithZone,
 	getStartOfTheWeekOffsetForUser,
 	hasCapabilityOnGroup,
 	parseTime,
@@ -81,7 +81,7 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 	const selectedCalendar = stream(calendarArray[0])
 	const startOfTheWeekOffset = getStartOfTheWeekOffsetForUser()
 	const startDatePicker = new DatePicker(startOfTheWeekOffset, "dateFrom_label", "emptyString_msg", true, readOnly)
-	startDatePicker.setDate(getStartOfDay(date))
+	startDatePicker.setDate(getStartOfDayWithZone(date))
 	const endDatePicker = new DatePicker(startOfTheWeekOffset, "dateTo_label", "emptyString_msg", true, readOnly)
 	const amPmFormat = logins.getUserController().userSettingsGroupRoot.timeFormat === TimeFormat.TWELVE_HOURS
 	const startTime = stream(timeString(date, amPmFormat))
@@ -145,7 +145,7 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 		if (allDay()) {
 			endDatePicker.setDate(incrementDate(getEventEnd(existingEvent), -1))
 		} else {
-			endDatePicker.setDate(getStartOfDay(getEventEnd(existingEvent)))
+			endDatePicker.setDate(getStartOfDayWithZone(getEventEnd(existingEvent)))
 		}
 		endTime(timeString(getEventEnd(existingEvent), amPmFormat))
 		if (existingEvent.repeatRule) {
@@ -174,7 +174,7 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 	} else {
 		const endTimeDate = new Date(date)
 		endTimeDate.setMinutes(endTimeDate.getMinutes() + 30)
-		endDatePicker.setDate(getStartOfDay(date))
+		endDatePicker.setDate(getStartOfDayWithZone(date))
 		endTime(timeString(endTimeDate, amPmFormat))
 		m.redraw()
 	}
@@ -268,7 +268,7 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 
 		if (allDay()) {
 			startDate = getAllDayDateUTC(startDate)
-			endDate = getAllDayDateUTC(getStartOfNextDay(endDate))
+			endDate = getAllDayDateUTC(getStartOfNextDayWithZone(endDate))
 		} else {
 			const parsedStartTime = parseTime(startTime())
 			const parsedEndTime = parseTime(endTime())
@@ -315,7 +315,7 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 					repeatRule.endValue = String(count)
 				}
 			} else if (stopType === EndType.UntilDate) {
-				const repeatEndDate = getStartOfNextDay(neverNull(repeatEndDatePicker.date()))
+				const repeatEndDate = getStartOfNextDayWithZone(neverNull(repeatEndDatePicker.date()))
 				if (repeatEndDate.getTime() < getEventStart(newEvent)) {
 					Dialog.error("startAfterEnd_label")
 					return

--- a/src/calendar/CalendarMonthView.js
+++ b/src/calendar/CalendarMonthView.js
@@ -15,7 +15,7 @@ import {
 	getDiffInDays,
 	getEventColor,
 	getEventEnd,
-	getEventStart,
+	getEventStart, getStartOfDayWithZone,
 	getStartOfTheWeekOffset,
 	getWeekNumber,
 	layOutEvents
@@ -92,7 +92,7 @@ export class CalendarMonthView implements MComponent<CalendarMonthAttrs> {
 	_renderCalendar(attrs: CalendarMonthAttrs, date: Date): Children {
 		const startOfTheWeekOffset = getStartOfTheWeekOffset(attrs.startOfTheWeek)
 		const {weekdays, weeks} = getCalendarMonth(date, startOfTheWeekOffset, false)
-		const today = getStartOfDay(new Date())
+		const today = getStartOfDayWithZone(new Date())
 		return m(".fill-absolute.flex.col.margin-are-inset-lr", [
 			styles.isDesktopLayout() ?
 				m(".mt-s.pr-l.flex.row.items-center",

--- a/src/calendar/CalendarView.js
+++ b/src/calendar/CalendarView.js
@@ -788,8 +788,6 @@ export class CalendarView implements CurrentView {
 						}
 					})
 
-				} else {
-					console.log(`unhandled update: ${update.operation} ${update.type}`)
 				}
 			})
 		})

--- a/src/calendar/ContinuingCalendarEventBubble.js
+++ b/src/calendar/ContinuingCalendarEventBubble.js
@@ -12,13 +12,14 @@ type ContinuingCalendarEventBubbleAttrs = {|
 	color: string,
 	onEventClicked: clickHandler,
 	showTime: EventTextTimeOptionEnum,
+	zone: string,
 |}
 
 export class ContinuingCalendarEventBubble implements MComponent<ContinuingCalendarEventBubbleAttrs> {
 
 	view({attrs}: Vnode<ContinuingCalendarEventBubbleAttrs>) {
-		const startsBefore = eventStartsBefore(attrs.startDate, attrs.event)
-		const endsAfter = eventEndsAfterDay(attrs.endDate, attrs.event)
+		const startsBefore = eventStartsBefore(attrs.startDate, attrs.zone, attrs.event)
+		const endsAfter = eventEndsAfterDay(attrs.endDate, attrs.zone, attrs.event)
 
 		return m(".flex.calendar-event-cont.darker-hover", [
 			startsBefore

--- a/src/misc/WindowFacade.js
+++ b/src/misc/WindowFacade.js
@@ -142,12 +142,10 @@ class WindowFacade {
 	 */
 	addHistoryEventListener(listener: (e: Event) => boolean): ()=>void {
 		this._historyStateEventListeners.push(listener)
-		console.log("added history state listener:", this._historyStateEventListeners.length)
 		return () => {
 			const index = this._historyStateEventListeners.indexOf(listener)
 			if (index !== -1) {
 				this._historyStateEventListeners.splice(index, 1)
-				console.log("removed history state listener:", this._historyStateEventListeners.length)
 			}
 		}
 	}
@@ -165,11 +163,9 @@ class WindowFacade {
 		const len = this._historyStateEventListeners.length
 		if (len === 0) return
 		if (this._ignoreNextPopstate) {
-			console.log("ignoring popstate")
 			this._ignoreNextPopstate = false
 			return
 		}
-		console.log("windowfacade._popState")
 		if (!this._historyStateEventListeners[len - 1](e)) {
 			this._ignoreNextPopstate = true
 			history.go(1)

--- a/test/client/calendar/CalendarImporterTest.js
+++ b/test/client/calendar/CalendarImporterTest.js
@@ -24,7 +24,7 @@ o.spec("CalendarImporterTest", function () {
 					description: "Descr \\ ; \n",
 					uid: "test@tutanota.com",
 					location: "Some location",
-				}), [], now)
+				}), [], now, zone)
 			).deepEquals([
 				"BEGIN:VEVENT",
 				"DTSTART:20190813T030600Z",
@@ -39,14 +39,15 @@ o.spec("CalendarImporterTest", function () {
 		})
 
 		o("all day", function () {
+			const zone = 'utc'
 			o(serializeEvent(createCalendarEvent({
 					_id: ["123", "456"],
 					_ownerGroup: "ownerId",
 					summary: "Word \\ ; \n",
-					startTime: DateTime.fromObject({year: 2019, month: 8, day: 13, zone: "UTC"}).toJSDate(),
-					endTime: DateTime.fromObject({year: 2019, month: 9, day: 14, zone: "UTC"}).toJSDate(),
+					startTime: DateTime.fromObject({year: 2019, month: 8, day: 13, zone}).toJSDate(),
+					endTime: DateTime.fromObject({year: 2019, month: 9, day: 14, zone}).toJSDate(),
 					description: "Descr \\ ; \n",
-				}), [], now)
+				}), [], now, zone)
 			).deepEquals([
 				"BEGIN:VEVENT",
 				`DTSTART:20190813`,
@@ -80,7 +81,7 @@ o.spec("CalendarImporterTest", function () {
 					startTime: DateTime.fromObject({year: 2019, month: 8, day: 13, hour: 5, minute: 6, zone}).toJSDate(),
 					endTime: DateTime.fromObject({year: 2019, month: 9, day: 13, hour: 5, minute: 6, zone}).toJSDate(),
 					description: "Descr \\ ; \n",
-				}), [alarmOne, alarmTwo], now)
+				}), [alarmOne, alarmTwo], now, zone)
 			).deepEquals([
 				"BEGIN:VEVENT",
 				"DTSTART:20190813T030600Z",
@@ -359,7 +360,7 @@ o.spec("CalendarImporterTest", function () {
 			}
 		]
 		const versionNumber = "3.57.6"
-		const serialized = serializeCalendar(versionNumber, events, now)
+		const serialized = serializeCalendar(versionNumber, events, now, zone)
 		const eventsWithoutIds = events.map(({event, alarms}) => {
 			return {
 				event: Object.assign({}, event, {_id: null, uid: event.uid || `ownerId${now.getTime()}@tutanota.com`, _ownerGroup: null}),
@@ -420,6 +421,7 @@ END:VEVENT
 END:VCALENDAR`
 			.split("\n").join("\r\n")
 
+		const zone = "Europe/Berlin"
 		const versionNumber = "3.57.6"
 		const parsed = parseCalendarStringData(text)
 		const serialized = serializeCalendar(versionNumber, parsed.map(({event, alarms}) => {
@@ -427,7 +429,7 @@ END:VCALENDAR`
 				event: Object.assign({}, event, {_id: ["123", "456"]}),
 				alarms: alarms.map(alarmInfo => createUserAlarmInfo({alarmInfo}))
 			}
-		}), now)
+		}), now, zone)
 
 		o(serialized).deepEquals(text)
 	})

--- a/test/client/calendar/CalendarModelTest.js
+++ b/test/client/calendar/CalendarModelTest.js
@@ -295,6 +295,30 @@ o.spec("CalendarModel", function () {
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJuneAndJuly)
 		})
 
+		o("weekly all-day with DST in another time zone", function () {
+			// This test checks that when there is a daylight saving change in UTC-m time zone all-day events in UTC+n still work like they
+			// should
+			const zone = 'Asia/Krasnoyarsk'
+			const event = createEvent(getAllDayDateUTC(new Date(2020, 1, 12)), getAllDayDateUTC(new Date(2020, 1, 13)))
+			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.WEEKLY, 1)
+			event.repeatRule.timeZone = 'America/Los_angeles'
+			const month = getMonth(DateTime.fromObject({year: 2020, month: 3, day: 1, zone}).toJSDate(), zone)
+			addDaysForRecurringEvent(eventsForDays, event, month, zone)
+			DateTime.fromObject({year: 2020, month: 3, day: 4, zone})
+
+			const expectedForMarch = {
+				[DateTime.fromObject({year: 2020, month: 3, day: 4, zone}).toMillis()]:
+					[cloneEventWithNewTime(event, getAllDayDateUTC(new Date(2020, 2, 4)), getAllDayDateUTC(new Date(2020, 2, 5)))],
+				[DateTime.fromObject({year: 2020, month: 3, day: 11, zone}).toMillis()]:
+					[cloneEventWithNewTime(event, getAllDayDateUTC(new Date(2020, 2, 11)), getAllDayDateUTC(new Date(2020, 2, 12)))],
+				[DateTime.fromObject({year: 2020, month: 3, day: 18, zone}).toMillis()]:
+					[cloneEventWithNewTime(event, getAllDayDateUTC(new Date(2020, 2, 18)), getAllDayDateUTC(new Date(2020, 2, 19)))],
+				[DateTime.fromObject({year: 2020, month: 3, day: 25, zone}).toMillis()]:
+					[cloneEventWithNewTime(event, getAllDayDateUTC(new Date(2020, 2, 25)), getAllDayDateUTC(new Date(2020, 2, 26)))],
+			}
+			o(Object.keys(mapToObject(eventsForDays))).deepEquals(Object.keys(expectedForMarch))
+		})
+
 		o("end count", function () {
 			const event = createEvent(new Date(2019, 5, 2, 10), new Date(2019, 5, 2, 12))
 			const repeatRule = createRepeatRuleWithValues(RepeatPeriod.WEEKLY, 1)

--- a/test/client/calendar/CalendarModelTest.js
+++ b/test/client/calendar/CalendarModelTest.js
@@ -18,6 +18,7 @@ import {generateEventElementId, getAllDayDateUTC} from "../../../src/api/common/
 
 o.spec("CalendarModel", function () {
 	o.spec("addDaysForEvent", function () {
+		const zone = getTimeZone()
 		let eventsForDays: Map<number, Array<CalendarEvent>>
 		o.beforeEach(function () {
 			eventsForDays = new Map()
@@ -25,7 +26,7 @@ o.spec("CalendarModel", function () {
 
 		o("short event same month", function () {
 			const event = createEvent(new Date(2019, 4, 1, 8), new Date(2019, 4, 1, 10))
-			const month = getMonth(event.startTime)
+			const month = getMonth(event.startTime, zone)
 
 			addDaysForEvent(eventsForDays, event, month)
 			const eventsForDay = neverNull(eventsForDays.get(getStartOfDay(event.startTime).getTime()))
@@ -34,7 +35,7 @@ o.spec("CalendarModel", function () {
 
 		o("short event prev month", function () {
 			const event = createEvent(new Date(2019, 4, 1, 8), new Date(2019, 4, 1, 10))
-			const prevMonth = getMonth(new Date(2019, 3, 1))
+			const prevMonth = getMonth(new Date(2019, 3, 1), zone)
 			addDaysForEvent(eventsForDays, event, prevMonth)
 			const eventsForDay = neverNull(eventsForDays.get(getStartOfDay(event.startTime).getTime()))
 			o(eventsForDay).deepEquals(undefined)
@@ -42,7 +43,7 @@ o.spec("CalendarModel", function () {
 
 		o("short event next month", function () {
 			const event = createEvent(new Date(2019, 4, 1, 8), new Date(2019, 4, 1, 10))
-			const nextMonth = getMonth(new Date(2019, 5, 1))
+			const nextMonth = getMonth(new Date(2019, 5, 1), zone)
 			addDaysForEvent(eventsForDays, event, nextMonth)
 			const eventsForDay = neverNull(eventsForDays.get(getStartOfDay(event.startTime).getTime()))
 			o(eventsForDay).deepEquals(undefined)
@@ -50,8 +51,8 @@ o.spec("CalendarModel", function () {
 
 		o("short event multiple days", function () {
 			const event = createEvent(new Date(2019, 4, 1, 8), new Date(2019, 4, 4, 10))
-			const thisMonth = getMonth(new Date(2019, 4, 1))
-			const nextMonth = getMonth(new Date(2019, 5, 1))
+			const thisMonth = getMonth(new Date(2019, 4, 1), zone)
+			const nextMonth = getMonth(new Date(2019, 5, 1), zone)
 
 			addDaysForEvent(eventsForDays, event, nextMonth)
 			o(eventsForDays.size).equals(0)
@@ -67,8 +68,8 @@ o.spec("CalendarModel", function () {
 
 		o("short event multiple days spans next month", function () {
 			const event = createEvent(new Date(2019, 4, 29, 8), new Date(2019, 5, 2, 10))
-			const thisMonth = getMonth(new Date(2019, 4, 1))
-			const nextMonth = getMonth(new Date(2019, 5, 1))
+			const thisMonth = getMonth(new Date(2019, 4, 1), zone)
+			const nextMonth = getMonth(new Date(2019, 5, 1), zone)
 
 			addDaysForEvent(eventsForDays, event, nextMonth)
 			o(eventsForDays.size).equals(0)
@@ -88,7 +89,7 @@ o.spec("CalendarModel", function () {
 			const endDateLocal = new Date(2019, 4, 2)
 
 			const event = createEvent(getAllDayDateUTC(startDateLocal), getAllDayDateUTC(endDateLocal))
-			const month = getMonth(startDateLocal)
+			const month = getMonth(startDateLocal, zone)
 
 			addDaysForEvent(eventsForDays, event, month)
 			const eventsForDay = neverNull(eventsForDays.get(startDateLocal.getTime()))
@@ -100,7 +101,7 @@ o.spec("CalendarModel", function () {
 
 		o("all day event two days", function () {
 			const event = createEvent(getAllDayDateUTC(new Date(2019, 3, 30)), getAllDayDateUTC(new Date(2019, 4, 2)))
-			const eventEndMonth = getMonth(new Date(2019, 4, 1))
+			const eventEndMonth = getMonth(new Date(2019, 4, 1), zone)
 
 			// do not create events if event does not start in specified month
 			{
@@ -110,7 +111,7 @@ o.spec("CalendarModel", function () {
 
 			// create events if event starts in specified month
 			{
-				const eventStartMonth = getMonth(new Date(2019, 3, 1))
+				const eventStartMonth = getMonth(new Date(2019, 3, 1), zone)
 				addDaysForEvent(eventsForDays, event, eventStartMonth)
 				const eventsForStartDay = neverNull(eventsForDays.get(getStartOfDay(new Date(2019, 3, 30)).getTime()))
 				const eventsForSecondDay = neverNull(eventsForDays.get(getStartOfDay(new Date(2019, 4, 1)).getTime()))
@@ -122,7 +123,7 @@ o.spec("CalendarModel", function () {
 
 		o("add same event", function () {
 			const event = createEvent(new Date(2019, 4, 1, 8), new Date(2019, 4, 1, 10))
-			const month = getMonth(event.startTime)
+			const month = getMonth(event.startTime, zone)
 
 			addDaysForEvent(eventsForDays, event, month)
 			const secondEvent = clone(event)
@@ -133,7 +134,7 @@ o.spec("CalendarModel", function () {
 	})
 
 	o.spec("addDaysForRecurringEvent", function () {
-		const timeZone = getTimeZone()
+		const zone = getTimeZone()
 
 		let eventsForDays: Map<number, Array<CalendarEvent>>
 		o.beforeEach(function () {
@@ -144,7 +145,7 @@ o.spec("CalendarModel", function () {
 			const event = createEvent(new Date(2019, 4, 2, 10), new Date(2019, 4, 2, 12))
 			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.WEEKLY, 1)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 
 			const expectedForJune = {
 				[new Date(2019, 5, 6).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 5, 6, 10), new Date(2019, 5, 6, 12))],
@@ -155,7 +156,7 @@ o.spec("CalendarModel", function () {
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4), zone), zone)
 
 			const expectedForJuneAndJuly = Object.assign({}, expectedForJune, {
 				[new Date(2019, 4, 2).getTime()]: [event],
@@ -171,7 +172,7 @@ o.spec("CalendarModel", function () {
 			const event = createEvent(new Date(2019, 4, 30, 10), new Date(2019, 4, 30, 12))
 			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.DAILY, 4)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 
 			const expectedForJune = {
 				[new Date(2019, 5, 3).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 5, 3, 10), new Date(2019, 5, 3, 12))],
@@ -189,25 +190,25 @@ o.spec("CalendarModel", function () {
 			const event = createEvent(new Date(2019, 4, 31, 10), new Date(2019, 4, 31, 12))
 			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.MONTHLY, 1)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4), zone), zone)
 			const expectedForMay = {
 				[new Date(2019, 4, 31).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 4, 31, 10), new Date(2019, 4, 31, 12))]
 			}
 			o(mapToObject(eventsForDays)).deepEquals(expectedForMay)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 			const expectedForJune = Object.assign({}, expectedForMay, {
 				[new Date(2019, 5, 30).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 5, 30, 10), new Date(2019, 5, 30, 12))]
 			})
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6), zone), zone)
 			const expectedForJuly = Object.assign({}, expectedForJune, {
 				[new Date(2019, 6, 31).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 6, 31, 10), new Date(2019, 6, 31, 12))]
 			})
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJuly)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2020, 1)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2020, 1), zone), zone)
 			const expectedForFebruary = Object.assign({}, expectedForJuly, {
 				[new Date(2020, 1, 29).getTime()]: [cloneEventWithNewTime(event, new Date(2020, 1, 29, 10), new Date(2020, 1, 29, 12))]
 			})
@@ -220,34 +221,34 @@ o.spec("CalendarModel", function () {
 			const event = createEvent(new Date(2019, 4, 31, 10), new Date(2019, 4, 31, 12))
 			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.MONTHLY, 2)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 			o(mapToObject(eventsForDays)).deepEquals({})
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6), zone), zone)
 			const expectedForJuly = {
 				[new Date(2019, 6, 31).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 6, 31, 10), new Date(2019, 6, 31, 12))]
 			}
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJuly)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 7)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 7), zone), zone)
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJuly)
 
 			const expectedForSeptember = Object.assign({}, expectedForJuly, {
 				[new Date(2019, 8, 30).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 8, 30, 10), new Date(2019, 8, 30, 12))]
 			})
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 8)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 8), zone), zone)
 			// o(mapToObject(eventsForDays)).deepEquals(expectedForSeptember)
 			const expectedForNovember = Object.assign({}, expectedForSeptember, {
 				[new Date(2019, 10, 30).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 10, 30, 10), new Date(2019, 10, 30, 12))]
 			})
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 10)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 10), zone), zone)
 			o(mapToObject(eventsForDays)).deepEquals(expectedForNovember)
 		})
 
 		o("recuring event - short multiple days ", function () {
 			const event = createEvent(new Date(2019, 4, 3, 10), new Date(2019, 4, 5, 12))
 			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.WEEKLY, 1)
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 
 			const expectedForJune = {
 				[new Date(2019, 5, 7).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 5, 7, 10), new Date(2019, 5, 9, 12))],
@@ -269,7 +270,7 @@ o.spec("CalendarModel", function () {
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4), zone), zone)
 
 			const expectedForJuneAndJuly = Object.assign({}, expectedForJune, {
 				[new Date(2019, 4, 3).getTime()]: [event],
@@ -304,7 +305,6 @@ o.spec("CalendarModel", function () {
 			event.repeatRule.timeZone = 'America/Los_angeles'
 			const month = getMonth(DateTime.fromObject({year: 2020, month: 3, day: 1, zone}).toJSDate(), zone)
 			addDaysForRecurringEvent(eventsForDays, event, month, zone)
-			DateTime.fromObject({year: 2020, month: 3, day: 4, zone})
 
 			const expectedForMarch = {
 				[DateTime.fromObject({year: 2020, month: 3, day: 4, zone}).toMillis()]:
@@ -316,7 +316,7 @@ o.spec("CalendarModel", function () {
 				[DateTime.fromObject({year: 2020, month: 3, day: 25, zone}).toMillis()]:
 					[cloneEventWithNewTime(event, getAllDayDateUTC(new Date(2020, 2, 25)), getAllDayDateUTC(new Date(2020, 2, 26)))],
 			}
-			o(Object.keys(mapToObject(eventsForDays))).deepEquals(Object.keys(expectedForMarch))
+			o(mapToObject(eventsForDays)).deepEquals(expectedForMarch)
 		})
 
 		o("end count", function () {
@@ -326,7 +326,7 @@ o.spec("CalendarModel", function () {
 			repeatRule.endValue = "2"
 			event.repeatRule = repeatRule
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 
 			const expectedForJune = {
 				[new Date(2019, 5, 2).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 5, 2, 10), new Date(2019, 5, 2, 12))],
@@ -335,7 +335,7 @@ o.spec("CalendarModel", function () {
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6), zone), zone)
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 		})
 
@@ -346,7 +346,7 @@ o.spec("CalendarModel", function () {
 			repeatRule.endValue = String(new Date(2019, 5, 29).getTime())
 			event.repeatRule = repeatRule
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 
 			const expectedForJune = {
 				[new Date(2019, 5, 2).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 5, 2, 10), new Date(2019, 5, 2, 12))],
@@ -356,7 +356,7 @@ o.spec("CalendarModel", function () {
 			}
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6), zone), zone)
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 		})
 
@@ -372,7 +372,7 @@ o.spec("CalendarModel", function () {
 			event.repeatRule = repeatRule
 			event.repeatRule.timeZone = "Asia/Anadyr" // +12
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 
 			const expectedForJune = {
 				[new Date(2019, 5, 2).getTime()]: [cloneEventWithNewTime(event, getAllDayDateUTC(new Date(2019, 5, 2)), getAllDayDateUTC(new Date(2019, 5, 3)))],
@@ -385,7 +385,7 @@ o.spec("CalendarModel", function () {
 			const event = createEvent(new Date(2019, 4, 2, 10), new Date(2019, 4, 2, 12))
 			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.WEEKLY, 1)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5), zone), zone)
 
 			const expectedForJune = {
 				[new Date(2019, 5, 6).getTime()]: [cloneEventWithNewTime(event, new Date(2019, 5, 6, 10), new Date(2019, 5, 6, 12))],
@@ -396,9 +396,9 @@ o.spec("CalendarModel", function () {
 			o(mapToObject(eventsForDays)).deepEquals(expectedForJune)
 
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 4), zone), zone)
 			const eventClone = clone(event)
-			addDaysForRecurringEvent(eventsForDays, eventClone, getMonth(new Date(2019, 4)), timeZone)
+			addDaysForRecurringEvent(eventsForDays, eventClone, getMonth(new Date(2019, 4), zone), zone)
 
 			const expectedForJuneAndJuly = Object.assign({}, expectedForJune, {
 				[new Date(2019, 4, 2).getTime()]: [event],
@@ -412,6 +412,7 @@ o.spec("CalendarModel", function () {
 	})
 
 	o.spec("addDaysForEvent for long events", function () {
+		const zone = getTimeZone()
 		let eventsForDays: Map<number, Array<CalendarEvent>>
 		o.beforeEach(function () {
 			eventsForDays = new Map()
@@ -419,13 +420,13 @@ o.spec("CalendarModel", function () {
 
 		o("longer than a month", function () {
 			const event = createEvent(new Date(2019, 4, 2, 10), new Date(2019, 5, 2, 12))
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2), zone))
 			o(eventsForDays.size).equals(2)
 			o(eventsForDays.get(new Date(2019, 5, 1).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 2).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 3).getTime())).equals(undefined)
 
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2), zone))
 			o(eventsForDays.size).equals(32)
 			o(eventsForDays.get(new Date(2019, 4, 1).getTime())).equals(undefined)
 			o(eventsForDays.get(new Date(2019, 4, 2).getTime())).deepEquals([event])
@@ -434,13 +435,13 @@ o.spec("CalendarModel", function () {
 
 		o("longer than a month all day", function () {
 			const event = createEvent(getAllDayDateUTC(new Date(2019, 4, 2, 10)), getAllDayDateUTC(new Date(2019, 5, 3, 12)))
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2), zone))
 			o(eventsForDays.size).equals(2)
 			o(eventsForDays.get(new Date(2019, 5, 1).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 2).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 3).getTime())).equals(undefined)
 
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2), zone))
 			o(eventsForDays.size).equals(32)
 			o(eventsForDays.get(new Date(2019, 4, 1).getTime())).equals(undefined)
 			o(eventsForDays.get(new Date(2019, 4, 2).getTime())).deepEquals([event])
@@ -449,20 +450,20 @@ o.spec("CalendarModel", function () {
 
 		o("multiple months", function () {
 			const event = createEvent(new Date(2019, 3, 2, 10), new Date(2019, 5, 2, 12))
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2), zone))
 			o(eventsForDays.size).equals(2)
 			o(eventsForDays.get(new Date(2019, 5, 1).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 2).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 3).getTime())).equals(undefined)
 
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2), zone))
 			o(eventsForDays.size).equals(2 + 31)
 			o(eventsForDays.get(new Date(2019, 4, 1).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 4, 2).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 4, 31).getTime())).deepEquals([event])
 
 
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 3, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 3, 2), zone))
 			o(eventsForDays.size).equals(2 + 31 + 29)
 			o(eventsForDays.get(new Date(2019, 3, 1).getTime())).equals(undefined)
 			o(eventsForDays.get(new Date(2019, 3, 2).getTime())).deepEquals([event])
@@ -472,7 +473,7 @@ o.spec("CalendarModel", function () {
 
 
 		o("longer than a month repeating", function () {
-			const timeZone = getTimeZone()
+			const zone = getTimeZone()
 			const event = createEvent(new Date(2019, 4, 2, 10), new Date(2019, 5, 2, 12))
 			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.MONTHLY, 1)
 
@@ -480,7 +481,7 @@ o.spec("CalendarModel", function () {
 			const startingInJune = cloneEventWithNewTime(event, new Date(2019, 5, 2, 10), new Date(2019, 6, 2, 12))
 			const startingInJuly = cloneEventWithNewTime(event, new Date(2019, 6, 2, 10), new Date(2019, 7, 2, 12))
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2)), timeZone) // invoke for June
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2), zone), zone) // invoke for June
 			o(eventsForDays.size).equals(30) // One starting in May and all the June
 			o(eventsForDays.get(new Date(2019, 4, 31).getTime())).deepEquals(undefined)
 			o(eventsForDays.get(new Date(2019, 5, 1).getTime())).deepEquals([startingInMay])
@@ -488,7 +489,7 @@ o.spec("CalendarModel", function () {
 			o(eventsForDays.get(new Date(2019, 5, 30).getTime())).deepEquals([startingInJune])
 			o(eventsForDays.get(new Date(2019, 6, 1).getTime())).deepEquals(undefined)
 
-			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6, 2)), timeZone) // invoke for July
+			addDaysForRecurringEvent(eventsForDays, event, getMonth(new Date(2019, 6, 2), zone), zone) // invoke for July
 			o(eventsForDays.size).equals(30 + 31) // Previous pls all of the July
 			o(eventsForDays.get(new Date(2019, 6, 1).getTime())).deepEquals([startingInJune])
 			o(eventsForDays.get(new Date(2019, 6, 2).getTime())).deepEquals([startingInJune, startingInJuly])
@@ -498,15 +499,15 @@ o.spec("CalendarModel", function () {
 
 		o("add same event", function () {
 			const event = createEvent(new Date(2019, 4, 2, 10), new Date(2019, 5, 2, 12))
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2)))
-			addDaysForLongEvent(eventsForDays, clone(event), getMonth(new Date(2019, 5, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 5, 2), zone))
+			addDaysForLongEvent(eventsForDays, clone(event), getMonth(new Date(2019, 5, 2), zone))
 			o(eventsForDays.size).equals(2)
 			o(eventsForDays.get(new Date(2019, 5, 1).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 2).getTime())).deepEquals([event])
 			o(eventsForDays.get(new Date(2019, 5, 3).getTime())).equals(undefined)
 
-			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2)))
-			addDaysForLongEvent(eventsForDays, clone(event), getMonth(new Date(2019, 4, 2)))
+			addDaysForLongEvent(eventsForDays, event, getMonth(new Date(2019, 4, 2), zone))
+			addDaysForLongEvent(eventsForDays, clone(event), getMonth(new Date(2019, 4, 2), zone))
 			o(eventsForDays.size).equals(32)
 			o(eventsForDays.get(new Date(2019, 4, 1).getTime())).equals(undefined)
 			o(eventsForDays.get(new Date(2019, 4, 2).getTime())).deepEquals([event])


### PR DESCRIPTION
For repeating events we remember time zone in which event was created
to have stable iterations across time zones. Unfortunately, this does
not work with all-day events which are supposed to be in the viewer's
time zone. When there's a daylight shift in creator's time zone viewer
may have day shifted by one. This commit makes calculation use viewer's
time zone for all-day events.

It also introduces some changes for extracting times of all-day events
to make them work with passed time zone. This is necessary for tests
and might also be helpful if we introduce "timezone override" in the
future.

Some functions from DateUtils had to be duplicated in CalendarUtils to
make them timezone-aware. We cannot make this change in DateUtils
because we don't depend on Luxon in the worker.