### PR TITLE
[android] Fix stuck connection notification

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
@@ -83,7 +83,7 @@ public final class PushNotificationService extends LifecycleJobService {
 			}
 
 			@Override
-			public void onTooManyReconnectionAttempts() {
+			public void onStoppingReconnectionAttempts() {
 				removeBackgroundServiceNotification();
 				finishJobIfNeeded();
 			}

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.java
@@ -146,12 +146,13 @@ public class SseClient {
 		if (failedConnectionAttempts > RECONNECTION_ATTEMPTS) {
 			failedConnectionAttempts = 0;
 			Log.e(TAG, "Too many failed connection attempts, will try to sync notifications next time system wakes app up");
-			sseListener.onTooManyReconnectionAttempts();
+			sseListener.onStoppingReconnectionAttempts();
 		} else if (this.networkObserver.hasNetworkConnection()) {
 			Log.e(TAG, "error opening sse, rescheduling after " + delay + ", failedConnectionAttempts: " + failedConnectionAttempts, exception);
 			reschedule(delay);
 		} else {
 			Log.e(TAG, "network is not connected, do not reschedule ", exception);
+			sseListener.onStoppingReconnectionAttempts();
 		}
 	}
 
@@ -245,6 +246,6 @@ public class SseClient {
 
 		void onNotAuthorized();
 
-		void onTooManyReconnectionAttempts();
+		void onStoppingReconnectionAttempts();
 	}
 }


### PR DESCRIPTION
This happened when background service was started when device is
offline. We give up on rescheduling in two cases: on too many attempts
or when being offline. We only dismissed notification in the first case
before.