### PR TITLE
[desktop] fix #1828

### DIFF
--- a/flow/electron.js
+++ b/flow/electron.js
@@ -511,7 +511,7 @@ declare module 'electron-localshortcut' {
 		register(win?: BrowserWindow, shortcut: string, cb: Function): void;
 		unregister(shortcut: string): void;
 		isRegistered(shortcut: string): boolean;
-		unregisterAll(): void;
+		unregisterAll(win?: BrowserWindow): void;
 		enableAll(win?: BrowserWindow): void;
 		disableAll(win?: BrowserWindow): void;
 	}

--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -157,29 +157,30 @@ export class ApplicationWindow {
 				        })
 			    }
 		    })
+		    .on('did-finish-load', () => {
+			    localShortcut.unregisterAll(this._browserWindow)
+			    const isMac = process.platform === 'darwin';
+			    this._addShortcuts([
+					    {key: Keys.F, meta: isMac, ctrl: !isMac, exec: () => this._openFindInPage(), help: "searchPage_label"},
+					    {key: Keys.P, meta: isMac, ctrl: !isMac, exec: () => this._printMail(), help: "print_action"},
+					    {key: Keys.F12, exec: () => this._toggleDevTools(), help: "toggleDevTools_action"},
+					    {key: Keys.F5, exec: () => this._browserWindow.loadURL(this._startFile), help: "reloadPage_action"},
+					    {key: Keys.N, meta: isMac, ctrl: !isMac, exec: () => {wm.newWindow(true)}, help: "openNewWindow_action"}
+				    ].concat(isMac
+				    ? [{key: Keys.F, meta: true, ctrl: true, exec: () => this._toggleFullScreen(), help: "toggleFullScreen_action"},]
+				    : [
+					    {key: Keys.F11, exec: () => this._toggleFullScreen(), help: "toggleFullScreen_action"},
+					    {key: Keys.RIGHT, alt: true, exec: () => this._browserWindow.webContents.goForward(), help: "pageForward_label"},
+					    {key: Keys.LEFT, alt: true, exec: () => this._tryGoBack(), help: "pageBackward_label"},
+					    {key: Keys.H, ctrl: true, exec: () => wm.hide(), help: "hideWindows_action"},
+				    ])
+			    )
+		    })
 		    .on('crashed', () => wm.recreateWindow(this))
 
 		this._browserWindow.webContents.on('dom-ready', () => {
 			this.sendMessageToWebContents('setup-context-menu', [])
 		})
-
-		const isMac = process.platform === 'darwin';
-
-		this._addShortcuts([
-				{key: Keys.F, meta: isMac, ctrl: !isMac, exec: () => this._openFindInPage(), help: "searchPage_label"},
-				{key: Keys.P, meta: isMac, ctrl: !isMac, exec: () => this._printMail(), help: "print_action"},
-				{key: Keys.F12, exec: () => this._toggleDevTools(), help: "toggleDevTools_action"},
-				{key: Keys.F5, exec: () => this._browserWindow.loadURL(this._startFile), help: "reloadPage_action"},
-				{key: Keys.N, meta: isMac, ctrl: !isMac, exec: () => {wm.newWindow(true)}, help: "openNewWindow_action"}
-			].concat(isMac
-			? [{key: Keys.F, meta: true, ctrl: true, exec: () => this._toggleFullScreen(), help: "toggleFullScreen_action"},]
-			: [
-				{key: Keys.F11, exec: () => this._toggleFullScreen(), help: "toggleFullScreen_action"},
-				{key: Keys.RIGHT, alt: true, exec: () => this._browserWindow.webContents.goForward(), help: "pageForward_label"},
-				{key: Keys.LEFT, alt: true, exec: () => this._tryGoBack(), help: "pageBackward_label"},
-				{key: Keys.H, ctrl: true, exec: () => wm.hide(), help: "hideWindows_action"},
-			])
-		)
 	}
 
 	_addShortcuts(shortcuts: Shortcut[]): void {

--- a/test/client/desktop/ApplicationWindowTest.js
+++ b/test/client/desktop/ApplicationWindowTest.js
@@ -153,7 +153,8 @@ o.spec("ApplicationWindow Test", () => {
 		callbacks: {},
 		register: function (bw, key, cb) {
 			this.callbacks[key] = cb
-		}
+		},
+		unregisterAll: function (key) {}
 	}
 	const lang = {
 		lang: {
@@ -260,6 +261,7 @@ o.spec("ApplicationWindow Test", () => {
 			'before-input-event',
 			'context-menu',
 			'did-fail-load',
+			'did-finish-load',
 			'crashed',
 			'dom-ready'
 		])
@@ -296,6 +298,8 @@ o.spec("ApplicationWindow Test", () => {
 		const {ApplicationWindow} = n.subject('../../src/desktop/ApplicationWindow.js')
 		const w = new ApplicationWindow(wmMock, 'preloadjs', 'desktophtml')
 
+		w._browserWindow.webContents.callbacks['did-finish-load']()
+
 		o(Object.keys(electronLocalshortcutMock.callbacks)).deepEquals([
 			'Control+F',
 			'Control+P',
@@ -315,6 +319,8 @@ o.spec("ApplicationWindow Test", () => {
 
 		const {ApplicationWindow} = n.subject('../../src/desktop/ApplicationWindow.js')
 		const w = new ApplicationWindow(wmMock, 'preloadjs', 'desktophtml')
+
+		w._browserWindow.webContents.callbacks['did-finish-load']()
 
 		o(Object.keys(electronLocalshortcutMock.callbacks)).deepEquals([
 			'Control+F',
@@ -336,6 +342,8 @@ o.spec("ApplicationWindow Test", () => {
 		const {ApplicationWindow} = n.subject('../../src/desktop/ApplicationWindow.js')
 		const w = new ApplicationWindow(wmMock, 'preloadjs', 'desktophtml')
 
+		w._browserWindow.webContents.callbacks['did-finish-load']()
+
 		o(Object.keys(electronLocalshortcutMock.callbacks)).deepEquals([
 			'Command+F',
 			'Command+P',
@@ -353,6 +361,9 @@ o.spec("ApplicationWindow Test", () => {
 		const {ApplicationWindow} = n.subject('../../src/desktop/ApplicationWindow.js')
 		const w = new ApplicationWindow(wmMock, 'preloadjs', 'desktophtml')
 
+		const bwInstance = electronMock.BrowserWindow.mockedInstances[0]
+		bwInstance.webContents.callbacks['did-finish-load']()
+
 		// call all the shortcut callbacks
 		electronLocalshortcutMock.callbacks["Control+F"]()
 		o(wmMock.ipc.sendRequest.callCount).equals(2)
@@ -363,7 +374,6 @@ o.spec("ApplicationWindow Test", () => {
 		o(wmMock.ipc.sendRequest.callCount).equals(3)
 		o(wmMock.ipc.sendRequest.args).deepEquals([w.id, 'print', []])
 
-		const bwInstance = electronMock.BrowserWindow.mockedInstances[0]
 		electronLocalshortcutMock.callbacks["F12"]()
 		o(bwInstance.webContents.isDevToolsOpened.callCount).equals(1)
 		o(bwInstance.webContents.openDevTools.callCount).equals(1)
@@ -405,6 +415,9 @@ o.spec("ApplicationWindow Test", () => {
 		const {ApplicationWindow} = n.subject('../../src/desktop/ApplicationWindow.js')
 		const w = new ApplicationWindow(wmMock, 'preloadjs', 'desktophtml')
 
+		const bwInstance = electronMock.BrowserWindow.mockedInstances[0]
+		bwInstance.webContents.callbacks['did-finish-load']()
+
 		// call all the shortcut callbacks
 		electronLocalshortcutMock.callbacks["Command+F"]()
 		o(wmMock.ipc.sendRequest.callCount).equals(2)
@@ -415,7 +428,6 @@ o.spec("ApplicationWindow Test", () => {
 		o(wmMock.ipc.sendRequest.callCount).equals(3)
 		o(wmMock.ipc.sendRequest.args).deepEquals([w.id, 'print', []])
 
-		const bwInstance = electronMock.BrowserWindow.mockedInstances[0]
 		electronLocalshortcutMock.callbacks["F12"]()
 		o(bwInstance.webContents.isDevToolsOpened.callCount).equals(1)
 		o(bwInstance.webContents.openDevTools.callCount).equals(1)
@@ -627,7 +639,7 @@ o.spec("ApplicationWindow Test", () => {
 		setTimeout(() => {
 			o(wmMock.ipc.initialized.callCount).equals(1)
 			o(wmMock.ipc.initialized.args[0]).equals(w.id)
-			o(wmMock.ipc.sendRequest.callCount).equals(2)
+			o(wmMock.ipc.sendRequest.callCount).equals(1)
 			o(wmMock.ipc.sendRequest.args[0]).equals(w.id)
 			o(wmMock.ipc.sendRequest.args[1]).equals("openMailbox")
 			o(wmMock.ipc.sendRequest.args[2]).deepEquals([


### PR DESCRIPTION
register shortcuts on did-finish-load event to retain them after F5 reload