### PR TITLE
Improved whitelist action translation for English language

### DIFF
--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -339,7 +339,7 @@ module.exports = {
 		"emailSenderInvalidRule_msg": "The rule for this email sender is not allowed.",
 		"emailSenderPlaceholder_label": "Email address or domain name",
 		"emailSenderRule_label": "Rule",
-		"emailSenderWhitelist_action": "No spam",
+		"emailSenderWhitelist_action": "Not spam",
 		"emailSender_label": "Email sender",
 		"emailSending_label": "Sending emails",
 		"emailSignatureTypeCustom_msg": "Custom",


### PR DESCRIPTION
In the context of creating a Spam rule, and in conjunction with its opposite 'Always Spam', 'Not Spam' seems more gramatically correct than 'No spam'. 