### PR TITLE
[desktop] improve mailto handling

### DIFF
--- a/flow/electron.js
+++ b/flow/electron.js
@@ -1,5 +1,4 @@
 import {IncomingMessage} from "electron"
-import {Function} from "estree"
 
 /**
  * this file is highly inaccurate, check the docs at electronjs.org

--- a/flow/electron.js
+++ b/flow/electron.js
@@ -1,4 +1,5 @@
 import {IncomingMessage} from "electron"
+import {Function} from "estree"
 
 /**
  * this file is highly inaccurate, check the docs at electronjs.org
@@ -205,11 +206,13 @@ declare module 'electron' {
 		on(AppEvent, (Event, ...Array<any>) => any): App,
 		once(AppEvent, (Event, ...Array<any>) => any): App,
 		emit(AppEvent): App,
+		removeListener(AppEvent, Function): App,
 		requestSingleInstanceLock(): void,
 		quit(): void,
 		exit(code: Number): void,
 		relaunch({args: Array<string>, execPath?: string}): void,
 		getVersion(): string,
+		isReady(): boolean,
 		name: string,
 		setPath(name: string, path: string): void;
 		allowRendererProcessReuse: boolean;

--- a/src/desktop/DesktopMain.js
+++ b/src/desktop/DesktopMain.js
@@ -86,6 +86,7 @@ if (process.argv.indexOf("-r") !== -1) {
 			// MacOS mailto handling
 			e.preventDefault()
 			if (!url.startsWith('mailto:')) {
+				// do nothing if this is not a mailto: url
 			} else if (app.isReady()) {
 				// we can open a window now
 				handleMailto(url)

--- a/src/desktop/DesktopMain.js
+++ b/src/desktop/DesktopMain.js
@@ -82,6 +82,17 @@ if (process.argv.indexOf("-r") !== -1) {
 				wm.getAll().forEach(w => w.show())
 			}
 			handleArgv(args)
+		}).on('open-url', (e, url) => {
+			// MacOS mailto handling
+			e.preventDefault()
+			if (!url.startsWith('mailto:')) {
+			} else if (app.isReady()) {
+				// we can open a window now
+				handleMailto(url)
+			} else {
+				// wait until opening windows is possible, then handle.
+				app.once('ready', () => handleMailto(url))
+			}
 		})
 	}
 
@@ -94,12 +105,6 @@ function onAppReady() {
 		if (!conf.getDesktopConfig('runAsTrayApp')) {
 			app.quit()
 		}
-	}).on('open-url', (e, url) => { // MacOS mailto handling
-		e.preventDefault()
-		if (!url.startsWith('mailto:')) {
-			return
-		}
-		handleMailto(url)
 	})
 
 	err.init(wm, ipc)

--- a/src/desktop/integration/DesktopIntegratorLinux.js
+++ b/src/desktop/integration/DesktopIntegratorLinux.js
@@ -3,7 +3,7 @@ import fs from "fs-extra"
 import {app, dialog} from "electron"
 import path from "path"
 import {lang} from "../../misc/LanguageViewModel"
-import {exec} from "child_process"
+import {execFile} from "child_process"
 
 const DATA_HOME = process.env.XDG_DATA_HOME || path.join(app.getPath('home'), ".local/share")
 const CONFIG_HOME = process.env.XDG_CONFIG_HOME || path.join(app.getPath('home'), ".config")
@@ -22,6 +22,12 @@ const nointegrationpath = path.join(CONFIG_HOME, 'tuta_integration/no_integratio
 
 fs.access(iconSourcePath512, fs.constants.F_OK)
   .catch(() => console.error("icon logo-solo-red.png not found, has the file name changed?"))
+
+function logExecFile(err, stdout, stderr) {
+	if (stdout && stdout !== "") console.log("stdout:", stdout)
+	if (err) console.error(err)
+	if (stderr && stderr !== "") console.error("stderr:", stderr)
+}
 
 export function isAutoLaunchEnabled(): Promise<boolean> {
 	return checkFileIsThere(autoLaunchPath)
@@ -111,7 +117,7 @@ export function integrate(): Promise<void> {
 	).then(() => {
 		if (process.env["XDG_CURRENT_DESKTOP"] !== "GNOME") return
 		try {
-			exec(`update-desktop-database "${path.join(app.getPath('home'), ".local/share/applications")}`)
+			execFile('update-desktop-database', [path.join(app.getPath('home'), ".local/share/applications")], logExecFile)
 		} catch (e) {
 		}
 	})
@@ -166,7 +172,7 @@ function copyIcons(): Promise<void> {
 		])
 	}).then(() => {
 		try {// refresh icon cache (update last modified timestamp)
-			exec(`touch "${path.join(app.getPath('home'), ".local/share/icons/hicolor")}"`)
+			execFile('touch', [path.join(app.getPath('home'), ".local/share/icons/hicolor")], logExecFile)
 		} catch (e) {
 			// it's ok if this fails for some reason, the icons will appear after a reboot at the latest
 		}

--- a/src/desktop/integration/DesktopIntegratorLinux.js
+++ b/src/desktop/integration/DesktopIntegratorLinux.js
@@ -108,7 +108,13 @@ export function integrate(): Promise<void> {
 	const prefix = app.name.includes("test") ? "test " : ""
 	return copyIcons().then(
 		() => createDesktopEntry(prefix)
-	)
+	).then(() => {
+		if (process.env["XDG_CURRENT_DESKTOP"] !== "GNOME") return
+		try {
+			exec(`update-desktop-database "${path.join(app.getPath('home'), ".local/share/applications")}`)
+		} catch (e) {
+		}
+	})
 }
 
 export function unintegrate(): Promise<void> {


### PR DESCRIPTION
- Linux: add a call to `update-desktop-database` after integration when using GNOME. close #1864
- MacOs: handle mailto link events received before app.isReady. close #1877