### PR TITLE
[desktop] handle file downloads like in the apps

### DIFF
--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -81,6 +81,10 @@ export class ApplicationWindow {
 	showInactive = () => this._browserWindow.showInactive()
 	isFocused = () => this._browserWindow.isFocused()
 
+	get browserWindow() {
+		return this._browserWindow
+	}
+
 	show() {
 		if (!this._browserWindow) {
 			return

--- a/src/desktop/IPC.js
+++ b/src/desktop/IPC.js
@@ -25,6 +25,7 @@ import type {DesktopCryptoFacade} from "./DesktopCryptoFacade"
 import type {DesktopDownloadManager} from "./DesktopDownloadManager"
 import {DesktopAlarmScheduler} from "./sse/DesktopAlarmScheduler"
 import type {SseInfo} from "./sse/DesktopSseClient"
+import {base64ToUint8Array} from "../api/common/utils/Encoding"
 
 /**
  * node-side endpoint for communication between the renderer thread and the node thread
@@ -133,6 +134,11 @@ export class IPC {
 			case 'download':
 				// sourceUrl, filename, headers
 				return this._dl.downloadNative(...args.slice(0, 3))
+			case 'saveBlob':
+				// args: [data.name, uint8ArrayToBase64(data.data)]
+				const filename : string = downcast(args[0])
+				const data : Uint8Array = base64ToUint8Array(downcast(args[1]))
+				return this._dl.saveBlob(filename, data, this._wm.get(windowId))
 			case "aesDecryptFile":
 				// key, path
 				return this._crypto.aesDecryptFile(...args.slice(0, 2))

--- a/src/file/FileController.js
+++ b/src/file/FileController.js
@@ -157,7 +157,7 @@ export class FileController {
 			return fileApp.open(_file)
 		} else {
 			let dataFile: DataFile = _file
-			if (isApp()) {
+			if (isApp() || isDesktop()) {
 				return fileApp.saveBlob(dataFile)
 				              .catch(err => Dialog.error("canNotOpenFileOnDevice_msg")).return()
 			}

--- a/test/client/desktop/DesktopDownloadManagerTest.js
+++ b/test/client/desktop/DesktopDownloadManagerTest.js
@@ -169,7 +169,7 @@ o.spec("DesktopDownloadManagerTest", () => {
 		}
 	}
 
-	o("no default download path => do nothing", () => {
+	o("no default download path => don't assign save path", () => {
 		const {electronMock, netMock} = standardMocks()
 		const confMock = n.mock("__conf", conf).with({
 			getDesktopConfig: (key) => {
@@ -189,8 +189,9 @@ o.spec("DesktopDownloadManagerTest", () => {
 		o(sessionMock.removeAllListeners.args[0]).equals("will-download")
 		o(sessionMock.on.callCount).equals(1)
 		o(sessionMock.on.args[0]).equals("will-download")
-		// no args so we throw when DownloadManager tries to do any work.
-		sessionMock.callbacks["will-download"]()
+		const itemMock = n.spyify({on: () => {}})
+		sessionMock.callbacks["will-download"](undefined, itemMock)
+		o(itemMock.on.callCount).equals(1)
 		o(electronMock.dialog.showMessageBox.callCount).equals(0)
 	})
 
@@ -226,8 +227,8 @@ o.spec("DesktopDownloadManagerTest", () => {
 		o(sessionMock.removeAllListeners.args[0]).equals("will-download")
 		o(sessionMock.on.callCount).equals(1)
 		o(sessionMock.on.args[0]).equals("will-download")
-		// no args so we throw when DownloadManager tries to do any work.
-		sessionMock.callbacks["will-download"]()
+		const itemMock = n.spyify({on: () => {}})
+		sessionMock.callbacks["will-download"](undefined, itemMock)
 		o(electronMock.dialog.showMessageBox.callCount).equals(0)
 	})
 


### PR DESCRIPTION
electron doesn't allow us to delay asking for the path if using the 'will-download' handler.
switching over to the app logic so the blobl is already downloaded when we ask for the save path
close #1886 