### PR TITLE
[android] Do not accidentally color navbar before API 26

### DIFF
--- a/app-android/app/src/main/res/values-v26/styles.xml
+++ b/app-android/app/src/main/res/values-v26/styles.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <!-- Base application theme. -->
     <style name="AppTheme" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:colorPrimary">@color/red</item>
@@ -14,6 +14,6 @@
         <item name="android:windowBackground">@drawable/splash_background</item>
         <item name="android:statusBarColor">@color/white</item>
         <item name="android:windowLightStatusBar">true</item>
+        <item name="android:navigationBarColor">@color/white</item>
     </style>
-
 </resources>


### PR DESCRIPTION
We cannot change navbar buttons color before API 26 but we changed
navbar color starting from API 23 because of the styles resource (we
defined it there so that system shows the right navbar color for splash
screen). This commit removes navbar color from values-v23 and defines
another style resource for API 26.