### PR TITLE
Sort aliases alphabetically in settings and mail editor

### DIFF
--- a/src/mail/MailEditor.js
+++ b/src/mail/MailEditor.js
@@ -164,7 +164,9 @@ export class MailEditor {
 			.map(mailAddress => ({
 				name: mailAddress,
 				value: mailAddress
-			})), stream(getDefaultSender(this._mailboxDetails)), 250)
+			}))
+			.sort((a, b) => (a.name > b.name) ? 1 : -1),
+			stream(getDefaultSender(this._mailboxDetails)), 250)
 
 		let sortedLanguages = languages.slice().sort((a, b) => lang.get(a.textId).localeCompare(lang.get(b.textId)))
 		this._selectedNotificationLanguage = stream(getAvailableLanguageCode(props.notificationMailLanguage || lang.code))

--- a/src/mail/MailEditor.js
+++ b/src/mail/MailEditor.js
@@ -161,12 +161,10 @@ export class MailEditor {
 		let props = logins.getUserController().props
 
 		this._senderField = new DropDownSelector("sender_label", null, getEnabledMailAddresses(this._mailboxDetails)
-			.map(mailAddress => ({
+			.sort().map(mailAddress => ({
 				name: mailAddress,
 				value: mailAddress
-			}))
-			.sort((a, b) => (a.name > b.name) ? 1 : -1),
-			stream(getDefaultSender(this._mailboxDetails)), 250)
+			})), stream(getDefaultSender(this._mailboxDetails)), 250)
 
 		let sortedLanguages = languages.slice().sort((a, b) => lang.get(a.textId).localeCompare(lang.get(b.textId)))
 		this._selectedNotificationLanguage = stream(getAvailableLanguageCode(props.notificationMailLanguage || lang.code))

--- a/src/settings/EditAliasesFormN.js
+++ b/src/settings/EditAliasesFormN.js
@@ -110,7 +110,7 @@ class _EditAliasesForm {
 				],
 				actionButtonAttrs: actionButtonAttrs
 			}
-		})
+		}).sort((a, b) => (a.cells[0] > b.cells[0]) ? 1 : -1)
 	}
 
 	_showAddAliasDialog(groupInfo: GroupInfo) {

--- a/src/settings/EditAliasesFormN.js
+++ b/src/settings/EditAliasesFormN.js
@@ -71,7 +71,7 @@ class _EditAliasesForm {
 	}
 
 	_getAliasLineAttrs(groupInfo: GroupInfo): Array<TableLineAttrs> {
-		return groupInfo.mailAddressAliases.map(alias => {
+		return groupInfo.mailAddressAliases.sort((a, b) => (a.mailAddress > b.mailAddress) ? 1 : -1).map(alias => {
 			const actionButtonAttrs: ButtonAttrs = attachDropdown(
 				{
 					label: "edit_action",
@@ -110,7 +110,7 @@ class _EditAliasesForm {
 				],
 				actionButtonAttrs: actionButtonAttrs
 			}
-		}).sort((a, b) => (a.cells[0] > b.cells[0]) ? 1 : -1)
+		})
 	}
 
 	_showAddAliasDialog(groupInfo: GroupInfo) {


### PR DESCRIPTION
This commit resolves #1844

Sections:
- User Settings > Email > Email aliases > Show email aliases
- User management > User > Email aliases > Show email aliases
- Emails > New email > Show > Sender