### PR TITLE
Fix display problem caused by negative margin

### DIFF
--- a/src/calendar/CalendarEventDialog.js
+++ b/src/calendar/CalendarEventDialog.js
@@ -434,12 +434,13 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 				disabled: readOnly,
 				injectionsRight: () => {
 					let address = encodeURIComponent(locationValue())
-					if (address == "") {
+					if (address === "") {
 						return null;
 					}
 					return m(ButtonN, {
 						label: 'showAddress_alt',
 						icon: () => Icons.Pin,
+						endAligned: true,
 						click: () => {
 							window.open(`https://www.openstreetmap.org/search?query=${address}`, '_blank')
 						}

--- a/src/contacts/ContactEditor.js
+++ b/src/contacts/ContactEditor.js
@@ -2,7 +2,7 @@
 import m from "mithril"
 import stream from "mithril/stream/stream.js"
 import {Dialog} from "../gui/base/Dialog"
-import {Button, createDropDownButton} from "../gui/base/Button"
+import {Button} from "../gui/base/Button"
 import {TextField, Type} from "../gui/base/TextField"
 import {lang} from "../misc/LanguageViewModel"
 import {parseBirthday} from "../misc/Formatter"
@@ -35,7 +35,8 @@ import {Icons} from "../gui/base/icons/Icons"
 import {createBirthday} from "../api/entities/tutanota/Birthday"
 import {NotFoundError} from "../api/common/error/RestError"
 import type {DialogHeaderBarAttrs} from "../gui/base/DialogHeaderBar"
-import {ButtonType} from "../gui/base/ButtonN"
+import {ButtonN, ButtonType} from "../gui/base/ButtonN"
+import {createDropdown} from "../gui/base/DropdownN"
 
 
 assertMainOrNode()
@@ -407,37 +408,42 @@ class ContactAggregateEditor {
 		if (isSameTypeRef(aggregate._type, ContactAddressTypeRef)) {
 			this.textfield.setType(Type.Area)
 		}
-		let typeButton = createDropDownButton("more_label",
-			() => Icons.More,
-			() => Object.keys(TypeToLabelMap)
-			            .map(key => {
-				            return new Button((TypeToLabelMap: any)[key], e => {
-					            if (isCustom(key)) {
-						            setTimeout(() => {
-							            Dialog.showTextInputDialog("customLabel_label",
-								            "customLabel_label",
-								            null,
-								            this.aggregate.customTypeName,
-								            null//validator needed?
-							            ).then((name) => {
-								            this.aggregate.customTypeName = name
-								            this.aggregate.type = key
-							            })
-						            }, DefaultAnimationTime)// wait till the dropdown is hidden
-					            } else {
-						            this.aggregate.type = key
-					            }
-				            }).setType(ButtonType.Dropdown)
-			            }))
-
-
-		let cancelButton = new Button('cancel_action', () => cancelAction(this), () => Icons.Cancel)
+		const typeButtonClickHandler = createDropdown(() =>
+			Object.keys(TypeToLabelMap)
+			      .map(key => {
+				      return new Button((TypeToLabelMap: any)[key], e => {
+					      if (isCustom(key)) {
+						      setTimeout(() => {
+							      Dialog.showTextInputDialog("customLabel_label",
+								      "customLabel_label",
+								      null,
+								      this.aggregate.customTypeName,
+								      null//validator needed?
+							      ).then((name) => {
+								      this.aggregate.customTypeName = name
+								      this.aggregate.type = key
+							      })
+						      }, DefaultAnimationTime)// wait till the dropdown is hidden
+					      } else {
+						      this.aggregate.type = key
+					      }
+				      }).setType(ButtonType.Dropdown)
+			      }))
 
 		this.textfield._injectionsRight = () => {
 			return [
-				m(typeButton),
+				m(ButtonN, {
+					label: "more_label",
+					icon: () => Icons.More,
+					endAligned: true,
+					click: typeButtonClickHandler,
+				}),
 				this.isInitialized
-					? m(cancelButton, {
+					? m(ButtonN, {
+						label: 'cancel_action',
+						click: () => cancelAction(this),
+						icon: () => Icons.Cancel,
+						endAligned: true,
 						oncreate: vnode => {
 							vnode.dom.style.opacity = 0
 							return animations.add(vnode.dom, opacity(0, 1, true))

--- a/src/contacts/ContactViewer.js
+++ b/src/contacts/ContactViewer.js
@@ -9,7 +9,6 @@ import {
 	getContactPhoneNumberTypeLabel,
 	getContactSocialTypeLabel
 } from "./ContactUtils"
-import {ActionBar} from "../gui/base/ActionBar"
 import {TextField, Type} from "../gui/base/TextField"
 import {erase} from "../api/main/Entity"
 import {assertMainOrNode} from "../api/Env"
@@ -23,6 +22,8 @@ import {BootIcons} from "../gui/base/icons/BootIcons"
 import {ContactSocialType, getContactSocialType, Keys} from "../api/common/TutanotaConstants"
 import {mailModel} from "../mail/MailModel"
 import {getEmailSignature} from "../mail/MailUtils"
+import {ButtonN} from "../gui/base/ButtonN"
+import {component} from "../gui/base/ComponentWrapper"
 
 assertMainOrNode()
 
@@ -54,19 +55,34 @@ export class ContactViewer {
 	constructor(contact: Contact) {
 		this.contact = contact
 
-		let actions = new ActionBar()
-			.add(new Button('edit_action', () => this.edit(), () => Icons.Edit))
-			.add(new Button('delete_action', () => this.delete(), () => Icons.Trash))
-		let title = this.contact.title ? this.contact.title + " " : ""
-		let nickname = (this.contact.nickname ? ' | "' + this.contact.nickname + '"' : "")
-		let fullName = this.contact.firstName + " " + this.contact.lastName
+		const actions = component(() => m(".action-bar.flex-end.items-center", [
+			m(ButtonN, {
+				label: "edit_action",
+				icon: () => Icons.Edit,
+				endAligned: true,
+				click: () => this.edit()
+			}),
+			m(ButtonN, {
+				label: "delete_action",
+				icon: () => Icons.Trash,
+				endAligned: true,
+				click: () => this.delete(),
+			})
+		]))
+		const title = this.contact.title ? this.contact.title + " " : ""
+		const nickname = (this.contact.nickname ? ' | "' + this.contact.nickname + '"' : "")
+		const fullName = this.contact.firstName + " " + this.contact.lastName
 		this.contactAppellation = (title + fullName + nickname).trim()
 		this.mailAddresses = this.contact.mailAddresses.map(element => {
 			let textField = new TextField(() => getContactAddressTypeLabel((element.type: any), element.customTypeName))
 				.setValue(element.address)
 				.setDisabled()
-			let newMailButton = new Button('sendMail_alt', () => this._writeMail(element.address), () => BootIcons.Mail)
-			textField._injectionsRight = () => [m(newMailButton)]
+			textField._injectionsRight = () => m(ButtonN, {
+				label: 'sendMail_alt',
+				icon: () => BootIcons.Mail,
+				endAligned: true,
+				click: () => this._writeMail(element.address),
+			})
 			return textField
 		})
 		this.phones = this.contact.phoneNumbers.map(element => {
@@ -75,7 +91,12 @@ export class ContactViewer {
 				.setValue(element.number)
 				.setDisabled()
 			let callButton = new Button('callNumber_alt', () => null, () => Icons.Call)
-			textField._injectionsRight = () => m(`a[href="tel:${element.number}"][target=_blank]`, m(callButton))
+			textField._injectionsRight = () => m(ButtonN, {
+				label: 'callNumber_alt',
+				icon: () => Icons.Call,
+				endAligned: true,
+				click: () => window.open(`tel:${element.number}`),
+			})
 			return textField
 		})
 		this.addresses = this.contact.addresses.map(element => {
@@ -90,8 +111,12 @@ export class ContactViewer {
 			} else {
 				prepAddress = encodeURIComponent(element.address)
 			}
-			let showButton = new Button('showAddress_alt', () => null, () => Icons.Pin)
-			showAddress._injectionsRight = () => m(`a[href="https://www.openstreetmap.org/search?query=${prepAddress}"][target=_blank]`, m(showButton))
+			showAddress._injectionsRight = () => m(ButtonN, {
+				label: 'showAddress_alt',
+				icon: () => Icons.Pin,
+				endAligned: true,
+				click: () => window.open(`https://www.openstreetmap.org/search?query=${prepAddress}`)
+			})
 			return showAddress
 		})
 		this.socials = this.contact.socialIds.map(element => {
@@ -99,7 +124,12 @@ export class ContactViewer {
 				.setValue(element.socialId)
 				.setDisabled()
 			let showButton = new Button('showURL_alt', () => null, () => Icons.ArrowForward)
-			showURL._injectionsRight = () => m(`a[href=${this.getSocialUrl(element)}][target=_blank]`, m(showButton))
+			showURL._injectionsRight = () => m(ButtonN, {
+				label: 'showURL_alt',
+				icon: () => Icons.ArrowForward,
+				endAligned: true,
+				click: () => window.open(this.getSocialUrl(element))
+			})
 			return showURL
 		})
 

--- a/src/gui/base/ButtonN.js
+++ b/src/gui/base/ButtonN.js
@@ -98,6 +98,7 @@ export type ButtonAttrs = {
 	isSelected?: lazy<boolean>,
 	noBubble?: boolean,
 	staticRightText?: string,
+	endAligned?: boolean,
 }
 
 /**
@@ -247,11 +248,10 @@ class _Button {
 	getWrapperClasses(a: ButtonAttrs) {
 		const type = this.getType(a.type)
 		let wrapperClasses = ["button-content", "flex", "items-center", type]
-		if (![ButtonType.Floating, ButtonType.TextBubble, ButtonType.Toggle].includes(type)) {
-			wrapperClasses.push("plr-button")
-		}
 		if (type === ButtonType.Dropdown) {
 			wrapperClasses.push("justify-start")
+		} else if (a.endAligned) {
+			wrapperClasses.push("justify-end")
 		} else {
 			wrapperClasses.push("justify-center")
 		}
@@ -264,7 +264,7 @@ class _Button {
 	_getLabelElement(a: ButtonAttrs) {
 		const type = this.getType(a.type)
 		const label = lang.getMaybeLazy(a.label)
-		if (label.trim() === '' || [ButtonType.Action, ButtonType.Floating].includes(type)) {
+		if (label.trim() === '' || [ButtonType.Action, ButtonType.Floating, ButtonType.ActionLarge].includes(type)) {
 			return null
 		}
 		let classes = ["text-ellipsis"]

--- a/src/gui/base/ComponentWrapper.js
+++ b/src/gui/base/ComponentWrapper.js
@@ -1,0 +1,5 @@
+//@flow
+
+export function component(view: () => Children): Component {
+	return {view}
+}

--- a/src/gui/base/DatePicker.js
+++ b/src/gui/base/DatePicker.js
@@ -3,7 +3,6 @@ import {TextField} from "./TextField"
 import m from "mithril"
 import stream from "mithril/stream/stream.js"
 import {Icons} from "./icons/Icons"
-import {Button} from "./Button"
 import {client} from "../../misc/ClientDetector"
 import {formatDate, formatDateWithMonth, formatMonthWithFullYear, parseDate} from "../../misc/Formatter"
 import {lang} from "../../misc/LanguageViewModel"
@@ -17,6 +16,8 @@ import {getDateIndicator, getStartOfDay, isSameDayOfDate} from "../../api/common
 import type {CalendarDay} from "../../calendar/CalendarUtils"
 import {getCalendarMonth} from "../../calendar/CalendarUtils"
 import {DateTime} from "luxon"
+import {ButtonN} from "./ButtonN"
+import type {TranslationKey} from "../../misc/LanguageViewModel"
 
 /**
  * The HTML input[type=date] is not usable on desktops because:
@@ -34,12 +35,12 @@ export class DatePicker implements Component {
 	_forceCompact: boolean;
 	_startOfTheWeekOffset: number
 
-	constructor(startOfTheWeekOffset: number, labelTextIdOrTextFunction: string | lazy<string>, nullSelectionTextId: TranslationKey = "emptyString_msg", forceCompact: boolean = false, disabled: boolean = false) {
+	constructor(startOfTheWeekOffset: number, labelTextIdOrTextFunction: TranslationKey | lazy<string>,
+	            nullSelectionTextId: TranslationKey = "emptyString_msg", forceCompact: boolean = false, disabled: boolean = false) {
 		this.date = stream(null)
 		this._forceCompact = forceCompact
 		this._startOfTheWeekOffset = startOfTheWeekOffset
 
-		let pickerButton = new Button(labelTextIdOrTextFunction, this._showPickerDialog, () => BootIcons.Calendar)
 		let inputDate: ?Date
 
 		this.invalidDate = false
@@ -55,7 +56,14 @@ export class DatePicker implements Component {
 		if (disabled) {
 			this.input.setDisabled()
 		}
-		this.input._injectionsRight = () => (forceCompact || client.isMobileDevice()) && !disabled ? [m(pickerButton)] : null
+		this.input._injectionsRight = () => (forceCompact || client.isMobileDevice()) && !disabled
+			? m(ButtonN, {
+				label: labelTextIdOrTextFunction,
+				icon: () => BootIcons.Calendar,
+				endAligned: true,
+				click: this._showPickerDialog
+			})
+			: null
 		this.input.onUpdate(value => {
 			try {
 				if (value.trim().length > 0) {

--- a/src/gui/base/DialogHeaderBar.js
+++ b/src/gui/base/DialogHeaderBar.js
@@ -12,18 +12,18 @@ export type DialogHeaderBarAttrs = {|
 /**
  * An action bar is a bar that contains buttons (either on the left or on the right).
  */
-class _DialogHeaderBar {
-
+export class DialogHeaderBar implements MComponent<DialogHeaderBarAttrs> {
 	view(vnode: Vnode<LifecycleAttrs<DialogHeaderBarAttrs>>): VirtualElement {
 		const a = Object.assign({}, {left: [], right: []}, vnode.attrs)
 		let columnClass = a.middle ? ".flex-third.overflow-hidden" : ".flex-half.overflow-hidden"
 		return m(".flex-space-between.dialog-header-line-height", [
-			m(columnClass + ".ml-negative-s", a.left.map(a => isVisible(a) ? m(ButtonN, a) : null)),
+			m(columnClass, a.left.map(a => isVisible(a) ? m(ButtonN, a) : null)),
 			// ellipsis is not working if the text is directly in the flex element, so create a child div for it
-			a.middle ? m("#dialog-title.flex-third-middle.overflow-hidden.flex.justify-center.items-center.b", [m(".text-ellipsis", a.middle())]) : null,
-			m(columnClass + ".mr-negative-s.flex.justify-end", a.right.map(a => isVisible(a) ? m(ButtonN, a) : null))
+			a.middle
+				? m("#dialog-title.flex-third-middle.overflow-hidden.flex.justify-center.items-center.b", m(".text-ellipsis", a.middle()))
+				: null,
+			m(columnClass + ".flex.justify-end",
+				a.right.map(a => isVisible(a) ? m(ButtonN, Object.assign({}, {endAligned: true}, a)) : null))
 		])
 	}
 }
-
-export const DialogHeaderBar: Class<MComponent<DialogHeaderBarAttrs>> = _DialogHeaderBar

--- a/src/gui/base/DropDownSelector.js
+++ b/src/gui/base/DropDownSelector.js
@@ -6,7 +6,8 @@ import {assertMainOrNode} from "../../api/Env"
 import {Icons} from "./icons/Icons"
 import {lazyStringValue} from "../../api/common/utils/StringUtils"
 import type {TranslationKey} from "../../misc/LanguageViewModel"
-import {ButtonType} from "./ButtonN"
+import {ButtonN, ButtonType} from "./ButtonN"
+import {createDropdown} from "./DropdownN"
 
 assertMainOrNode()
 
@@ -33,19 +34,27 @@ export class DropDownSelector<T> {
 				return ''
 			}
 		})
-		let itemChooser = createDropDownButton(labelIdOrLabelTextFunction, () => Icons.Edit, () => {
-			return items.map(item => new Button(() => item.name, () => {
-				if (this.selectedValue() !== item.value) {
-					if (this._changeHandler) {
-						this._changeHandler(item.value)
-					} else {
-						this.selectedValue(item.value)
-						m.redraw()
-					}
-				}
-			}).setType(ButtonType.Dropdown).setSelected(() => this.selectedValue() === item.value))
-		}, (dropdownWidth) ? dropdownWidth : undefined)
-		this._field._injectionsRight = () => [m(itemChooser)]
+
+		this._field._injectionsRight = () => m(ButtonN, {
+			label: labelIdOrLabelTextFunction,
+			icon: () => Icons.Edit,
+			endAligned: true,
+			click: createDropdown(
+				() => items.map(item => ({
+					label: () => item.name,
+					click: () => {
+						if (this._changeHandler) {
+							this._changeHandler(item.value)
+						} else {
+							this.selectedValue(item.value)
+							m.redraw()
+						}
+					},
+					type: ButtonType.Dropdown,
+					isSelected: () => this.selectedValue() === item.value,
+				})),
+				dropdownWidth || undefined)
+		})
 
 		this.view = () => {
 			return m(this._field)

--- a/src/gui/base/DropDownSelectorN.js
+++ b/src/gui/base/DropDownSelectorN.js
@@ -41,6 +41,7 @@ export class DropDownSelectorN<T> implements MComponent<DropDownSelectorAttrs<T>
 				: m(ButtonN, {
 					label: a.label,
 					icon: () => a.icon ? a.icon : Icons.Edit,
+					endAligned: true,
 					click: this.createDropdown(a),
 				})
 		})

--- a/src/gui/base/ExpanderN.js
+++ b/src/gui/base/ExpanderN.js
@@ -30,7 +30,7 @@ class _ExpanderButton {
 	view(vnode: Vnode<ExpanderAttrs>) {
 		const a = vnode.attrs
 		return m(".flex.limit-width", [ // .limit-width does not work without .flex in IE11
-			m("button.expander.bg-transparent.pt-s.hover-ul.limit-width.mr-s", {
+			m("button.expander.bg-transparent.pt-s.hover-ul.limit-width", {
 				style: a.style,
 				onclick: (event: MouseEvent) => {
 					this.toggle(a.expanded)

--- a/src/gui/base/TextField.js
+++ b/src/gui/base/TextField.js
@@ -109,7 +109,7 @@ export class TextField {
 						this._injectionsLeft ? this._injectionsLeft() : null,
 						m(".inputWrapper.flex-space-between.items-end", [ // additional wrapper element for bubble input field. input field should always be in one line with right injections
 							this.type !== Type.Area ? this._getInputField() : this._getTextArea(),
-							this._injectionsRight ? m(".mr-negative-s.flex-end.flex-fixed", this._injectionsRight()) : null
+							this._injectionsRight ? m(".flex-end.flex-fixed", this._injectionsRight()) : null
 						])
 					]),
 				]),

--- a/src/gui/base/TextFieldN.js
+++ b/src/gui/base/TextFieldN.js
@@ -104,7 +104,7 @@ export class _TextField {
 					a.injectionsLeft ? a.injectionsLeft() : null,
 					m(".inputWrapper.flex-space-between.items-end", {}, [ // additional wrapper element for bubble input field. input field should always be in one line with right injections
 						a.type !== Type.Area ? this._getInputField(a) : this._getTextArea(a),
-						a.injectionsRight ? m(".mr-negative-s.flex-end", a.injectionsRight()) : null
+						a.injectionsRight ? m(".flex-end", a.injectionsRight()) : null
 					])
 				]),
 			]),

--- a/src/login/ContactFormRequestDialog.js
+++ b/src/login/ContactFormRequestDialog.js
@@ -30,10 +30,13 @@ import stream from "mithril/stream/stream.js"
 import {CheckboxN} from "../gui/base/CheckboxN"
 import {getPrivacyStatementLink} from "./LoginView"
 import type {DialogHeaderBarAttrs} from "../gui/base/DialogHeaderBar"
-import {ButtonType} from "../gui/base/ButtonN"
+import {ButtonN, ButtonType} from "../gui/base/ButtonN"
 
 assertMainOrNode()
 
+/**
+ * Contact Form/Secure Connect dialog, shown when user makes a request via contact form.
+ */
 export class ContactFormRequestDialog {
 	_dialog: Dialog;
 	_subject: TextField;
@@ -41,7 +44,6 @@ export class ContactFormRequestDialog {
 	view: Function;
 	_attachments: Array<TutanotaFile | DataFile | FileReference>; // contains either Files from Tutanota or DataFiles of locally loaded files. these map 1:1 to the _attachmentButtons
 	_attachmentButtons: Button[]; // these map 1:1 to the _attachments
-	_attachFilesButton: Button;
 	_loadingAttachments: boolean;
 	_contactForm: ContactForm;
 	_domElement: HTMLElement;
@@ -61,10 +63,12 @@ export class ContactFormRequestDialog {
 		this._attachmentButtons = []
 		this._loadingAttachments = false
 		this._subject = new TextField("subject_label", () => this.getConfidentialStateMessage())
-		this._attachFilesButton = new Button('attachFiles_action', () => this._showFileChooserForAttachments(), () => Icons.Attachment)
-		this._subject._injectionsRight = () => {
-			return [m(this._attachFilesButton)]
-		}
+		this._subject._injectionsRight = () => m(ButtonN, {
+			label: 'attachFiles_action',
+			icon: () => Icons.Attachment,
+			endAligned: true,
+			click: () => this._showFileChooserForAttachments(),
+		})
 
 		this._statisticFields = this._createStatisticFields(contactForm)
 		this._notificationEmailAddress = new TextField("mailAddress_label", () => lang.get("contactFormMailAddressInfo_msg")).setType(Type.Area);

--- a/src/login/RecoverLoginDialog.js
+++ b/src/login/RecoverLoginDialog.js
@@ -52,7 +52,8 @@ export function show(mailAddress?: ?string, resetAction?: ResetAction): Dialog {
 	const resetActionButtonAttrs: ButtonAttrs = {
 		label: "action_label",
 		click: resetActionClickHandler,
-		icon: () => Icons.Edit
+		icon: () => Icons.Edit,
+		endAligned: true,
 	}
 
 	const selectedValueLabelStream = selectedAction.map(v => {

--- a/src/mail/MailEditor.js
+++ b/src/mail/MailEditor.js
@@ -11,7 +11,8 @@ import type {ConversationTypeEnum} from "../api/common/TutanotaConstants"
 import {
 	ALLOWED_IMAGE_FORMATS,
 	ConversationType,
-	FeatureType, Keys,
+	FeatureType,
+	Keys,
 	MAX_ATTACHMENT_SIZE,
 	OperationType,
 	ReplyType
@@ -188,13 +189,15 @@ export class MailEditor {
 			icon: () => this._confidentialButtonState ? Icons.Lock : Icons.Unlock,
 			isSelected: () => this._confidentialButtonState,
 			noBubble: true,
+			endAligned: true,
 		}
 
 		let attachFilesButtonAttrs = {
 			label: "attachFiles_action",
 			click: (ev, attrs) => this._showFileChooserForAttachments(ev.target.getBoundingClientRect()),
 			icon: () => Icons.Attachment,
-			noBubble: true
+			noBubble: true,
+			endAligned: true,
 		}
 
 		const toolbarButton = () => (!logins.getUserController().props.sendPlaintextOnly)
@@ -203,7 +206,8 @@ export class MailEditor {
 				icon: () => Icons.FontSize,
 				click: () => this._showToolbar = !this._showToolbar,
 				isSelected: () => this._showToolbar,
-				noBubble: true
+				noBubble: true,
+				endAligned: true,
 			})
 			: null
 
@@ -1003,7 +1007,7 @@ export class MailEditor {
 			label: () => getDisplayText(recipientInfo.name, mailAddress, false),
 			type: ButtonType.TextBubble,
 			isSelected: () => false,
-			color: ButtonColors.Elevated
+			colors: ButtonColors.Elevated
 		}, () => {
 			if (recipientInfo.resolveContactPromise) {
 				return recipientInfo.resolveContactPromise.then(contact => {

--- a/src/search/SearchView.js
+++ b/src/search/SearchView.js
@@ -6,7 +6,8 @@ import {isSameTypeRef, TypeRef} from "../api/common/EntityFunctions"
 import {lang} from "../misc/LanguageViewModel"
 import {
 	FeatureType,
-	FULL_INDEXED_TIMESTAMP, Keys,
+	FULL_INDEXED_TIMESTAMP,
+	Keys,
 	MailFolderType,
 	NOTHING_INDEXED_TIMESTAMP,
 	OperationType
@@ -34,7 +35,6 @@ import {getFolderName, getSortedCustomFolders, getSortedSystemFolders} from "../
 import {getGroupInfoDisplayName, neverNull, noOp} from "../api/common/utils/Utils"
 import {formatDateWithMonth, formatDateWithTimeIfNotEven} from "../misc/Formatter"
 import {TextField} from "../gui/base/TextField"
-import {Button} from "../gui/base/Button"
 import {showDatePickerDialog} from "../gui/base/DatePickerDialog"
 import {Icons} from "../gui/base/icons/Icons"
 import {getEndOfDay, getStartOfDay, isSameDay, isToday} from "../api/common/utils/DateUtils"
@@ -96,29 +96,33 @@ export class SearchView implements CurrentView {
 		this._endDate = null
 		this._startDate = null
 		this._time = new TextField("periodOfTime_label").setValue().setDisabled()
-		let changeTimeButton = new Button("selectPeriodOfTime_label", () => {
-			if (logins.getUserController().isFreeAccount()) {
-				showNotAvailableForFreeDialog(true)
-			} else {
-				showDatePickerDialog(getStartOfTheWeekOffsetForUser(), (this._startDate) ? this._startDate : this._getCurrentMailIndexDate(),
-					(this._endDate) ? this._endDate : new Date())
-					.then(dates => {
-						if (dates.end && isToday(dates.end)) {
-							this._endDate = null
-						} else {
-							this._endDate = dates.end
-						}
-						let current = this._getCurrentMailIndexDate()
-						if (dates.start && current && isSameDay(current, neverNull(dates.start))) {
-							this._startDate = null
-						} else {
-							this._startDate = dates.start
-						}
-						this._searchAgain()
-					})
+		this._time._injectionsRight = () => m(ButtonN, {
+			label: "selectPeriodOfTime_label",
+			icon: () => Icons.Edit,
+			endAligned: true,
+			click: () => {
+				if (logins.getUserController().isFreeAccount()) {
+					showNotAvailableForFreeDialog(true)
+				} else {
+					showDatePickerDialog(getStartOfTheWeekOffsetForUser(), (this._startDate) ? this._startDate : this._getCurrentMailIndexDate(),
+						(this._endDate) ? this._endDate : new Date())
+						.then(dates => {
+							if (dates.end && isToday(dates.end)) {
+								this._endDate = null
+							} else {
+								this._endDate = dates.end
+							}
+							let current = this._getCurrentMailIndexDate()
+							if (dates.start && current && isSameDay(current, neverNull(dates.start))) {
+								this._startDate = null
+							} else {
+								this._startDate = dates.start
+							}
+							this._searchAgain()
+						})
+				}
 			}
-		}, () => Icons.Edit)
-		this._time._injectionsRight = () => [m(changeTimeButton)]
+		})
 
 		let mailAttributes = SEARCH_MAIL_FIELDS.map(f => {
 			return {name: lang.get(f.textId), value: f.field}

--- a/src/settings/DesktopSettingsViewer.js
+++ b/src/settings/DesktopSettingsViewer.js
@@ -128,7 +128,8 @@ export class DesktopSettingsViewer implements UpdatableSettingsViewer {
 			label: "edit_action",
 			type: ButtonType.Action,
 			click: noOp,
-			icon: () => Icons.Edit
+			icon: () => Icons.Edit,
+			endAligned: true,
 		}, () => [
 			{
 				label: "alwaysAsk_action",

--- a/src/settings/EditCustomColorsDialog.js
+++ b/src/settings/EditCustomColorsDialog.js
@@ -26,7 +26,7 @@ export function show(whitelabelConfig: WhitelabelConfig, themeToEdit: Theme) {
 			                        return [
 				                        m("", {
 					                        style: {
-						                        width: "106px", // 100 + 6px negative margin
+						                        width: "100px", // 100 + 6px negative margin
 						                        height: "20px",
 						                        "margin-bottom": "2px",
 						                        "background-color": getValidColorValue(field) || theme.content_bg

--- a/src/settings/EditSecondFactorsForm.js
+++ b/src/settings/EditSecondFactorsForm.js
@@ -175,7 +175,8 @@ export class EditSecondFactorsForm {
 				const copyButtonAttrs: ButtonAttrs = {
 					label: "copy_action",
 					click: () => copyToClipboard(totpKeys.readableKey),
-					icon: () => Icons.Copy
+					icon: () => Icons.Copy,
+					endAligned: true,
 				}
 
 				let totpQRCodeSvg

--- a/src/settings/GroupViewer.js
+++ b/src/settings/GroupViewer.js
@@ -31,6 +31,7 @@ import stream from "mithril/stream/stream.js"
 import type {EntityUpdateData} from "../api/main/EventController"
 import {isUpdateForTypeRef} from "../api/main/EventController"
 import {CustomerTypeRef} from "../api/entities/sys/Customer"
+import {ButtonN} from "../gui/base/ButtonN"
 
 assertMainOrNode()
 
@@ -64,21 +65,25 @@ export class GroupViewer {
 		})
 
 		this._name = new TextField("name_label").setValue(this.groupInfo.name).setDisabled()
-		let editNameButton = new Button("edit_action", () => {
-			Dialog.showTextInputDialog("edit_action", "name_label", null, this._name.value(), newName => {
-				if (this._group.isLoaded() && this._group.getLoaded().type === GroupType.MailingList && newName.trim()
-					=== "") {
-					return "enterName_msg"
-				} else {
-					return null
-				}
-			}).then(newName => {
-				let newGroupInfo = Object.assign({}, this.groupInfo)
-				newGroupInfo.name = newName
-				update(newGroupInfo)
-			})
-		}, () => Icons.Edit)
-		this._name._injectionsRight = () => [m(editNameButton)]
+		this._name._injectionsRight = () => m(ButtonN, {
+			label: "edit_action",
+			icon: () => Icons.Edit,
+			endAligned: true,
+			click: () => {
+				Dialog.showTextInputDialog("edit_action", "name_label", null, this._name.value(), newName => {
+					if (this._group.isLoaded() && this._group.getLoaded().type === GroupType.MailingList && newName.trim()
+						=== "") {
+						return "enterName_msg"
+					} else {
+						return null
+					}
+				}).then(newName => {
+					let newGroupInfo = Object.assign({}, this.groupInfo)
+					newGroupInfo.name = newName
+					update(newGroupInfo)
+				})
+			}
+		})
 
 		let mailAddress = new TextField("mailAddress_label").setValue(this.groupInfo.mailAddress).setDisabled()
 		let created = new TextField("created_label").setValue(formatDateWithMonth(this.groupInfo.created)).setDisabled()
@@ -236,7 +241,7 @@ export class GroupViewer {
 					Dialog.showActionDialog({
 						title: lang.get("addUserToGroup_label"),
 						child: {view: () => m(dropdown)},
-						allowOkWithReturn: true,okAction: addUserToGroupOkAction
+						allowOkWithReturn: true, okAction: addUserToGroupOkAction
 					})
 				}
 			})

--- a/src/settings/LoginSettingsViewer.js
+++ b/src/settings/LoginSettingsViewer.js
@@ -54,23 +54,24 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 			value: this._mailAddress,
 			disabled: true,
 		}
-		const changePasswordButtonAttrs: ButtonAttrs = {
-			label: "changePassword_label",
-			click: () => PasswordForm.showChangeOwnPasswordDialog(),
-			icon: () => Icons.Edit
-		}
 		const passwordAttrs: TextFieldAttrs = {
 			label: "password_label",
 			value: this._stars,
 			disabled: true,
-			injectionsRight: () => m(ButtonN, changePasswordButtonAttrs)
+			injectionsRight: () => m(ButtonN, {
+				label: "changePassword_label",
+				click: () => PasswordForm.showChangeOwnPasswordDialog(),
+				icon: () => Icons.Edit,
+				endAligned: true,
+			})
 		}
 
 		const recoveryCodeDropdownButtonAttrs: ButtonAttrs = attachDropdown(
 			{
 				label: "edit_action",
 				icon: () => Icons.Edit,
-				click: noOp
+				click: noOp,
+				endAligned: true,
 			}, () => [
 				{
 					label: "show_action",

--- a/src/settings/MailSettingsViewer.js
+++ b/src/settings/MailSettingsViewer.js
@@ -95,6 +95,7 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 				      })
 			},
 			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 
 		const senderNameAttrs: TextFieldAttrs = {
@@ -108,14 +109,15 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 		const changeSignatureButtonAttrs: ButtonAttrs = {
 			label: "userEmailSignature_label",
 			click: () => EditSignatureDialog.show(logins.getUserController().props),
-			icon: () => Icons.Edit
+			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 
 		const signatureAttrs: TextFieldAttrs = {
 			label: "userEmailSignature_label",
 			value: this._signature,
 			disabled: true,
-			injectionsRight: () => [m(ButtonN, changeSignatureButtonAttrs)]
+			injectionsRight: () => [m(ButtonN, changeSignatureButtonAttrs)],
 		}
 
 		const defaultUnconfidentialAttrs: DropDownSelectorAttrs<boolean> = {

--- a/src/settings/PasswordForm.js
+++ b/src/settings/PasswordForm.js
@@ -44,7 +44,7 @@ export class PasswordForm {
 
 		let passwordIndicator = new PasswordIndicator(() => this._getPasswordStrength())
 		this._newPasswordField = new TextField("newPassword_label", () => m(this._newPasswordFieldStatus)).setType(Type.Password).setPreventAutofill(true)
-		this._newPasswordField._injectionsRight = () => m(".mb-s.mlr", [m(passwordIndicator)])
+		this._newPasswordField._injectionsRight = () => m(".mb-s.ml-s", m(passwordIndicator))
 		this._newPasswordFieldStatus = new StatusField(Stream.combine(() => {
 			if (this._newPasswordField.value() === "") {
 				return {type: "neutral", text: "password1Neutral_msg"}

--- a/src/settings/SelectMailAddressForm.js
+++ b/src/settings/SelectMailAddressForm.js
@@ -46,7 +46,8 @@ export class SelectMailAddressForm {
 		const domainChooserAttrs: ButtonAttrs = attachDropdown({
 			label: "domain_label",
 			icon: () => Icons.More,
-			noBubble: true
+			noBubble: true,
+			endAligned: true,
 		}, () => this._availableDomains.map(domain => {
 			return {
 				label: () => domain,
@@ -61,7 +62,7 @@ export class SelectMailAddressForm {
 			alignRight: true,
 			helpLabel: () => lang.get(this._messageId()),
 			injectionsRight: () => [
-				m(".flex.items-end.mr-s", {style: {"padding-bottom": '1px', "flex": "1 1 auto"}}, `@${this.domain()}`),
+				m(".flex.items-end", {style: {"padding-bottom": '1px', "flex": "1 1 auto"}}, `@${this.domain()}`),
 				m(ButtonN, domainChooserAttrs)
 			]
 		}

--- a/src/settings/SetDomainCertificateDialog.js
+++ b/src/settings/SetDomainCertificateDialog.js
@@ -4,7 +4,6 @@ import {lang} from "../misc/LanguageViewModel"
 import {assertMainOrNode} from "../api/Env"
 import {TextField} from "../gui/base/TextField"
 import {Dialog} from "../gui/base/Dialog"
-import {Button} from "../gui/base/Button"
 import {worker} from "../api/main/WorkerClient"
 import {fileController} from "../file/FileController"
 import {utf8Uint8ArrayToString} from "../api/common/utils/Encoding"
@@ -18,6 +17,7 @@ import stream from "mithril/stream/stream.js"
 import type {CertificateTypeEnum} from "../api/common/TutanotaConstants"
 import {CertificateType, getCertificateType} from "../api/common/TutanotaConstants"
 import {getWhitelabelDomain} from "../api/common/utils/Utils"
+import {ButtonN} from "../gui/base/ButtonN"
 
 assertMainOrNode()
 
@@ -64,28 +64,36 @@ export function show(customerInfo: CustomerInfo, certificateInfo: ?CertificateIn
 	}
 
 	let certChainFile: ?DataFile = null
-	let certificateChainField = new TextField("certificateChain_label",
+	const certificateChainField = new TextField("certificateChain_label",
 		() => lang.get("certificateChainInfo_msg")).setValue("").setDisabled()
-	let chooseCertificateChainButton = new Button("edit_action", () => {
-		fileController.showFileChooser(false).then(files => {
-			certChainFile = files[0]
-			certificateChainField.setValue(certChainFile.name)
-			m.redraw()
-		})
-	}, () => Icons.Edit)
-	certificateChainField._injectionsRight = () => [m(chooseCertificateChainButton)]
+	certificateChainField._injectionsRight = () => m(ButtonN, {
+		label: "edit_action",
+		icon: () => Icons.Edit,
+		endAligned: true,
+		click: () => {
+			fileController.showFileChooser(false).then(files => {
+				certChainFile = files[0]
+				certificateChainField.setValue(certChainFile.name)
+				m.redraw()
+			})
+		}
+	})
 
 	let privKeyFile: ?DataFile = null
-	let privateKeyField = new TextField("privateKey_label",
+	const privateKeyField = new TextField("privateKey_label",
 		() => lang.get("privateKeyInfo_msg")).setValue("").setDisabled()
-	let choosePrivateKeyButton = new Button("edit_action", () => {
-		fileController.showFileChooser(false).then(files => {
-			privKeyFile = files[0]
-			privateKeyField.setValue(privKeyFile.name)
-			m.redraw()
-		})
-	}, () => Icons.Edit)
-	privateKeyField._injectionsRight = () => [m(choosePrivateKeyButton)]
+	privateKeyField._injectionsRight = () => m(ButtonN, {
+		label: "edit_action",
+		icon: () => Icons.Edit,
+		endAligned: true,
+		click: () => {
+			fileController.showFileChooser(false).then(files => {
+				privKeyFile = files[0]
+				privateKeyField.setValue(privKeyFile.name)
+				m.redraw()
+			})
+		}
+	})
 
 	const selectedType = stream(certificateInfo ? getCertificateType(certificateInfo) : CertificateType.LETS_ENCRYPT)
 	const certOptionDropDownAttrs: DropDownSelectorAttrs<CertificateTypeEnum> = {

--- a/src/settings/UserViewer.js
+++ b/src/settings/UserViewer.js
@@ -41,6 +41,7 @@ import {HtmlEditor as Editor, Mode} from "../gui/base/HtmlEditor"
 import {filterContactFormsForLocalAdmin} from "./ContactFormListView"
 import {checkAndImportUserData} from "./ImportUsersViewer"
 import {EditAliasesFormN} from "./EditAliasesFormN"
+import {ButtonN} from "../gui/base/ButtonN"
 
 assertMainOrNode()
 export const CSV_USER_FORMAT = "username;user@domain.com;password"
@@ -72,14 +73,18 @@ export class UserViewer {
 		this._teamGroupInfos = new LazyLoaded(() => this._customer.getAsync()
 		                                                .then(customer => loadAll(GroupInfoTypeRef, customer.teamGroups)))
 		this._senderName = new TextField("mailName_label").setValue(this.userGroupInfo.name).setDisabled()
-		let editSenderNameButton = new Button("edit_action", () => {
-			Dialog.showTextInputDialog("edit_action", "mailName_label", null, this._senderName.value())
-			      .then(newName => {
-				      this.userGroupInfo.name = newName
-				      update(this.userGroupInfo)
-			      })
-		}, () => Icons.Edit)
-		this._senderName._injectionsRight = () => [m(editSenderNameButton)]
+		this._senderName._injectionsRight = () => m(ButtonN, {
+			label: "edit_action",
+			icon: () => Icons.Edit,
+			endAligned: true,
+			click: () => {
+				Dialog.showTextInputDialog("edit_action", "mailName_label", null, this._senderName.value())
+				      .then(newName => {
+					      this.userGroupInfo.name = newName
+					      update(this.userGroupInfo)
+				      })
+			}
+		})
 
 		let mailAddress = new TextField("mailAddress_label").setValue(this.userGroupInfo.mailAddress).setDisabled()
 		let created = new TextField("created_label").setValue(formatDateWithMonth(this.userGroupInfo.created))
@@ -115,8 +120,12 @@ export class UserViewer {
 		})
 
 		let password = new TextField("password_label").setValue("***").setDisabled()
-		let changePasswordButton = new Button("changePassword_label", () => this._changePassword(), () => Icons.Edit)
-		password._injectionsRight = () => [m(changePasswordButton)]
+		password._injectionsRight = () => m(ButtonN, {
+			label: "changePassword_label",
+			icon: () => Icons.Edit,
+			endAligned: true,
+			click: () => this._changePassword()
+		})
 
 		this._secondFactorsForm = new EditSecondFactorsForm(this._user);
 

--- a/src/settings/WhitelabelChildViewer.js
+++ b/src/settings/WhitelabelChildViewer.js
@@ -13,10 +13,10 @@ import {showProgressDialog} from "../gui/base/ProgressDialog"
 import {WhitelabelChildTypeRef} from "../api/entities/sys/WhitelabelChild"
 import {Icons} from "../gui/base/icons/Icons"
 import {Dialog} from "../gui/base/Dialog"
-import {Button} from "../gui/base/Button"
 import stream from "mithril/stream/stream.js"
 import type {EntityUpdateData} from "../api/main/EventController"
 import {isUpdateForTypeRef} from "../api/main/EventController"
+import {ButtonN} from "../gui/base/ButtonN"
 
 assertMainOrNode()
 
@@ -37,15 +37,16 @@ export class WhitelabelChildViewer {
 		                                              .setValue(whitelabelChild.comment)
 		                                              .setDisabled()
 
-		let editCommentButton = new Button("edit_action", () => {
-			Dialog.showTextAreaInputDialog("edit_action", "comment_label", null, this._comment.value())
-			      .then(newComment => {
-				      this.whitelabelChild.comment = newComment
-				      update(this.whitelabelChild)
-			      })
-		}, () => Icons.Edit)
-
-		this._comment._injectionsRight = () => [m(editCommentButton)]
+		this._comment._injectionsRight = () => m(ButtonN, {
+			label: "edit_action",
+			icon: () => Icons.Edit,
+			endAligned: true,
+			click: () => Dialog.showTextAreaInputDialog("edit_action", "comment_label", null, this._comment.value())
+			                   .then(newComment => {
+				                   this.whitelabelChild.comment = newComment
+				                   update(this.whitelabelChild)
+			                   })
+		})
 
 		this._deactivated = new DropDownSelector("state_label", null, [
 			{name: lang.get("activated_label"), value: false},

--- a/src/subscription/PaymentViewer.js
+++ b/src/subscription/PaymentViewer.js
@@ -39,6 +39,7 @@ import {CustomerInfoTypeRef} from "../api/entities/sys/CustomerInfo"
 import {InvoiceInfoTypeRef} from "../api/entities/sys/InvoiceInfo"
 import {createCustomerAccountPosting} from "../api/entities/accounting/CustomerAccountPosting"
 import {ExpanderButtonN, ExpanderPanelN} from "../gui/base/ExpanderN"
+import {component} from "../gui/base/ComponentWrapper"
 
 assertMainOrNode()
 
@@ -62,7 +63,7 @@ export class PaymentViewer implements UpdatableSettingsViewer {
 			.setEnabled(false)
 			.setPlaceholderId("invoiceAddress_label")
 
-		const changeInvoiceDataButtonAttrs = {
+		const changeInvoiceDataButton = component(() => m(ButtonN, {
 			label: "invoiceData_msg",
 			click: createNotAvailableForFreeClickHandler(true, () => {
 				if (this._accountingInfo) {
@@ -80,28 +81,28 @@ export class PaymentViewer implements UpdatableSettingsViewer {
 				}
 			}, () => logins.getUserController().isPremiumAccount()),
 			icon: () => Icons.Edit
-		}
-		const changePaymentDataButtonAttrs = {
-			label: "paymentMethod_label",
-			click: createNotAvailableForFreeClickHandler(true, () => {
-					if (this._accountingInfo) {
-						PaymentDataDialog.show(this._accountingInfo).then(success => {
-							if (success) {
-								if (this._isPayButtonVisible()) {
-									return this._showPayDialog(this._openBalance())
-								}
-							}
-						})
-					}
-				},
-				// iOS app doesn't work with PayPal button or 3dsecure redirects
-				() => !isIOSApp() && logins.getUserController().isPremiumAccount()),
-			icon: () => Icons.Edit
-		}
-
+		}))
 		this._invoiceVatNumber = new TextField("invoiceVatIdNo_label").setValue(lang.get("loading_msg")).setDisabled()
 		this._paymentMethodField = new TextField("paymentMethod_label").setValue(lang.get("loading_msg")).setDisabled()
-		this._paymentMethodField._injectionsRight = () => [m(ButtonN, changePaymentDataButtonAttrs)]
+		this._paymentMethodField._injectionsRight = () => m(ButtonN, {
+				label: "paymentMethod_label",
+				endAligned: true,
+				click: createNotAvailableForFreeClickHandler(true, () => {
+						if (this._accountingInfo) {
+							PaymentDataDialog.show(this._accountingInfo).then(success => {
+								if (success) {
+									if (this._isPayButtonVisible()) {
+										return this._showPayDialog(this._openBalance())
+									}
+								}
+							})
+						}
+					},
+					// iOS app doesn't work with PayPal button or 3dsecure redirects
+					() => !isIOSApp() && logins.getUserController().isPremiumAccount()),
+				icon: () => Icons.Edit
+			}
+		)
 		this._postings = []
 		this._paymentBusy = false
 
@@ -114,7 +115,7 @@ export class PaymentViewer implements UpdatableSettingsViewer {
 			}, [
 				m(".flex-space-between.items-center.mt-l.mb-s", [
 					m(".h4", lang.get('invoiceData_msg')),
-					m(".mr-negative-s", m(ButtonN, changeInvoiceDataButtonAttrs))
+					m(".mr-negative-s", m(changeInvoiceDataButton))
 				]),
 				m(this._invoiceAddressField),
 				(this._accountingInfo && this._accountingInfo.invoiceVatIdNo.trim().length > 0)

--- a/src/subscription/SubscriptionViewer.js
+++ b/src/subscription/SubscriptionViewer.js
@@ -101,24 +101,27 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 		const upgradeActionAttrs = {
 			label: "upgrade_action",
 			click: showUpgradeWizard,
-			icon: () => Icons.Edit
+			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 		const usageTypeActionAttrs = {
 			label: "pricing.businessUse_label",
 			click: () => this._switchToBusinessUse(),
-			icon: () => Icons.Edit
+			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 		const signOrderAgreementActionAttrs = {
 			label: "sign_action",
 			click: () => SignOrderAgreementDialog.showForSigning(neverNull(this._customer), neverNull(this._accountingInfo)),
-			icon: () => Icons.Edit
+			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 		const showOrderAgreementActionAttrs = {
 			label: "show_action",
 			click: () => load(GroupInfoTypeRef, neverNull(this._orderAgreement).signerUserGroupInfo)
 				.then(signerUserGroupInfo => SignOrderAgreementDialog.showForViewing(neverNull(this._orderAgreement), signerUserGroupInfo)),
 			icon: () => Icons.Download,
-
+			endAligned: true,
 		}
 
 		let subscriptionPeriods = [
@@ -133,73 +136,85 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 			click: createNotAvailableForFreeClickHandler(false, AddUserDialog.show, isPremiumPredicate),
 			icon: () => Icons.Add,
 			type: ButtonType.Action,
+			endAligned: true,
 		}
 		const editUsersButtonAttrs = {
 			label: "bookingItemUsers_label",
 			click: createNotAvailableForFreeClickHandler(false, () => m.route.set("/settings/users"), isPremiumPredicate),
 			icon: () => Icons.Edit,
 			type: ButtonType.Action,
+			endAligned: true,
 		}
 		const changeStorageCapacityButtonAttrs = {
 			label: "storageCapacity_label",
 			click: createNotAvailableForFreeClickHandler(false, () => StorageCapacityOptionsDialog.show(), isPremiumPredicate),
 			icon: () => Icons.Edit,
 			type: ButtonType.Action,
+			endAligned: true,
 		}
 		const changeEmailAliasPackageButtonAttrs = {
 			label: "emailAlias_label",
 			click: createNotAvailableForFreeClickHandler(true, EmailAliasOptionsDialog.show, isPremiumPredicate),
 			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 		const addGroupsActionAttrs = {
 			label: "addGroup_label",
 			click: createNotAvailableForFreeClickHandler(false, AddGroupDialog.show, isPremiumPredicate),
 			icon: () => Icons.Add,
+			endAligned: true,
 		}
 		const editGroupsActionAttrs = {
 			label: "groups_label",
 			click: createNotAvailableForFreeClickHandler(false, () => m.route.set("/settings/groups"), isPremiumPredicate),
 			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 		const addContactFormActionAttrs = {
 			label: "createContactForm_label",
 			click: createNotAvailableForFreeClickHandler(false, () => ContactFormEditor.show(null, true, noOp), isPremiumPredicate),
 			icon: () => Icons.Add,
+			endAligned: true,
 		}
 		const editContactFormsActionAttrs = {
 			label: "contactForms_label",
 			click: createNotAvailableForFreeClickHandler(false, () => m.route.set("/settings/contactforms"), isPremiumPredicate),
 			icon: () => Icons.Edit,
-
+			endAligned: true,
 		}
 		const enableWhiteLabelActionAttrs = {
 			label: "whitelabelDomain_label",
 			click: createNotAvailableForFreeClickHandler(false,
 				() => WhitelabelAndSharingBuyDialog.showWhitelabelBuyDialog(true), isPremiumPredicate),
 			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 		const disableWhiteLabelActionAttrs = {
 			label: "whitelabelDomain_label",
 			click: createNotAvailableForFreeClickHandler(false,
 				() => WhitelabelAndSharingBuyDialog.showWhitelabelBuyDialog(false), isPremiumPredicate),
 			icon: () => Icons.Cancel,
+			endAligned: true,
 		}
 		const enableSharingActionAttrs = {
 			label: "sharingFeature_label",
 			click: createNotAvailableForFreeClickHandler(false,
 				() => WhitelabelAndSharingBuyDialog.showSharingBuyDialog(true), isPremiumPredicate),
 			icon: () => Icons.Edit,
+			endAligned: true,
 		}
 		const disableSharingActionAttrs = {
 			label: "sharingFeature_label",
 			click: createNotAvailableForFreeClickHandler(false,
 				() => WhitelabelAndSharingBuyDialog.showSharingBuyDialog(false), isPremiumPredicate),
 			icon: () => Icons.Cancel,
+			endAligned: true,
 		}
 		const deleteButtonAttrs = {
 			label: "adminDeleteAccount_action",
 			click: showDeleteAccountDialog,
 			type: ButtonType.Login,
+			endAligned: true,
 		}
 		let deleteAccountExpander = new ExpanderButton("adminDeleteAccount_action", new ExpanderPanel({
 			view: () => m(".flex-center.mb-l", m("", {style: {"width": '200px'}}, m(ButtonN, deleteButtonAttrs)))


### PR DESCRIPTION
Changes in Blink caused our text fields with buttons to look incorrectly
after focusing one of the buttons. This happened because we used
negative margin to align button to the right edge (to the text field
and other component).

Instead we now align button contents to the right in text fields.
There are still couple of places where negative margin is used but
there are no issues with it so far.

This commit changes old-style DropdownSelector to use new-style buttons
internally to avoid implementing endAligned for the old-style Button.

This commit also changes buttons to the new ones whenever possible.