### PR TITLE
[desktop] add builds w/o auto-updates and unpacked builds, close #1857

### DIFF
--- a/buildSrc/DesktopBuilder.js
+++ b/buildSrc/DesktopBuilder.js
@@ -22,7 +22,7 @@ function build(dirname, version, targets, updateUrl, nameSuffix, notarize, outDi
 		version,
 		updateUrl,
 		path.join(dirname, "/resources/desktop-icons/logo-solo-red.png"),
-		nameSuffix !== "-snapshot",
+		nameSuffix !== '-snapshot' && updateUrl !== "", // don't sign if it's a test build or if we don't download updates
 		notarize,
 		unpacked
 	)

--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -6,7 +6,9 @@ const pj = require('../package.json')
  * 2. copied to app-desktop/build/dist from dist.js (DesktopBuilder)
  */
 
-module.exports = function (nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked) {
+module.exports = function (opts) {
+	const {nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked} = opts
+
 	return {
 		"name": "tutanota-desktop" + nameSuffix,
 		"main": "./src/desktop/DesktopMain.js",

--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -6,7 +6,7 @@ const pj = require('../package.json')
  * 2. copied to app-desktop/build/dist from dist.js (DesktopBuilder)
  */
 
-module.exports = function (nameSuffix, version, targetUrl, iconPath, sign, notarize) {
+module.exports = function (nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked) {
 	return {
 		"name": "tutanota-desktop" + nameSuffix,
 		"main": "./src/desktop/DesktopMain.js",
@@ -88,12 +88,14 @@ module.exports = function (nameSuffix, version, targetUrl, iconPath, sign, notar
 				}
 			],
 			"forceCodeSigning": sign || !!process.env.JENKINS,
-			"publish": {
-				"provider": "generic",
-				"url": targetUrl,
-				"channel": "latest",
-				"publishAutoUpdate": true
-			},
+			"publish": updateUrl
+				? {
+					"provider": "generic",
+					"url": updateUrl,
+					"channel": "latest",
+					"publishAutoUpdate": true
+				}
+				: undefined,
 			"directories": {
 				"output": "installers"
 			},
@@ -112,7 +114,7 @@ module.exports = function (nameSuffix, version, targetUrl, iconPath, sign, notar
 					: undefined,
 				"target": [
 					{
-						"target": "nsis",
+						"target": unpacked ? "dir" : "nsis",
 						"arch": "x64"
 					}
 				]
@@ -134,16 +136,18 @@ module.exports = function (nameSuffix, version, targetUrl, iconPath, sign, notar
 				"extendInfo": {
 					"LSUIElement": 1 //hide dock icon on startup
 				},
-				"target": [
-					{
-						"target": "zip",
-						"arch": "x64"
-					},
-					{
-						"target": "dmg",
-						"arch": "x64"
-					}
-				]
+				"target": unpacked
+					? [{"target": "dir", "arch": "x64"}]
+					: [
+						{
+							"target": "zip",
+							"arch": "x64"
+						},
+						{
+							"target": "dmg",
+							"arch": "x64"
+						}
+					]
 			},
 			"linux": {
 				"icon": path.join(path.dirname(iconPath), "icon/"),
@@ -154,7 +158,7 @@ module.exports = function (nameSuffix, version, targetUrl, iconPath, sign, notar
 				},
 				"target": [
 					{
-						"target": "AppImage",
+						"target": unpacked ? "dir" : "AppImage",
 						"arch": "x64"
 					}
 				]

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -12,7 +12,7 @@ your own. If you prefer the auto-update feature, you can use the official [mail]
 1. Clone the repository: `git clone https://github.com/tutao/tutanota.git`
 2. Switch into the repository directory: `cd tutanota`
 3. Checkout the latest web release tag: `git checkout tutanota-release-xxx`
-4. Do `npm install`
+4. run `npm install` to install dependencies.
 5. Build the web part: `node dist prod`
 6. Switch into the build directory: `cd build/dist`
 7. Run local server. Either use `node server` or `python -m SimpleHTTPServer 9000`.
@@ -21,7 +21,7 @@ your own. If you prefer the auto-update feature, you can use the official [mail]
 ## Building and running your own Tutanota Android app
 
 If you build and install the Tutanota Android app by yourself, keep in mind that you will not get updates automatically.
-If you prefer the auto-update feature, use the Google Play Store or F-Droid in the future.
+If you prefer the auto-update feature, download the app from the Google Play Store or F-Droid.
 
 #### Pre-requisites:
 * An up-to-date version of Git is installed
@@ -37,3 +37,27 @@ If you prefer the auto-update feature, use the Google Play Store or F-Droid in t
 5. Create a keystore if you don't have one: `keytool -genkey -noprompt -keystore MyKeystore.jks -alias tutaKey -keyalg RSA -keysize 2048 -validity 10000 -deststoretype pkcs12 -storepass CHANGEME -keypass CHANGEME -dname "CN=com.example"`
 6. run `APK_SIGN_ALIAS="tutaKey" APK_SIGN_STORE='MyKeystore.jks' APK_SIGN_STORE_PASS="CHANGEME" APK_SIGN_KEY_PASS="CHANGEME" node android`
 7. Install the app on your device: `adb install -r <path-to-apk>` (path as printed by the build script)
+
+## Building and running your own Tutanota Desktop client
+
+Keep in mind that your own build of Tutanota Desktop will not update automatically.
+
+### Pre-requisites:
+* An up-to-date version of Git is installed.
+* An up-to-date version of Node.js is installed
+
+### Preparations:
+0. Open a terminal.
+1. Clone the repository: `git clone https://github.com/tutao/tutanota.git`.
+2. Switch into the Tutanota directory: `cd tutanota`
+3. Checkout the latest web release tag: `git checkout tutanota-release-xxx`
+4. Run `npm install` to install dependencies.
+
+### Build:  
+Linux: `node dist -l --custom-release`  
+Windows: `node dist -w --custom-release`  
+MacOs: `node dist -m --custom-release`
+
+The client will be in `build/desktop/`
+Note that you can add `--unpacked` to the build command to skip the packaging of the installer.
+This will yield a directory containing the client that can be run without installation.

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -54,10 +54,8 @@ Keep in mind that your own build of Tutanota Desktop will not update automatical
 4. Run `npm install` to install dependencies.
 
 ### Build:  
-Linux: `node dist -l --custom-release`  
-Windows: `node dist -w --custom-release`  
-MacOs: `node dist -m --custom-release`
+Run `node dist --custom-desktop-release`.
 
-The client will be in `build/desktop/`
+The client for your platform will be in `build/desktop/`.
 Note that you can add `--unpacked` to the build command to skip the packaging of the installer.
 This will yield a directory containing the client that can be run without installation.

--- a/make.js
+++ b/make.js
@@ -87,13 +87,13 @@ function startDesktop() {
 	if (options.desktop) {
 		console.log("Trying to start desktop client...")
 		const version = require('./package.json').version
-		const packageJSON = require('./buildSrc/electron-package-json-template.js')(
-			"-debug",
-			version,
-			"http://localhost:9000",
-			path.join(__dirname, "/resources/desktop-icons/logo-solo-red.png"),
-			false
-		)
+		const packageJSON = require('./buildSrc/electron-package-json-template.js')({
+			nameSuffix: "-debug",
+			version: version,
+			updateUrl: "http://localhost:9000",
+			iconPath: path.join(__dirname, "/resources/desktop-icons/logo-solo-red.png"),
+			sign: false
+		})
 		const content = JSON.stringify(packageJSON)
 		return fs.writeFileAsync("./build/package.json", content, 'utf-8')
 		         .then(() => {

--- a/src/desktop/ElectronUpdater.js
+++ b/src/desktop/ElectronUpdater.js
@@ -36,6 +36,8 @@ export class ElectronUpdater {
 			error: (m: string, ...args: any) => console.error.apply(console, ["autoUpdater error:\n", m].concat(args)),
 		}
 		autoUpdater.logger = null
+		// default behaviour is to just dl the update as soon as found, but we want to check the signature
+		// before doing telling the updater to get the file.
 		autoUpdater.autoDownload = false
 		autoUpdater.autoInstallOnAppQuit = false
 		autoUpdater.on('update-available', updateInfo => {

--- a/src/desktop/ElectronUpdater.js
+++ b/src/desktop/ElectronUpdater.js
@@ -9,6 +9,8 @@ import type {DesktopConfigHandler} from './config/DesktopConfigHandler'
 import {neverNull} from "../api/common/utils/Utils"
 import {UpdateError} from "../api/common/error/UpdateError"
 import {DesktopTray} from "./tray/DesktopTray"
+import fs from 'fs-extra'
+import path from 'path'
 
 export class ElectronUpdater {
 	_conf: DesktopConfigHandler;
@@ -91,6 +93,14 @@ export class ElectronUpdater {
 	+_enableAutoUpdateListener = () => this.start()
 
 	start() {
+		try {
+			const appUpdateYmlPath = path.join(path.dirname(app.getPath('exe')), 'resources', 'app-update.yml')
+			fs.accessSync(appUpdateYmlPath, fs.constants.R_OK)
+		} catch (e) {
+			console.log("no update info on disk, disabling updater.")
+			return
+		}
+
 		// if user changes auto update setting, we want to know
 		this._conf.removeListener('enableAutoUpdate', this._enableAutoUpdateListener)
 		    .on('enableAutoUpdate', this._enableAutoUpdateListener)

--- a/src/desktop/ElectronUpdater.js
+++ b/src/desktop/ElectronUpdater.js
@@ -98,8 +98,13 @@ export class ElectronUpdater {
 			fs.accessSync(appUpdateYmlPath, fs.constants.R_OK)
 		} catch (e) {
 			console.log("no update info on disk, disabling updater.")
+			this._conf.setDesktopConfig('showAutoUpdateOption', false)
 			return
 		}
+
+		// if we got here, we could theoretically download updates.
+		// show the option in the settings menu
+		this._conf.setDesktopConfig('showAutoUpdateOption', true)
 
 		// if user changes auto update setting, we want to know
 		this._conf.removeListener('enableAutoUpdate', this._enableAutoUpdateListener)

--- a/src/desktop/config/DesktopConfigHandler.js
+++ b/src/desktop/config/DesktopConfigHandler.js
@@ -11,6 +11,7 @@ export const DesktopConfigKey = {
 	heartbeatTimeoutInSeconds: 'heartbeatTimeoutInSeconds',
 	defaultDownloadPath: 'defaultDownloadPath',
 	enableAutoUpdate: 'enableAutoUpdate',
+	showAutoUpdateOption: 'showAutoUpdateOption',
 	pushIdentifier: 'pushIdentifier',
 	runAsTrayApp: 'runAsTrayApp',
 	lastBounds: 'lastBounds',

--- a/src/desktop/config/migrations/DesktopConfigMigrator.js
+++ b/src/desktop/config/migrations/DesktopConfigMigrator.js
@@ -15,6 +15,8 @@ export default function applyMigrations(migrationFunction: "migrateClient" | "mi
 			oldConfig = applyMigration(require('./migration-0000')[migrationFunction], oldConfig)
 		// no break, fallthrough applies all migrations in sequence
 		case 0:
+			oldConfig = applyMigration(require('./migration-0001')[migrationFunction], oldConfig)
+		case 1:
 			console.log("config up to date")
 			/* add new migrations as needed */
 			break;

--- a/src/desktop/config/migrations/migration-0001.js
+++ b/src/desktop/config/migrations/migration-0001.js
@@ -1,0 +1,7 @@
+// @flow
+function migrate(oldConfig: any) {
+	return Object.assign(oldConfig, {"desktopConfigVersion": 1, "showAutoUpdateOption": true})
+}
+
+export const migrateClient = migrate
+export const migrateAdmin = migrate

--- a/src/settings/DesktopSettingsViewer.js
+++ b/src/settings/DesktopSettingsViewer.js
@@ -32,6 +32,7 @@ export class DesktopSettingsViewer implements UpdatableSettingsViewer {
 	_runOnStartup: Stream<?boolean>;
 	_isIntegrated: Stream<?boolean>;
 	_isAutoUpdateEnabled: Stream<?boolean>;
+	_showAutoUpdateOption: Stream<?boolean>;
 	_isPathDialogOpen: boolean;
 
 	constructor() {
@@ -40,6 +41,7 @@ export class DesktopSettingsViewer implements UpdatableSettingsViewer {
 		this._runOnStartup = stream(false)
 		this._isIntegrated = stream(false)
 		this._isAutoUpdateEnabled = stream(false)
+		this._showAutoUpdateOption = stream(true)
 		this._requestDesktopConfig()
 	}
 
@@ -157,7 +159,7 @@ export class DesktopSettingsViewer implements UpdatableSettingsViewer {
 				m(DropDownSelectorN, setRunOnStartupAttrs),
 				m(TextFieldN, defaultDownloadPathAttrs),
 				env.platformId === 'linux' ? m(DropDownSelectorN, setDesktopIntegrationAttrs) : null,
-				m(DropDownSelectorN, setAutoUpdateAttrs)
+				this._showAutoUpdateOption() ? m(DropDownSelectorN, setAutoUpdateAttrs) : null,
 			])
 		]
 	}
@@ -190,6 +192,7 @@ export class DesktopSettingsViewer implements UpdatableSettingsViewer {
 			         this._runAsTrayApp(desktopConfig.runAsTrayApp)
 			         this._runOnStartup(desktopConfig.runOnStartup)
 			         this._isIntegrated(desktopConfig.isIntegrated)
+			         this._showAutoUpdateOption(desktopConfig.showAutoUpdateOption)
 			         this._isAutoUpdateEnabled(desktopConfig.enableAutoUpdate)
 			         m.redraw()
 		         })

--- a/test/client/desktop/ElectronUpdaterTest.js
+++ b/test/client/desktop/ElectronUpdaterTest.js
@@ -98,6 +98,13 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 		}
 	}
 
+	const fs = {
+		accessSync: () => {},
+		constants: {
+			"R_OK": 1
+		}
+	}
+
 	const lang = {
 		lang: {
 			get: (key: string) => {
@@ -142,6 +149,7 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 
 	o("update is available", done => {
 		//mock node modules
+		const fsMock = n.mock('fs-extra', fs).set()
 		const forgeMock = n.mock('node-forge', nodeForge).set()
 		const autoUpdaterMock = n.mock('electron-updater', autoUpdater).set().autoUpdater
 		const electronMock = n.mock('electron', electron).set()
@@ -201,6 +209,7 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 
 	o("update is not available", done => {
 		//mock node modules
+		const fsMock = n.mock('fs-extra', fs).set()
 		const forgeMock = n.mock('node-forge', nodeForge).set()
 		const electronMock = n.mock('electron', electron).set()
 		const autoUpdaterMock = n.mock('electron-updater', autoUpdater)
@@ -242,6 +251,7 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 
 	o("enable autoUpdate while running", done => {
 		//mock node modules
+		const fsMock = n.mock('fs-extra', fs).set()
 		const forgeMock = n.mock('node-forge', nodeForge).set()
 		const electronMock = n.mock('electron', electron).set()
 		const autoUpdaterMock = n.mock('electron-updater', autoUpdater).set().autoUpdater
@@ -317,6 +327,7 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 
 	o("retry after autoUpdater reports an error", done => {
 		//mock node modules
+		const fsMock = n.mock('fs-extra', fs).set()
 		const forgeMock = n.mock('node-forge', nodeForge).set()
 		const electronMock = n.mock('electron', electron).set()
 		const autoUpdaterMock = n.mock('electron-updater', autoUpdater)
@@ -388,6 +399,7 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 		const MAX_NUM_ERRORS = 5
 		let threw = false
 		//mock node modules
+		const fsMock = n.mock('fs-extra', fs).set()
 		const forgeMock = n.mock('node-forge', nodeForge).set()
 		const electronMock = n.mock('electron', electron).set()
 		const autoUpdaterMock = n.mock('electron-updater', autoUpdater)
@@ -432,6 +444,7 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 	o("works if second key is right one", done => {
 
 		//mock node modules
+		const fsMock = n.mock('fs-extra', fs).set()
 		const forgeMock = n.mock('node-forge', nodeForge).with({
 			publicKeyFromPem: (pem: string) => n.spyify(pem === "no" ? rightKey : wrongKey)
 		}).set()
@@ -492,4 +505,33 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 			done()
 		}, 190)
 	})
+
+	o("updater disables itself if accessSync throws", function () {
+			//mock node modules
+			const fsMock = n.mock('fs-extra', fs).with({
+				accessSync: undefined
+			}).set()
+			const forgeMock = n.mock('node-forge', nodeForge).set()
+			const autoUpdaterMock = n.mock('electron-updater', autoUpdater).set().autoUpdater
+			const electronMock = n.mock('electron', electron).set()
+
+			//mock our modules
+			n.mock('./tray/DesktopTray', desktopTray).set()
+			n.mock('../misc/LanguageViewModel', lang).set()
+
+			//mock instances
+			const confMock = n.mock('__conf', conf).set()
+			const notifierMock = n.mock('__notifier', notifier).set()
+
+			const {ElectronUpdater} = n.subject('../../src/desktop/ElectronUpdater.js')
+			const upd = new ElectronUpdater(confMock, notifierMock)
+
+			o(autoUpdaterMock.on.callCount).equals(5)
+			o(autoUpdaterMock.logger).equals(null)
+
+			upd.start()
+
+			o(confMock.removeListener.callCount).equals(0)
+		}
+	)
 })

--- a/test/client/desktop/ElectronUpdaterTest.js
+++ b/test/client/desktop/ElectronUpdaterTest.js
@@ -123,9 +123,12 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 	const conf = {
 		removeListener: (key: string, cb: ()=>void) => n.spyify(conf),
 		on: (key: string) => n.spyify(conf),
+		setDesktopConfig: (key, value) => {},
 		getDesktopConfig: (key: string) => {
 			switch (key) {
 				case 'enableAutoUpdate':
+					return true
+				case 'showAutoUpdateOption':
 					return true
 				default:
 					throw new Error(`unexpected getDesktopConfig key ${key}`)
@@ -169,6 +172,9 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 		o(autoUpdaterMock.logger).equals(null)
 
 		upd.start()
+
+		o(confMock.setDesktopConfig.callCount).equals(1)
+		o(confMock.setDesktopConfig.args).deepEquals(['showAutoUpdateOption', true])
 
 		// there is only one enableAutoUpdate listener
 		o(confMock.removeListener.callCount).equals(1)
@@ -278,6 +284,8 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 				                  switch (key) {
 					                  case 'enableAutoUpdate':
 						                  return enabled
+					                  case 'showAutoUpdateOption':
+						                  return true
 					                  default:
 						                  throw new Error(`unexpected getDesktopConfig key ${key}`)
 				                  }
@@ -531,6 +539,8 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 
 			upd.start()
 
+			o(confMock.setDesktopConfig.callCount).equals(1)
+			o(confMock.setDesktopConfig.args).deepEquals(['showAutoUpdateOption', false])
 			o(confMock.removeListener.callCount).equals(0)
 		}
 	)

--- a/test/client/desktop/config/migrations/DesktopConfigMigratorTest.js
+++ b/test/client/desktop/config/migrations/DesktopConfigMigratorTest.js
@@ -7,9 +7,14 @@ o.spec('desktop config migrator test', function () {
 	o("migrations result in correct default config, client", function () {
 		const migrator = n.subject('../../src/desktop/config/migrations/DesktopConfigMigrator.js').default
 		const configPath = "../../../../../../buildSrc/electron-package-json-template.js"
-		const oldConfig = require(configPath)(
-			"", "0.0.0", "", "", "", false, false
-		)["tutao-config"]["defaultDesktopConfig"]
+		const oldConfig = require(configPath)({
+			nameSuffix: "",
+			version: "0.0.0",
+			updateUrl: "",
+			iconPath: "",
+			sign: false,
+			notarize: false
+		})["tutao-config"]["defaultDesktopConfig"]
 		const requiredResult = {
 			"heartbeatTimeoutInSeconds": 30,
 			"defaultDownloadPath": null,

--- a/test/client/desktop/config/migrations/DesktopConfigMigratorTest.js
+++ b/test/client/desktop/config/migrations/DesktopConfigMigratorTest.js
@@ -15,7 +15,8 @@ o.spec('desktop config migrator test', function () {
 			"defaultDownloadPath": null,
 			"enableAutoUpdate": true,
 			"runAsTrayApp": true,
-			"desktopConfigVersion": 0
+			"desktopConfigVersion": 1,
+			"showAutoUpdateOption": true,
 		}
 
 		o(migrator("migrateClient", oldConfig, oldConfig)).deepEquals(requiredResult)
@@ -28,7 +29,8 @@ o.spec('desktop config migrator test', function () {
 		}
 		const requiredResult = {
 			"runAsTrayApp": true,
-			"desktopConfigVersion": 0
+			"desktopConfigVersion": 1,
+			"showAutoUpdateOption": true,
 		}
 
 		o(migrator("migrateAdmin", oldConfig, oldConfig)).deepEquals(requiredResult)


### PR DESCRIPTION
adds some options to the dist.js build script:
--unpacked
disables the building of installers (dir target for all platforms)

--out-dir \<outDir\>
move the built installers (or dirs) into the path outDir after building.
Defaults to build/desktop and build/desktop-test

--custom-release
disable autoUpdate in the release target by not including an update url.
disable building of the test client.