### PR TITLE
Upgrading Flow version to 0.81.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3332,9 +3332,9 @@
 			}
 		},
 		"flow-bin": {
-			"version": "0.77.0",
-			"resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.77.0.tgz",
-			"integrity": "sha1-TlyTkp8omgwo4I+zYalzSUShEpc=",
+			"version": "0.81.0",
+			"resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.81.0.tgz",
+			"integrity": "sha512-5e8oL3/5rm3G0Eet3yDCne2R/TLo5Fkn+Z5MtHd4wtz+1miLC35Sgo8XvnbTmiZ9epdTZ1q6GLmJWYh7tUlfGg==",
 			"dev": true
 		},
 		"for-in": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"electron-rebuild": "1.10.0",
 		"electron-updater": "4.2.4",
 		"express": "4.17.1",
-		"flow-bin": "0.77.0",
+		"flow-bin": "0.81.0",
 		"fs-extra": "8.1.0",
 		"glob": "7.1.6",
 		"js-yaml": "3.13.1",

--- a/src/api/main/UserController.js
+++ b/src/api/main/UserController.js
@@ -141,7 +141,7 @@ export class UserController implements IUserController {
 	}
 
 
-	deleteSessionSync() {
+	deleteSessionSync(): Promise<void> {
 		return new Promise((resolve, reject) => {
 			const sendBeacon = navigator.sendBeacon // Save sendBeacon to variable to satisfy type checker
 			if (sendBeacon) {

--- a/test/client/desktop/DesktopUtilsTest.js
+++ b/test/client/desktop/DesktopUtilsTest.js
@@ -26,7 +26,7 @@ function setEnv(platform: string) {
 		enumerable: true
 	})
 
-	Object.defineProperty(path, 'sep', {
+	Object.defineProperty((path: any), 'sep', {
 		value: sep,
 		writable: false,
 		enumerable: true


### PR DESCRIPTION
This PR is for upgrading the version of Flow from 0.77.0 to 0.80.0. No code changes were necessary, except 
1. `path` in `test/client/desktop/DesktopUtilsTest.js` had to be cast to `any` in order to edit the `sep` property--otherwise Flow complains about `sep` not being a writeable property of `path`. 
2. Flow complained that the there was a missing type annotation for the Promise returned by `deleteSessionSync()`, so the function's return type had to be annotated. 