### PR TITLE
[desktop] manually install update on quit, close #1413

### DIFF
--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -102,13 +102,14 @@ module.exports = function (nameSuffix, version, targetUrl, iconPath, sign, notar
 				"to": "./icons/"
 			},
 			"win": {
+				"verifyUpdateCodeSignature": sign,
 				"publisherName": "Tutao GmbH",
 				"sign": sign
 					? "./buildSrc/winsigner.js"
 					: undefined,
-				"signingHashAlgorithms": [
-					"sha256"
-				],
+				"signingHashAlgorithms": sign
+					? ["sha256"]
+					: undefined,
 				"target": [
 					{
 						"target": "nsis",

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -19,10 +19,6 @@ export type WindowBounds = {|
 |}
 
 const windows: ApplicationWindow[] = []
-let forceQuit = false
-let enableForceQuit = () => forceQuit = true
-app.once('before-quit', enableForceQuit)
-   .once('enable-force-quit', enableForceQuit)
 
 export class WindowManager {
 	_conf: DesktopConfigHandler

--- a/test/client/desktop/ElectronUpdaterTest.js
+++ b/test/client/desktop/ElectronUpdaterTest.js
@@ -27,7 +27,12 @@ o.spec("ElectronUpdater Test", function (done, timeout) {
 		app: {
 			getPath: (path: string) => `/mock-${path}/`,
 			getVersion: (): string => "3.45.0",
-			emit: () => {}
+			emit: () => {},
+			callbacks: [],
+			once: function (ev: string, cb: ()=>void) {
+				this.callbacks[ev] = cb
+				return n.spyify(electron.app)
+			},
 		}
 	}
 


### PR DESCRIPTION
electron-updater currently does not correctly update system-wide windows
installs on app-quit because of missing admin rights.
manually calling autoUpdater.quitAndInstall seems to correctly trigger
the UAC dialog.

To test in local network, first reproduce the problem in the following way on the master branch:
* serve `build/desktop/` directory on the local network under some url
* add the line `sign=false` to `buildSrc/electron-package-json-template.js` before the return statement
* also change `build.publish.url` from `targetUrl` to the url the build directory is served under
* build client with `node dist -w` or `node dist -we` for subsequent tries
* install client on windows machine, selecting system-wide installation.
* increment version number in `build/desktop/latest.yml`
* start client on windows machine
* wait for update notification to pop up, but don't click it
* quit the application via the tray or the icon in the app. it should now open the update dialog.
* after selecting the system-wide update, the app has uninstalled itself, but didn't install the new version.

with the changes from this pull request, the process above should lead to a properly updated desktop client.