### PR TITLE
Fix duplicated shortcuts

### DIFF
--- a/src/calendar/CalendarView.js
+++ b/src/calendar/CalendarView.js
@@ -120,7 +120,7 @@ export class CalendarView implements CurrentView {
 	_calendarInvitations: Array<ReceivedGroupInvitation>
 
 	oncreate: Function;
-	onbeforeremove: Function;
+	onremove: Function;
 
 	constructor() {
 		this._currentViewType = deviceConfig.getDefaultCalendarView(logins.getUserController().user._id) || CalendarViewType.MONTH
@@ -324,7 +324,7 @@ export class CalendarView implements CurrentView {
 		]
 
 		this.oncreate = () => keyManager.registerShortcuts(shortcuts)
-		this.onbeforeremove = () => keyManager.unregisterShortcuts(shortcuts)
+		this.onremove = () => keyManager.unregisterShortcuts(shortcuts)
 	}
 
 	_viewPeriod(next: boolean) {

--- a/src/contacts/ContactView.js
+++ b/src/contacts/ContactView.js
@@ -55,7 +55,7 @@ export class ContactView implements CurrentView {
 	_multiContactViewer: MultiContactViewer;
 	view: Function;
 	oncreate: Function;
-	onbeforeremove: Function;
+	onremove: Function;
 	_throttledSetUrl: (string) => void;
 
 	constructor() {
@@ -193,7 +193,7 @@ export class ContactView implements CurrentView {
 		]
 
 		this.oncreate = () => keyManager.registerShortcuts(shortcuts)
-		this.onbeforeremove = () => keyManager.unregisterShortcuts(shortcuts)
+		this.onremove = () => keyManager.unregisterShortcuts(shortcuts)
 	}
 
 	createContactFoldersExpander(): ExpanderButton {

--- a/src/contacts/ContactViewer.js
+++ b/src/contacts/ContactViewer.js
@@ -49,7 +49,7 @@ export class ContactViewer {
 	addresses: TextField[];
 	socials: TextField[];
 	oncreate: Function;
-	onbeforeremove: Function;
+	onremove: Function;
 
 	constructor(contact: Contact) {
 		this.contact = contact
@@ -226,7 +226,7 @@ export class ContactViewer {
 		]
 
 		this.oncreate = () => keyManager.registerShortcuts(shortcuts)
-		this.onbeforeremove = () => keyManager.unregisterShortcuts(shortcuts)
+		this.onremove = () => keyManager.unregisterShortcuts(shortcuts)
 	}
 
 	delete() {

--- a/src/gui/base/Button.js
+++ b/src/gui/base/Button.js
@@ -73,7 +73,7 @@ export class Button {
 					oncreate: (vnode) => {
 						this._domButton = vnode.dom
 					},
-					onbeforeremove: (vnode) => removeFlash(vnode.dom)
+					onremove: (vnode) => removeFlash(vnode.dom)
 				}, m("", {// additional wrapper for flex box styling as safari does not support flex box on buttons.
 					class: this.getWrapperClasses().join(' '),
 					oncreate: (vnode) => {

--- a/src/gui/base/ButtonN.js
+++ b/src/gui/base/ButtonN.js
@@ -126,7 +126,7 @@ class _Button {
 					this._domButton = vnode.dom
 					a.oncreate && a.oncreate(vnode)
 				},
-				onbeforeremove: (vnode) => removeFlash(vnode.dom),
+				onremove: (vnode) => removeFlash(vnode.dom),
 			}, m("", {// additional wrapper for flex box styling as safari does not support flex box on buttons.
 				class: this.getWrapperClasses(a).join(' '),
 				style: {
@@ -136,7 +136,8 @@ class _Button {
 					if (type !== ButtonType.Toggle) {
 						addFlash(vnode.dom)
 					}
-				}
+				},
+				onremove: (vnode) => removeFlash(vnode.dom),
 			}, [
 				this.getIcon(a),
 				this._getLabelElement(a),

--- a/src/gui/base/Checkbox.js
+++ b/src/gui/base/Checkbox.js
@@ -41,7 +41,7 @@ export class Checkbox {
 			}, [
 				m(".wrapper.flex.items-center", {
 					oncreate: (vnode) => this.enabled ? addFlash(vnode.dom) : null,
-					onbeforeremove: (vnode) => removeFlash(vnode.dom),
+					onremove: (vnode) => removeFlash(vnode.dom),
 				}, [
 					// the real checkbox is transparent and only used to allow keyboard focusing and selection
 					m("input[type=checkbox]", {

--- a/src/gui/base/CheckboxN.js
+++ b/src/gui/base/CheckboxN.js
@@ -32,7 +32,7 @@ export class _Checkbox {
 		}, [
 			m(".wrapper.flex.items-center", {
 				oncreate: (vnode) => addFlash(vnode.dom),
-				onbeforeremove: (vnode) => removeFlash(vnode.dom),
+				onremove: (vnode) => removeFlash(vnode.dom),
 			}, [
 				// the real checkbox is transparent and only used to allow keyboard focusing and selection
 				m("input[type=checkbox]", {

--- a/src/gui/base/Expander.js
+++ b/src/gui/base/Expander.js
@@ -36,7 +36,7 @@ export class ExpanderButton {
 							event.stopPropagation()
 						},
 						oncreate: vnode => addFlash(vnode.dom),
-						onbeforeremove: (vnode) => removeFlash(vnode.dom),
+						onremove: (vnode) => removeFlash(vnode.dom),
 						// Must be "true" or "false" strings, mere presence of attribute doesn't signify anything
 						"aria-expanded": String(!!this.panel.expanded),
 					}, m(".flex.items-center", [ // TODO remove wrapper after Firefox 52 has been deployed widely https://bugzilla.mozilla.org/show_bug.cgi?id=984869

--- a/src/gui/base/ExpanderN.js
+++ b/src/gui/base/ExpanderN.js
@@ -37,7 +37,7 @@ class _ExpanderButton {
 					event.stopPropagation()
 				},
 				oncreate: vnode => addFlash(vnode.dom),
-				onbeforeremove: (vnode) => removeFlash(vnode.dom),
+				onremove: (vnode) => removeFlash(vnode.dom),
 				"aria-expanded": String(!!a.expanded()),
 			}, m(".flex.items-center", [ // TODO remove wrapper after Firefox 52 has been deployed widely https://bugzilla.mozilla.org/show_bug.cgi?id=984869
 				(a.showWarning) ? m(Icon, {

--- a/src/gui/base/Header.js
+++ b/src/gui/base/Header.js
@@ -4,6 +4,7 @@ import {NavBar} from "./NavBar"
 import {NavButtonColors, NavButtonN} from "./NavButtonN"
 import {styles} from "../styles"
 import {asyncImport, neverNull} from "../../api/common/utils/Utils"
+import type {Shortcut} from "../../misc/KeyManager"
 import {keyManager} from "../../misc/KeyManager"
 import {lang} from "../../misc/LanguageViewModel"
 import {logins} from "../../api/main/LoginController"
@@ -18,7 +19,6 @@ import type {WorkerClient} from "../../api/main/WorkerClient";
 import {client} from "../../misc/ClientDetector"
 import {CALENDAR_PREFIX, CONTACTS_PREFIX, MAIL_PREFIX, navButtonRoutes, SEARCH_PREFIX} from "../../misc/RouteChange"
 import {AriaLandmarks, landmarkAttrs} from "../../api/common/utils/AriaUtils"
-import type {Shortcut} from "../../misc/KeyManager"
 
 const LogoutPath = '/login?noAutoLogin=true'
 export const LogoutUrl = location.hash.startsWith("#mail")
@@ -43,7 +43,7 @@ class Header {
 	view: Function;
 	_currentView: ?CurrentView;  // decoupled from ViewSlider implementation to reduce size of bootstrap bundle
 	oncreate: Function;
-	onbeforeremove: Function;
+	onremove: Function;
 	_shortcuts: Shortcut[];
 	searchBar: ?SearchBar
 	_wsState: WsConnectionState = "terminated"
@@ -184,7 +184,7 @@ class Header {
 		]
 
 		this.oncreate = () => keyManager.registerShortcuts(this._shortcuts)
-		this.onbeforeremove = () => keyManager.unregisterShortcuts(this._shortcuts)
+		this.onremove = () => keyManager.unregisterShortcuts(this._shortcuts)
 	}
 
 

--- a/src/gui/base/NavButtonN.js
+++ b/src/gui/base/NavButtonN.js
@@ -104,7 +104,7 @@ class _NavButton {
 				this._domButton = vnode.dom
 				addFlash(vnode.dom)
 			},
-			onbeforeremove: (vnode) => {
+			onremove: (vnode) => {
 				removeFlash(vnode.dom)
 			},
 			selector: navButtonSelector(a.vertical),

--- a/src/mail/MailView.js
+++ b/src/mail/MailView.js
@@ -24,6 +24,7 @@ import {lazyMemoized, neverNull, noOp} from "../api/common/utils/Utils"
 import {MailListView} from "./MailListView"
 import {MailEditor, newMail} from "./MailEditor"
 import {assertMainOrNode, isApp} from "../api/Env"
+import type {Shortcut} from "../misc/KeyManager"
 import {keyManager} from "../misc/KeyManager"
 import {MultiMailViewer} from "./MultiMailViewer"
 import {logins} from "../api/main/LoginController"
@@ -62,7 +63,6 @@ import {size} from "../gui/size"
 import {FolderColumnView} from "../gui/base/FolderColumnView"
 import {modal} from "../gui/base/Modal"
 import {DomRectReadOnlyPolyfilled} from "../gui/base/Dropdown"
-import type {Shortcut} from "../misc/KeyManager"
 
 assertMainOrNode()
 
@@ -86,7 +86,7 @@ export class MailView implements CurrentView {
 	selectedFolder: ?MailFolder;
 	mailViewer: ?MailViewer;
 	oncreate: Function;
-	onbeforeremove: Function;
+	onremove: Function;
 	_mailboxExpanders: {[mailGroupId: Id]: MailboxExpander}
 	_folderToUrl: {[folderId: Id]: string};
 	_multiMailViewer: MultiMailViewer;
@@ -399,7 +399,7 @@ export class MailView implements CurrentView {
 			keyManager.registerShortcuts(shortcuts)
 			this._countersStream = mailModel.mailboxCounters.map(m.redraw)
 		}
-		this.onbeforeremove = () => {
+		this.onremove = () => {
 			keyManager.unregisterShortcuts(shortcuts)
 			this._countersStream.end(true)
 		}

--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -446,7 +446,7 @@ export class MailViewer {
 			]
 		}
 
-		this.onbeforeremove = () => windowFacade.removeResizeListener(resizeListener)
+		this.onremove = () => windowFacade.removeResizeListener(resizeListener)
 		this._setupShortcuts()
 	}
 

--- a/src/search/SearchBar.js
+++ b/src/search/SearchBar.js
@@ -82,7 +82,6 @@ export class SearchBar implements Component {
 	skipNextBlur: Stream<boolean>;
 	_state: Stream<SearchBarState>
 	oncreate: Function;
-	onbeforeremove: Function;
 	busy: boolean;
 	_groupInfoRestrictionListId: ?Id;
 	lastSelectedGroupInfoResult: Stream<GroupInfo>;

--- a/src/search/SearchView.js
+++ b/src/search/SearchView.js
@@ -69,7 +69,7 @@ export class SearchView implements CurrentView {
 	_searchList: SearchListView;
 	view: Function;
 	oncreate: Function;
-	onbeforeremove: Function;
+	onremove: Function;
 
 	_mailFolder: NavButtonAttrs;
 	_contactFolder: NavButtonAttrs;
@@ -429,7 +429,7 @@ export class SearchView implements CurrentView {
 			keyManager.registerShortcuts(shortcuts)
 			neverNull(header.searchBar).setReturnListener(() => this.resultListColumn.focus())
 		}
-		this.onbeforeremove = () => {
+		this.onremove = () => {
 			keyManager.unregisterShortcuts(shortcuts)
 			neverNull(header.searchBar).setReturnListener(noOp)
 		}

--- a/src/settings/MailSettingsViewer.js
+++ b/src/settings/MailSettingsViewer.js
@@ -209,7 +209,7 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 						m.redraw()
 					})
 				},
-				onbeforeremove: () => {
+				onremove: () => {
 					if (this._indexStateWatch) {
 						this._indexStateWatch.end(true)
 					}


### PR DESCRIPTION
 fix #1700

Shortcuts were duplicated because `onbeforeremove()` mithril hook is only
called when element loses its parent. If the parent is removed, hook
is not called for children. This made us miss some of the
`keyManager.unregisterShortcuts()` calls and also some of the
`removeFlash()` calls.

`onremove()` on the other hand is called each time element is removed
from the DOM (whether via parent or directly) and that's what we need
in most cases.