### PR TITLE
[desktop] reduce API surface of preload script after it has run

### DIFF
--- a/flow/api/types.js
+++ b/flow/api/types.js
@@ -215,9 +215,9 @@ type JsRequestType = 'createMailEditor'
 	| 'addShortcuts'
 
 type WebContentsMessage
-	= 'setup-context-menu'
-	| 'open-context-menu'
+	= 'initialize-ipc'
 	| 'set-zoom-factor'
+	| 'socket-message'
 
 type Callback<T> = (err: ?Error, data?: T) => void
 type Command = (msg: Request) => Promise<any>

--- a/flow/electron.js
+++ b/flow/electron.js
@@ -12,6 +12,7 @@ declare module 'electron' {
 	declare export var remote: any;
 	declare export var screen: ElectronScreen;
 	declare export var webFrame: WebFrame;
+	declare export var clipboard: ClipBoard;
 	declare export var dialog: ElectronDialog;
 	declare export var globalShortcut: {
 		register(shortcut: string, cb: Function): void;
@@ -42,6 +43,21 @@ declare module 'electron' {
 		width: number,
 		height: number
 	|};
+
+	declare export type ClipBoard = {
+		writeText(string): void;
+	}
+
+	declare export type ContextMenuParams = {
+		linkURL: string,
+		editFlags: {
+			canCut: boolean,
+			canPaste: boolean,
+			canCopy: boolean,
+			canUndo: boolean,
+			canRedo: boolean
+		}
+	}
 
 	declare export type IncomingMessage = {
 		on('error' | 'data' | 'end', (any) => void): IncomingMessage,
@@ -100,7 +116,7 @@ declare module 'electron' {
 		 * Will be called with `click(menuItem, browserWindow, event)` when the menu item
 		 * is clicked.
 		 */
-		click?: (menuItem: MenuItem, browserWindow: BrowserWindow, event: KeyboardEvent) => void;
+		+click?: (menuItem: MenuItem, browserWindow: BrowserWindow, event: KeyboardEvent) => void;
 		/**
 		 * Can be `undo`, `redo`, `cut`, `copy`, `paste`, `pasteAndMatchStyle`, `delete`,
 		 * `selectAll`, `reload`, `forceReload`, `toggleDevTools`, `resetZoom`, `zoomIn`,
@@ -364,6 +380,8 @@ declare module 'electron' {
 			beforeGroupContaining?: string,
 			afterGroupContaining?: string,
 		}): MenuItem;
+		click(): void;
+		enabled: boolean;
 	}
 
 	declare export class BrowserWindow {
@@ -466,6 +484,11 @@ declare module 'electron' {
 		executeJavaScript(code: string): Promise<any>;
 		findInPage(searchString: string, opts: {forward: boolean, matchCase: boolean}): void;
 		stopFindInPage(action: "clearSelection" | "keepSelection" | "activateSelection"): void;
+		copy(): void;
+		cut(): void;
+		paste(): void;
+		undo(): void;
+		redo(): void;
 	}
 
 	declare export class WebFrame {
@@ -502,7 +525,7 @@ declare module 'electron' {
 
 
 declare type ClientRequest = {
-	on('error' | 'response' | 'information' | 'connect' | 'timeout', (Error & IncomingMessage)=>void): ClientRequest,
+	on('error' | 'response' | 'information' | 'connect' | 'timeout', (Error & IncomingMessage) => void): ClientRequest,
 	end(): ClientRequest,
 	abort(): void,
 };
@@ -725,13 +748,13 @@ declare module 'request' {
 
 declare module 'https' {
 	declare module .exports: {
-		request: (url: string, options: any, callback: ?() => void)=> ClientRequest;
+		request: (url: string, options: any, callback: ?() => void) => ClientRequest;
 	}
 }
 
 declare module 'http' {
 	declare module .exports: {
-		request: (url: string, options: any, callback: ?() => void)=> ClientRequest;
+		request: (url: string, options: any, callback: ?() => void) => ClientRequest;
 	}
 }
 

--- a/src/desktop/DesktopContextMenu.js
+++ b/src/desktop/DesktopContextMenu.js
@@ -1,0 +1,53 @@
+// @flow
+
+import {clipboard, Menu, MenuItem} from 'electron'
+import {lang} from "../misc/LanguageViewModel"
+import type {WebContents, ContextMenuParams} from "electron"
+
+export class DesktopContextMenu {
+	_menu: Menu;
+	_pasteItem: MenuItem;
+	_copyItem : MenuItem;
+	_cutItem: MenuItem;
+	_copyLinkItem: MenuItem;
+	_undoItem: MenuItem;
+	_redoItem: MenuItem;
+	_link: string;
+
+	constructor() {
+		this._menu = new Menu()
+		this._pasteItem = new MenuItem({label: lang.get("paste_action"), accelerator: "CmdOrCtrl+V", click:(mi, bw) => bw.webContents.paste()})
+		this._copyItem = new MenuItem({label: lang.get("copy_action"), accelerator: "CmdOrCtrl+C", click: (mi, bw) => bw.webContents.copy()})
+		this._cutItem = new MenuItem({label: lang.get("cut_action"), accelerator: "CmdOrCtrl+X", click: (mi, bw) => bw.webContents.cut()})
+		this._copyLinkItem = new MenuItem({label: lang.get("copyLink_action"), click: () => clipboard.writeText(this._link)})
+		this._undoItem = new MenuItem({
+			label: lang.get("undo_action"),
+			accelerator: "CmdOrCtrl+Z",
+			click:(mi, bw) => bw.webContents.undo()
+		})
+		this._redoItem = new MenuItem({
+			label: lang.get("redo_action"),
+			accelerator: "CmdOrCtrl+Shift+Z",
+			click:(mi, bw) => bw.webContents.redo()
+		})
+
+		this._menu.append(this._copyItem)
+		this._menu.append(this._cutItem)
+		this._menu.append(this._copyLinkItem)
+		this._menu.append(this._pasteItem)
+		this._menu.append(new MenuItem({type: 'separator'}))
+		this._menu.append(this._undoItem)
+		this._menu.append(this._redoItem)
+	}
+
+	open(params: ContextMenuParams, wc: WebContents) {
+		this._link = params.linkURL
+		this._copyLinkItem.enabled = !!params.linkURL
+		this._cutItem.enabled = params.editFlags.canCut
+		this._pasteItem.enabled = params.editFlags.canPaste
+		this._copyItem.enabled = params.editFlags.canCopy
+		this._undoItem.enabled = params.editFlags.canUndo
+		this._redoItem.enabled = params.editFlags.canRedo
+		this._menu.popup()
+	}
+}

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -11,6 +11,7 @@ import type {DesktopNotifier} from "./DesktopNotifier.js"
 import {LOGIN_TITLE} from "../api/Env"
 import type {DesktopDownloadManager} from "./DesktopDownloadManager"
 import type {IPC} from "./IPC"
+import {DesktopContextMenu} from "./DesktopContextMenu"
 
 export type WindowBounds = {|
 	rect: Rectangle,
@@ -24,6 +25,7 @@ export class WindowManager {
 	_conf: DesktopConfigHandler
 	_tray: DesktopTray
 	_notifier: DesktopNotifier
+	_contextMenu: DesktopContextMenu
 	ipc: IPC
 	dl: DesktopDownloadManager
 
@@ -32,6 +34,7 @@ export class WindowManager {
 		this._tray = tray
 		this._notifier = notifier
 		this.dl = dl
+		this._contextMenu = new DesktopContextMenu()
 	}
 
 	setIPC(ipc: IPC) {
@@ -76,6 +79,7 @@ export class WindowManager {
 			}
 		})
 
+		w.setContextMenuHandler((params, wc) => this._contextMenu.open(params, wc))
 
 		return w
 	}

--- a/src/desktop/IPC.js
+++ b/src/desktop/IPC.js
@@ -136,8 +136,8 @@ export class IPC {
 				return this._dl.downloadNative(...args.slice(0, 3))
 			case 'saveBlob':
 				// args: [data.name, uint8ArrayToBase64(data.data)]
-				const filename : string = downcast(args[0])
-				const data : Uint8Array = base64ToUint8Array(downcast(args[1]))
+				const filename: string = downcast(args[0])
+				const data: Uint8Array = base64ToUint8Array(downcast(args[1]))
 				return this._dl.saveBlob(filename, data, this._wm.get(windowId))
 			case "aesDecryptFile":
 				// key, path
@@ -192,7 +192,6 @@ export class IPC {
 					)
 				]).return()
 			case 'initPushNotifications':
-				console.log("initPushNotifications")
 				this._sse.connect()
 				return Promise.resolve()
 			case 'closePushNotifications':

--- a/src/desktop/Socketeer.js
+++ b/src/desktop/Socketeer.js
@@ -3,6 +3,8 @@
 import net from 'net'
 import {app} from 'electron'
 import {neverNull} from "../api/common/utils/Utils"
+import type {WindowManager} from "./DesktopWindowManager"
+import {isMailAddress} from "../misc/FormatValidator"
 
 const SOCKET_PATH = '/tmp/tutadb.sock'
 
@@ -26,6 +28,15 @@ export class Socketeer {
 				if (this._server) {
 					this._server.close()
 				}
+			}
+		})
+	}
+
+	attachWindowManager(wm: WindowManager) {
+		this.startClient(msg => {
+			const mailAddress = JSON.parse(msg).mailAddress
+			if (typeof mailAddress === 'string' && isMailAddress(mailAddress, false)) {
+				wm.getLastFocused(true).sendMessageToWebContents('socket-message', {mailAddress})
 			}
 		})
 	}

--- a/src/desktop/preload.js
+++ b/src/desktop/preload.js
@@ -1,77 +1,40 @@
 // @flow
-import {ipcRenderer, remote} from 'electron'
+import {ipcRenderer, webFrame} from 'electron'
 
-/**
- * preload scripts can only load modules that have previously been loaded
- * in the main thread.
- */
-const app = remote.require('electron').app
-const webFrame = require('electron').webFrame
-const clipboard = remote.require('electron').clipboard
-const PreloadImports = remote.require('./PreloadImports.js').default
-const lang = PreloadImports.lang
-const Menu = remote.Menu
-const MenuItem = remote.MenuItem
-
-/**
- * create the context menu
- * @type {Electron.Menu}
- */
-const contextMenu = new Menu()
-let pasteItem, copyItem, copyLinkItem: MenuItem
+let requestId = 0
 let hoverUrl: string = "" // for the link popup
-let urlToCopy: string = "" // for the context menu
+let linkToolTip = null
 
+ipcRenderer
+	.on('set-zoom-factor', setZoomFactor)
+	.once('initialize-ipc', initializeIPC)
 
-// copy function
-function copy(copyLink: boolean) {
-	if (copyLink && !!urlToCopy) {
-		clipboard.writeText(urlToCopy)
-	} else if (!copyLink) {
-		document.execCommand('copy')
-	}
-}
+function initializeIPC(e, params) {
+	const [version, windowId] = params
 
-function setupContextMenu() {
-	pasteItem = new MenuItem({label: lang.get("paste_action"), accelerator: "CmdOrCtrl+V", click() { document.execCommand('paste') }})
-	copyItem = new MenuItem({label: lang.get("copy_action"), accelerator: "CmdOrCtrl+C", click: () => copy(false)})
-	copyLinkItem = new MenuItem({label: lang.get("copyLink_action"), click: () => copy(true)})
-	contextMenu.append(copyItem)
-	contextMenu.append(copyLinkItem)
-	contextMenu.append(new MenuItem({label: lang.get("cut_action"), accelerator: "CmdOrCtrl+X", click() { document.execCommand('cut') }}))
-	contextMenu.append(pasteItem)
-	contextMenu.append(new MenuItem({type: 'separator'}))
-	contextMenu.append(new MenuItem({label: lang.get("undo_action"), accelerator: "CmdOrCtrl+Z", click() { document.execCommand('undo') }}))
-	contextMenu.append(new MenuItem({
-		label: lang.get("redo_action"),
-		accelerator: "CmdOrCtrl+Shift+Z",
-		click() { document.execCommand('redo') }
-	}))
-
-	ipcRenderer.on('open-context-menu', (e, params) => {
-		console.log(params[0])
-		const linkURL = params[0].linkURL
-		copyLinkItem.enabled = !!linkURL
-		pasteItem.enabled = clipboard.readText().length > 0
-		copyItem.enabled = window.getSelection().toString().length > 0
-		urlToCopy = linkURL
-		contextMenu.popup({window: remote.getCurrentWindow()})
+	ipcRenderer.on(`${windowId}`, (ev, msg) => {
+		window.tutao.nativeApp.handleMessageObject(msg)
 	})
+
+	window.nativeApp = {
+		invoke: (msg: string) => ipcRenderer.send(`${windowId}`, msg),
+		getVersion: () => version
+	}
 }
 
 function setZoomFactor(ev, newFactor) {
 	webFrame.setZoomFactor(newFactor)
 }
 
-ipcRenderer
-	.on(`${remote.getCurrentWindow().id}`, (ev, msg) => {
-		window.tutao.nativeApp.handleMessageObject(msg)
-	})
-	.on('setup-context-menu', setupContextMenu)
-	.on('set-zoom-factor', setZoomFactor)
+// for completeness - atm the preload requests never expect a response
+function createRequestId() {
+	if (requestId >= Number.MAX_SAFE_INTEGER) {
+		requestId = 0
+	}
+	return "preload" + requestId++
+}
 
 // href URL reveal
-let linkToolTip
 window.addEventListener('mouseover', (e) => {
 	// if there are nested elements like <strong/> in the link element,
 	// we may not get a mouseover or mouseout for the actual <a/>, so
@@ -108,7 +71,11 @@ window.addEventListener('mouseup', e => {
 	* not search the next result for enter key events (otherwise we couldn't type newlines while the overlay is open)
 	*/
 	if (e.target.id === "search-overlay-input") return
-	window.tutao.nativeApp.invokeNative(new PreloadImports.Request("setSearchOverlayState", [false, true]))
+	window.tutao.nativeApp.invokeNative({
+		type: "setSearchOverlayState",
+		id: createRequestId(),
+		args: [false, true]
+	})
 })
 
 // needed to help the MacOs client to distinguish between Cmd+Arrow to navigate the history
@@ -139,14 +106,18 @@ window.onmousewheel = (e) => {
 // window.focus() doesn't seem to be working right now, so we're replacing it
 // https://github.com/electron/electron/issues/8969#issuecomment-288024536
 window.focus = () => {
-	window.tutao.nativeApp.invokeNative(new PreloadImports.Request('showWindow', []))
-}
-
-window.nativeApp = {
-	invoke: (msg: string) => ipcRenderer.send(`${remote.getCurrentWindow().id}`, msg),
-	getVersion: () => app.getVersion()
+	window.tutao.nativeApp.invokeNative({
+		type: 'showWindow',
+		id: createRequestId(),
+		args: []
+	})
 }
 
 window.addEventListener("beforeunload", () =>
-	// There's no good way to detect reload using Electron APIs so we have to resort to DOM events
-	window.tutao && window.tutao.nativeApp && window.tutao.nativeApp.invokeNative({type: "unload", args: []}))
+		// There's no good way to detect reload using Electron APIs so we have to resort to DOM events
+	window.tutao && window.tutao.nativeApp && window.tutao.nativeApp.invokeNative({
+		type: "unload",
+		id: createRequestId(),
+		args: []
+	})
+)

--- a/src/gui/main-styles.js
+++ b/src/gui/main-styles.js
@@ -38,6 +38,7 @@ styles.registerStyle('main', () => {
 		"#link-tt.reveal": isDesktop() ? {
 			"opacity": 1,
 			"transition": "opacity .1s linear",
+			"z-index": 100,
 		} : {},
 
 		"*:not(input):not(textarea)": isAdminClient() ? {} : {

--- a/test/client/desktop/DesktopWindowManagerTest.js
+++ b/test/client/desktop/DesktopWindowManagerTest.js
@@ -14,7 +14,7 @@ o.spec("Desktop Window Manager Test", () => {
 	const electron = {
 		app: {
 			callbacks: [],
-			once: function (ev: string, cb: ()=>void) {
+			once: function (ev: string, cb: () => void) {
 				this.callbacks[ev] = cb
 				return n.spyify(electron.app)
 			},
@@ -46,11 +46,11 @@ o.spec("Desktop Window Manager Test", () => {
 				openMailbox: function (info: UserInfo, path: string) {
 
 				},
-				on: function (ev: string, cb: ()=>void) {
+				on: function (ev: string, cb: () => void) {
 					this.callbacks[ev] = cb
 					return this
 				},
-				once: function (ev: string, cb: ()=>void) {
+				once: function (ev: string, cb: () => void) {
 					this.callbacks[ev] = cb
 					return this
 				},
@@ -92,7 +92,8 @@ o.spec("Desktop Window Manager Test", () => {
 					return Promise.resolve()
 				},
 				showInactive: function () {
-				}
+				},
+				setContextMenuHandler: function(){}
 			},
 			statics: {
 				lastId: 0
@@ -103,7 +104,7 @@ o.spec("Desktop Window Manager Test", () => {
 	const dl = {}
 
 	const conf = {
-		removeListener: (key: string, cb: ()=>void) => n.spyify(conf),
+		removeListener: (key: string, cb: () => void) => n.spyify(conf),
 		on: (key: string) => n.spyify(conf),
 		getDesktopConfig: (key: string) => {
 			switch (key) {
@@ -153,23 +154,31 @@ o.spec("Desktop Window Manager Test", () => {
 
 	const ipc = {}
 
+	const contextMenu = {
+		DesktopContextMenu: n.classify({
+			prototype: {},
+			statics: {}
+		})
+	}
+
 	const standardMocks = () => {
 		const electronMock = n.mock('electron', electron).set()
 		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
 		const dlMock = n.mock("__dl", dl).set()
-		const confMock = n.mock("__conf", conf).set()
 		const desktopTrayMock = n.mock("./tray/DesktopTray", desktopTray).set()
-		const notifierMock = n.mock("__notifier", notifier).set()
-		const ipcMock = n.mock("__ipc", ipc).set()
-
+		const confMock = n.mock('__conf', conf).set()
+		const notifierMock = n.mock('__notifier', notifier).set()
+		const ipcMock = n.mock('__ipc', ipc).set()
+		const contextMenuMock = n.mock("./DesktopContextMenu", contextMenu).set()
 		return {
 			electronMock,
 			applicationWindowMock,
 			dlMock,
-			confMock,
 			desktopTrayMock,
+			confMock,
 			notifierMock,
 			ipcMock,
+			contextMenuMock
 		}
 	}
 
@@ -191,7 +200,6 @@ o.spec("Desktop Window Manager Test", () => {
 	})
 
 	o("create one window with showWhenReady=false, no lastBounds", () => {
-		// node modules
 		const {
 			applicationWindowMock,
 			dlMock,
@@ -221,6 +229,7 @@ o.spec("Desktop Window Manager Test", () => {
 		o(win.center.callCount).equals(1)
 		o(win.setBounds.callCount).equals(0)
 		o(win.show.callCount).equals(0)
+		o(win.setContextMenuHandler.callCount).equals(1)
 		o(applicationWindowMock.ApplicationWindow.args).deepEquals([
 			wm, "/app/path/src/desktop/preload.js", "/app/path/desktop.html", undefined
 		])
@@ -236,6 +245,7 @@ o.spec("Desktop Window Manager Test", () => {
 			ipcMock
 		} = standardMocks()
 
+		// instances
 		const testBounds = {rect: {height: 10, width: 10, x: 10, y: 10}, fullscreen: false, scale: 1}
 		const confMock = n.mock('__conf', conf)
 		                  .with({
@@ -249,6 +259,7 @@ o.spec("Desktop Window Manager Test", () => {
 			                  }
 		                  })
 		                  .set()
+
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)
@@ -286,9 +297,9 @@ o.spec("Desktop Window Manager Test", () => {
 			applicationWindowMock,
 			dlMock,
 			confMock,
+			desktopTrayMock,
 			notifierMock,
-			ipcMock,
-			desktopTrayMock
+			ipcMock
 		} = standardMocks()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')


### PR DESCRIPTION
also close #1620 since the new ipc api is essentially what we're doing, only not fully bidirectional.