### PR TITLE
Add Saturday to week start options - Fix #1941

### DIFF
--- a/src/api/common/TutanotaConstants.js
+++ b/src/api/common/TutanotaConstants.js
@@ -456,6 +456,7 @@ export type TimeFormatEnum = $Values<typeof TimeFormat>
 export const WeekStart = Object.freeze({
 	MONDAY: '0',
 	SUNDAY: '1',
+	SATURDAY: '2'
 })
 
 export function getWeekStart(userSettings: UserSettingsGroupRoot): WeekStartEnum {

--- a/src/calendar/CalendarUtils.js
+++ b/src/calendar/CalendarUtils.js
@@ -202,10 +202,10 @@ export type CalendarMonth = {
 
 /**
  * @param date
- * @param firstDayOfWeekFromSundayOffset
+ * @param firstDayOfWeekFromOffset
  * @return {{weeks: Array[], weekdays: Array}}
  */
-export function getCalendarMonth(date: Date, firstDayOfWeekFromSundayOffset: number, weekdayNarrowFormat: boolean): CalendarMonth {
+export function getCalendarMonth(date: Date, firstDayOfWeekFromOffset: number, weekdayNarrowFormat: boolean): CalendarMonth {
 	const weeks = [[]]
 	const calculationDate = getStartOfDay(date)
 	calculationDate.setDate(1)
@@ -215,10 +215,10 @@ export function getCalendarMonth(date: Date, firstDayOfWeekFromSundayOffset: num
 	// getDay returns the day of the week (from 0 to 6) for the specified date (with first one being Sunday)
 
 	let firstDay
-	if (firstDayOfWeekFromSundayOffset > calculationDate.getDay()) {
-		firstDay = (calculationDate.getDay() + 7) - firstDayOfWeekFromSundayOffset
+	if (firstDayOfWeekFromOffset > calculationDate.getDay()) {
+		firstDay = (calculationDate.getDay() + 7) - firstDayOfWeekFromOffset
 	} else {
-		firstDay = calculationDate.getDay() - firstDayOfWeekFromSundayOffset
+		firstDay = calculationDate.getDay() - firstDayOfWeekFromOffset
 	}
 
 	let dayCount
@@ -269,7 +269,7 @@ export function getCalendarMonth(date: Date, firstDayOfWeekFromSundayOffset: num
 	}
 	const weekdays = []
 	const weekdaysDate = new Date()
-	incrementDate(weekdaysDate, -weekdaysDate.getDay() + firstDayOfWeekFromSundayOffset)// get first day of week
+	incrementDate(weekdaysDate, -weekdaysDate.getDay() + firstDayOfWeekFromOffset)// get first day of week
 	for (let i = 0; i < 7; i++) {
 		weekdays.push(weekdayNarrowFormat ? lang.formats.weekdayNarrow.format(weekdaysDate) : lang.formats.weekdayShort.format(weekdaysDate))
 		incrementDate(weekdaysDate, 1)
@@ -414,12 +414,12 @@ export function getEventColor(event: CalendarEvent, groupColors: {[Id]: string})
 	return groupColors[neverNull(event._ownerGroup)] || defaultCalendarColor
 }
 
-export function getStartOfWeek(date: Date, firstDayOfWeekFromSundayOffset: number): Date {
+export function getStartOfWeek(date: Date, firstDayOfWeekFromOffset: number): Date {
 	let firstDay
-	if (firstDayOfWeekFromSundayOffset > date.getDay()) {
-		firstDay = (date.getDay() + 7) - firstDayOfWeekFromSundayOffset
+	if (firstDayOfWeekFromOffset > date.getDay()) {
+		firstDay = (date.getDay() + 7) - firstDayOfWeekFromOffset
 	} else {
-		firstDay = date.getDay() - firstDayOfWeekFromSundayOffset
+		firstDay = date.getDay() - firstDayOfWeekFromOffset
 	}
 	return incrementDate(getStartOfDay(date), -firstDay)
 }
@@ -438,6 +438,8 @@ export function getStartOfTheWeekOffset(weekStart: WeekStartEnum): number {
 	switch (weekStart) {
 		case WeekStart.SUNDAY:
 			return 0
+		case WeekStart.SATURDAY:
+			return 6
 		case WeekStart.MONDAY:
 		default:
 			return 1

--- a/src/settings/AppearanceSettingsViewer.js
+++ b/src/settings/AppearanceSettingsViewer.js
@@ -60,14 +60,17 @@ export class AppearanceSettingsViewer implements UpdatableSettingsViewer {
 
 		const weekdayFormat = new Intl.DateTimeFormat(lang.languageTag, {weekday: "long"})
 		const calcDate = new Date()
-		incrementDate(calcDate, -calcDate.getDay()) // Sunday
-		const sundayName = weekdayFormat.format(calcDate)
-		incrementDate(calcDate, 1) // Monday
-		const mondayName = weekdayFormat.format(calcDate)
+		const sundayName = weekdayFormat.format(incrementDate(calcDate, -calcDate.getDay())) // Sunday as reference
+		const mondayName = weekdayFormat.format(incrementDate(calcDate, 1)) // Monday is one day later
+		const saturdayName = weekdayFormat.format(incrementDate(calcDate, 5)) // Saturday is five days later
 
 		const weekStartDropDownAttrs: DropDownSelectorAttrs<WeekStartEnum> = {
 			label: "weekStart_label",
-			items: [{name: mondayName, value: WeekStart.MONDAY}, {name: sundayName, value: WeekStart.SUNDAY}],
+			items: [
+				{name: mondayName, value: WeekStart.MONDAY}, 
+				{name: saturdayName, value: WeekStart.SATURDAY}, 
+				{name: sundayName, value: WeekStart.SUNDAY}
+			],
 			selectedValue: stream(downcast(userSettingsGroupRoot.startOfTheWeek)),
 			selectionChangedHandler: (value) => {
 				userSettingsGroupRoot.startOfTheWeek = value


### PR DESCRIPTION
- add the ability to display calendar with Saturday being the first day of the week
- rename firstDayOfWeekFromSundayOffset to firstDayOfWeekFromOffset for clarity as Saturday can be an offset
- add Saturday as an option in the Appearance Settings
- add comment to clarify how names of the days are generated