### PR TITLE
[desktop] clear dock badge on each window focus, close #1971

### DIFF
--- a/flow/electron.js
+++ b/flow/electron.js
@@ -371,6 +371,7 @@ declare module 'electron' {
 		constructor(any): BrowserWindow;
 		on(BrowserWindowEvent, (Event, ...Array<any>) => void): BrowserWindow;
 		once(BrowserWindowEvent, (Event, ...Array<any>) => void): BrowserWindow;
+		emit(BrowserWindowEvent): void;
 		focus(): void;
 		hide(): void;
 		close(): void;
@@ -649,6 +650,7 @@ export type BrowserWindowEvent
 	| 'sheet-begin'
 	| 'sheet-end'
 	| 'new-window-for-tab'
+	| 'did-start-navigation' // passed through from webContents
 
 // https://github.com/electron/electron/blob/master/docs/api/web-contents.md#instance-events
 export type WebContentsEvent

--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -152,6 +152,7 @@ export class ApplicationWindow {
 		    })
 		    .on('will-attach-webview', e => e.preventDefault())
 		    .on('did-start-navigation', (e, url, isInPlace) => {
+		    	this._browserWindow.emit('did-start-navigation')
 			    const newURL = this._rewriteURL(url, isInPlace)
 			    if (newURL !== url) {
 				    e.preventDefault()

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -54,6 +54,7 @@ export class WindowManager {
 		}).on('focus', ev => {
 			windows.splice(windows.indexOf(w), 1)
 			windows.push(w)
+			this._tray.clearBadge()
 			this._notifier.resolveGroupedNotification(w.getUserId())
 		}).on('page-title-updated', ev => {
 			if (w.getTitle() === LOGIN_TITLE) {

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -56,6 +56,8 @@ export class WindowManager {
 			windows.push(w)
 			this._tray.clearBadge()
 			this._notifier.resolveGroupedNotification(w.getUserId())
+		}).on('did-start-navigation', ()=>{
+			this._tray.clearBadge()
 		}).on('page-title-updated', ev => {
 			if (w.getTitle() === LOGIN_TITLE) {
 				w.setUserInfo(null)

--- a/test/client/desktop/ApplicationWindowTest.js
+++ b/test/client/desktop/ApplicationWindowTest.js
@@ -33,6 +33,9 @@ o.spec("ApplicationWindow Test", function () {
 					this.callbacks[ev] = cb
 					return this
 				},
+				emit: function (ev: string) {
+					this.callbacks[ev]()
+				},
 				constructor: function (opts) {
 					this.opts = opts
 					this.id = electron.BrowserWindow.lastId
@@ -493,10 +496,13 @@ o.spec("ApplicationWindow Test", function () {
 
 		const {ApplicationWindow} = n.subject('../../src/desktop/ApplicationWindow.js')
 		const w = new ApplicationWindow(wmMock, 'preloadjs', 'desktophtml')
+		w.on('did-start-navigation', ()=>{})
 		const bwInstance = electronMock.BrowserWindow.mockedInstances[0]
 
 		const e = {preventDefault: o.spy()}
 		bwInstance.webContents.callbacks['did-start-navigation'](e, "evil.com", true)
+		o(bwInstance.emit.callCount).equals(1)
+		o(bwInstance.emit.args).deepEquals(["did-start-navigation"])
 		o(e.preventDefault.callCount).equals(1)
 		o(bwInstance.loadURL.callCount).equals(2) // initial + navigation
 		o(bwInstance.loadURL.args[0]).equals("desktophtml")

--- a/test/client/desktop/DesktopWindowManagerTest.js
+++ b/test/client/desktop/DesktopWindowManagerTest.js
@@ -147,25 +147,41 @@ o.spec("Desktop Window Manager Test", () => {
 		DesktopTray: {
 			getIcon: () => "this is a static icon"
 		},
-		update: () => {}
+		update: () => {},
+		clearBadge: ()=>{}
 	}
 
 	const ipc = {}
 
-	o("construction", () => {
-		// node modules
-		const electronMock = n.mock("electron", electron).set()
-
-		// our modules
+	const standardMocks = () => {
+		const electronMock = n.mock('electron', electron).set()
 		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
 		const dlMock = n.mock("__dl", dl).set()
-		n.mock("./tray/DesktopTray", desktopTray).set()
+		const confMock = n.mock("__conf", conf).set()
+		const desktopTrayMock = n.mock("./tray/DesktopTray", desktopTray).set()
+		const notifierMock = n.mock("__notifier", notifier).set()
+		const ipcMock = n.mock("__ipc", ipc).set()
 
-		// instances
-		const confMock = n.mock('__conf', conf).set()
-		const desktopTrayMock = n.mock('__tray', {getIcon: () => "this is an icon"}).set()
-		const notifierMock = n.mock('__notifier', notifier).set()
-		const ipcMock = n.mock('__ipc', ipc).set()
+		return {
+			electronMock,
+			applicationWindowMock,
+			dlMock,
+			confMock,
+			desktopTrayMock,
+			notifierMock,
+			ipcMock,
+		}
+	}
+
+	o("construction", () => {
+		const {
+			applicationWindowMock,
+			dlMock,
+			confMock,
+			desktopTrayMock,
+			notifierMock,
+			ipcMock
+		} = standardMocks()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)
@@ -176,18 +192,14 @@ o.spec("Desktop Window Manager Test", () => {
 
 	o("create one window with showWhenReady=false, no lastBounds", () => {
 		// node modules
-		const electronMock = n.mock("electron", electron).set()
-
-		// our modules
-		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
-		const dlMock = n.mock("__dl", dl).set()
-		n.mock("./tray/DesktopTray", desktopTray).set()
-
-		// instances
-		const confMock = n.mock('__conf', conf).set()
-		const desktopTrayMock = n.mock('__tray', desktopTray).set()
-		const notifierMock = n.mock('__notifier', notifier).set()
-		const ipcMock = n.mock('__ipc', ipc).set()
+		const {
+			applicationWindowMock,
+			dlMock,
+			confMock,
+			desktopTrayMock,
+			notifierMock,
+			ipcMock
+		} = standardMocks()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)
@@ -208,15 +220,14 @@ o.spec("Desktop Window Manager Test", () => {
 	})
 
 	o("create one window with showWhenReady=true, with lastBounds", () => {
-		// node modules
-		const electronMock = n.mock("electron", electron).set()
+		const {
+			applicationWindowMock,
+			dlMock,
+			desktopTrayMock,
+			notifierMock,
+			ipcMock
+		} = standardMocks()
 
-		// our modules
-		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
-		const dlMock = n.mock("__dl", dl).set()
-		n.mock("./tray/DesktopTray", desktopTray).set()
-
-		// instances
 		const testBounds = {rect: {height: 10, width: 10, x: 10, y: 10}, fullscreen: false, scale: 1}
 		const confMock = n.mock('__conf', conf)
 		                  .with({
@@ -230,12 +241,6 @@ o.spec("Desktop Window Manager Test", () => {
 			                  }
 		                  })
 		                  .set()
-		const desktopTrayMock = n.mock('__tray', {
-			getIcon: () => "this is an icon", update: () => {
-			}
-		}).set()
-		const notifierMock = n.mock('__notifier', notifier).set()
-		const ipcMock = n.mock('__ipc', ipc).set()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)
@@ -254,28 +259,21 @@ o.spec("Desktop Window Manager Test", () => {
 		o(win.setBounds.args).deepEquals([testBounds])
 		o(win.setZoomFactor.callCount).equals(0)
 		o(win.show.callCount).equals(1)
+		o(desktopTrayMock.clearBadge.callCount).equals(1)
 		o(wm.get(1)).equals(win)
 
 		o(desktopTrayMock.update.callCount).equals(1)
 	})
 
 	o("create window with noAutoLogin", () => {
-		// node modules
-		const electronMock = n.mock("electron", electron).set()
-
-		// our modules
-		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
-		const dlMock = n.mock("__dl", dl).set()
-		n.mock("./tray/DesktopTray", desktopTray).set()
-
-		// instances
-		const confMock = n.mock('__conf', conf).set()
-		const desktopTrayMock = n.mock('__tray', {
-			getIcon: () => "this is an icon", update: () => {
-			}
-		}).set()
-		const notifierMock = n.mock('__notifier', notifier).set()
-		const ipcMock = n.mock('__ipc', ipc).set()
+		const {
+			applicationWindowMock,
+			dlMock,
+			confMock,
+			notifierMock,
+			ipcMock,
+			desktopTrayMock
+		} = standardMocks()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)
@@ -295,22 +293,13 @@ o.spec("Desktop Window Manager Test", () => {
 	})
 
 	o("getLastFocused returns the last focused window", () => {
-		// node modules
-		const electronMock = n.mock("electron", electron).set()
-
-		// our modules
-		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
-		const dlMock = n.mock("__dl", dl).set()
-		n.mock("./tray/DesktopTray", desktopTray).set()
-
-		// instances
-		const confMock = n.mock('__conf', conf).set()
-		const desktopTrayMock = n.mock('__tray', {
-			getIcon: () => "this is an icon", update: () => {
-			}
-		}).set()
-		const notifierMock = n.mock('__notifier', notifier).set()
-		const ipcMock = n.mock('__ipc', ipc).set()
+		const {
+			dlMock,
+			confMock,
+			desktopTrayMock,
+			notifierMock,
+			ipcMock
+		} = standardMocks()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)
@@ -337,22 +326,13 @@ o.spec("Desktop Window Manager Test", () => {
 	})
 
 	o("wm is saving bounds to file when closing window", () => {
-		// node modules
-		const electronMock = n.mock("electron", electron).set()
-
-		// our modules
-		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
-		const dlMock = n.mock("__dl", dl).set()
-		n.mock("./tray/DesktopTray", desktopTray).set()
-
-		// instances
-		const confMock = n.mock('__conf', conf).set()
-		const desktopTrayMock = n.mock('__tray', {
-			getIcon: () => "this is an icon", update: () => {
-			}
-		}).set()
-		const notifierMock = n.mock('__notifier', notifier).set()
-		const ipcMock = n.mock('__ipc', ipc).set()
+		const {
+			dlMock,
+			confMock,
+			desktopTrayMock,
+			notifierMock,
+			ipcMock
+		} = standardMocks()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)
@@ -371,20 +351,15 @@ o.spec("Desktop Window Manager Test", () => {
 	})
 
 	o("hide() hides all windows", () => {
-		// node modules
-		const electronMock = n.mock("electron", electron).set()
-
-		// our modules
-		const applicationWindowMock = n.mock("./ApplicationWindow", applicationWindow).set()
-		n.mock("__dl", dl).set()
-		n.mock("./tray/DesktopTray", desktopTray).set()
-
-		// instances
-		const confMock = n.mock('__conf', conf).set()
-		const desktopTrayMock = n.mock('__tray', desktopTray).set()
-		const notifierMock = n.mock('__notifier', notifier).set()
-		const ipcMock = n.mock('__ipc', ipc).set()
-		const dlMock = n.mock("__dl", dl).set()
+		const {
+			electronMock,
+			applicationWindowMock,
+			dlMock,
+			confMock,
+			desktopTrayMock,
+			notifierMock,
+			ipcMock
+		} = standardMocks()
 
 		const {WindowManager} = n.subject('../../src/desktop/DesktopWindowManager.js')
 		const wm = new WindowManager(confMock, desktopTrayMock, notifierMock, dlMock)

--- a/test/client/desktop/DesktopWindowManagerTest.js
+++ b/test/client/desktop/DesktopWindowManagerTest.js
@@ -209,6 +209,14 @@ o.spec("Desktop Window Manager Test", () => {
 
 		o(applicationWindowMock.ApplicationWindow.mockedInstances.length).equals(1)
 		const win = applicationWindowMock.ApplicationWindow.mockedInstances[0]
+		o(Object.keys(win.callbacks)).deepEquals([
+			'close',
+			'closed',
+			'focus',
+			'did-start-navigation',
+			'page-title-updated',
+			'ready-to-show'
+			])
 		win.callbacks["ready-to-show"]()
 		o(win.center.callCount).equals(1)
 		o(win.setBounds.callCount).equals(0)
@@ -253,6 +261,14 @@ o.spec("Desktop Window Manager Test", () => {
 			wm, "/app/path/src/desktop/preload.js", "/app/path/desktop.html", undefined
 		])
 		const win = applicationWindowMock.ApplicationWindow.mockedInstances[0]
+		o(Object.keys(win.callbacks)).deepEquals([
+			'close',
+			'closed',
+			'focus',
+			'did-start-navigation',
+			'page-title-updated',
+			'ready-to-show'
+		])
 		win.callbacks["ready-to-show"]()
 		o(win.center.callCount).equals(0)
 		o(win.setBounds.callCount).equals(1)


### PR DESCRIPTION
this fix will clear the dock icon badge on mac when **any**
window is focused (including newly created), in addition to
the "activate" callback that's already on the app object
(see DesktopMain.js).