### PR TITLE
Sort default sender list alphabetically - fix tutao/tutanota#2017

### DIFF
--- a/src/settings/MailSettingsViewer.js
+++ b/src/settings/MailSettingsViewer.js
@@ -73,6 +73,7 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 		const defaultSenderAttrs: DropDownSelectorAttrs<string> = {
 			label: "defaultSenderMailAddress_label",
 			items: getEnabledMailAddressesForGroupInfo(logins.getUserController().userGroupInfo)
+				.sort()
 				.map(a => {
 					return {name: a, value: a}
 				}),


### PR DESCRIPTION
Tested:

1. Send an email using the default sender X from Tutanota account A to Tutanota account B
2. Verify in account B that it was received and showing the correct default address X of account A
3. Change the default sender of account A now in "Settings/Email/Sending addresses/Default sender" to email address Y
4. Send a 2nd email using the new default sender Y from account A to account B
5. Verify in account B that the email was received and is showing the new default address Y of acccount A