### PR TITLE
Fix late U2F error dialog shown after login was accepted

### DIFF
--- a/src/login/SecondFactorHandler.js
+++ b/src/login/SecondFactorHandler.js
@@ -215,8 +215,8 @@ export class SecondFactorHandler {
 								&& this._waitingForSecondFactorDialog.visible) {
 								Dialog.error("u2fUnexpectedError_msg")
 								this.closeWaitingForSecondFactorDialog()
-							}
-							if (e instanceof U2fWrongDeviceError) {
+							} else if (e instanceof U2fWrongDeviceError && this._waitingForSecondFactorDialog
+								&& this._waitingForSecondFactorDialog.visible) {
 								Dialog.error("u2fAuthUnregisteredDevice_msg")
 							} else if (e instanceof NotAuthenticatedError) {
 								Dialog.error("loginFailed_msg")


### PR DESCRIPTION
 fix #1792

We fixed this issue before for Firefox in 0edfcf3 but turns out that
Firefox and Chrome return different error codes on timeout: Firefox 1
(OTHER_ERROR), Chrome 4 (DEVICE_INELIGIBLE) and neither is really
correct as it should be 5 (TIMEOUT). This commit also silences
DEVICE_INELIGIBLE if the dialog is already hidden.