### PR TITLE
Battery optimization due excesive wakelock

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
@@ -72,7 +72,8 @@ public final class PushNotificationService extends LifecycleJobService {
 			public void onConnectionEstablished() {
 				removeBackgroundServiceNotification();
 				// After establishing connection we finish in some time.
-				scheduleJobFinish();
+				// Wakelock is not needed
+				//scheduleJobFinish();
 			}
 
 			@Override
@@ -133,7 +134,7 @@ public final class PushNotificationService extends LifecycleJobService {
 	public boolean onStartJob(JobParameters params) {
 		Log.d(TAG, "onStartJob");
 		jobParameters = params;
-		return true;
+		return false; // Wakelock is not needed
 	}
 
 	@Override


### PR DESCRIPTION
The JobService wakelock is not letting the device going into deep sleep. Also it's not needed since Doze exclusion are being used too by the app. See #2025 for Wakelock Detector screenshot