### PR TITLE
Remove 'forward' option from more menu (fixes #2039)

### DIFF
--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -568,12 +568,6 @@ export class MailViewer {
 							type: ButtonType.Dropdown,
 						})
 					}
-					moreButtons.push({
-						label: "forward_action",
-						click: () => this._forward(),
-						icon: () => Icons.Forward,
-						type: ButtonType.Dropdown,
-					})
 					if (!this._isAnnouncement() && !client.isMobileDevice() && !logins.isEnabled(FeatureType.DisableMailExport)) {
 						moreButtons.push({
 							label: "export_action",


### PR DESCRIPTION
I'm assuming the desired fix was to only have `forward` with the main actions.

It seems that in the past the `forward` action was placed in the `more` menu for mobile users only: https://github.com/tutao/tutanota/blob/c93358398f6411be130d82368aa4d6083df964cb/src/mail/MailViewer.js#L501-L508

 I had a quick look, and it seems that `actionButtons` is only ever called with `false` these days, so is it safe to say that the argument and check can be removed now? 

fix #2039 