### PR TITLE
Allow word wrap for headers dialog

### DIFF
--- a/src/gui/main-styles.js
+++ b/src/gui/main-styles.js
@@ -158,6 +158,10 @@ styles.registerStyle('main', () => {
 		".border": {border: `1px solid ${theme.content_border}`},
 
 		".white-space-pre": {'white-space': "pre"},
+		".white-space-pre-wrap-break-word": {
+			'white-space': "pre-wrap",
+			'word-break': 'break-word'
+		},
 
 		// margins
 		'.m-0': {margin: 0},

--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -200,7 +200,7 @@ export class MailViewer {
 		this.mailHeaderInfo = ""
 		this.mailHeaderDialog = Dialog.largeDialog(headerBarAttrs, {
 			view: () => {
-				return m(".white-space-pre.pt.pb.selectable", this.mailHeaderInfo)
+				return m(".white-space-pre-wrap-break-word.pt.pb.selectable", this.mailHeaderInfo)
 			}
 		}).addShortcut({
 			key: Keys.ESC,


### PR DESCRIPTION
Viewing the header dialog on a mobile device can be painful with side-to-side scrolling. This makes the display for headers in the dialog word break, so there is no side-to-side scrolling.