### PR TITLE
Remove alternating background colors on email list

### DIFF
--- a/src/gui/base/List.js
+++ b/src/gui/base/List.js
@@ -185,7 +185,7 @@ export class List<T: ListElement, R:VirtualRow<T>> {
 									width: px(this._width),
 								}
 							}, this._config.swipe.renderRightSpacer()),
-							m("ul.list.list-alternate-background.fill-absolute.click", {
+							m("ul.list.fill-absolute.click", {
 									oncreate: (vnode) => this._setDomList(vnode.dom),
 									style: {height: this._calculateListHeight()},
 									className: this._config.className
@@ -206,8 +206,8 @@ export class List<T: ListElement, R:VirtualRow<T>> {
 											}, virtualRow.render()
 										)
 									}),
-									// odd-row is switched directly on the dom element when the number of elements changes
-									m("li#spinnerinlist.list-loading.list-row.flex-center.items-center.odd-row", {
+									// No more odd row styling is done here
+									m("li#spinnerinlist.list-loading.list-row.flex-center.items-center", {
 										oncreate: (vnode) => {
 											this._domLoadingRow = vnode.dom
 											this._domLoadingRow.style.display = this._displayingProgress ? '' : 'none'
@@ -762,11 +762,6 @@ export class List<T: ListElement, R:VirtualRow<T>> {
 			this._updateVirtualRow(row, entity, (pos % 2: any))
 
 		}
-		if (this._loadedEntities.length % 2 === 0) {
-			this._domLoadingRow.classList.add("odd-row")
-		} else {
-			this._domLoadingRow.classList.remove("odd-row")
-		}
 
 		log(Cat.debug, "repositioned list")
 		this.updateLater = false
@@ -779,11 +774,6 @@ export class List<T: ListElement, R:VirtualRow<T>> {
 	_updateVirtualRow(row: VirtualRow<T>, entity: ?T, odd: boolean) {
 		row.entity = entity
 		if (row.domElement) {
-			if (odd) {
-				row.domElement.classList.remove('odd-row')
-			} else {
-				row.domElement.classList.add('odd-row')
-			}
 			if (entity) {
 				row.domElement.style.display = 'list-item'
 				row.update(entity, this.isEntitySelected(getLetId(entity)[1]))
@@ -1148,4 +1138,3 @@ class ListSwipeHandler<T: ListElement, R:VirtualRow<T>> extends SwipeHandler {
 		return Promise.resolve()
 	}
 }
-

--- a/src/gui/main-styles.js
+++ b/src/gui/main-styles.js
@@ -678,20 +678,15 @@ styles.registerStyle('main', () => {
 			padding: 0,
 			'border-bottom': `1px solid ${theme.list_border}`
 		},
-		'.list-alternate-background': {
-			'background': `repeating-linear-gradient(to bottom, ${theme.list_bg}, ${theme.list_bg} ${px(size.list_row_height)},  ${theme.list_alternate_bg} ${px(size.list_row_height)}, ${theme.list_alternate_bg} ${px(size.list_row_height
-				* 2)})`
-		},
 		'.list-row': {
 			position: 'absolute', left: 0, right: 0,
-			'background-color': theme.list_alternate_bg,
+			'background-color': theme.list_bg,
 			height: px(size.list_row_height),
-			'border-left': px(size.border_selection) + " solid transparent"
+			'border-left': px(size.border_selection) + " solid transparent",
+			'border-bottom': `1px solid ${theme.list_border}`,
+			'border-top': `1px solid ${theme.list_border}`
 		},
 		'.list-row > div': {'margin-left': px(-size.border_selection)},
-		'.odd-row': {
-			'background-color': theme.list_bg,
-		},
 		'.list-loading': {bottom: 0},
 
 		// mail list


### PR DESCRIPTION
As mentioned on this [reddit thread](https://www.reddit.com/r/tutanota/comments/gkiyq9/unread_emails/), I'm submitting this PR that removes the alternating background from the list of emails. I'll admit this is far from perfect and can be further improved on, but here we have it.

- Adds a bottom and top border to each list item of 1px, and is colored based on selected/not selected.
- Removed now unused styles and everywhere that added odd-line styling