### PR TITLE
[desktop] write logs to disk on process exit, close #2061

### DIFF
--- a/src/desktop/DesktopMain.js
+++ b/src/desktop/DesktopMain.js
@@ -50,8 +50,7 @@ wm.setIPC(ipc)
 PreloadImports.keep(sock)
 app.setAppUserModelId(conf.get("appUserModelId"))
 app.allowRendererProcessReuse = false
-console.log("argv: ", process.argv)
-console.log("version:  ", app.getVersion())
+ßconsole.log("version:  ", app.getVersion())
 
 let wasAutolaunched = process.platform !== 'darwin'
 	? process.argv.indexOf("-a") !== -1
@@ -78,7 +77,6 @@ if (process.argv.indexOf("-r") !== -1) {
 				if (overridden) {
 					app.quit()
 				} else {
-					console.log("2nd instance args:", args)
 					if (wm.getAll().length === 0) {
 						wm.newWindow(true)
 					} else {

--- a/src/desktop/DesktopMonkeyPatch.js
+++ b/src/desktop/DesktopMonkeyPatch.js
@@ -4,7 +4,7 @@ import fs from 'fs-extra'
 import path from 'path'
 import {app} from 'electron'
 import {execSync} from 'child_process'
-import {last} from '../../src/api/common/utils/ArrayUtils'
+import {last} from '../api/common/utils/ArrayUtils'
 import {neverNull} from "../api/common/utils/Utils"
 import {Logger, replaceNativeLogger} from "../api/common/Logger"
 
@@ -15,12 +15,22 @@ process.on('exit', () => {
 	const logFilePath = path.join(logDir, "tutanota_desktop.log")
 	const oldLogFilePath = path.join(logDir, "tutanota_desktop_old.log")
 	const entries = logger.getEntries()
-	fs.mkdirp(logDir)
-	  .then(() => fs.renameSync(logFilePath, oldLogFilePath))
-	  .catch(e => {if (e.code !== "ENOENT") throw e})
-	  .then(() => fs.writeFileSync(logFilePath, entries.join('\n')))
-	  .then(() => console.log("wrote log file to", logFilePath))
-	  .catch(e => console.error("could not write log file: ", e.message))
+
+	fs.mkdirpSync(logDir)
+
+	try {
+		fs.renameSync(logFilePath, oldLogFilePath)
+	} catch (e) {
+		// If the old log was not found, ignore it
+		if (e.code !== "ENOENT") {
+			console.error("could not rename old log file: ", e.message)
+		}
+	}
+	try {
+		fs.writeFileSync(logFilePath, entries.join('\n'))
+	} catch (e) {
+		console.error("could not write log file: ", e.message)
+	}
 })
 
 global.env = {rootPathPrefix: "../../", adminTypes: []}

--- a/src/desktop/DesktopUtils.js
+++ b/src/desktop/DesktopUtils.js
@@ -235,7 +235,6 @@ function getLockFilePath() {
  */
 function _writeToDisk(contents: string): string {
 	const filename = DesktopCryptoFacade.randomHexString(12)
-	console.log("Wrote file to ", filename)
 	const filePath = path.join(path.dirname(process.execPath), filename)
 	fs.writeFileSync(filePath, contents, {encoding: 'utf-8', mode: 0o400})
 	return filePath

--- a/src/desktop/sse/DesktopSseClient.js
+++ b/src/desktop/sse/DesktopSseClient.js
@@ -71,7 +71,6 @@ export class DesktopSseClient {
 		INITIAL_CONNECT_TIMEOUT = this._conf.get("initialSseConnectTimeoutInSeconds")
 		MAX_CONNECT_TIMEOUT = this._conf.get("maxSseConnectTimeoutInSeconds")
 		this._connectedSseInfo = conf.getDesktopConfig('pushIdentifier')
-		console.log("_connectedSseInfo", this._connectedSseInfo)
 		this._readTimeoutInSeconds = conf.getDesktopConfig('heartbeatTimeoutInSeconds')
 		if (typeof this._readTimeoutInSeconds !== 'number' || Number.isNaN(this._readTimeoutInSeconds)) {
 			this._readTimeoutInSeconds = 30
@@ -232,7 +231,7 @@ export class DesktopSseClient {
 	 */
 	hasNotificationTTLExpired(): boolean {
 		const lastMissedNotificationCheckTime = this._conf.getDesktopConfig(DesktopConfigKey.lastMissedNotificationCheckTime)
-		console.log({lastMissedNotificationCheckTime})
+		console.log("last missed notification check:", {lastMissedNotificationCheckTime})
 		return lastMissedNotificationCheckTime && (Date.now() - lastMissedNotificationCheckTime) > MISSED_NOTIFICATION_TTL
 	}
 


### PR DESCRIPTION
will write the desktop logs to
app.getPath('userData')+'/logs/' + tutanota_desktop.log
on quit, renaming any old logfile to tutanota_desktop_old.log