### PR TITLE
[desktop] prevent saving of attachments with invalid names, close #2063

### DIFF
--- a/test/client/desktop/DesktopUtilsTest.js
+++ b/test/client/desktop/DesktopUtilsTest.js
@@ -161,6 +161,61 @@ o.spec("nonClobberingFileName Test", function () {
 			'hello.ext',
 		], '')).equals('')
 	})
+
+	o('invalid/reserved filenames', function () {
+		o(DesktopUtils.nonClobberingFilename([], "\x00-\x1f\x80-\x9f.exe"))
+			.equals('_-__-_.exe')
+
+		n.setPlatform("win32")
+		o(DesktopUtils.nonClobberingFilename(["CON-1.exe"], "CON.exe"))
+			.equals('CON-2.exe')
+
+		o(DesktopUtils.nonClobberingFilename([], "."))
+			.equals("_")
+
+		o(DesktopUtils.nonClobberingFilename(["_"], ".."))
+			.equals("_-1")
+
+		o(DesktopUtils.nonClobberingFilename([], "<>|?/\\.mp3"))
+			.equals("______.mp3")
+
+		o(DesktopUtils.nonClobberingFilename([], "CON<>|?/\\CON.mp3"))
+			.equals("CON______CON.mp3")
+
+		o(DesktopUtils.nonClobberingFilename([], "PRN.<p2."))
+			.equals("PRN-1._p2_")
+
+		o(DesktopUtils.nonClobberingFilename([], "LPT0"))
+			.equals("LPT0-1")
+
+		o(DesktopUtils.nonClobberingFilename([], "COM9"))
+			.equals("COM9-1")
+
+		o(DesktopUtils.nonClobberingFilename([], "AUX.AUX"))
+			.equals("AUX-1.AUX")
+
+		o(DesktopUtils.nonClobberingFilename([], "NUL"))
+			.equals("NUL-1")
+
+		o(DesktopUtils.nonClobberingFilename([], "nul"))
+			.equals("nul-1")
+
+		o(DesktopUtils.nonClobberingFilename([], "NULNUL"))
+			.equals("NULNUL")
+
+		o(DesktopUtils.nonClobberingFilename([], ".NUL"))
+			.equals(".NUL")
+
+		o(DesktopUtils.nonClobberingFilename([], "<>|?/\\CON."))
+			.equals("______CON_")
+
+		n.setPlatform("linux")
+		o(DesktopUtils.nonClobberingFilename([], "nul"))
+			.equals("nul")
+
+		o(DesktopUtils.nonClobberingFilename([], ".."))
+			.equals("..-1")
+	})
 })
 
 o.spec("touch test", function () {


### PR DESCRIPTION
checks each attachment file name against a number of regexes, preventing
saving of files with names that
* contain illegal characters (unicode control characters, <>?/\ )
* have trailing periods on windows
* are reserved on the current platform (CON, CON.txt, .., .)

invalid characters are replaced with underscores while reserved names
are treated as if the file with the reserved name already exists in the
target directory, adding a suffix number: CON.txt -> CON-1.txt