### PR TITLE
Remove redundant argument in actionButtons

### DIFF
--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -269,9 +269,9 @@ export class MailViewer {
 											this._isAnnouncement() || !styles.isUsingBottomNavigation() ? null : m(detailsExpander)),
 									]),
 								]),
-								styles.isUsingBottomNavigation() ? null : this.actionButtons(false),
+								styles.isUsingBottomNavigation() ? null : this.actionButtons(),
 							]),
-							styles.isUsingBottomNavigation() ? this.actionButtons(false) : null,
+							styles.isUsingBottomNavigation() ? this.actionButtons() : null,
 							this._suspicious
 								? m(Banner, {
 									type: BannerType.Warning,
@@ -500,7 +500,7 @@ export class MailViewer {
 		}
 	}
 
-	actionButtons(mobile: boolean): Children {
+	actionButtons(): Children {
 		const mail = this.mail
 		const actions = []
 		const colors = ButtonColors.Content
@@ -534,14 +534,12 @@ export class MailViewer {
 					}))
 				}
 				if (userController.isInternalUser() && !restrictedParticipants) {
-					if (!mobile) { // put forward in "more" menu only
-						actions.push(m(ButtonN, {
-							label: "forward_action",
-							click: () => this._forward(),
-							icon: () => Icons.Forward,
-							colors,
-						}))
-					}
+					actions.push(m(ButtonN, {
+						label: "forward_action",
+						click: () => this._forward(),
+						icon: () => Icons.Forward,
+						colors,
+					}))
 				} else if (userController.isInternalUser()
 					&& restrictedParticipants
 					&& userController.getUserMailGroupMembership().group !== this.mail._ownerGroup) {


### PR DESCRIPTION
Looks like this argument is redundant now. It's only ever called with `false`, so it can safely be removed and the code can be simplified slightly