### PR TITLE
let context menu click noop if webContents is unavailable, fix #2112

### DIFF
--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -235,9 +235,9 @@ export class ApplicationWindow {
 		).then(() => this.show())
 	}
 
-	setContextMenuHandler(handler: (ContextMenuParams, WebContents)=>void) {
+	setContextMenuHandler(handler: (ContextMenuParams)=>void) {
 		const wc = this.browserWindow.webContents
-		wc.on('context-menu', (e, params) => handler(params, wc))
+		wc.on('context-menu', (e, params) => handler(params))
 	}
 
 	sendMessageToWebContents(message: WebContentsMessage | number, args: any) {

--- a/src/desktop/DesktopContextMenu.js
+++ b/src/desktop/DesktopContextMenu.js
@@ -1,13 +1,13 @@
 // @flow
 
+import type {ContextMenuParams} from "electron"
 import {clipboard, Menu, MenuItem} from 'electron'
 import {lang} from "../misc/LanguageViewModel"
-import type {WebContents, ContextMenuParams} from "electron"
 
 export class DesktopContextMenu {
 	_menu: Menu;
 	_pasteItem: MenuItem;
-	_copyItem : MenuItem;
+	_copyItem: MenuItem;
 	_cutItem: MenuItem;
 	_copyLinkItem: MenuItem;
 	_undoItem: MenuItem;
@@ -16,19 +16,35 @@ export class DesktopContextMenu {
 
 	constructor() {
 		this._menu = new Menu()
-		this._pasteItem = new MenuItem({label: lang.get("paste_action"), accelerator: "CmdOrCtrl+V", click:(mi, bw) => bw.webContents.paste()})
-		this._copyItem = new MenuItem({label: lang.get("copy_action"), accelerator: "CmdOrCtrl+C", click: (mi, bw) => bw.webContents.copy()})
-		this._cutItem = new MenuItem({label: lang.get("cut_action"), accelerator: "CmdOrCtrl+X", click: (mi, bw) => bw.webContents.cut()})
-		this._copyLinkItem = new MenuItem({label: lang.get("copyLink_action"), click: () => clipboard.writeText(this._link)})
+		this._link = ""
+		this._pasteItem = new MenuItem({
+			label: lang.get("paste_action"),
+			accelerator: "CmdOrCtrl+V",
+			click: (mi, bw) => bw && bw.webContents && bw.webContents.paste()
+		})
+		this._copyItem = new MenuItem({
+			label: lang.get("copy_action"),
+			accelerator: "CmdOrCtrl+C",
+			click: (mi, bw) => bw && bw.webContents && bw.webContents.copy()
+		})
+		this._cutItem = new MenuItem({
+			label: lang.get("cut_action"),
+			accelerator: "CmdOrCtrl+X",
+			click: (mi, bw) => bw && bw.webContents && bw.webContents.cut()
+		})
+		this._copyLinkItem = new MenuItem({
+			label: lang.get("copyLink_action"),
+			click: () => !!this._link && clipboard.writeText(this._link)
+		})
 		this._undoItem = new MenuItem({
 			label: lang.get("undo_action"),
 			accelerator: "CmdOrCtrl+Z",
-			click:(mi, bw) => bw.webContents.undo()
+			click: (mi, bw) => bw && bw.webContents && bw.webContents.undo()
 		})
 		this._redoItem = new MenuItem({
 			label: lang.get("redo_action"),
 			accelerator: "CmdOrCtrl+Shift+Z",
-			click:(mi, bw) => bw.webContents.redo()
+			click: (mi, bw) => bw && bw.webContents && bw.webContents.redo()
 		})
 
 		this._menu.append(this._copyItem)
@@ -40,7 +56,7 @@ export class DesktopContextMenu {
 		this._menu.append(this._redoItem)
 	}
 
-	open(params: ContextMenuParams, wc: WebContents) {
+	open(params: ContextMenuParams) {
 		this._link = params.linkURL
 		this._copyLinkItem.enabled = !!params.linkURL
 		this._cutItem.enabled = params.editFlags.canCut

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -77,7 +77,7 @@ export class WindowManager {
 			}
 		})
 
-		w.setContextMenuHandler((params, wc) => this._contextMenu.open(params, wc))
+		w.setContextMenuHandler((params) => this._contextMenu.open(params))
 
 		return w
 	}

--- a/test/client/Suite.js
+++ b/test/client/Suite.js
@@ -40,6 +40,7 @@ node(() => {
 	require("./desktop/SocketeerTest.js")
 	require("./desktop/integration/DesktopIntegratorTest.js")
 	require("./desktop/DesktopCryptoFacadeTest.js")
+	require("./desktop/DesktopContextMenuTest.js")
 })()
 
 o.run()

--- a/test/client/desktop/ApplicationWindowTest.js
+++ b/test/client/desktop/ApplicationWindowTest.js
@@ -661,10 +661,7 @@ o.spec("ApplicationWindow Test", function () {
 		o(e.preventDefault.callCount).equals(0)
 
 		o(handlerMock.callCount).equals(1)
-		o(handlerMock.args).deepEquals([
-			{linkURL: 'dies.ist.ne/url', editFlags: "someflags"},
-			bwInstance.webContents
-		])
+		o(handlerMock.args).deepEquals([{linkURL: 'dies.ist.ne/url', editFlags: "someflags"}])
 	})
 
 	o("dom-ready causes ipc setup", function (done) {

--- a/test/client/desktop/DesktopContextMenuTest.js
+++ b/test/client/desktop/DesktopContextMenuTest.js
@@ -1,0 +1,65 @@
+// @flow
+import o from "ospec/ospec.js"
+import n from "../nodemocker"
+
+o.spec("DesktopContextMenu Test", () => {
+	n.startGroup({
+		group: __filename,
+		allowables: [],
+	})
+
+	const lang = {
+		lang: {get: key => key}
+	}
+
+	const electron = {
+		clipboard: {
+			writeText: () => {}
+		},
+		Menu: n.classify({
+			prototype: {
+				append: function () {},
+				popup: function () {},
+			},
+			statics: {}
+		}),
+		MenuItem: n.classify({
+			prototype: {
+				enabled: true,
+				constructor: function (p) {
+					Object.assign(this, p)
+				}
+			},
+			statics: {}
+		})
+	}
+
+	const standardMocks = () => {
+		// node modules
+		const electronMock = n.mock('electron', electron).set()
+		const langMock = n.mock("../misc/LanguageViewModel", lang).set()
+
+		return {
+			electronMock,
+			langMock,
+		}
+	}
+
+	o("can handle undefined browserWindow and webContents in callback", () => {
+		const {electronMock} = standardMocks()
+		const {DesktopContextMenu} = n.subject("../../src/desktop/DesktopContextMenu.js")
+		const contextMenu = new DesktopContextMenu()
+		contextMenu.open({
+			linkURL: "nourl",
+			editFlags: {
+				canCut: false,
+				canPaste: false,
+				canCopy: false,
+				canUndo: false,
+				canRedo: false
+			}
+		})
+		electronMock.MenuItem.mockedInstances.forEach(i => i.click && i.click(undefined, undefined))
+		electronMock.MenuItem.mockedInstances.forEach(i => i.click && i.click(undefined, "nowebcontents"))
+	})
+})


### PR DESCRIPTION
BrowserWindow arg to the handler will be undefined if no window is open.
Since context menu actions make no sense without context, the click
handlers should noop in this case.