### PR TITLE
[desktop] use 'wheel' event instead of window.onmousewheel

### DIFF
--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -1,6 +1,6 @@
 // @flow
-import type {ElectronPermission, FindInPageResult, ContextMenuParams} from 'electron'
-import {BrowserWindow, Menu, shell, WebContents, app} from 'electron'
+import type {ContextMenuParams, ElectronPermission, FindInPageResult} from 'electron'
+import {app, BrowserWindow, Menu, shell, WebContents} from 'electron'
 import * as localShortcut from 'electron-localshortcut'
 import DesktopUtils from './DesktopUtils.js'
 import u2f from '../misc/u2f-api.js'
@@ -151,7 +151,7 @@ export class ApplicationWindow {
 		    })
 		    .on('will-attach-webview', e => e.preventDefault())
 		    .on('did-start-navigation', (e, url, isInPlace) => {
-		    	this._browserWindow.emit('did-start-navigation')
+			    this._browserWindow.emit('did-start-navigation')
 			    const newURL = this._rewriteURL(url, isInPlace)
 			    if (newURL !== url) {
 				    e.preventDefault()

--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -122,6 +122,7 @@ export class ApplicationWindow {
 				// the preload script changes to the web app
 				contextIsolation: false,
 				webSecurity: true,
+				enableRemoteModule: false,
 				preload: preloadPath
 			}
 		})

--- a/src/desktop/preload.js
+++ b/src/desktop/preload.js
@@ -20,6 +20,23 @@ function initializeIPC(e, params) {
 		invoke: (msg: string) => ipcRenderer.send(`${windowId}`, msg),
 		getVersion: () => version
 	}
+
+	/* this event listener doesn't get fired
+	 * if it's registered during the initial preload.js
+	 * execution
+	 */
+	window.addEventListener('wheel', e => {
+		if (!e.ctrlKey) {
+			return
+		}
+		let newFactor = ((webFrame.getZoomFactor() * 100) + (e.deltaY > 0 ? -10 : 10)) / 100
+		if (newFactor > 3) {
+			newFactor = 3
+		} else if (newFactor < 0.5) {
+			newFactor = 0.5
+		}
+		webFrame.setZoomFactor(newFactor)
+	})
 }
 
 function setZoomFactor(ev, newFactor) {
@@ -89,19 +106,6 @@ window.addEventListener('keydown', e => {
 		window.history.back()
 	} else if (e.key === 'ArrowRight') window.history.forward()
 })
-
-window.onmousewheel = (e) => {
-	if (!e.ctrlKey) {
-		return
-	}
-	let newFactor = ((webFrame.getZoomFactor() * 100) + (e.deltaY > 0 ? -10 : 10)) / 100
-	if (newFactor > 3) {
-		newFactor = 3
-	} else if (newFactor < 0.5) {
-		newFactor = 0.5
-	}
-	webFrame.setZoomFactor(newFactor)
-}
 
 // window.focus() doesn't seem to be working right now, so we're replacing it
 // https://github.com/electron/electron/issues/8969#issuecomment-288024536

--- a/test/client/desktop/ApplicationWindowTest.js
+++ b/test/client/desktop/ApplicationWindowTest.js
@@ -262,6 +262,7 @@ o.spec("ApplicationWindow Test", function () {
 				sandbox: true,
 				contextIsolation: false,
 				webSecurity: true,
+				enableRemoteModule: false,
 				preload: '/path/to/app/preloadjs'
 			}
 		})


### PR DESCRIPTION
There seems to be an issue that prevents the wheel listener that's set in the initial execution of the preload script from receiving WheelEvents that were not dispatched manually.

If the listener is attached after the web app has initialized, the problem doesn't occur.

 fix #2165 