### PR TITLE
fix: [desktop] inconsistent wm class in package config, .desktop file and actua…

### DIFF
--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -8,9 +8,10 @@ const pj = require('../package.json')
 
 module.exports = function (opts) {
 	const {nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked} = opts
-
+	const appName = "tutanota-desktop" + nameSuffix
+	const appId = "de.tutao." + appName
 	return {
-		"name": "tutanota-desktop" + nameSuffix,
+		"name": appName,
 		"main": "./src/desktop/DesktopMain.js",
 		"version": version,
 		"author": "Tutao GmbH",
@@ -46,7 +47,7 @@ module.exports = function (opts) {
 			"fileManagerTimeout": 30000,
 			// true if this version checks its updates. use to prevent local builds from checking sigs.
 			"checkUpdateSignature": sign || !!process.env.JENKINS,
-			"appUserModelId": "de.tutao.tutanota" + nameSuffix,
+			"appUserModelId": appId,
 			"initialSseConnectTimeoutInSeconds": 60,
 			"maxSseConnectTimeoutInSeconds": 2400,
 			"configMigrationFunction": "migrateClient",
@@ -74,7 +75,7 @@ module.exports = function (opts) {
 		"build": {
 			"electronVersion": pj.devDependencies.electron,
 			"icon": iconPath,
-			"appId": "de.tutao.tutanota" + nameSuffix,
+			"appId": appId,
 			"productName": nameSuffix.length > 0
 				? nameSuffix.slice(1) + " Tutanota Desktop"
 				: "Tutanota Desktop",
@@ -157,7 +158,7 @@ module.exports = function (opts) {
 				"synopsis": "Tutanota Desktop Client",
 				"category": "Network",
 				"desktop": {
-					"StartupWMClass": "tutanota-desktop" + nameSuffix
+					"StartupWMClass": appName
 				},
 				"target": [
 					{

--- a/src/desktop/integration/DesktopIntegratorLinux.js
+++ b/src/desktop/integration/DesktopIntegratorLinux.js
@@ -55,6 +55,7 @@ export function enableAutoLaunch(): Promise<void> {
 	Comment=${app.name} startup script
 	Exec=${packagePath} -a
 	StartupNotify=false
+	StartupWMClass=${app.name}
 	Terminal=false`
 		fs.ensureDirSync(path.dirname(autoLaunchPath))
 		fs.writeFileSync(autoLaunchPath, autoLaunchDesktopEntry, {encoding: 'utf-8'})
@@ -148,7 +149,7 @@ Exec="${packagePath}" %U
 Terminal=false
 Type=Application
 Icon=${app.name}.png
-StartupWMClass=de.tutao.${app.name}
+StartupWMClass=${app.name}
 MimeType=x-scheme-handler/mailto;
 Categories=Network;
 X-Tutanota-Version=${app.getVersion()}

--- a/test/client/desktop/integration/DesktopIntegratorTest.js
+++ b/test/client/desktop/integration/DesktopIntegratorTest.js
@@ -1,7 +1,7 @@
 // @flow
 import o from "ospec/ospec.js"
 import n from "../../nodemocker"
-
+const desktopEntry = '[Desktop Entry]\nName=Tutanota Desktop\nComment=The desktop client for Tutanota, the secure e-mail service.\nExec="/appimage/path/file.appImage" %U\nTerminal=false\nType=Application\nIcon=appName.png\nStartupWMClass=appName\nMimeType=x-scheme-handler/mailto;\nCategories=Network;\nX-Tutanota-Version=appVersion\nTryExec=/appimage/path/file.appImage'
 o.spec("DesktopIntegrator Test", () => {
 	n.startGroup({
 		group: __filename,
@@ -231,7 +231,7 @@ o.spec("DesktopIntegrator Test", () => {
 			o(fsExtraMock.writeFileSync.callCount).equals(1)
 			o(fsExtraMock.writeFileSync.args.length).equals(3)
 			o(fsExtraMock.writeFileSync.args[0]).equals("/app/path/file/.config/autostart/appName.desktop")
-			o(fsExtraMock.writeFileSync.args[1]).equals('[Desktop Entry]\n\tType=Application\n\tVersion=appVersion\n\tName=appName\n\tComment=appName startup script\n\tExec=/appimage/path/file.appImage -a\n\tStartupNotify=false\n\tTerminal=false')
+			o(fsExtraMock.writeFileSync.args[1]).equals('[Desktop Entry]\n\tType=Application\n\tVersion=appVersion\n\tName=appName\n\tComment=appName startup script\n\tExec=/appimage/path/file.appImage -a\n\tStartupNotify=false\n\tStartupWMClass=appName\n\tTerminal=false')
 			o(fsExtraMock.writeFileSync.args[2]).deepEquals({encoding: 'utf-8'})
 
 			o(fsExtraMock.ensureDirSync.callCount).equals(1)
@@ -390,7 +390,7 @@ o.spec("DesktopIntegrator Test", () => {
 			o(fsExtraMock.writtenFiles).deepEquals([
 				{
 					file: '/app/path/file/.local/share/applications/appName.desktop',
-					content: '[Desktop Entry]\nName=Tutanota Desktop\nComment=The desktop client for Tutanota, the secure e-mail service.\nExec="/appimage/path/file.appImage" %U\nTerminal=false\nType=Application\nIcon=appName.png\nStartupWMClass=de.tutao.appName\nMimeType=x-scheme-handler/mailto;\nCategories=Network;\nX-Tutanota-Version=appVersion\nTryExec=/appimage/path/file.appImage',
+					content: desktopEntry,
 					opts: {encoding: 'utf-8'}
 				}
 			])
@@ -431,7 +431,7 @@ o.spec("DesktopIntegrator Test", () => {
 					opts: {encoding: 'utf-8', flag: 'a'}
 				}, {
 					file: '/app/path/file/.local/share/applications/appName.desktop',
-					content: '[Desktop Entry]\nName=Tutanota Desktop\nComment=The desktop client for Tutanota, the secure e-mail service.\nExec="/appimage/path/file.appImage" %U\nTerminal=false\nType=Application\nIcon=appName.png\nStartupWMClass=de.tutao.appName\nMimeType=x-scheme-handler/mailto;\nCategories=Network;\nX-Tutanota-Version=appVersion\nTryExec=/appimage/path/file.appImage',
+					content: desktopEntry,
 					opts: {encoding: 'utf-8'}
 				}
 			])
@@ -514,7 +514,7 @@ o.spec("DesktopIntegrator Test", () => {
 			o(fsExtraMock.writtenFiles).deepEquals([
 				{
 					file: '/app/path/file/.local/share/applications/appName.desktop',
-					content: '[Desktop Entry]\nName=Tutanota Desktop\nComment=The desktop client for Tutanota, the secure e-mail service.\nExec="/appimage/path/file.appImage" %U\nTerminal=false\nType=Application\nIcon=appName.png\nStartupWMClass=de.tutao.appName\nMimeType=x-scheme-handler/mailto;\nCategories=Network;\nX-Tutanota-Version=appVersion\nTryExec=/appimage/path/file.appImage',
+					content: desktopEntry,
 					opts: {encoding: 'utf-8'}
 				}
 			])


### PR DESCRIPTION
…l window

electron ignores the "StartupWMClass" and just uses the name property set in the electron package.json,
so we use it for the WMClass as well.

close #2328