### PR TITLE
Correctly handle custom domain alias when sending mail

### DIFF
--- a/src/mail/MailEditorN.js
+++ b/src/mail/MailEditorN.js
@@ -41,7 +41,7 @@ import {
 	chooseAndAttachFile,
 	cleanupInlineAttachments,
 	createAttachmentButtonAttrs,
-	createPasswordField,
+	createPasswordField, getConfidentialStateMessage,
 	MailEditorRecipientField
 } from "./MailEditorViewModel"
 import {ExpanderButtonN, ExpanderPanelN} from "../gui/base/ExpanderN"
@@ -242,7 +242,7 @@ export class MailEditorN implements MComponent<MailEditorAttrs> {
 
 		const subjectFieldAttrs: TextFieldAttrs = {
 			label: "subject_label",
-			helpLabel: () => lang.get(model.getConfidentialStateTranslationKey()),
+			helpLabel: () => getConfidentialStateMessage(model.isConfidential()),
 			value: stream(model.getSubject()),
 			oninput: val => model.setSubject(val),
 			injectionsRight: () => {

--- a/src/mail/MailEditorViewModel.js
+++ b/src/mail/MailEditorViewModel.js
@@ -170,6 +170,13 @@ function _getRecipientFieldLabelTranslationKey(field: RecipientField): Translati
 	}[field]
 }
 
+
+export function getConfidentialStateMessage(isConfidential: boolean): string {
+	return isConfidential
+		? lang.get('confidentialStatus_msg')
+		: lang.get('nonConfidentialStatus_msg')
+}
+
 export class MailEditorRecipientField implements RecipientInfoBubbleFactory {
 
 	model: SendMailModel

--- a/src/mail/SendMailModel.js
+++ b/src/mail/SendMailModel.js
@@ -246,11 +246,6 @@ export class SendMailModel {
 		return this._passwords.get(mailAddress) || ""
 	}
 
-	getConfidentialStateTranslationKey(): TranslationKey {
-		return this._isConfidential
-			? 'confidentialStatus_msg'
-			: 'nonConfidentialStatus_msg'
-	}
 
 	getSubject(): string {
 		return this._subject
@@ -654,6 +649,10 @@ export class SendMailModel {
 		return this._isConfidential || !this.containsExternalRecipients()
 	}
 
+	isConfidentialExternal(): boolean {
+		return this._isConfidential && this.containsExternalRecipients()
+	}
+
 	setConfidential(confidential: boolean): void {
 		this._isConfidential = confidential
 	}
@@ -743,12 +742,11 @@ export class SendMailModel {
 	}
 
 	_externalPasswordConfirm(getConfirmation: (TranslationKey | lazy<string>) => Promise<boolean>): Promise<void> {
-		if (this.isConfidential()
-			&& this.containsExternalRecipients()
+		if (this.isConfidentialExternal()
 			&& this.getExternalRecipients().some(r => !this.getPassword(r.mailAddress))) {
 			throw new UserError("noPreSharedPassword_msg")
 		}
-		return this.isConfidential() && this.hasInsecurePasswords()
+		return this.isConfidentialExternal() && this.hasInsecurePasswords()
 			? getConfirmation("presharedPasswordNotStrongEnough_msg").then(confirmation => {
 				if (!confirmation) {
 					throw new CancelledError("password not confirmed")


### PR DESCRIPTION
The correct message is shown under the subject line, and any set passwords are disregarded when sending to a custom domain alias of a tutanota account

commit also contains a very minor cleanup