### PR TITLE
Handle exceptions when resolving deferred promises in suspension handler

### DIFF
--- a/src/api/worker/SuspensionHandler.js
+++ b/src/api/worker/SuspensionHandler.js
@@ -45,7 +45,8 @@ export class SuspensionHandler {
 				// do wee need to delay those requests?
 				Promise.each(deferredRequests, (deferredRequest) => {
 					deferredRequest.resolve()
-					return deferredRequest.promise
+					// Ignore all errors here, any errors should be caught by whoever is handling the deferred request
+					return deferredRequest.promise.catch(e => console.warn("Encountered error in SuspensionHandler:\n", e))
 				})
 			}, suspensionDurationSeconds * this._suspensionTimeFactor)
 

--- a/src/api/worker/SuspensionHandler.js
+++ b/src/api/worker/SuspensionHandler.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type {DeferredObject} from "../common/utils/Utils"
-import {defer} from "../common/utils/Utils"
+import {defer, noOp} from "../common/utils/Utils"
 import {WorkerImpl} from "./WorkerImpl"
 
 export class SuspensionHandler {
@@ -46,7 +46,7 @@ export class SuspensionHandler {
 				Promise.each(deferredRequests, (deferredRequest) => {
 					deferredRequest.resolve()
 					// Ignore all errors here, any errors should be caught by whoever is handling the deferred request
-					return deferredRequest.promise.catch(e => console.warn("Encountered error in SuspensionHandler:\n", e))
+					return deferredRequest.promise.catch(noOp)
 				})
 			}, suspensionDurationSeconds * this._suspensionTimeFactor)
 

--- a/src/calendar/CalendarUpdateDistributor.js
+++ b/src/calendar/CalendarUpdateDistributor.js
@@ -16,6 +16,7 @@ import type {CalendarEventAttendee} from "../api/entities/tutanota/CalendarEvent
 import {createCalendarEventAttendee} from "../api/entities/tutanota/CalendarEventAttendee"
 import {isTutanotaMailAddress} from "../api/common/RecipientInfo"
 import {createMailAddress} from "../api/entities/tutanota/MailAddress"
+import {Dialog} from "../gui/base/Dialog"
 
 export interface CalendarUpdateDistributor {
 	sendInvite(existingEvent: CalendarEvent, sendMailModel: SendMailModel): Promise<void>;
@@ -98,7 +99,7 @@ export class CalendarMailDistributor implements CalendarUpdateDistributor {
 				              })
 			              })
 			              .then(model => {
-				              model.attachFiles([makeInvitationCalendarFile(event, CalendarMethod.REPLY, new Date(), getTimeZone())])
+				              model.attachFiles([makeInvitationCalendarFile(event, CalendarMethod.REPLY, new Date(), getTimeZone())], m => Dialog.error(() => m))
 				              return model.send(MailMethod.ICAL_REPLY)
 			              })
 			              .finally(() => this._sendEnd())
@@ -117,7 +118,7 @@ export class CalendarMailDistributor implements CalendarUpdateDistributor {
 	}): Promise<void> {
 		const inviteFile = makeInvitationCalendarFile(event, mailMethodToCalendarMethod(method), new Date(), getTimeZone())
 		sendMailModel.setSender(sender)
-		sendMailModel.attachFiles([inviteFile])
+		sendMailModel.attachFiles([inviteFile], m => Dialog.error(() => m))
 		sendMailModel.setSubject(subject)
 		sendMailModel.setBody(body)
 		this._sendStart()

--- a/src/calendar/CalendarUpdateDistributor.js
+++ b/src/calendar/CalendarUpdateDistributor.js
@@ -16,7 +16,6 @@ import type {CalendarEventAttendee} from "../api/entities/tutanota/CalendarEvent
 import {createCalendarEventAttendee} from "../api/entities/tutanota/CalendarEventAttendee"
 import {isTutanotaMailAddress} from "../api/common/RecipientInfo"
 import {createMailAddress} from "../api/entities/tutanota/MailAddress"
-import {Dialog} from "../gui/base/Dialog"
 
 export interface CalendarUpdateDistributor {
 	sendInvite(existingEvent: CalendarEvent, sendMailModel: SendMailModel): Promise<void>;
@@ -99,7 +98,7 @@ export class CalendarMailDistributor implements CalendarUpdateDistributor {
 				              })
 			              })
 			              .then(model => {
-				              model.attachFiles([makeInvitationCalendarFile(event, CalendarMethod.REPLY, new Date(), getTimeZone())], m => Dialog.error(() => m))
+				              model.attachFiles([makeInvitationCalendarFile(event, CalendarMethod.REPLY, new Date(), getTimeZone())])
 				              return model.send(MailMethod.ICAL_REPLY)
 			              })
 			              .finally(() => this._sendEnd())
@@ -118,7 +117,7 @@ export class CalendarMailDistributor implements CalendarUpdateDistributor {
 	}): Promise<void> {
 		const inviteFile = makeInvitationCalendarFile(event, mailMethodToCalendarMethod(method), new Date(), getTimeZone())
 		sendMailModel.setSender(sender)
-		sendMailModel.attachFiles([inviteFile], m => Dialog.error(() => m))
+		sendMailModel.attachFiles([inviteFile])
 		sendMailModel.setSubject(subject)
 		sendMailModel.setBody(body)
 		this._sendStart()

--- a/src/mail/MailEditorN.js
+++ b/src/mail/MailEditorN.js
@@ -167,7 +167,9 @@ export class MailEditorN implements MComponent<MailEditorAttrs> {
 			a.inlineImages.then((loadedInlineImages) => {
 				Object.keys(loadedInlineImages).forEach((key) => {
 					const {file} = loadedInlineImages[key]
-					if (!model.getAttachments().includes(file)) model.attachFiles([file])
+					if (!model.getAttachments().includes(file)) {
+						model.attachFiles([file], m => Dialog.error(() => m))
+					}
 				})
 				m.redraw()
 
@@ -316,7 +318,7 @@ export class MailEditorN implements MComponent<MailEditorAttrs> {
 			ondrop: (ev) => {
 				if (ev.dataTransfer.files && ev.dataTransfer.files.length > 0) {
 					fileController.readLocalFiles(ev.dataTransfer.files).then(dataFiles => {
-						model.attachFiles((dataFiles: any))
+						model.attachFiles((dataFiles: any), m => Dialog.error(() => m))
 						m.redraw()
 					}).catch(e => {
 						console.log(e)

--- a/src/mail/MailEditorN.js
+++ b/src/mail/MailEditorN.js
@@ -167,9 +167,7 @@ export class MailEditorN implements MComponent<MailEditorAttrs> {
 			a.inlineImages.then((loadedInlineImages) => {
 				Object.keys(loadedInlineImages).forEach((key) => {
 					const {file} = loadedInlineImages[key]
-					if (!model.getAttachments().includes(file)) {
-						model.attachFiles([file], m => Dialog.error(() => m))
-					}
+					if (!model.getAttachments().includes(file)) model.attachFiles([file])
 				})
 				m.redraw()
 
@@ -318,7 +316,7 @@ export class MailEditorN implements MComponent<MailEditorAttrs> {
 			ondrop: (ev) => {
 				if (ev.dataTransfer.files && ev.dataTransfer.files.length > 0) {
 					fileController.readLocalFiles(ev.dataTransfer.files).then(dataFiles => {
-						model.attachFiles((dataFiles: any), m => Dialog.error(() => m))
+						model.attachFiles((dataFiles: any))
 						m.redraw()
 					}).catch(e => {
 						console.log(e)

--- a/src/mail/MailEditorViewModel.js
+++ b/src/mail/MailEditorViewModel.js
@@ -39,7 +39,7 @@ import type {TranslationKey} from "../misc/LanguageViewModel"
 export function chooseAndAttachFile(model: SendMailModel, boundingRect: ClientRect, fileTypes?: Array<string>): Promise<?$ReadOnlyArray<FileReference | DataFile>> {
 	return showFileChooserForAttachments(boundingRect, fileTypes)
 		.then(files => {
-			model.attachFiles((files: any), m => Dialog.error(() => m))
+			model.attachFiles((files: any))
 			return files
 		})
 }

--- a/src/mail/MailEditorViewModel.js
+++ b/src/mail/MailEditorViewModel.js
@@ -35,13 +35,15 @@ import {ContactTypeRef} from "../api/entities/tutanota/Contact"
 import {cleanMatch} from "../api/common/utils/StringUtils"
 import {ConnectionError, TooManyRequestsError} from "../api/common/error/RestError"
 import type {TranslationKey} from "../misc/LanguageViewModel"
+import {UserError} from "../api/common/error/UserError"
+import {showUserError} from "../misc/ErrorHandlerImpl"
 
 export function chooseAndAttachFile(model: SendMailModel, boundingRect: ClientRect, fileTypes?: Array<string>): Promise<?$ReadOnlyArray<FileReference | DataFile>> {
 	return showFileChooserForAttachments(boundingRect, fileTypes)
 		.then(files => {
 			model.attachFiles((files: any))
 			return files
-		})
+		}).catch(UserError, showUserError)
 }
 
 export function showFileChooserForAttachments(boundingRect: ClientRect, fileTypes?: Array<string>): Promise<?$ReadOnlyArray<FileReference | DataFile>> {

--- a/src/mail/MailEditorViewModel.js
+++ b/src/mail/MailEditorViewModel.js
@@ -39,7 +39,7 @@ import type {TranslationKey} from "../misc/LanguageViewModel"
 export function chooseAndAttachFile(model: SendMailModel, boundingRect: ClientRect, fileTypes?: Array<string>): Promise<?$ReadOnlyArray<FileReference | DataFile>> {
 	return showFileChooserForAttachments(boundingRect, fileTypes)
 		.then(files => {
-			model.attachFiles((files: any))
+			model.attachFiles((files: any), m => Dialog.error(() => m))
 			return files
 		})
 }

--- a/src/mail/MailView.js
+++ b/src/mail/MailView.js
@@ -65,6 +65,8 @@ import {modal} from "../gui/base/Modal"
 import {DomRectReadOnlyPolyfilled} from "../gui/base/Dropdown"
 import type {MailFolder} from "../api/entities/tutanota/MailFolder"
 import {newMailEditor, newMailEditorFromTemplate, newMailtoUrlMailEditor, writeSupportMail} from "./MailEditorN"
+import {UserError} from "../api/common/error/UserError"
+import {showUserError} from "../misc/ErrorHandlerImpl"
 
 assertMainOrNode()
 
@@ -166,6 +168,7 @@ export class MailView implements CurrentView {
 								(mailbox, dataFiles) => {
 									newMailEditorFromTemplate(mailbox, {}, "", getDefaultSignature(), dataFiles).then(dialog => dialog.show())
 								}).catch(PermissionError, noOp)
+							       .catch(UserError, showUserError)
 						}
 						// prevent in any case because firefox tries to open
 						// dataTransfer as a URL otherwise.

--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -123,6 +123,8 @@ import {newMailEditorAsResponse, newMailEditorFromDraft, newMailtoUrlMailEditor}
 import type {MailboxDetail} from "./MailModel"
 import type {ResponseMailParameters} from "./SendMailModel"
 import {defaultSendMailModel} from "./SendMailModel"
+import {UserError} from "../api/common/error/UserError"
+import {showUserError} from "../misc/ErrorHandlerImpl"
 
 assertMainOrNode()
 
@@ -1187,10 +1189,10 @@ export class MailViewer {
 		return checkApprovalStatus(false).then(sendAllowed => {
 			if (sendAllowed) {
 				return locator.mailModel.getMailboxDetailsForMail(this.mail)
-				              .then((mailboxDetails) => {
-					              newMailEditorFromDraft(this.mail, this._attachments, this._getMailBody(), this._contentBlocked, this._inlineImages, mailboxDetails)
-						              .then(editorDialog => editorDialog.show())
-				              })
+				              .then(mailboxDetails => newMailEditorFromDraft(this.mail, this._attachments, this._getMailBody(), this._contentBlocked, this._inlineImages, mailboxDetails))
+				              .then(editorDialog => editorDialog.show())
+				              .catch(UserError, showUserError)
+
 			}
 		})
 	}
@@ -1250,7 +1252,8 @@ export class MailViewer {
 						}, this._contentBlocked, this._inlineImages, mailboxDetails)
 					}).then(editor => {
 						editor.show()
-					})
+					}).catch(UserError, showUserError)
+
 				})
 			}
 		})
@@ -1271,6 +1274,7 @@ export class MailViewer {
 					return this._getMailboxDetails().then(mailboxDetails => {
 						newMailEditorAsResponse(args, this._contentBlocked, this._inlineImages, mailboxDetails)
 							.then(editor => editor.show())
+							.catch(UserError, showUserError)
 					})
 				})
 			}

--- a/src/mail/SendMailModel.js
+++ b/src/mail/SendMailModel.js
@@ -539,7 +539,9 @@ export class SendMailModel {
 		// make a new recipient info if we don't have one for that recipient
 		if (!recipientInfo) {
 			let p: Promise<RecipientInfo>
-			[recipientInfo, p] = this._createAndResolveRecipientInfo(recipient.name, recipient.address, recipient.contact, skipResolveContact)
+			[
+				recipientInfo, p
+			] = this._createAndResolveRecipientInfo(recipient.name, recipient.address, recipient.contact, skipResolveContact)
 			this.getRecipientList(type).push(recipientInfo)
 			this.setMailChanged(true)
 			return [recipientInfo, p]
@@ -604,11 +606,12 @@ export class SendMailModel {
 			}
 		})
 
+		this.setMailChanged(true)
+
 		if (tooBigFiles.length > 0) {
 			throw new UserError(() => lang.get("tooBigAttachment_msg") + tooBigFiles.join(", "))
 		}
 
-		this.setMailChanged(true)
 	}
 
 	removeAttachment(file: Attachment): void {

--- a/src/mail/SendMailModel.js
+++ b/src/mail/SendMailModel.js
@@ -466,9 +466,7 @@ export class SendMailModel {
 		this._isConfidential = confidential == null ? !this.user().props.defaultUnconfidential : confidential
 		this._attachments = []
 		if (attachments) {
-			// I don't want to throw here because we should finish initializing the email.
-			// And it's nice to not have to think about exceptions everytime we open up a mail editor
-			this.attachFiles(attachments, m => console.error(m))
+			this.attachFiles(attachments)
 			this._mailChanged = false
 		}
 
@@ -541,9 +539,7 @@ export class SendMailModel {
 		// make a new recipient info if we don't have one for that recipient
 		if (!recipientInfo) {
 			let p: Promise<RecipientInfo>
-			[
-				recipientInfo, p
-			] = this._createAndResolveRecipientInfo(recipient.name, recipient.address, recipient.contact, skipResolveContact)
+			[recipientInfo, p] = this._createAndResolveRecipientInfo(recipient.name, recipient.address, recipient.contact, skipResolveContact)
 			this.getRecipientList(type).push(recipientInfo)
 			this.setMailChanged(true)
 			return [recipientInfo, p]
@@ -595,13 +591,8 @@ export class SendMailModel {
 		return this._attachments
 	}
 
-	/**
-	 *
-	 * @param files: the files to attach
-	 * @param onTooBigFiles: action to take when there are too big files. we used to throw but this way we don't have to wrap every single
-	 * call in a try catch, as there are quite a few
-	 */
-	attachFiles(files: $ReadOnlyArray<Attachment>, onTooBigFiles: (string) => any = () => {}): void {
+	/** @throws UserError in case files are too big to add */
+	attachFiles(files: $ReadOnlyArray<Attachment>): void {
 		let totalSize = this._attachments.reduce((total, file) => total + Number(file.size), 0)
 		const tooBigFiles: Array<string> = [];
 		files.forEach(file => {
@@ -614,7 +605,7 @@ export class SendMailModel {
 		})
 
 		if (tooBigFiles.length > 0) {
-			onTooBigFiles(lang.get("tooBigAttachment_msg") + tooBigFiles.join(", "))
+			throw new UserError(() => lang.get("tooBigAttachment_msg") + tooBigFiles.join(", "))
 		}
 
 		this.setMailChanged(true)
@@ -797,7 +788,7 @@ export class SendMailModel {
 			this._draft = draft
 			return Promise.map(draft.attachments, fileId => this._entity.load(FileTypeRef, fileId)).then(attachments => {
 				this._attachments = [] // attachFiles will push to existing files but we want to overwrite them
-				this.attachFiles(attachments, m => {throw new UserError(() => m)})
+				this.attachFiles(attachments)
 				this._mailChanged = false
 			})
 		}).catch(PayloadTooLargeError, () => {

--- a/src/misc/ErrorHandlerImpl.js
+++ b/src/misc/ErrorHandlerImpl.js
@@ -39,6 +39,7 @@ import {QuotaExceededError} from "../api/common/error/QuotaExceededError"
 import {copyToClipboard} from "./ClipboardUtils"
 import {px} from "../gui/size"
 import {generatedIdToTimestamp} from "../api/common/utils/Encoding"
+import {UserError} from "../api/common/error/UserError"
 
 assertMainOrNode()
 
@@ -425,4 +426,9 @@ function showErrorDialogNotLoggedIn(e) {
 
 if (typeof window !== "undefined") {
 	window.tutao.testError = () => handleUncaughtError(new Error("test error!"))
+}
+
+
+export function showUserError(error: UserError): Promise<void> {
+	return Dialog.error(() => error.message)
 }

--- a/src/settings/AboutDialog.js
+++ b/src/settings/AboutDialog.js
@@ -8,11 +8,12 @@ import {isApp, isDesktop} from "../api/Env"
 import {worker} from "../api/main/WorkerClient"
 import {createLogFile} from "../api/common/Logger"
 import {downcast} from "../api/common/utils/Utils"
-import {clientInfoString} from "../misc/ErrorHandlerImpl"
+import {clientInfoString, showUserError} from "../misc/ErrorHandlerImpl"
 import {locator} from "../api/main/MainLocator"
 import {isColorLight} from "../gui/Color"
 import {lang} from "../misc/LanguageViewModel"
 import {newMailEditorFromTemplate} from "../mail/MailEditorN"
+import {UserError} from "../api/common/error/UserError"
 
 export class AboutDialog implements MComponent<void> {
 	view(vnode: Vnode<void>): ?Children {
@@ -92,4 +93,5 @@ function sendDeviceLogs() {
 		 return newMailEditorFromTemplate(mailboxDetails, {}, `Device logs v${env.versionNumber} - ${type} - ${client}`, message, attachments, true)
 	 })
 	 .then(editor => editor.show())
+	 .catch(UserError, showUserError)
 }

--- a/test/api/worker/SuspensionHandlerTest.js
+++ b/test/api/worker/SuspensionHandlerTest.js
@@ -93,6 +93,28 @@ o.spec("SuspensionHandler test", () => {
 		o(suspensionHandler._deferredRequests.length).equals(0)
 	}))
 
+	o("deferred request throws exception", async () => {
+		const callOnResolve = o.spy()
+		const shouldntGetCalled = o.spy()
+
+		suspensionHandler.activateSuspensionIfInactive(100)
+		const d1 = suspensionHandler.deferRequest(() => Promise.resolve("noice")).tap(callOnResolve)
+		const d2 = suspensionHandler.deferRequest(() => { throw "oi" }).tap(shouldntGetCalled).catch(e => e) // no exception should be thrown anywhere
+		const d3 = suspensionHandler.deferRequest(() => Promise.resolve("'ken oath")).tap(callOnResolve)
+		const d4 = suspensionHandler.deferRequest(() => { throw "karn" }).tap(shouldntGetCalled).catch(e => e) // no exception should be thrown anywhere
+
+		const returned1 = await d1
+		const caught1 = await d2
+		const returned2 = await d3
+		const caught2 = await d4
+
+		o(returned1).equals("noice")
+		o(returned2).equals("'ken oath")
+		o(caught1).equals("oi")
+		o(caught2).equals("karn")
+		o(callOnResolve.callCount).equals(2)
+		o(shouldntGetCalled.callCount).equals(0)
+	})
 
 })
 


### PR DESCRIPTION
When resolving deferred requests in the suspension handler, errors still need to be handled internally even if theyre being caught by the original caller, because Promise.each waits for them to be resolved and will error out otherwise. For example, there are cases like when loading UserGroupRoot where the call to load expects the possibility of a NotFoundError, but the SuspensionHandler itself was still throwing an unhandled exception