### PR TITLE
fix tabbing to invisible inputs, fix #1932

### DIFF
--- a/src/gui/base/TextField.js
+++ b/src/gui/base/TextField.js
@@ -9,6 +9,7 @@ import {ease} from "../animation/Easing"
 import {assertMainOrNodeBoot} from "../../api/Env"
 import {theme} from "../theme"
 import type {keyHandler} from "../../misc/KeyManager"
+import {TabIndex} from "../../api/common/TutanotaConstants"
 
 assertMainOrNodeBoot()
 
@@ -163,13 +164,13 @@ export class TextField {
 			// If it is ExternalPassword type, we hide input and show substitute element when the field is not active.
 			// This is mostly done to prevent autofill which happens if the field type="password".
 			const autofillGuard = this._preventAutofill ? [
-				m("input.abs", {style: {opacity: '0', height: '0'}, type: Type.Text}),
-				m("input.abs", {style: {opacity: '0', height: '0'}, type: Type.Password}),
-				m("input.abs", {style: {opacity: '0', height: '0'}, type: Type.Text})
+				m("input.abs", {style: {opacity: '0', height: '0'}, tabIndex: TabIndex.Programmatic, type: Type.Text}),
+				m("input.abs", {style: {opacity: '0', height: '0'}, tabIndex: TabIndex.Programmatic, type: Type.Password}),
+				m("input.abs", {style: {opacity: '0', height: '0'}, tabIndex: TabIndex.Programmatic, type: Type.Text})
 			] : []
 
 			return m('.flex-grow', autofillGuard.concat(
-				m("input.input" + (this._alignRight ? ".right" : ""), {
+				m("input.input[tabindex=0]" + (this._alignRight ? ".right" : ""), {
 					autocomplete: this._preventAutofill ? "off" : this.autocomplete,
 					type: typeAttr,
 					"aria-label": lang.getMaybeLazy(this.label),

--- a/src/misc/KeyManager.js
+++ b/src/misc/KeyManager.js
@@ -39,7 +39,7 @@ export interface Shortcut {
 }
 
 export function focusPrevious(dom: HTMLElement): boolean {
-	let tabbable = Array.from(dom.querySelectorAll(TABBABLE)).filter(e => e.style.display !== 'none')
+	let tabbable = Array.from(dom.querySelectorAll(TABBABLE)).filter(e => e.style.display !== 'none' && e.tabIndex !==-1) // also filter for tabIndex here to restrict tabbing to invisible inputs
 	let selected = tabbable.find(e => document.activeElement === e)
 	if (selected) {
 		//work around for squire so tabulator actions are executed properly
@@ -62,11 +62,11 @@ export function focusPrevious(dom: HTMLElement): boolean {
 }
 
 export function focusNext(dom: HTMLElement): boolean {
-	let tabbable = Array.from(dom.querySelectorAll(TABBABLE)).filter(e => e.style.display !== 'none')
+	let tabbable = Array.from(dom.querySelectorAll(TABBABLE)).filter(e => e.style.display !== 'none' && e.tabIndex !== -1) // also filter for tabIndex here to restrict tabbing to invisible inputs
 	let selected = tabbable.find(e => document.activeElement === e)
 	if (selected) {
 		//work around for squire so tabulator actions are executed properly
-		//squiere makes a list which can be indented and manages this with tab and shift tab
+		//squire makes a list which can be indented and manages this with tab and shift tab
 		const selection = window.getSelection()
 		if (selection && selection.focusNode
 			&& (selection.focusNode.nodeName === "LI"


### PR DESCRIPTION
The shortcut for tabbing doesn't consider tabIndex, just focuses the next element. Added filter for tabIndex. 