### PR TITLE
Calendar invite organizer fixes

### DIFF
--- a/src/api/common/utils/MapUtils.js
+++ b/src/api/common/utils/MapUtils.js
@@ -34,3 +34,9 @@ export function addMapEntry<K, V>(map: $ReadOnlyMap<K, V>, key: K, value: V): Ma
 	newMap.set(key, value)
 	return newMap
 }
+
+export function deleteMapEntry<K, V>(map: $ReadOnlyMap<K, V>, key: K): Map<K, V> {
+	const newMap = new Map(map)
+	newMap.delete(key)
+	return newMap
+}

--- a/src/api/worker/search/IndexUtils.js
+++ b/src/api/worker/search/IndexUtils.js
@@ -370,9 +370,6 @@ export function printMeasure(prefix: string, names: string[]) {
 		} catch (e) {
 		}
 	}
-
-
-	console.log(prefix, JSON.stringify(measures))
 }
 
 export function markStart(name: string) {

--- a/src/calendar/CalendarEventViewModel.js
+++ b/src/calendar/CalendarEventViewModel.js
@@ -408,16 +408,17 @@ export class CalendarEventViewModel {
 			this._guestStatuses(addMapEntry(this._guestStatuses(), mailAddress, status))
 		}
 
-		// Add organizer as attendee if not currenly in the list
-		if (this.attendees().length === 1 && this.findOwnAttendee() == null) {
-			this.selectGoing(CalendarAttendeeStatus.ACCEPTED)
-		}
-
 		// this duplicated condition check may or may not be redundant to do here
 		if (isOwnAttendee) {
 			const newOrganizer = this.possibleOrganizers.find(o => o.address === mailAddress)
 			if (newOrganizer) this.setOrganizer(newOrganizer)
 		}
+
+		// Add organizer as attendee if not currenly in the list
+		if (this.attendees().length === 1 && this.findOwnAttendee() == null) {
+			this.selectGoing(CalendarAttendeeStatus.ACCEPTED)
+		}
+
 	}
 
 	getGuestPassword(guest: Guest): string {
@@ -788,7 +789,8 @@ export class CalendarEventViewModel {
 				if (ownAttendee) {
 					this._guestStatuses(addMapEntry(this._guestStatuses(), ownAttendee.address, going))
 				} else if (this._eventType === EventType.OWN) {
-					const newOwnAttendee = createEncryptedMailAddress({address: firstThrow(this._ownMailAddresses)})
+					// use the default sender as the organizer
+					const newOwnAttendee = createEncryptedMailAddress({address: this._inviteModel.getSender()})
 					this._ownAttendee(newOwnAttendee)
 					this._guestStatuses(addMapEntry(this._guestStatuses(), newOwnAttendee.address, going))
 				}


### PR DESCRIPTION
We pick the default sender from the inviteModel to use as the default organizer when inviting guests, and allow setting organizer by "inviting" yourself