### PR TITLE
[desktop] electron stopped firing found-in-page if request has findNe…

### DIFF
--- a/src/desktop/IPC.js
+++ b/src/desktop/IPC.js
@@ -87,7 +87,10 @@ export class IPC {
 				return this.initialized(windowId).then(() => {
 					const w = this._wm.get(windowId)
 					if (w) {
+						// findInPage might reject if requests come too quickly
+						// if it's rejecting for another reason we'll have logs
 						return w.findInPage(args)
+						        .catch(e => console.log("findInPage reject:", args, e))
 					} else {
 						return {numberOfMatches: 0, currentMatch: 0}
 					}

--- a/src/gui/base/SearchInPageOverlay.js
+++ b/src/gui/base/SearchInPageOverlay.js
@@ -89,7 +89,7 @@ export class SearchInPageOverlay {
 					}
 				},
 				onfocus: e => nativeApp.invokeNative(new Request("setSearchOverlayState", [true, false])),
-				oninput: e => this._find(true, false),
+				oninput: e => this._find(true, true),
 				style: {
 					width: px(250),
 					top: 0,
@@ -102,7 +102,6 @@ export class SearchInPageOverlay {
 	}
 
 	_find: ((forward: boolean, findNext: boolean) => Promise<void>) = (forward, findNext) => {
-		console.log("finding next", this._domInput.value)
 		this._skipNextBlur = true
 		return nativeApp.invokeNative(new Request("findInPage", [
 			this._domInput.value, {
@@ -173,6 +172,7 @@ export class SearchInPageOverlay {
 									if (keyCode === Keys.ESC.code) {
 										this.close()
 									}
+									// prevent key from getting picked up by shortcuts etc.
 									e.stopPropagation()
 									return true
 								},

--- a/test/client/desktop/IPCTest.js
+++ b/test/client/desktop/IPCTest.js
@@ -136,11 +136,9 @@ o.spec("IPC tests", () => {
 			id: 42,
 			sendMessageToWebContents: () => {
 			},
-			findInPage: () => {
-				return {
-					then: cb => cb({numberOfMatches: 37, currentMatch: 13})
-				}
-			},
+			findInPage: () => new Promise((resolve, reject) => {
+				resolve({numberOfMatches: 37, currentMatch: 13})
+			}),
 			stopFindInPage: () => {
 
 			},
@@ -283,7 +281,7 @@ o.spec("IPC tests", () => {
 			o(windowMock.sendMessageToWebContents.args[1]).deepEquals({
 				id: 'id2',
 				type: 'response',
-				value: {numberOfMatches: 37, currentMatch: 13}// there it is
+				value: {numberOfMatches: 37, currentMatch: 13}
 			})
 
 			electronMock.ipcMain.callbacks[CALLBACK_ID]({}, JSON.stringify({


### PR DESCRIPTION
…xt=false, always set it to true

also adds a little more bookkeeping to the findInPage request handling and reject
old request when a new one comes in.

doesn't require extra changes to admin client since the changed files are used by it as-is and the protocol didn't change.

fix #2355