### PR TITLE
add tabindex 0 to editor component

### DIFF
--- a/src/gui/base/Editor.js
+++ b/src/gui/base/Editor.js
@@ -7,6 +7,7 @@ import {px} from "../size"
 import {Dialog} from "./Dialog"
 import {isMailAddress} from '../../misc/FormatValidator.js'
 import type {ImageHandler} from '../../mail/MailUtils'
+import {TabIndex} from "../../api/common/TutanotaConstants"
 
 type SanitizerFn = (html: string, isPaste: boolean) => DocumentFragment
 
@@ -72,6 +73,7 @@ export class Editor implements ImageHandler {
 			return m(".hide-outline.selectable", {
 				role: "textbox",
 				"aria-multiline": "true",
+				tabindex: TabIndex.Default,
 				oncreate: vnode => this.initSquire(vnode.dom),
 				style: this._minHeight ? {"min-height": px(this._minHeight)} : {},
 			})


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation

If a focusable area is omitted from the sequential
focus navigation order of its Document, then it is
unreachable via sequential focus navigation.

fix #2394
fix #2380