### PR TITLE
Set Beacon content type header

### DIFF
--- a/src/api/main/UserController.js
+++ b/src/api/main/UserController.js
@@ -6,7 +6,7 @@ import type {Customer} from "../entities/sys/Customer"
 import {CustomerTypeRef} from "../entities/sys/Customer"
 import type {User} from "../entities/sys/User"
 import {UserTypeRef} from "../entities/sys/User"
-import {isSameId} from "../common/EntityFunctions"
+import {isSameId, MediaType} from "../common/EntityFunctions"
 import type {GroupInfo} from "../entities/sys/GroupInfo"
 import {GroupInfoTypeRef} from "../entities/sys/GroupInfo"
 import {assertMainOrNode, getHttpOrigin} from "../Env"
@@ -195,7 +195,9 @@ export class UserController implements IUserController {
 						sessionId: this.sessionId
 					})
 					delete downcast(requestObject)["_type"] // Remove extra field which is not part of the data model
-					const queued = sendBeacon.call(navigator, path, JSON.stringify(requestObject))
+					// Send as Blob to be able to set content type otherwise sends 'text/plain'
+					const queued = sendBeacon.call(navigator, path,
+						new Blob([JSON.stringify(requestObject)], {type: MediaType.Json}));
 					console.log("queued closing session: ", queued)
 					resolve()
 				} catch (e) {


### PR DESCRIPTION
`navigator.sendBeacon` sets `Content-Type: text/plain` if passed a
string. Using `Blob` it uses the blobs type for the header (see
https://codereview.chromium.org/996143002 for chromium and
https://stackoverflow.com/questions/40523469/navigator-sendbeacon-to-pass-header-information)

Should help for some blocked content types returning `415` errors, fixes #2391

## Test notes:

 * Make sure you are using HTTPS, Beacons are disabled for HTTP
 * Login to the client without saving a session. Sessions are not closed for saved credentials
* To get a log of the beacon on closing a tab in firefox go to `about:networking` -> Logging and set the logging modules to `timestamp,nsHttp:3` to log the http headers.
