### PR TITLE
Don't close the mail editor if tab is not closed (fix #2423)

### DIFF
--- a/src/api/Env.js
+++ b/src/api/Env.js
@@ -51,6 +51,10 @@ export function isDesktop(): boolean {
 	return env.mode === Mode.Desktop
 }
 
+export function isBrowser(): boolean {
+	return env.mode === Mode.Browser
+}
+
 export function ifDesktop<T>(obj: T | null): T | null {
 	return isDesktop()
 		? obj

--- a/src/mail/MailEditorN.js
+++ b/src/mail/MailEditorN.js
@@ -31,7 +31,7 @@ import {ButtonN, ButtonType} from "../gui/base/ButtonN"
 import {attachDropdown, createDropdown} from "../gui/base/DropdownN"
 import {fileController} from "../file/FileController"
 import {RichTextToolbar} from "../gui/base/RichTextToolbar"
-import {isApp} from "../api/Env"
+import {isApp, isBrowser} from "../api/Env"
 import {Icons} from "../gui/base/icons/Icons"
 import {RecipientInfoType} from "../api/common/RecipientInfo"
 import {animations, height, opacity} from "../gui/animation/Animations"
@@ -449,7 +449,10 @@ function createMailEditorDialog(model: SendMailModel, blockExternalContent: bool
 		middle: () => conversationTypeString(model.getConversationType()),
 		create: () => {
 			windowCloseUnsubscribe = windowFacade.addWindowCloseListener(() => {
-				closeButtonAttrs.click(newMouseEvent(), domCloseButton)
+				// Simulate a button click only if we're on not on browser, since on a browser, we can't override it closing, only ask if the user is sure they want to close
+				if (!isBrowser()) {
+					closeButtonAttrs.click(newMouseEvent(), domCloseButton)
+				}
 			})
 		},
 		remove: () => {

--- a/src/mail/MailEditorN.js
+++ b/src/mail/MailEditorN.js
@@ -31,7 +31,7 @@ import {ButtonN, ButtonType} from "../gui/base/ButtonN"
 import {attachDropdown, createDropdown} from "../gui/base/DropdownN"
 import {fileController} from "../file/FileController"
 import {RichTextToolbar} from "../gui/base/RichTextToolbar"
-import {isApp, isBrowser} from "../api/Env"
+import {isApp, isBrowser, isDesktop} from "../api/Env"
 import {Icons} from "../gui/base/icons/Icons"
 import {RecipientInfoType} from "../api/common/RecipientInfo"
 import {animations, height, opacity} from "../gui/animation/Animations"
@@ -448,12 +448,15 @@ function createMailEditorDialog(model: SendMailModel, blockExternalContent: bool
 		],
 		middle: () => conversationTypeString(model.getConversationType()),
 		create: () => {
-			windowCloseUnsubscribe = windowFacade.addWindowCloseListener(() => {
-				// Simulate a button click only if we're on not on browser, since on a browser, we can't override it closing, only ask if the user is sure they want to close
-				if (!isBrowser()) {
+			if (isBrowser()) {
+				// Have a simple listener on browser, so their browser will make the user ask if they are sure they want to close when closing the tab/window
+				windowCloseUnsubscribe = windowFacade.addWindowCloseListener(() => {})
+			} else if (isDesktop()) {
+				// Simulate clicking the Close button when on the desktop so they can see they can save a draft rather than completely closing it
+				windowCloseUnsubscribe = windowFacade.addWindowCloseListener(() => {
 					closeButtonAttrs.click(newMouseEvent(), domCloseButton)
-				}
-			})
+				})
+			}
 		},
 		remove: () => {
 			windowCloseUnsubscribe()


### PR DESCRIPTION
Fixes #2423 by changing the listener to do nothing but still trigger if the tab is closed when on browser, allowing the user the option to not close the tab if they are unsure without closing the editor regardless of their choice.