### PR TITLE
Handle commas for BubbleTextField (fixes #2427)

### DIFF
--- a/src/gui/base/BubbleTextField.js
+++ b/src/gui/base/BubbleTextField.js
@@ -102,6 +102,7 @@ export class BubbleTextField<T> {
 		this.textField.baseLabelPosition = size.text_field_label_top
 		this.textField.onblur.map(() => this.createBubbles())
 		this.textField._keyHandler = key => this.handleKey(key)
+        this.textField._keyPressHandler = key => this.handleKeypress(key)
 
 		this.bubbleHandler = bubbleHandler
 
@@ -188,8 +189,7 @@ export class BubbleTextField<T> {
 		switch (key.keyCode) {
 			case 13: // return
 			case 32: // whitespace
-			case 188: //comma
-				return this.createBubbles() || false
+                return this.createBubbles() || false
 			case 8:
 				return this.handleBackspace()
 			case 46:
@@ -207,9 +207,18 @@ export class BubbleTextField<T> {
 			case 17: // do not react on ctrl key
 				return true
 		}
+        
 		this.removeBubbleSelection()
 		return true
 	}
+    
+    handleKeypress(key: KeyboardEvent): boolean {
+        if (key.key === ",") {
+            return this.createBubbles() || false
+        }
+        
+        return true
+    }
 
 	createBubbles(): void {
 		let value = this.textField.value().trim()

--- a/src/gui/base/BubbleTextField.js
+++ b/src/gui/base/BubbleTextField.js
@@ -102,7 +102,6 @@ export class BubbleTextField<T> {
 		this.textField.baseLabelPosition = size.text_field_label_top
 		this.textField.onblur.map(() => this.createBubbles())
 		this.textField._keyHandler = key => this.handleKey(key)
-        this.textField._keyPressHandler = key => this.handleKeypress(key)
 
 		this.bubbleHandler = bubbleHandler
 
@@ -207,18 +206,15 @@ export class BubbleTextField<T> {
 			case 17: // do not react on ctrl key
 				return true
 		}
-        
-		this.removeBubbleSelection()
-		return true
-	}
-    
-    handleKeypress(key: KeyboardEvent): boolean {
+		
+		// Handle commas
         if (key.key === ",") {
             return this.createBubbles() || false
         }
         
-        return true
-    }
+		this.removeBubbleSelection()
+		return true
+	}
 
 	createBubbles(): void {
 		let value = this.textField.value().trim()

--- a/src/gui/base/TextField.js
+++ b/src/gui/base/TextField.js
@@ -51,6 +51,7 @@ export class TextField {
 	onblur: Stream<*>;
 	skipNextBlur: boolean;
 	_keyHandler: ?keyHandler; // interceptor used by the BubbleTextField to react on certain keys
+	_keyPressHandler: ?Function; // used by BubbleTextField to react on commas
 	_alignRight: boolean;
 	_preventAutofill: boolean;
 	autocomplete: string;
@@ -79,6 +80,7 @@ export class TextField {
 		this.onblur = stream()
 		this.skipNextBlur = false
 		this._keyHandler = null
+		this._keyPressHandler = null
 		this._preventAutofill = false
 
 		this.view = (): VirtualElement => {
@@ -193,6 +195,9 @@ export class TextField {
 					},
 					onfocus: (e) => this.focus(),
 					onblur: e => this.blur(e),
+					onkeypress: e => {
+						return this._keyPressHandler != null ? this._keyPressHandler(e) : true
+					},
 					onkeydown: e => {
 						// keydown is used to cancel certain keypresses of the user (mainly needed for the BubbleTextField)
 						let key = {keyCode: e.which, ctrl: e.ctrlKey, shift: e.shiftKey}

--- a/src/gui/base/TextField.js
+++ b/src/gui/base/TextField.js
@@ -51,7 +51,6 @@ export class TextField {
 	onblur: Stream<*>;
 	skipNextBlur: boolean;
 	_keyHandler: ?keyHandler; // interceptor used by the BubbleTextField to react on certain keys
-	_keyPressHandler: (KeyboardEvent) => mixed; // used by BubbleTextField to react on commas
 	_alignRight: boolean;
 	_preventAutofill: boolean;
 	autocomplete: string;
@@ -80,7 +79,6 @@ export class TextField {
 		this.onblur = stream()
 		this.skipNextBlur = false
 		this._keyHandler = null
-		this._keyPressHandler = () => {}
 		this._preventAutofill = false
 
 		this.view = (): VirtualElement => {
@@ -195,10 +193,9 @@ export class TextField {
 					},
 					onfocus: (e) => this.focus(),
 					onblur: e => this.blur(e),
-					onkeypress: e => this._keyPressHandler(e),
 					onkeydown: e => {
 						// keydown is used to cancel certain keypresses of the user (mainly needed for the BubbleTextField)
-						let key = {keyCode: e.which, ctrl: e.ctrlKey, shift: e.shiftKey}
+						let key = {keyCode: e.which, key: e.key, ctrl: e.ctrlKey, shift: e.shiftKey}
 						const input = this._domInput
 						if (input && input.value !== this.value()) {
 							this.value(input.value) // password managers like CKPX set the value directly and only send a key event (oninput is not invoked), e.g. https://github.com/subdavis/Tusk/blob/9eecda720c1ecfe5d44af89fb96125cfd9921f2a/background/inject.js#L191
@@ -258,7 +255,7 @@ export class TextField {
 				onfocus: (e) => this.focus(),
 				onblur: e => this.blur(e),
 				onkeydown: e => {
-					let key = {keyCode: e.which, ctrl: e.ctrlKey, shift: e.shiftKey}
+					let key = {keyCode: e.which, key: e.key, ctrl: e.ctrlKey, shift: e.shiftKey}
 					return this._keyHandler != null ? this._keyHandler(key) : true
 				},
 				oninput: e => {

--- a/src/gui/base/TextField.js
+++ b/src/gui/base/TextField.js
@@ -51,7 +51,7 @@ export class TextField {
 	onblur: Stream<*>;
 	skipNextBlur: boolean;
 	_keyHandler: ?keyHandler; // interceptor used by the BubbleTextField to react on certain keys
-	_keyPressHandler: ?Function; // used by BubbleTextField to react on commas
+	_keyPressHandler: (KeyboardEvent) => mixed; // used by BubbleTextField to react on commas
 	_alignRight: boolean;
 	_preventAutofill: boolean;
 	autocomplete: string;
@@ -80,7 +80,7 @@ export class TextField {
 		this.onblur = stream()
 		this.skipNextBlur = false
 		this._keyHandler = null
-		this._keyPressHandler = null
+		this._keyPressHandler = () => {}
 		this._preventAutofill = false
 
 		this.view = (): VirtualElement => {
@@ -195,9 +195,7 @@ export class TextField {
 					},
 					onfocus: (e) => this.focus(),
 					onblur: e => this.blur(e),
-					onkeypress: e => {
-						return this._keyPressHandler != null ? this._keyPressHandler(e) : true
-					},
+					onkeypress: e => this._keyPressHandler(e),
 					onkeydown: e => {
 						// keydown is used to cancel certain keypresses of the user (mainly needed for the BubbleTextField)
 						let key = {keyCode: e.which, ctrl: e.ctrlKey, shift: e.shiftKey}

--- a/src/gui/base/TextFieldN.js
+++ b/src/gui/base/TextFieldN.js
@@ -157,7 +157,7 @@ export class _TextField {
 					onblur: e => this.blur(e, a),
 					onkeydown: e => {
 						// keydown is used to cancel certain keypresses of the user (mainly needed for the BubbleTextField)
-						let key = {keyCode: e.which, ctrl: e.ctrlKey, shift: e.shiftKey}
+						let key = {keyCode: e.which, key: e.key, ctrl: e.ctrlKey, shift: e.shiftKey}
 						return a.keyHandler != null ? a.keyHandler(key) : true
 					},
 					onremove: e => {
@@ -232,7 +232,7 @@ export class _TextField {
 				onfocus: (e) => this.focus(e, a),
 				onblur: e => this.blur(e, a),
 				onkeydown: e => {
-					let key = {keyCode: e.which, ctrl: e.ctrlKey, shift: e.shiftKey}
+					let key = {keyCode: e.which, key: e.key, ctrl: e.ctrlKey, shift: e.shiftKey}
 					return a.keyHandler != null ? a.keyHandler(key) : true
 				},
 				oninput: e => {

--- a/src/misc/KeyManager.js
+++ b/src/misc/KeyManager.js
@@ -18,7 +18,7 @@ assertMainOrNodeBoot()
 
 export const TABBABLE = "button, input, textarea, div[contenteditable='true']"
 
-export type KeyPress = {keyCode: number, ctrl: boolean, shift: boolean};
+export type KeyPress = {keyCode: number, key: string, ctrl: boolean, shift: boolean};
 type Key = {code: number, name: string};
 
 /**
@@ -118,6 +118,7 @@ class KeyManager {
 			if (shortcut != null && (shortcut.enabled == null || shortcut.enabled())) {
 				if (shortcut.exec({
 					keyCode,
+					key: e.key,
 					ctrl: e.ctrlKey,
 					alt: e.altKey,
 					shift: e.shiftKey,


### PR DESCRIPTION
This fixes #2427 by using onkeypress instead of onkeydown, which lets us intercept keys while knowing the actual value of the character being inserted.

I tested this by changing my system's keyboard layout to one that doesn't have the U.S. comma key code correspond to a comma.