### PR TITLE
Restore the address properly (fixes #2379)

### DIFF
--- a/src/mail/SendMailModel.js
+++ b/src/mail/SendMailModel.js
@@ -426,7 +426,7 @@ export class SendMailModel {
 		      replyTos,
 		      previousMail,
 		      previousMessageId,
-	      }: {
+	      }: {|
 		conversationType: ConversationTypeEnum,
 		subject: string,
 		bodyText: string,
@@ -438,7 +438,7 @@ export class SendMailModel {
 		replyTos?: EncryptedMailAddress[],
 		previousMail?: ?Mail,
 		previousMessageId?: ?string,
-	}): Promise<SendMailModel> {
+	|}): Promise<SendMailModel> {
 		this._conversationType = conversationType
 		this._subject = subject
 		this._body = bodyText

--- a/src/mail/SendMailModel.js
+++ b/src/mail/SendMailModel.js
@@ -403,7 +403,7 @@ export class SendMailModel {
 				bodyText,
 				recipients,
 				draft,
-				sender: sender.address,
+				senderMailAddress: sender.address,
 				confidential,
 				attachments,
 				replyTos,


### PR DESCRIPTION
Fixes #2379. It was probably a typo, since there was code for restoring the sender address. It just didn't set it since the parameter key used was "sender" instead of the expected "senderMailAddress" thus it defaulted to the default address.