### PR TITLE
Ignore "inherit" color when determining if white background is needed (fixes #1710)

### DIFF
--- a/src/mail/MailViewer.js
+++ b/src/mail/MailViewer.js
@@ -843,13 +843,13 @@ export class MailViewer {
 			/**
 			 * check if we need to improve contrast for dark theme.
 			 * 1. theme id must be 'dark'
-			 * 2. html body needs to contain any tag with a style attribute that has the color property set
+			 * 2. html body needs to contain any tag with a style attribute that has the color property set (besides "inherit")
 			 * OR
 			 * there is a font tag with the color attribute set
 			 */
 			this._contrastFixNeeded = (
 				'undefined' !== typeof Array.from(sanitizeResult.html.querySelectorAll('*[style]'), e => e.style)
-				                            .find(s => s.color !== "" && typeof s.color !== 'undefined')
+				                            .find(s => s.color !== "" && s.color !== "inherit" && typeof s.color !== 'undefined')
 				|| 0 < Array.from(sanitizeResult.html.querySelectorAll('font[color]'), e => e.style).length
 			)
 			this._htmlBody = urlify(stringifyFragment(sanitizeResult.html))


### PR DESCRIPTION
This resolves #1710 by ignoring "inherit" color properties when we're using a dark theme and need to check if we need a light background, instead.

Before:
![image](https://user-images.githubusercontent.com/39858815/99320963-61d8b500-2832-11eb-913b-3ba48996999a.png)

After:
![image](https://user-images.githubusercontent.com/39858815/99321098-afedb880-2832-11eb-83d8-ccb70a1280ee.png)
