### PR TITLE
Add isUserLoggedIn check before calls to getUserController

### DIFF
--- a/src/settings/LoginSettingsViewer.js
+++ b/src/settings/LoginSettingsViewer.js
@@ -15,6 +15,7 @@ import {formatDateTimeFromYesterdayOn} from "../misc/Formatter"
 import {SessionState} from "../api/common/TutanotaConstants"
 import {EditSecondFactorsForm} from "./EditSecondFactorsForm"
 import {LazyLoaded} from "../api/common/utils/LazyLoaded"
+import type {EntityUpdateData} from "../api/main/EventController"
 import {isUpdateForTypeRef} from "../api/main/EventController"
 import type {ButtonAttrs} from "../gui/base/ButtonN"
 import {ButtonN, ButtonType} from "../gui/base/ButtonN"
@@ -25,7 +26,6 @@ import type {ExpanderAttrs} from "../gui/base/ExpanderN"
 import {ExpanderButtonN, ExpanderPanelN} from "../gui/base/ExpanderN"
 import type {TableAttrs, TableLineAttrs} from "../gui/base/TableN"
 import {ColumnWidth, TableN} from "../gui/base/TableN"
-import type {EntityUpdateData} from "../api/main/EventController"
 
 assertMainOrNode()
 
@@ -130,28 +130,31 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 			lines: this._closedSessionsTableLines(),
 		}
 
-		const user = logins.getUserController()
-
-		return m("", [
-			m("#user-settings.fill-absolute.scroll.plr-l.pb-xl", [
-				m(".h4.mt-l", lang.get('loginCredentials_label')),
-				m(TextFieldN, mailAddressAttrs),
-				m(TextFieldN, passwordAttrs),
-				user.isGlobalAdmin() ? m(TextFieldN, recoveryCodeFieldAttrs) : null,
-				(!user.isOutlookAccount()) ?
-					m(this._secondFactorsForm) : null,
-				m(".h4.mt-l", lang.get('activeSessions_label')),
-				m(TableN, activeSessionTableAttrs),
-				m(".small", lang.get("sessionsInfo_msg")),
-				m(".flex-space-between.items-center.mt-l.mb-s", [
-					m(".h4", lang.get('closedSessions_label')),
-					m(ExpanderButtonN, closedSessionExpanderAttrs)
-				]),
-				m(ExpanderPanelN, {expanded: this._closedSessionsExpanded}, m(TableN, closedSessionTableAttrs)),
-				m(".small", lang.get("sessionsWillBeDeleted_msg")),
-				m(".small", lang.get("sessionsInfo_msg")),
+		if (logins.isUserLoggedIn()) {
+			const user = logins.getUserController()
+			return m("", [
+				m("#user-settings.fill-absolute.scroll.plr-l.pb-xl", [
+					m(".h4.mt-l", lang.get('loginCredentials_label')),
+					m(TextFieldN, mailAddressAttrs),
+					m(TextFieldN, passwordAttrs),
+					user.isGlobalAdmin() ? m(TextFieldN, recoveryCodeFieldAttrs) : null,
+					(!user.isOutlookAccount()) ?
+						m(this._secondFactorsForm) : null,
+					m(".h4.mt-l", lang.get('activeSessions_label')),
+					m(TableN, activeSessionTableAttrs),
+					m(".small", lang.get("sessionsInfo_msg")),
+					m(".flex-space-between.items-center.mt-l.mb-s", [
+						m(".h4", lang.get('closedSessions_label')),
+						m(ExpanderButtonN, closedSessionExpanderAttrs)
+					]),
+					m(ExpanderPanelN, {expanded: this._closedSessionsExpanded}, m(TableN, closedSessionTableAttrs)),
+					m(".small", lang.get("sessionsWillBeDeleted_msg")),
+					m(".small", lang.get("sessionsInfo_msg")),
+				])
 			])
-		])
+		} else {
+			return []
+		}
 	}
 
 	_updateSessions(): Promise<void> {

--- a/src/settings/LoginSettingsViewer.js
+++ b/src/settings/LoginSettingsViewer.js
@@ -130,6 +130,7 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 			lines: this._closedSessionsTableLines(),
 		}
 
+		// Might be not there when we are logging out
 		if (logins.isUserLoggedIn()) {
 			const user = logins.getUserController()
 			return m("", [
@@ -153,7 +154,7 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 				])
 			])
 		} else {
-			return []
+			return null
 		}
 	}
 

--- a/src/settings/SettingsView.js
+++ b/src/settings/SettingsView.js
@@ -113,9 +113,12 @@ export class SettingsView implements CurrentView {
 				content: m(".flex.flex-grow.col", [
 					m(".plr-l", m(userFolderExpander)),
 					m(userFolderExpander.panel),
-					logins.isUserLoggedIn()
-					&& logins.getUserController().isGlobalOrLocalAdmin() ? m(".plr-l", m(adminFolderExpander)) : null,
-					logins.isUserLoggedIn() && logins.getUserController().isGlobalOrLocalAdmin() ? m(adminFolderExpander.panel) : null,
+					logins.isUserLoggedIn() && logins.getUserController().isGlobalOrLocalAdmin()
+						? [
+							m(".plr-l", m(adminFolderExpander)),
+							m(adminFolderExpander.panel),
+						]
+						: null,
 					isTutanotaDomain() ? this._aboutThisSoftwareLink() : null,
 				]),
 				ariaLabel: "settings_label"

--- a/src/settings/SettingsView.js
+++ b/src/settings/SettingsView.js
@@ -113,8 +113,9 @@ export class SettingsView implements CurrentView {
 				content: m(".flex.flex-grow.col", [
 					m(".plr-l", m(userFolderExpander)),
 					m(userFolderExpander.panel),
-					logins.getUserController().isGlobalOrLocalAdmin() ? m(".plr-l", m(adminFolderExpander)) : null,
-					logins.getUserController().isGlobalOrLocalAdmin() ? m(adminFolderExpander.panel) : null,
+					logins.isUserLoggedIn()
+					&& logins.getUserController().isGlobalOrLocalAdmin() ? m(".plr-l", m(adminFolderExpander)) : null,
+					logins.isUserLoggedIn() && logins.getUserController().isGlobalOrLocalAdmin() ? m(adminFolderExpander.panel) : null,
 					isTutanotaDomain() ? this._aboutThisSoftwareLink() : null,
 				]),
 				ariaLabel: "settings_label"


### PR DESCRIPTION
When refreshing from the settings view, we try to get the UserController in some of the component view functions after we've logged out, leading to a failed assertNotNull, so we now check if there is a UserController to be gotten before trying to get it

close #2403 