### PR TITLE
Bump minimum Chrome version to 56

### DIFF
--- a/src/misc/ClientDetector.js
+++ b/src/misc/ClientDetector.js
@@ -376,7 +376,7 @@ class ClientDetector {
 	}
 
 	notOldChrome(): boolean {
-		return this.browser !== BrowserType.CHROME || this.browserVersion > 37
+		return this.browser !== BrowserType.CHROME || this.browserVersion > 55
 	}
 
 	canDownloadMultipleFiles(): boolean {

--- a/test/client/common/ClientDetectorTest.js
+++ b/test/client/common/ClientDetectorTest.js
@@ -401,8 +401,14 @@ o.spec("ClientDetector test", function () {
 		o(client.isSupportedBrowserVersion()).equals(false)
 	})
 
+	o("Chrome 55 is not supported", function () {
+		client.init("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2062.120 Safari/537.36", "Linux")
+		o(client.isSupportedBrowserVersion()).equals(false)
+	})
+
+
 	o("newer Chrome is supported", function () {
-		client.init("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.104 Safari/537.36", "Linux")
+		client.init("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2125.104 Safari/537.36", "Linux")
 		o(client.isSupportedBrowserVersion()).equals(true)
 	})
 


### PR DESCRIPTION
see #2069, close #1861

This should be a safe change as date formatting didn't properly work
with Chrome 55 anyway (see #1861) which was breaking the app.

This is a first step of requiring modern browser versions.