### PR TITLE
Redirect to buying aliases when OK is selected (fixes #1919)

### DIFF
--- a/src/settings/EditAliasesFormN.js
+++ b/src/settings/EditAliasesFormN.js
@@ -14,6 +14,7 @@ import {showNotAvailableForFreeDialog} from "../misc/ErrorHandlerImpl"
 import {logins} from "../api/main/LoginController"
 import {Icons} from "../gui/base/icons/Icons"
 import {showProgressDialog} from "../gui/base/ProgressDialog"
+import * as EmailAliasOptionsDialog from "../subscription/EmailAliasOptionsDialog"
 import {getAvailableDomains} from "./AddUserDialog"
 import type {ButtonAttrs} from "../gui/base/ButtonN"
 import {ButtonType} from "../gui/base/ButtonN"
@@ -74,9 +75,9 @@ export class EditAliasesFormN implements MComponent<EditAliasesFormAttrs> {
 				Dialog.confirm(() => lang.get("adminMaxNbrOfAliasesReached_msg") + " "
 					+ lang.get("orderAliasesConfirm_msg")).then(confirmed => {
 					if (confirmed) {
-						// TODO: Navigate to alias upgrade
-						//tutao.locator.navigator.settings();
-						//tutao.locator.settingsViewModel.show(tutao.tutanota.ctrl.SettingsViewModel.DISPLAY_ADMIN_PAYMENT);
+						// Navigate to subscriptions folder and show alias options
+						m.route.set("/settings/subscription")
+						EmailAliasOptionsDialog.show()
 					}
 				})
 			}


### PR DESCRIPTION
This fixes #1919 by navigating to the subscriptions folder and bringing up alias options.

![fix2](https://user-images.githubusercontent.com/39858815/100133484-73cae100-2e4c-11eb-914e-5208d87500c2.gif)