### PR TITLE
Don't prepend whitespace for custom signatures (fixes #2473)

### DIFF
--- a/src/mail/MailUtils.js
+++ b/src/mail/MailUtils.js
@@ -468,7 +468,7 @@ export function getEmailSignature(logins: LoginController = globalLogins): strin
 		// default signature already contains empty lines
 		return getDefaultSignature()
 	} else if (TutanotaConstants.EMAIL_SIGNATURE_TYPE_CUSTOM === type) {
-		return SIGNATURE_DISTANCE + logins.getUserController().props.customEmailSignature
+		return logins.getUserController().props.customEmailSignature
 	} else {
 		return ""
 	}


### PR DESCRIPTION
This fixes #2473 by not prepending SIGNATURE_DISTANCE in getEmailSignature()