### PR TITLE
Unset search bars lastQuery on close

### DIFF
--- a/src/search/SearchBar.js
+++ b/src/search/SearchBar.js
@@ -478,6 +478,7 @@ export class SearchBar implements Component {
 		if (this.expanded) {
 			this.expanded = false
 			this._updateState({query: ""})
+			locator.search.lastQuery("")
 			this._domInput.blur() // remove focus from the input field in case ESC is pressed
 		}
 		if (m.route.get().startsWith("/search")) {


### PR DESCRIPTION
Prevents from expanding the search bar again after closing when changing views (E-Mail, Calendar, Contacts)

closes #2534