### PR TITLE
Remove keyboard shortcuts from ProgressDialog

### DIFF
--- a/src/gui/base/Dialog.js
+++ b/src/gui/base/Dialog.js
@@ -189,6 +189,11 @@ export class Dialog {
 		return this
 	}
 
+	setShortcuts(shortcuts: Shortcut[]): Dialog {
+		this._shortcuts = shortcuts
+		return this
+	}
+
 	/**
 	 * Sets a close handler to the dialog. If set the handler will be notified when onClose is called on the dialog.
 	 * The handler must is then responsible for closing the dialog.

--- a/src/gui/base/ProgressDialog.js
+++ b/src/gui/base/ProgressDialog.js
@@ -37,7 +37,7 @@ export function showProgressDialog<T>(messageIdOrMessageFunction: TranslationKey
 		])
 	}).setCloseHandler(() => {
 		// do not close progress on onClose event
-	})
+	}).setShortcuts([]) // remove any shortcuts
 
 	progressDialog.show()
 	let start = new Date().getTime()


### PR DESCRIPTION
Make shortcuts overwriteable for a dialog to remove default (tab) shortcuts on progress Dialog.

fix #2550