### PR TITLE
Always show 'Tutanota Team' badge for mails from @tutao.de

### DIFF
--- a/src/mail/MailUtils.js
+++ b/src/mail/MailUtils.js
@@ -220,7 +220,7 @@ export function getSenderOrRecipientHeadingTooltip(mail: Mail): string {
 }
 
 export function isTutanotaTeamMail(mail: Mail): boolean {
-	return mail.confidential && (mail.state === MailState.RECEIVED) && endsWith(mail.sender.address, "@tutao.de")
+	return mail.state === MailState.RECEIVED && endsWith(mail.sender.address, "@tutao.de")
 }
 
 export function isExcludedMailAddress(mailAddress: string): boolean {


### PR DESCRIPTION
When sending an email from @tutao.de to any user show team badge even if
not encrypted.

fix #2218