### PR TITLE
fix: VSCode flow errors

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["flowtype.flow-for-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"javascript.validate.enable": false
+}


### PR DESCRIPTION
## What
When the project repository is opened up in VSCode, a bunch of `flow` errors start showing up as seen in the following screenshot:

![Screenshot from 2020-12-31 00-28-56](https://user-images.githubusercontent.com/2741371/103396226-f99f1380-4aff-11eb-9121-9698455bd8a6.png)

## Fix
This PR fixes these errors by doing two things:
1. Recommend installing a VSCode specific [extension](https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode) that supports Flow typings throw an [`extensions.json`](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) file.
2. Disable JavaScript validation as mentioned on the official [`flowtype` README](https://github.com/flowtype/flow-for-vscode#setup) by adding a `settings.json` file.

Please note that these additions are specific to VSCode only and should not interfere with other editors.
