### PR TITLE
Do not produce error when logging cyclic objects

### DIFF
--- a/src/api/common/Logger.js
+++ b/src/api/common/Logger.js
@@ -42,7 +42,12 @@ export class Logger {
 
 	formatLogEntry(date: Date, level: string, ...rest: Array<any>): string {
 		const formattedArgs = rest.map((obj) => {
-			return (obj instanceof Error ? errorToString(obj) : JSON.stringify(obj))
+			try {
+				return (obj instanceof Error ? errorToString(obj) : JSON.stringify(obj))
+			} catch (e) {
+				return "[cyclic object]"
+			}
+
 		})
 		const message = formattedArgs.join(",")
 		return `${date.toISOString()} ${level} ${message}`


### PR DESCRIPTION
Easy way out. We loose the logs about the whole object, but should be
lighter than c1ea9f94bf.

fix #2184

see https://github.com/tutao/tutanota/issues/2562#issuecomment-753990738_