### PR TITLE
Assume UTF-8 charset for vcard imports

### DIFF
--- a/src/contacts/VCardImporter.js
+++ b/src/contacts/VCardImporter.js
@@ -111,7 +111,7 @@ export function vCardListToContacts(vCardList: string[], ownerGroupId: Id): Cont
 			let encoding = encodingObj ? encodingObj.split('=')[1] : ''
 
 			let charsetObj = vCardLines[j].split(';').find((line) => line.includes('CHARSET='))
-			let charset = charsetObj ? charsetObj.split('=')[1] : ''
+			let charset = charsetObj ? charsetObj.split('=')[1] : 'utf-8'
 
 			tagValue = _decodeTag(encoding, charset, tagValue)
 

--- a/test/client/contact/VCardImporterTest.js
+++ b/test/client/contact/VCardImporterTest.js
@@ -348,4 +348,24 @@ END:VCARD`
 		let contacts = vCardListToContacts(neverNull(vCardFileToVCards(vcards)), "")
 		o(neverNull(contacts[0].addresses[0].address)).equals("Rua das Nações")
 	})
+
+	o("test with no charset but encoding", function () {
+		let vcards = "BEGIN:VCARD\n"
+			+ "VERSION:2.1\n"
+			+ "N;ENCODING=QUOTED-PRINTABLE:=4E;\n"
+			+ "END:VCARD\nD"
+		let contacts = vCardListToContacts(neverNull(vCardFileToVCards(vcards)), "")
+		o(neverNull(contacts[0].lastName)).equals("N")
+	})
+
+	o("base64 implicit utf-8", function () {
+		let vcards = "BEGIN:VCARD\n"
+			+ "VERSION:2.1\n"
+			+ "N:Mustermann;Max;;;\n"
+			+ "FN:Max Mustermann\n"
+			+ "ADR;HOME;ENCODING=BASE64:;;w4TDpMOkaGhtbQ==;;;;\n"
+			+ "END:VCARD"
+		let contacts = vCardListToContacts(neverNull(vCardFileToVCards(vcards)), "")
+		o(neverNull(contacts[0].addresses[0].address)).equals("Ääähhmm")
+	})
 })


### PR DESCRIPTION
RFC-compliant vcards do not contain `CHARSET` parameter at all anymore.

Charset can only be set via MIME type on the vcard itself, see https://tools.ietf.org/html/rfc6350#section-3.1 and this errata https://www.rfc-editor.org/errata/eid3199 which removes the `CHARSET` reference. Apparently, there is some confusion and i don't know if this RFC is respected anyways.
We should still support, but in case no charset is given i think it will be sensible to assume standard compliance.

Also adds a test case based on #2572 

fix #2572