### PR TITLE
Ignore duplicate UID error when creating calendar events

### DIFF
--- a/src/calendar/export/CalendarImporterDialog.js
+++ b/src/calendar/export/CalendarImporterDialog.js
@@ -60,6 +60,7 @@ export function showCalendarImportDialog(calendarGroupRoot: CalendarGroupRoot) {
 							              }
 							              assignEventId(event, zone, calendarGroupRoot)
 							              return worker.createCalendarEvent(event, alarms, null)
+							                           .catch(PreconditionFailedError, () => console.log("ignoring create calendar event with duplicate uid"))
 							                           .then(() => progressMonitor.workDone(1))
 							                           .delay(100)
 						              })

--- a/src/calendar/model/CalendarModel.js
+++ b/src/calendar/model/CalendarModel.js
@@ -192,6 +192,7 @@ export class CalendarModelImpl implements CalendarModel {
 			event._ownerGroup = groupRoot._id
 
 			return this._worker.createCalendarEvent(event, alarmInfos, existingEvent)
+			           .catch(PreconditionFailedError, () => console.log("ignoring create calendar event with duplicate uid"))
 		})
 	}
 


### PR DESCRIPTION
I suspect that the problem is something to do with getting rate limited when importing or accepting invites