### PR TITLE
Reroute back to app after payment details verification on android

### DIFF
--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
             android:supportsRtl="true"
             android:theme="@style/AppTheme"
             android:resizeableActivity="true"
-            android:usesCleartextTraffic="true">
+            android:usesCleartextTraffic="true"
+            android:exported="true">
         <activity
                 android:name=".MainActivity"
                 android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale"
@@ -32,8 +33,8 @@
                 android:theme="@style/SplashTheme">
             <!--Main intent for launching from home screen-->
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
             <!--Handler for "share" event or when another app wants to send an email-->
             <intent-filter>
@@ -51,16 +52,24 @@
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
 
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="mailto" />
+                <data android:scheme="mailto"/>
             </intent-filter>
             <!--Another handler for mailto links, when user pressed them in browser-->
             <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <data android:scheme="mailto" />
+                <action android:name="android.intent.action.VIEW"/>
+                <data android:scheme="mailto"/>
 
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
             </intent-filter>
+
+            <intent-filter>
+                <data android:scheme="tutanota" android:host="app"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <action android:name="android.intent.action.VIEW"/>
+            </intent-filter>
+
         </activity>
         <provider
                 android:name="androidx.core.content.FileProvider"

--- a/src/braintree.html
+++ b/src/braintree.html
@@ -9,10 +9,8 @@
         document.addEventListener("DOMContentLoaded", function (event) {
             let params = parseQueryString(location.hash.substring(1))
 
-            let msgBox = document.createElement("div")
-            msgBox.id = "t-message"
-            msgBox.innerText = decodeURIComponent(params.message)
-            document.body.appendChild(msgBox)
+            let msgBox = document.getElementById("t-messagebox")
+            msgBox.innerHTML = decodeURIComponent(`<p>${params.message}</p>`)
 
             confirm3ds2(decodeURIComponent(params.clientToken), decodeURIComponent(params.nonce), decodeURIComponent(params.bin), decodeURIComponent(params.price))
         });
@@ -46,10 +44,14 @@
                     }) // body data type must match "Content-Type" header
                 }).then(response => {
                     // console.log(">>>", response)
+                    document.getElementById("t-messagebox").innerHTML = "<p>Your payment details were successfully linked to your Tutanota account.</p><p>You may close this tab and return to the app</p>"
+                    window.location.href = "tutanota://app"
                     window.close();
                 })
             }).catch(e => {
                 // console.log("error", e)
+                document.getElementById("t-messagebox").innerHTML = "<p>Failed to process payment information.</p><p>Please return to the app</p>"
+                window.location.href = "tutanota://app"
                 window.close();
             })
         }
@@ -1755,15 +1757,34 @@
     <link rel="apple-touch-icon" sizes="152x152" href="images/logo-favicon-152.png">
     <link rel="icon" sizes="192x192" href="/images/logo-favicon-192.png">
     <style>
-        #t-message {
-            text-align: center;
-            margin-top: 80px;
+        #t-messagebox {
             font-size: 20px;
             font-family: -apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
         }
     </style>
 </head>
 <body>
-<noscript>This site requires javascript to be enabled. Please activate it in the settings of your browser.</noscript>
+<div style="text-align: center; padding: 60px">
+    <div style="display: inline-block; padding: 20px 30px; background: #ffffff; border-radius: 5px; filter: drop-shadow(10px 10px 10px #00000088)">
+        <noscript>This site requires javascript to be enabled. Please activate it in the settings of your browser.
+        </noscript>
+        <div id="t-messagebox">
+        </div>
+    </div>
+    <div style="padding-top: 50px">
+        <svg xmlns="http://www.w3.org/2000/svg" width="200px" preserveAspectRatio="xMinYMid"
+             viewBox="0 0 1054.473 236.49">
+            <g fill="#4a4a4a">
+                <path d="M361.388 77.059h-42.696v-8.082h94.178v8.082h-42.696v121.939h-8.785V77.059zM410.581 173.697v-66.943h8.434v65.889c0 14.057 6.15 20.908 20.206 20.908 12.827 0 23.544-6.676 34.965-17.57v-69.228h8.434v92.245h-8.434v-15.285c-10.191 9.662-22.139 17.219-35.668 17.219-19.152-.001-27.937-10.543-27.937-27.235zM519.691 178.441v-64.133h-16.165v-7.555h16.165v-33.56h8.434v33.56h24.071v7.555h-24.071v62.902c0 9.84 3.339 15.463 14.935 15.463 3.515 0 7.028-.352 9.664-1.23v7.906c-2.987.527-6.501.879-10.366.879-15.287 0-22.667-6.15-22.667-21.787zM570.642 177.738c0-17.57 14.935-30.749 63.43-38.831v-5.623c0-14.056-7.38-21.084-20.03-21.084-15.287 0-25.478 5.974-35.845 15.287l-4.919-5.271c11.421-10.542 23.192-17.395 40.938-17.395 19.152 0 28.289 10.894 28.289 27.937v43.399c0 11.246.703 18.097 2.636 22.841h-8.961c-1.23-3.865-2.108-8.434-2.108-13.705-11.245 9.664-23.545 15.287-37.426 15.287-16.868 0-26.004-8.785-26.004-22.842zm63.429-.703v-31.803c-44.98 7.907-54.996 18.976-54.996 31.978 0 10.367 6.853 15.99 18.273 15.99 13.706.001 26.18-5.974 36.723-16.165z"></path>
+            </g>
+            <g fill="#4a4a4a">
+                <path d="M671.323 198.998v-92.772h15.286v13.881c8.083-7.907 19.68-15.813 34.79-15.813 17.746 0 27.41 10.191 27.41 27.762v66.943h-15.111v-63.604c0-12.299-5.271-18.098-17.043-18.098-11.069 0-20.382 5.798-30.046 14.935V199h-15.286zM770.944 152.612c0-31.978 20.382-48.319 43.224-48.319 22.666 0 43.048 16.341 43.048 48.319 0 31.802-20.382 48.319-43.048 48.319s-43.224-16.517-43.224-48.319zm70.986 0c0-19.328-9.313-35.316-27.762-35.316-17.746 0-27.937 14.408-27.937 35.316 0 19.679 9.137 35.493 27.937 35.493 17.57 0 27.762-14.233 27.762-35.493zM886.907 176.508v-57.807h-16.165v-12.475h16.165V73.194h15.11v33.032h24.072v12.475h-24.072v54.469c0 9.84 3.163 14.76 14.408 14.76 3.338 0 7.028-.527 9.488-1.23v12.475c-2.636.527-8.435 1.055-13.178 1.055-19.503-.002-25.828-7.556-25.828-23.722zM942.429 177.035c0-18.801 15.988-32.154 62.023-38.655v-4.217c0-11.597-6.149-17.219-17.57-17.219-14.057 0-24.423 6.15-33.56 14.056l-7.907-9.488c10.718-9.839 24.599-17.219 43.048-17.219 22.139 0 30.924 11.597 30.924 30.924v40.939c0 11.246.703 18.097 2.636 22.841h-15.462c-1.229-3.865-2.108-7.555-2.108-12.826-10.366 9.664-21.963 14.232-35.844 14.232-15.99.001-26.18-8.432-26.18-23.368zm62.023-2.108v-26.004c-35.316 5.623-47.089 14.232-47.089 25.829 0 8.961 5.974 13.706 15.638 13.706 12.299-.001 22.842-5.097 31.451-13.531z"></path>
+            </g>
+            <path d="M22.875 0C10.235 0 0 10.246 0 22.872v211.23c0 .801.046 1.608.123 2.388 8.5-3.167 17.524-6.629 27.054-10.436 66.336-26.48 120.569-48.994 120.618-74.415 0-.814-.056-1.636-.172-2.458-3.43-25.098-63.407-32.879-63.324-44.381.007-.611.18-1.25.548-1.889 7.205-12.619 35.743-12.015 46.253-12.907 10.519-.913 35.206-.724 36.399-8.244.035-.232.057-.463.057-.695.028-6.987-16.977-9.726-16.977-9.726s20.635 3.083 20.579 11.11c0 .393-.048.8-.158 1.214-2.222 8.624-20.379 10.246-32.386 10.835-11.356.569-28.648 1.861-28.707 7.408-.007.323.049.66.165 1.004 2.71 8.11 66.09 12.015 106.64 33.061 23.335 12.099 34.94 32.422 40.263 53.418V22.869c0-12.626-10.243-22.872-22.869-22.872H22.875z"
+                  fill="#840010"></path>
+        </svg>
+    </div>
+</div>
 </body>
 </html>
+


### PR DESCRIPTION
After braintree and paypal verification on android, the user will be taken back to the app. On desktop this doesn't currently seem doable (at least not in a nicely cross-platform way), so we instruct the user to go back themselves, closes #2516