### PR TITLE
Use legalizeFilename to preserve duplicate files

### DIFF
--- a/src/api/common/utils/FileUtils.js
+++ b/src/api/common/utils/FileUtils.js
@@ -17,3 +17,55 @@ export function sanitizeFilename(filename: string): string {
 		.replace(controlRe, "_")
 		.replace(windowsTrailingRe, "_")
 }
+
+/**
+ * take array of file names and add numbered suffixes to the basename of
+ * duplicates. Use to make a legal set of names for files written to disk
+ * at the same time.
+ *
+ * treats file names that already have numbered suffixes as non-numbered.
+ * assumes the file system is case insensitive (a.txt would overwrite A.TXT)
+ *
+ * @param files file names.
+ * @param isReserved (optional) function returning true for filenames that are reserved and will be suffixed.
+ * @returns map from old names to array of new names. use map[oldname].shift() to replace oldname with newname.
+ */
+export function legalizeFilenames(files: Array<string>, isReserved: ?(string)=>boolean): {[string]: Array<string>} {
+	const suffix = (name, suf) => {
+		const basename = name.substring(0, name.indexOf('.')) || name
+		const ext = name.substring(name.indexOf('.'))
+		return `${basename}-${suf}${ext}`
+	}
+
+	const unreserveFilename = name => (isReserved && isReserved(name))
+		? suffix(name, "")
+		: name
+
+	let cleaned = files.map(sanitizeFilename).map(unreserveFilename)
+	let dedup = new Set(cleaned.map(s => s.toLowerCase()))
+	let conv = cleaned.map((e, i) => [files[i], e]) // pairs [oldname, newname]
+	if (dedup.size === cleaned.length) {
+		return conv.reduce((m, [o, n]) => ({...m, [o]: [n]}), {}) // convert into map oldname -> [newname]
+	}
+
+	const out = {}
+	const news = {}
+	conv.forEach(([o, n]) => {
+		const lower = n.toLowerCase()
+		let newname
+		if (news[lower] === undefined) {
+			news[lower] = 0
+			newname = n
+		} else {
+			news[lower] = news[lower] + 1
+			newname = suffix(n, news[lower])
+		}
+		if (out[o]) {
+			out[o].push(newname)
+		} else {
+			out[o] = [newname]
+		}
+	})
+
+	return out
+}

--- a/src/desktop/DesktopUtils.js
+++ b/src/desktop/DesktopUtils.js
@@ -10,10 +10,12 @@ import {log} from "./DesktopLog"
 import {uint8ArrayToHex} from "../api/common/utils/Encoding"
 import {cryptoFns} from "./CryptoFns"
 
-import {legalizeFilenames} from "./PathUtils"
+
 import {AttachmentType, Email, MessageEditorFormat} from "oxmsg"
 import {delay} from "../api/common/utils/PromiseUtils"
 import type {MailBundle} from "../mail/export/Bundler";
+import {legalizeFilenames} from "../api/common/utils/FileUtils"
+import {isReservedFilename} from "./PathUtils"
 
 export class DesktopUtils {
 	checkIsMailtoHandler(): Promise<boolean> {
@@ -154,7 +156,7 @@ export class DesktopUtils {
 	// to do it's thing
 	async writeFilesToTmp(files: Array<{name: string, content: Uint8Array}>): Promise<string> {
 		const dirPath = path.join(app.getPath('temp'), 'tutanota', randomHexString(12))
-		const legalNames = legalizeFilenames(files.map(f => f.name))
+		const legalNames = legalizeFilenames(files.map(f => f.name), isReservedFilename)
 		const legalFiles = files.map(f => ({
 			content: f.content,
 			name: legalNames[f.name].shift()

--- a/src/desktop/PathUtils.js
+++ b/src/desktop/PathUtils.js
@@ -33,7 +33,7 @@ export function pathToFileURL(pathToConvert: string): string {
 export function nonClobberingFilename(files: Array<string>, filename: string): string {
 	filename = sanitizeFilename(filename)
 	const clashingFile = files.find(f => f === filename)
-	if (typeof clashingFile !== "string" && !_isReservedFilename(filename)) { // all is well
+	if (typeof clashingFile !== "string" && !isReservedFilename(filename)) { // all is well
 		return filename
 	} else { // there are clashing file names or the file name is reserved
 		const ext = path.extname(filename)
@@ -65,7 +65,7 @@ export function nonClobberingFilename(files: Array<string>, filename: string): s
  * @returns {boolean}
  * @private
  */
-function _isReservedFilename(filename: string): boolean {
+export function isReservedFilename(filename: string): boolean {
 	// CON, CON.txt, COM0 etc. (windows device files)
 	const winReservedRe = /^(CON|PRN|LPT[0-9]|COM[0-9]|AUX|NUL)($|\..*$)/i
 	// .. and .
@@ -91,50 +91,3 @@ export function looksExecutable(file: string): boolean {
 	return false
 }
 
-/**
- * take array of file names and add numbered suffixes to the basename of
- * duplicates. Use to make a legal set of names for files written to disk
- * at the same time.
- *
- * treats file names that already have numbered suffixes as non-numbered.
- * assumes the file system is case insensitive (a.txt would overwrite A.TXT)
- *
- * @param files file names.
- * @returns map from old names to array of new names. use map[oldname].shift() to replace oldname with newname.
- */
-export function legalizeFilenames(files: Array<string>): {[string]: Array<string>} {
-	const suffix = (name, suf) => {
-		const ext = path.extname(name)
-		const basename = path.basename(name, ext)
-		return `${basename}-${suf}${ext}`
-	}
-	const unreserveFilename = name => _isReservedFilename(name) ? suffix(name, "") : name
-
-	let cleaned = files.map(sanitizeFilename).map(unreserveFilename)
-	let dedup = new Set(cleaned.map(s => s.toLowerCase()))
-	let conv = cleaned.map((e, i) => [files[i], e]) // pairs [oldname, newname]
-	if (dedup.size === cleaned.length) {
-		return conv.reduce((m, [o, n]) => ({...m, [o]: [n]}), {}) // convert into map oldname -> [newname]
-	}
-
-	const out = {}
-	const news = {}
-	conv.forEach(([o, n]) => {
-		const lower = n.toLowerCase()
-		let newname
-		if (news[lower] === undefined) {
-			news[lower] = 0
-			newname = n
-		} else {
-			news[lower] = news[lower] + 1
-			newname = suffix(n, news[lower])
-		}
-		if (out[o]) {
-			out[o].push(newname)
-		} else {
-			out[o] = [newname]
-		}
-	})
-
-	return out
-}

--- a/src/file/FileController.js
+++ b/src/file/FileController.js
@@ -12,7 +12,7 @@ import {client} from "../misc/ClientDetector"
 import {ConnectionError} from "../api/common/error/RestError"
 import type {File as TutanotaFile} from "../api/entities/tutanota/File"
 import {sortableTimestamp} from "../api/common/utils/DateUtils"
-import {sanitizeFilename} from "../api/common/utils/FileUtils"
+import {legalizeFilenames, sanitizeFilename} from "../api/common/utils/FileUtils"
 
 assertMainOrNode()
 
@@ -263,8 +263,9 @@ export class FileController {
 		//$FlowFixMe[cannot-resolve-module] - we are missing definitions for it
 		return import("jszip").then(jsZip => {
 			const zip = jsZip.default()
+			let legalFilenameMap = legalizeFilenames(dataFiles.map(df => df.name))
 			dataFiles.forEach(df => {
-				zip.file(sanitizeFilename(df.name), df.data, {binary: true})
+				zip.file(sanitizeFilename(legalFilenameMap[df.name].shift()), df.data, {binary: true})
 			})
 			return zip.generateAsync({type: 'uint8array'})
 		}).then(zf => convertToDataFile(file, zf))


### PR DESCRIPTION
fix #2637

`legalizeFilenames` is in `/src/desktop/PathUtils`, is that going to be a problem for dependencies?