### PR TITLE
[desktop] enable context isolation for all BrowserWindows

### DIFF
--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -45,7 +45,6 @@ export default function generateTemplate({nameSuffix, version, updateUrl, iconPa
 				+ "-----END PUBLIC KEY-----"
 			],
 			"pollingInterval": 1000 * 60 * 60 * 3, // 3 hours
-			"preloadjs": "./desktop/preload.js",
 			"desktophtml": "./index-desktop.html",
 			"iconName": "logo-solo-red.png",
 			"fileManagerTimeout": 30000,

--- a/flow/api/types.js
+++ b/flow/api/types.js
@@ -190,7 +190,6 @@ type NativeRequestType = 'init'
 	| 'registerMailto'
 	| 'unregisterMailto'
 	| 'openNewWindow'
-	| 'showWindow'
 	| 'sendDesktopConfig'
 	| 'updateDesktopConfig'
 	| 'enableAutoLaunch'
@@ -205,7 +204,6 @@ type NativeRequestType = 'init'
 	| 'unIntegrateDesktop'
 	| 'unscheduleAlarms'
 	| 'setSearchOverlayState'
-	| 'unload' // desktop
 	| 'changeLanguage'
 	| 'isUpdateAvailable' // check if update is ready to install
 	| 'manualUpdate' // progress update process (check, dl, install)
@@ -226,11 +224,7 @@ type JsRequestType = 'createMailEditor'
 	| 'addShortcuts'
 	| 'appUpdateDownloaded'
 	| 'openCustomer' // only for admin clients
-
-type WebContentsMessage
-	= 'initialize-ipc'
-	| 'set-zoom-factor'
-	| 'open-customer'
+	| 'updateTargetUrl'
 
 type Callback<T> = (err: ?Error, data?: T) => void
 type Command = (msg: Request) => Promise<any>

--- a/flow/electron.js
+++ b/flow/electron.js
@@ -17,6 +17,9 @@ declare module 'electron' {
 	declare export var webFrame: WebFrame;
 	declare export var clipboard: ClipBoard;
 	declare export var dialog: ElectronDialog;
+	declare export var contextBridge: {
+		exposeInMainWorld: (string, any) => void
+	};
 	declare export var globalShortcut: {
 		register(shortcut: string, cb: Function): void;
 		unregister(shortcut: string): void;

--- a/flow/electron.js
+++ b/flow/electron.js
@@ -441,6 +441,7 @@ declare module 'electron' {
 		id: number;
 
 		static fromId(number): BrowserWindow;
+		static fromWebContents(WebContents): BrowserWindow;
 		static getAllWindows(): Array<BrowserWindow>
 	}
 
@@ -478,16 +479,19 @@ declare module 'electron' {
 
 	declare export type DragInfo = {files: string[] | string, icon?: NativeImage | string}
 
+	declare export type WebContentsEvent = {sender: WebContents, preventDefault: ()=>void}
+
 	declare export class WebContents {
-		on(WebContentsEvent, (Event, ...Array<any>) => void): WebContents;
-		once(WebContentsEvent, (Event, ...Array<any>) => void): WebContents;
-		removeListener(WebContentsEvent, (Event, ...any) => void): BrowserWindow;
-		removeAllListeners(WebContentsEvent): WebContents;
+		on(WebContentsEventType, (WebContentsEvent, ...Array<any>) => void): WebContents;
+		once(WebContentsEventType, (WebContentsEvent, ...Array<any>) => void): WebContents;
+		removeListener(WebContentsEventType, (WebContentsEvent, ...any) => void): WebContents;
+		removeAllListeners(WebContentsEventType): WebContents;
 		send(string, any): void;
 		session: ElectronSession;
 		getURL(): string;
 		getTitle(): string;
 		zoomFactor: number;
+		id: number;
 		openDevTools(opts?: {|mode: string|}): void;
 		isDevToolsOpened(): boolean;
 		isDestroyed(): boolean;
@@ -500,6 +504,8 @@ declare module 'electron' {
 		executeJavaScript(code: string): Promise<any>;
 		findInPage(searchString: string, opts: {forward: boolean, matchCase: boolean}): void;
 		stopFindInPage(action: "clearSelection" | "keepSelection" | "activateSelection"): void;
+		setZoomFactor(f: number) : void;
+		getZoomFactor() : number;
 		copy(): void;
 		cut(): void;
 		paste(): void;
@@ -738,7 +744,7 @@ export type BrowserWindowEvent
 	| 'did-start-navigation' // passed through from webContents
 
 // https://github.com/electron/electron/blob/master/docs/api/web-contents.md#instance-events
-export type WebContentsEvent
+export type WebContentsEventType
 	= 'did-finish-load'
 	| 'did-fail-load'
 	| 'did-frame-finish-load'
@@ -781,6 +787,7 @@ export type WebContentsEvent
 	| 'did-attach-webview'
 	| 'console-message'
 	| 'closed'
+	| 'zoom-changed'
 
 export type AutoUpdaterEvent
 	= 'error'

--- a/flow/libs.js
+++ b/flow/libs.js
@@ -32,6 +32,33 @@ interface Lifecycle<Attrs> {
 
 type LifecycleAttrs<T> = T & Lifecycle<T>
 
+declare interface Mithril {
+	// We would like to write a definition which allows omitting Attrs if all keys are optional
+	(component: string | Component | MComponent<void> | Class<MComponent<void>>, children?: Children): Vnode<any>;
+
+	<Attrs: $ReadOnly<{[?string]: any}>>(
+		component: string | Component | Class<MComponent<Attrs>> | MComponent<Attrs>,
+		attributes: Attrs,
+		children?: Children
+	): Vnode<any>;
+
+	route: Router;
+
+	redraw(): void;
+
+	fragment<Attrs: $ReadOnly<{[?string]: any}>>(attributes: Attrs, children?: Children): Vnode<any>;
+
+	trust(html: string): any;
+
+	withAttr(attrName: string, callback: Function): Function;
+
+	buildQueryString(args: {[string]: any}): string;
+
+	parseQueryString(queryString: string): {[string]: string};
+
+	render(element: HTMLElement, vnodes: Children): void;
+}
+
 declare module 'mithril' {
 	declare interface Router {
 		(root: HTMLElement, defaultRoute: string, routes: {[string]: Component | RouteResolver}): void;
@@ -48,33 +75,6 @@ declare module 'mithril' {
 		prefix: string;
 
 		Link: MComponent<any>;
-	}
-
-	declare interface Mithril {
-		// We would like to write a definition which allows omitting Attrs if all keys are optional
-		(component: string | Component | MComponent<void> | Class<MComponent<void>>, children?: Children): Vnode<any>;
-
-		<Attrs: $ReadOnly<{[?string]: any}>>(
-			component: string | Component | Class<MComponent<Attrs>> | MComponent<Attrs>,
-			attributes: Attrs,
-			children?: Children
-		): Vnode<any>;
-
-		route: Router;
-
-		redraw(): void;
-
-		fragment<Attrs: $ReadOnly<{[?string]: any}>>(attributes: Attrs, children?: Children): Vnode<any>;
-
-		trust(html: string): any;
-
-		withAttr(attrName: string, callback: Function): Function;
-
-		buildQueryString(args: {[string]: any}): string;
-
-		parseQueryString(queryString: string): {[string]: string};
-
-		render(element: HTMLElement, vnodes: Children): void;
 	}
 
 	declare export default Mithril;
@@ -241,6 +241,7 @@ declare type Squire = any
 
 declare var tutao: {
 	currentView: any;
+	m: Mithril
 }
 
 declare class ContactFindOptions { // cordova contact plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -4217,14 +4217,6 @@
 				"mime-types": "^2.1.24",
 				"source-map": "^0.5.6",
 				"source-map-fast": "npm:source-map@0.7.3"
-			},
-			"dependencies": {
-				"source-map-fast": {
-					"version": "npm:source-map@0.7.3",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-					"dev": true
-				}
 			}
 		},
 		"noop-logger": {
@@ -5253,6 +5245,12 @@
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"source-map-fast": {
+			"version": "npm:source-map@0.7.3",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
 			"dev": true
 		},
 		"source-map-support": {

--- a/src/app.js
+++ b/src/app.js
@@ -49,6 +49,7 @@ window.tutao = {
 setupExceptionHandling()
 
 client.init(navigator.userAgent, navigator.platform)
+// this needs to stay after client.init
 windowFacade.init()
 
 export const state: {prefix: ?string, prefixWithoutFile: ?string} = (module.hot && module.hot.data)

--- a/src/app.js
+++ b/src/app.js
@@ -49,6 +49,7 @@ window.tutao = {
 setupExceptionHandling()
 
 client.init(navigator.userAgent, navigator.platform)
+windowFacade.init()
 
 export const state: {prefix: ?string, prefixWithoutFile: ?string} = (module.hot && module.hot.data)
 	? downcast(module.hot.data.state) : {prefix: null, prefixWithoutFile: null}

--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -326,7 +326,6 @@ export class ApplicationWindow {
 	}
 
 	findInPage(args: Array<any>): Promise<FindInPageResult> {
-		console.log("findInPage")
 		this._findingInPage = true
 		const [searchTerm, options] = args
 		if (searchTerm !== '') {

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type {NativeImage, Rectangle} from "electron"
+import type {NativeImage, Rectangle, WebContentsEvent} from "electron"
 import {app, screen} from "electron"
 import type {UserInfo} from "./ApplicationWindow"
 import {ApplicationWindow} from "./ApplicationWindow"
@@ -112,6 +112,11 @@ export class WindowManager {
 		return w
 			? w
 			: null
+	}
+
+	getEventSender(ev: WebContentsEvent) : ?ApplicationWindow {
+		if(ev.sender.id == null) return null
+		return this.get(ev.sender.id)
 	}
 
 	getAll(): ApplicationWindow[] {

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -114,6 +114,12 @@ export class WindowManager {
 			: null
 	}
 
+	/**
+	 * this relies on BrowserWindow.id === BrowserWindow.webContents.id,
+	 * which is not guaranteed anywhere but also seems to be true
+	 * @param ev
+	 * @returns {?ApplicationWindow|null}
+	 */
 	getEventSender(ev: WebContentsEvent) : ?ApplicationWindow {
 		if(ev.sender.id == null) return null
 		return this.get(ev.sender.id)

--- a/src/desktop/Socketeer.js
+++ b/src/desktop/Socketeer.js
@@ -3,6 +3,7 @@
 import type {App} from 'electron'
 import {neverNull} from "../api/common/utils/Utils"
 import type {WindowManager} from "./DesktopWindowManager"
+import type {IPC} from "./IPC"
 import {isMailAddress} from "../misc/FormatValidator"
 import {log} from "./DesktopLog";
 
@@ -35,11 +36,12 @@ export class Socketeer {
 		})
 	}
 
-	attachWindowManager(wm: WindowManager) {
+	attach(wm: WindowManager, ipc: IPC) {
 		this.startClient(msg => {
 			const mailAddress = JSON.parse(msg).mailAddress
 			if (typeof mailAddress === 'string' && isMailAddress(mailAddress, false)) {
-				wm.getLastFocused(false).sendMessageToWebContents('open-customer', {mailAddress})
+				const targetWindowId = wm.getLastFocused(false).id
+				ipc.sendRequest(targetWindowId, 'openCustomer', [mailAddress])
 			}
 		})
 	}

--- a/src/desktop/electron-localshortcut/LocalShortcut.js
+++ b/src/desktop/electron-localshortcut/LocalShortcut.js
@@ -1,5 +1,6 @@
 //@flow
 import {app, BrowserWindow} from "electron"
+import type {WebContentsEvent} from "electron"
 import isAccelerator from "./IsAccelerator"
 import equals from "./KeyboardEventsAreEqual"
 import {toKeyEvent} from "./KeyboardeventFromElectronAccelerator"
@@ -188,7 +189,7 @@ interface Input {
 	meta: boolean;
 }
 
-const _onBeforeInput = shortcutsOfWindow => (e: Event, input: Input): void => {
+const _onBeforeInput = shortcutsOfWindow => (e: WebContentsEvent, input: Input): void => {
 	if (input.type === 'keyUp') {
 		return;
 	}

--- a/src/desktop/preload.js
+++ b/src/desktop/preload.js
@@ -2,7 +2,8 @@
 
 /**
  * Preload for the render thread of the electron.
- * Executed for every new window. Sets up inter-process communication and Electron-specific functions like scaling.
+ * Executed for every new window and on every reload.
+ * Sets up inter-process communication.
  *
  * Note: we can't import any other desktop code here because it is in the web (render) process.
  */
@@ -10,129 +11,8 @@
 // This should come from bundler banner. We are in a weird environment here where there's "require" but no "module" so we can't really
 // use commonjs format. We use iife but "require" is shadowed in it. To work around this we save require before shadowing.
 declare var dynamicRequire: typeof require;
-const {ipcRenderer, webFrame} = dynamicRequire('electron')
+const {ipcRenderer, contextBridge} = dynamicRequire('electron')
 
-let requestId = 0
-let hoverUrl = "" // for the link popup
-let linkToolTip = null
-
-ipcRenderer
-	.on('set-zoom-factor', setZoomFactor)
-	.once('initialize-ipc', initializeIPC)
-
-function initializeIPC(e, params) {
-	const [version, windowId] = params
-
-	ipcRenderer.on(`${windowId}`, (ev, msg) => {
-		window.tutao.nativeApp.handleMessageObject(msg)
-	})
-
-	window.nativeApp = {
-		invoke: (msg: string) => ipcRenderer.send(`${windowId}`, msg),
-		getVersion: () => version
-	}
-
-	/* this event listener doesn't get fired
-	 * if it's registered during the initial preload.js
-	 * execution
-	 */
-	window.addEventListener('wheel', e => {
-		if (!e.ctrlKey) {
-			return
-		}
-		let newFactor = ((webFrame.getZoomFactor() * 100) + (e.deltaY > 0 ? -10 : 10)) / 100
-		if (newFactor > 3) {
-			newFactor = 3
-		} else if (newFactor < 0.5) {
-			newFactor = 0.5
-		}
-		webFrame.setZoomFactor(newFactor)
-	})
-}
-
-function setZoomFactor(ev, newFactor) {
-	webFrame.setZoomFactor(newFactor)
-}
-
-// for completeness - atm the preload requests never expect a response
-function createRequestId() {
-	if (requestId >= Number.MAX_SAFE_INTEGER) {
-		requestId = 0
-	}
-	return "preload" + requestId++
-}
-
-// href URL reveal
-window.addEventListener('mouseover', (e) => {
-	// if there are nested elements like <strong/> in the link element,
-	// we may not get a mouseover or mouseout for the actual <a/>, so
-	// so we inspect the path.
-	let linkElem = e.path.find(elem => elem.tagName === 'A')
-	if (!linkElem || !linkElem.matches('#mail-viewer a')) {
-		return
-	}
-	if (!linkToolTip) {
-		linkToolTip = document.createElement("DIV")
-		linkToolTip.id = "link-tt";
-		(document.body: any).appendChild(linkToolTip)
-	}
-	linkToolTip.innerText = linkElem.href
-	hoverUrl = linkElem.href
-	linkToolTip.className = "reveal"
+contextBridge.exposeInMainWorld('nativeApp', {
+	invoke: (msg: string) => ipcRenderer.invoke('message', msg)
 })
-
-window.addEventListener('mouseout', (e) => {
-	let linkElem = e.path.find(elem => elem.tagName === 'A')
-	if (linkElem && linkToolTip) {
-		linkToolTip.className = ""
-		hoverUrl = ""
-	}
-})
-
-window.addEventListener('mouseup', e => {
-	/*
-	* we're catching enter key events on the main thread while the search overlay is open to enable
-	* next-result-via-enter behaviour.
-	*
-	* since losing focus on the overlay via issuing a search request seems to be indistinguishable
-	* from losing it via click/tab we need to check if anything else was clicked and tell the main thread to
-	* not search the next result for enter key events (otherwise we couldn't type newlines while the overlay is open)
-	*/
-	if (e.target.id === "search-overlay-input") return
-	window.tutao.nativeApp.invokeNative({
-		type: "setSearchOverlayState",
-		id: createRequestId(),
-		args: [false, true]
-	})
-})
-
-// needed to help the MacOs client to distinguish between Cmd+Arrow to navigate the history
-// and Cmd+Arrow to navigate a text editor
-window.addEventListener('keydown', e => {
-	if (!e.metaKey || e.key === 'Meta' || !window.tutao || !window.tutao.client || !window.tutao.client.isMacOS) return
-	// prevent history nav if the active element is an input / squire editor
-	if (e.target && (e.target.tagName === "INPUT" || e.target.contentEditable === 'true')) {
-		e.stopPropagation()
-	} else if (e.key === 'ArrowLeft') {
-		window.history.back()
-	} else if (e.key === 'ArrowRight') window.history.forward()
-})
-
-// window.focus() doesn't seem to be working right now, so we're replacing it
-// https://github.com/electron/electron/issues/8969#issuecomment-288024536
-window.focus = () => {
-	window.tutao.nativeApp.invokeNative({
-		type: 'showWindow',
-		id: createRequestId(),
-		args: []
-	})
-}
-
-window.addEventListener("beforeunload", () =>
-		// There's no good way to detect reload using Electron APIs so we have to resort to DOM events
-	window.tutao && window.tutao.nativeApp && window.tutao.nativeApp.invokeNative({
-		type: "unload",
-		id: createRequestId(),
-		args: []
-	})
-)

--- a/src/desktop/preload.js
+++ b/src/desktop/preload.js
@@ -1,18 +1,13 @@
-//@flow
-
 /**
  * Preload for the render thread of the electron.
  * Executed for every new window and on every reload.
  * Sets up inter-process communication.
  *
  * Note: we can't import any other desktop code here because it is in the web (render) process.
+ * It's also not processed by babel or flow, so don't add any code here
  */
-
-// This should come from bundler banner. We are in a weird environment here where there's "require" but no "module" so we can't really
-// use commonjs format. We use iife but "require" is shadowed in it. To work around this we save require before shadowing.
-declare var dynamicRequire: typeof require;
-const {ipcRenderer, contextBridge} = dynamicRequire('electron')
+const {ipcRenderer, contextBridge} = require('electron')
 
 contextBridge.exposeInMainWorld('nativeApp', {
-	invoke: (msg: string) => ipcRenderer.invoke('message', msg)
+	invoke: msg => ipcRenderer.invoke('message', msg)
 })

--- a/src/gui/SearchInPageOverlay.js
+++ b/src/gui/SearchInPageOverlay.js
@@ -134,7 +134,7 @@ export class SearchInPageOverlay {
 	* not search the next result for enter key events (otherwise we couldn't type newlines while the overlay is open)
 	*/
 	handleMouseUp(e: Event) {
-		if (!(e.target instanceof Element && e.target.id === "search-overlay-input")) return
+		if (!(e.target instanceof Element && e.target.id !== "search-overlay-input")) return
 		nativeApp.invokeNative(new Request('setSearchOverlayState', [false, true]))
 	}
 

--- a/src/gui/SearchInPageOverlay.js
+++ b/src/gui/SearchInPageOverlay.js
@@ -125,19 +125,6 @@ export class SearchInPageOverlay {
 		m.redraw()
 	}
 
-	/*
-	* we're catching enter key events on the main thread while the search overlay is open to enable
-	* next-result-via-enter behaviour.
-	*
-	* since losing focus on the overlay via issuing a search request seems to be indistinguishable
-	* from losing it via click/tab we need to check if anything else was clicked and tell the main thread to
-	* not search the next result for enter key events (otherwise we couldn't type newlines while the overlay is open)
-	*/
-	handleMouseUp(e: Event) {
-		if (!(e.target instanceof Element && e.target.id !== "search-overlay-input")) return
-		nativeApp.invokeNative(new Request('setSearchOverlayState', [false, true]))
-	}
-
 	_getComponent(): VirtualElement {
 		let caseButtonAttrs = {
 			label: "matchCase_alt",
@@ -178,8 +165,8 @@ export class SearchInPageOverlay {
 			view: (vnode: Object) => {
 				return m(".flex.flex-space-between",
 					{
-						oncreate: () => window.addEventListener('mouseup', this.handleMouseUp),
-						onremove: () => window.removeEventListener('mouseup', this.handleMouseUp)
+						oncreate: () => window.addEventListener('mouseup', handleMouseUp),
+						onremove: () => window.removeEventListener('mouseup', handleMouseUp)
 					},
 					[
 						m(".flex-start.center-vertically",
@@ -210,6 +197,20 @@ export class SearchInPageOverlay {
 
 		}
 	}
+}
+
+
+/*
+* we're catching enter key events on the main thread while the search overlay is open to enable
+* next-result-via-enter behaviour.
+*
+* since losing focus on the overlay via issuing a search request seems to be indistinguishable
+* from losing it via click/tab we need to check if anything else was clicked and tell the main thread to
+* not search the next result for enter key events (otherwise we couldn't type newlines while the overlay is open)
+*/
+function handleMouseUp(e: Event) {
+	if (!(e.target instanceof Element && e.target.id !== "search-overlay-input")) return
+	nativeApp.invokeNative(new Request('setSearchOverlayState', [false, true]))
 }
 
 export const searchInPageOverlay: SearchInPageOverlay = new SearchInPageOverlay()

--- a/src/misc/WindowFacade.js
+++ b/src/misc/WindowFacade.js
@@ -108,6 +108,21 @@ class WindowFacade {
 			window.addEventListener("popstate", e => this._popState(e))
 			window.addEventListener("unload", e => this._onUnload())
 		}
+
+
+		// needed to help the MacOs desktop client to distinguish between Cmd+Arrow to navigate the history
+		// and Cmd+Arrow to navigate a text editor
+		if(env.mode === Mode.Desktop && client.isMacOS && window.addEventListener) {
+			window.addEventListener('keydown', e => {
+				if (!e.metaKey || e.key === 'Meta') return
+				// prevent history nav if the active element is an input / squire editor
+				if (e.target && (e.target.tagName === "INPUT" || e.target.contentEditable === 'true')) {
+					e.stopPropagation()
+				} else if (e.key === 'ArrowLeft') {
+					window.history.back()
+				} else if (e.key === 'ArrowRight') window.history.forward()
+			})
+		}
 	}
 
 	_resize() {

--- a/src/misc/WindowFacade.js
+++ b/src/misc/WindowFacade.js
@@ -27,7 +27,6 @@ class WindowFacade {
 		this.resizeTimeout = null
 		this.windowCloseConfirmation = false
 		this._windowCloseListeners = new Set()
-		this.init()
 		import("../api/main/MainLocator")
 			.then(locatorModule => locatorModule.locator.initializedWorker)
 			.then(worker => {
@@ -120,7 +119,9 @@ class WindowFacade {
 					e.stopPropagation()
 				} else if (e.key === 'ArrowLeft') {
 					window.history.back()
-				} else if (e.key === 'ArrowRight') window.history.forward()
+				} else if (e.key === 'ArrowRight') {
+					window.history.forward()
+				}
 			})
 		}
 	}

--- a/src/native/common/NativeWrapper.js
+++ b/src/native/common/NativeWrapper.js
@@ -77,14 +77,6 @@ class NativeWrapper {
 		neverNull(this._nativeQueue)._handleMessage(JSON.parse(msg))
 	}
 
-	/**
-	 * used by the preload script to save on encoding
-	 * @param msg
-	 */
-	handleMessageObject: ((msg: any) => void) = (msg: any) => {
-		neverNull(this._nativeQueue)._handleMessage(msg)
-	}
-
 	setWorkerQueue(queue: Queue) {
 		this._workerQueue = queue;
 		this._nativeQueue = null

--- a/src/native/main/NativeWrapperCommands.js
+++ b/src/native/main/NativeWrapperCommands.js
@@ -149,6 +149,34 @@ function appUpdateDownloaded(msg: Request): Promise<void> {
 	return Promise.resolve()
 }
 
+function openCustomer(msg: Request): Promise<void> {
+	const mailAddress = msg.args[0]
+	if (typeof mailAddress === 'string' && tutao.m.route.get().startsWith("/customer")) {
+		tutao.m.route.set(`/customer?query=${encodeURIComponent(mailAddress)}`)
+		console.log('switching to customer', mailAddress)
+	}
+
+	return Promise.resolve()
+}
+
+function updateTargetUrl(msg: Request) : Promise<void> {
+	const url = msg.args[0]
+	let linkToolTip = document.getElementById("link-tt")
+	if (!linkToolTip) {
+		linkToolTip = document.createElement("DIV")
+		linkToolTip.id = "link-tt";
+		(document.body: any).appendChild(linkToolTip)
+	}
+	if(url === "") {
+		linkToolTip.className = ""
+	} else {
+		linkToolTip.innerText = url
+		linkToolTip.className = "reveal"
+	}
+
+	return Promise.resolve()
+}
+
 export const appCommands = {
 	createMailEditor,
 	showAlertDialog,
@@ -171,5 +199,7 @@ export const desktopCommands = {
 	applySearchResultToOverlay,
 	reportError,
 	addShortcuts,
-	appUpdateDownloaded
+	appUpdateDownloaded,
+	openCustomer,
+	updateTargetUrl,
 }

--- a/src/native/main/NativeWrapperCommands.js
+++ b/src/native/main/NativeWrapperCommands.js
@@ -149,6 +149,9 @@ function appUpdateDownloaded(msg: Request): Promise<void> {
 	return Promise.resolve()
 }
 
+/**
+ * this is only used in the admin client to sync the DB view with the inbox
+ */
 function openCustomer(msg: Request): Promise<void> {
 	const mailAddress = msg.args[0]
 	if (typeof mailAddress === 'string' && tutao.m.route.get().startsWith("/customer")) {
@@ -159,6 +162,10 @@ function openCustomer(msg: Request): Promise<void> {
 	return Promise.resolve()
 }
 
+/**
+ * this updates the link-reveal on hover when the main thread detects that
+ * the hovered url changed
+ */
 function updateTargetUrl(msg: Request) : Promise<void> {
 	const url = msg.args[0]
 	let linkToolTip = document.getElementById("link-tt")


### PR DESCRIPTION
The preload script required some access to the window object of the renderer
thread to implement browser functionality that's missing in a BrowserWindow.
This prevented use of the contextI isolation option.

This commit moves that functionality from the preload script to either the main
thread or the web app so we can enable context isolation.

* mouse wheel zoom was moved to the main thread, listening to the new
 zoom-changed event on WebContents (ApplicationWindow.js)
* url reveal on hover was split into a main part listening on update-target-url
 on WebContent (ApplicationWindow.js) and a new NativeWrapperCommand to fill in
 the url element
* the fix for MacOS navigation history when trying to navigate a text box with
 cmd+arrows moved to WindowFacade.js
* the SearchPageOverlay now fixes the non-detection of focus change itself
* unregistering the window on unload moved to ApplicationWindow.js, detecting
 a reload in the did-start-navigation handler
* the fix for the nonfunctional window focus was removed since it works in current
 electron versions

all windows now use the same ipc channel, the IPC component uses the Event sender
to route responses back to the correct window, removing the need to set up
the channel with the window id