### PR TITLE
Do not try to reload tutadb service if not running

### DIFF
--- a/resources/scripts/after-install.sh
+++ b/resources/scripts/after-install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-systemctl reload tutadb
+systemctl try-reload-or-restart tutadb


### PR DESCRIPTION
The systemctl command is named quite misunderstandably, the man page is
clearer:

   try-reload-or-restart PATTERN...
   	Reload one or more units if they support it. If not, stop and then
        start them instead. *This does nothing if the units are not running.*