### PR TITLE
Remove unsafe Promise operations

### DIFF
--- a/flow/api/libs.js
+++ b/flow/api/libs.js
@@ -61,23 +61,12 @@ declare class Promise<+R> {
 
 	finally<R>(onDone?: () => mixed): Promise<R>;
 
-	each<T, U>(iterator: (item: T, index: number, arrayLength: number) => Promise<U> | U): Promise<T[]>;
-
-	map<T, U>(mapper: (item: T, index: number, arrayLength: number) => Promise<U> | U, options?: Bluebird$ConcurrencyOption): Promise<Array<U>>;
-
-	filter<T>(iterator: (item: T, index: number, arrayLength: number) => Promise<boolean> | boolean): Promise<T[]>;
-
 	isFulfilled(): boolean;
 	isRejected(): boolean;
 	isPending(): boolean;
 	value(): R;
 
 	return<T>(returnValue: T): Promise<T>;
-
-	reduce<T>(mapper: (accumulator: any, item: T, index: number, arrayLength: number) => any, initialValue: any): Promise<any>;
-
-	spread<T>(...args: Array<T>): Promise<*>;
-
 	delay<T>(millis: number): Promise<T>;
 
 	tap(handler: (R => $Promisable<mixed>)): Promise<R>;

--- a/src/api/worker/facades/CalendarFacade.js
+++ b/src/api/worker/facades/CalendarFacade.js
@@ -230,7 +230,7 @@ export class CalendarFacade {
 			return this._entity.loadAll(UserAlarmInfoTypeRef, alarmInfoList.alarms)
 			           .then((userAlarmInfos) =>
 				           Promise
-					           .map(userAlarmInfos, (userAlarmInfo) =>
+					           .mapSeries(userAlarmInfos, (userAlarmInfo) =>
 						           this._entity.load(CalendarEventTypeRef, [
 							           userAlarmInfo.alarmInfo.calendarRef.listId, userAlarmInfo.alarmInfo.calendarRef.elementId
 						           ])
@@ -247,7 +247,7 @@ export class CalendarFacade {
 							               console.warn("NotAuthorized when downloading alarm event", e)
 							               return null
 						               }))
-					           .filter(Boolean) // filter out orphan alarms
+					           .then((alarms) => alarms.filter(Boolean)) // filter out orphan alarms
 			           )
 		} else {
 			console.warn("No alarmInfo list on user")
@@ -280,7 +280,7 @@ export class CalendarFacade {
 			.then((indexEntry) => {
 				if (indexEntry) {
 					return this._entity.load(CalendarEventTypeRef, indexEntry.calendarEvent)
-						.catch(NotFoundError, () => null)
+					           .catch(NotFoundError, () => null)
 				}
 			})
 	}

--- a/src/api/worker/facades/MailFacade.js
+++ b/src/api/worker/facades/MailFacade.js
@@ -233,7 +233,7 @@ export class MailFacade {
 	_createAddedAttachments(providedFiles: ?Array<TutanotaFile | DataFile | FileReference>, existingFileIds: IdTuple[], mailGroupKey: Aes128Key): Promise<DraftAttachment[]> {
 		if (providedFiles) {
 			return Promise
-				.map((providedFiles: any), providedFile => {
+				.mapSeries((providedFiles: any), providedFile => {
 					// check if this is a new attachment or an existing one
 					if (providedFile._type === "DataFile") {
 						// user added attachment
@@ -259,8 +259,8 @@ export class MailFacade {
 					} else {
 						return null
 					}
-				}, {concurrency: 1}) // disable concurrent file upload to avoid timeout because of missing progress events on Firefox.
-				.filter(attachment => (attachment != null))
+				}) // disable concurrent file upload to avoid timeout because of missing progress events on Firefox.
+				.then((attachments) => attachments.filter(Boolean))
 				.tap(() => {
 					// only delete the temporary files after all attachments have been uploaded
 					if (isApp()) {

--- a/src/api/worker/rest/EntityRestCache.js
+++ b/src/api/worker/rest/EntityRestCache.js
@@ -424,7 +424,7 @@ export class EntityRestCache implements EntityRestInterface {
 	 */
 	entityEventsReceived(batch: $ReadOnlyArray<EntityUpdate>): Promise<Array<EntityUpdate>> {
 		return Promise
-			.map(batch, (update) => {
+			.mapSeries(batch, (update) => {
 				const {instanceListId, instanceId, operation, type, application} = update
 				if (application === "monitor") return null
 
@@ -444,8 +444,8 @@ export class EntityRestCache implements EntityRestInterface {
 					case OperationType.CREATE:
 						return this._processCreateEvent(typeRef, update, batch)
 				}
-			}, {concurrency: 1})
-			.filter(Boolean)
+			})
+			.then((result) => result.filter(Boolean))
 	}
 
 	_processCreateEvent(

--- a/src/api/worker/search/Indexer.js
+++ b/src/api/worker/search/Indexer.js
@@ -291,18 +291,16 @@ export class Indexer {
 	}
 
 
-	_updateIndexedGroups(): Promise<void> {
-		return this.db.dbFacade.createTransaction(true, [GroupDataOS])
-		           .then(t => t.getAll(GroupDataOS)
-		                       .map((groupDataEntry: {key: Id, value: GroupData}) => groupDataEntry.key))
-		           .then(indexedGroupIds => {
-			           if (indexedGroupIds.length === 0) {
-				           // tried to index twice, this is probably not our fault
-				           console.log("no group ids in database, disabling indexer")
-				           this.disableMailIndexing()
-			           }
-			           this._indexedGroupIds = indexedGroupIds
-		           })
+	async _updateIndexedGroups(): Promise<void> {
+		const t: DbTransaction = await this.db.dbFacade.createTransaction(true, [GroupDataOS])
+		const indexedGroupIds = (await t.getAll(GroupDataOS))
+			.map((groupDataEntry: {key: string | number, value: GroupData}) => downcast<Id>(groupDataEntry.key))
+		if (indexedGroupIds.length === 0) {
+			// tried to index twice, this is probably not our fault
+			console.log("no group ids in database, disabling indexer")
+			this.disableMailIndexing()
+		}
+		this._indexedGroupIds = indexedGroupIds
 	}
 
 
@@ -354,25 +352,26 @@ export class Indexer {
 		if (restrictTo) {
 			memberships = memberships.filter(membership => contains(restrictTo, membership.group))
 		}
-		return Promise.map(memberships, (membership: GroupMembership) => {
-			// we only need the latest EntityEventBatch to synchronize the index state after reconnect. The lastBatchIds are filled up to 100 with each event we receive.
-			return this._entity.loadRange(EntityEventBatchTypeRef, membership.group, GENERATED_MAX_ID, 1, true)
-			           .then(eventBatches => {
-				           return {
-					           groupId: membership.group,
-					           groupData: ({
-						           lastBatchIds: eventBatches.map(eventBatch => eventBatch._id[1]),
-						           indexTimestamp: NOTHING_INDEXED_TIMESTAMP,
-						           groupType: getMembershipGroupType(membership)
-					           }: GroupData)
-				           }
-			           })
-			           .catch(NotAuthorizedError, () => {
-				           console.log("could not download entity updates => lost permission on list")
-				           return null
-			           })
-		}, {concurrency: 1}) // sequentially to avoid rate limiting
-		              .filter(r => r != null)
+		return Promise
+			.mapSeries(memberships, (membership: GroupMembership) => {
+				// we only need the latest EntityEventBatch to synchronize the index state after reconnect. The lastBatchIds are filled up to 100 with each event we receive.
+				return this._entity.loadRange(EntityEventBatchTypeRef, membership.group, GENERATED_MAX_ID, 1, true)
+				           .then(eventBatches => {
+					           return {
+						           groupId: membership.group,
+						           groupData: ({
+							           lastBatchIds: eventBatches.map(eventBatch => eventBatch._id[1]),
+							           indexTimestamp: NOTHING_INDEXED_TIMESTAMP,
+							           groupType: getMembershipGroupType(membership)
+						           }: GroupData)
+					           }
+				           })
+				           .catch(NotAuthorizedError, () => {
+					           console.log("could not download entity updates => lost permission on list")
+					           return null
+				           })
+			}) // sequentially to avoid rate limiting
+			.then((data) => data.filter(r => r != null))
 	}
 
 	/**

--- a/src/file/FileController.js
+++ b/src/file/FileController.js
@@ -83,7 +83,7 @@ export class FileController {
 					.catch(CryptoError, () => showErr("corrupted_msg", tutanotaFile.name))
 					.catch(ConnectionError, () => showErr("couldNotAttachFile_msg", tutanotaFile.name)),
 				concurrency)
-			.filter(Boolean) // filter out failed files
+			.then((results) => results.filter(Boolean)) // filter out failed files
 		// in apps, p is a  Promise<FileReference[]> that have location props.
 		// otherwise, it's a Promise<DataFile[]> and can be handled by zipDataFiles
 		return save(downcast(p)).return()

--- a/src/mail/export/Bundler.js
+++ b/src/mail/export/Bundler.js
@@ -49,7 +49,7 @@ export function makeMailBundle(mail: Mail, entityClient: EntityClient, worker: W
 		: Promise.resolve(null)
 	const recipientMapper = addr => ({address: addr.address, name: addr.name})
 	return Promise.all([bodyTextPromise, attachmentsPromise, headersPromise])
-	              .spread((bodyText, attachments, headers) => ({
+	              .then(([bodyText, attachments, headers]) => ({
 		              subject: mail.subject,
 		              body: bodyText,
 		              sender: recipientMapper(mail.sender),

--- a/src/mail/model/MailModel.js
+++ b/src/mail/model/MailModel.js
@@ -92,7 +92,7 @@ export class MailModel {
 					this._entityClient.load(MailboxGroupRootTypeRef, mailGroupMembership.group),
 					this._entityClient.load(GroupInfoTypeRef, mailGroupMembership.groupInfo),
 					this._entityClient.load(GroupTypeRef, mailGroupMembership.group)
-				]).spread((mailboxGroupRoot, mailGroupInfo, mailGroup) => {
+				]).then(([mailboxGroupRoot, mailGroupInfo, mailGroup]) => {
 					return this._entityClient.load(MailBoxTypeRef, mailboxGroupRoot.mailbox).then((mailbox) => {
 						return this._loadFolders(neverNull(mailbox.systemFolders).folders, true)
 						           .then((folders) => {

--- a/src/mail/view/MailViewer.js
+++ b/src/mail/view/MailViewer.js
@@ -778,19 +778,26 @@ export class MailViewer {
 	}
 
 	_createAssignActionButton(mail: Mail): Button {
-		// remove the current mailbox/owner from the recipients list.
-		const mailRecipients = this._getAssignableMailRecipients().filter(userOrMailGroupInfo => {
-			if (logins.getUserController().getUserMailGroupMembership().group === this.mail._ownerGroup) {
-				return userOrMailGroupInfo.group !== logins.getUserController().userGroupInfo.group
-					&& userOrMailGroupInfo.group !== mail._ownerGroup
-			} else {
-				return userOrMailGroupInfo.group !== mail._ownerGroup
-			}
-		}).map(userOrMailGroupInfo => {
-			return new Button(() => getDisplayText(userOrMailGroupInfo.name, neverNull(userOrMailGroupInfo.mailAddress), true), () => this._assignMail(userOrMailGroupInfo), () => BootIcons.Contacts)
-				.setType(ButtonType.Dropdown)
-		})
-		return createAsyncDropDownButton('forward_action', () => Icons.Forward, () => mailRecipients, 250)
+		const makeButtons = async () => {
+			// remove the current mailbox/owner from the recipients list.
+			const userOrMailGroupInfos = await this._getAssignableMailRecipients()
+			return userOrMailGroupInfos.filter(userOrMailGroupInfo => {
+				if (logins.getUserController().getUserMailGroupMembership().group === this.mail._ownerGroup) {
+					return userOrMailGroupInfo.group !== logins.getUserController().userGroupInfo.group
+						&& userOrMailGroupInfo.group !== mail._ownerGroup
+				} else {
+					return userOrMailGroupInfo.group !== mail._ownerGroup
+				}
+			}).map(userOrMailGroupInfo => {
+				return new Button(
+					() => getDisplayText(userOrMailGroupInfo.name,
+						neverNull(userOrMailGroupInfo.mailAddress), true),
+					() => this._assignMail(userOrMailGroupInfo), () => BootIcons.Contacts
+				).setType(ButtonType.Dropdown)
+			})
+		}
+
+		return createAsyncDropDownButton('forward_action', () => Icons.Forward, makeButtons, 250)
 	}
 
 	_createLoadExternalContentButton(mail: Mail, colors: ButtonColorEnum): Children {
@@ -1345,18 +1352,17 @@ export class MailViewer {
 		return this._mailModel.getMailboxDetailsForMail(this.mail)
 	}
 
-	_getAssignableMailRecipients(): Promise<GroupInfo[]> {
+	async _getAssignableMailRecipients(): Promise<GroupInfo[]> {
 		if (this.mail.restrictions != null && this.mail.restrictions.participantGroupInfos.length > 0) {
 			const participantGroupInfos = this.mail.restrictions.participantGroupInfos
-			return this._entityClient.load(CustomerTypeRef, neverNull(logins.getUserController().user.customer)).then(customer => {
-				return import("../../settings/LoadingUtils").then(({loadGroupInfos}) => {
-					return loadGroupInfos(participantGroupInfos.filter(groupInfoId => {
-						return neverNull(customer.contactFormUserGroups).list !== groupInfoId[0]
-					})).filter(groupInfo => groupInfo.deleted == null)
-				})
-			})
+			const customer = await this._entityClient.load(CustomerTypeRef, neverNull(logins.getUserController().user.customer))
+			const {loadGroupInfos} = await import("../../settings/LoadingUtils")
+			const groupInfos = await loadGroupInfos(participantGroupInfos.filter(groupInfoId => {
+				return neverNull(customer.contactFormUserGroups).list !== groupInfoId[0]
+			}))
+			return groupInfos.filter(groupInfo => groupInfo.deleted == null)
 		} else {
-			return Promise.resolve([])
+			return []
 		}
 	}
 

--- a/src/native/common/FileApp.js
+++ b/src/native/common/FileApp.js
@@ -44,7 +44,8 @@ function openFileChooser(boundingRect: ClientRect): Promise<Array<FileReference>
 		"height": boundingRect.height
 	}
 
-	return nativeApp.invokeNative(new Request("openFileChooser", [srcRect, false])).map(uriToFileRef)
+	return nativeApp.invokeNative(new Request("openFileChooser", [srcRect, false]))
+	                .then((response) => response.map(uriToFileRef))
 }
 
 function openFolderChooser(): Promise<Array<string>> {

--- a/src/settings/ContactFormEditor.js
+++ b/src/settings/ContactFormEditor.js
@@ -53,7 +53,7 @@ let PATH_PATTERN = /^[a-zA-Z0-9_\\-]+$/
 export class ContactFormEditor {
 	_createNew: boolean;
 	_contactForm: ContactForm;
-	_newContactFormIdReceiver: Function
+	_newContactFormIdReceiver: (string) => void
 
 	dialog: Dialog;
 	view: Function;
@@ -76,7 +76,9 @@ export class ContactFormEditor {
 	/**
 	 * This constructor is only used internally. See show() for the external interface.
 	 */
-	constructor(c: ?ContactForm, createNew: boolean, newContactFormIdReceiver: Function, allUserGroupInfos: GroupInfo[], allSharedMailboxGroupInfos: GroupInfo[], brandingDomain: string) {
+	constructor(c: ?ContactForm, createNew: boolean, newContactFormIdReceiver: (string) => void, allUserGroupInfos: GroupInfo[],
+	            allSharedMailboxGroupInfos: GroupInfo[], brandingDomain: string
+	) {
 		this._createNew = createNew
 		this._contactForm = c ? c : createContactForm()
 		this._newContactFormIdReceiver = newContactFormIdReceiver
@@ -414,31 +416,25 @@ export class ContactFormEditor {
  * @param createNew If true creates a new contact form. if c is provided it is taken as template for the new form.
  * @param newContactFormIdReceiver. Is called receiving the contact id as soon as the new contact was saved.
  */
-export function show(c: ?ContactForm, createNew: boolean, newContactFormIdReceiver: Function) {
-	load(CustomerTypeRef, neverNull(logins.getUserController().user.customer)).then(customer => {
-		load(CustomerInfoTypeRef, customer.customerInfo).then(customerInfo => {
-			const whitelabelDomain = getWhitelabelDomain(customerInfo)
-			if (whitelabelDomain) {
-				showProgressDialog("loading_msg", loadAll(GroupInfoTypeRef, customer.userGroups)
-					.filter(g => !g.deleted)
-					.then(userGroupInfos => {
-						// get and separate all enabled shared mail groups and shared team groups
-						return loadAll(GroupInfoTypeRef, customer.teamGroups)
-							.then((groupInfos) => {
-								const sharedMailGroupInfos = groupInfos.filter(g => !g.deleted && g.groupType === GroupType.Mail)
-								return {userGroupInfos, sharedMailGroupInfos}
-							})
-					}))
-					.then(({userGroupInfos, sharedMailGroupInfos}) => {
-						let editor = new ContactFormEditor(c, createNew, newContactFormIdReceiver, userGroupInfos, sharedMailGroupInfos,
-							whitelabelDomain.domain)
-						editor.dialog.show()
-					})
-			} else {
-				Dialog.error("whitelabelDomainNeeded_msg")
-			}
-		})
-	})
+export async function show(c: ?ContactForm, createNew: boolean, newContactFormIdReceiver: (string) => void) {
+	const customer = await load(CustomerTypeRef, neverNull(logins.getUserController().user.customer))
+	const customerInfo = await load(CustomerInfoTypeRef, customer.customerInfo)
+
+	const whitelabelDomain = getWhitelabelDomain(customerInfo)
+	if (whitelabelDomain) {
+		showProgressDialog("loading_msg", loadAll(GroupInfoTypeRef, customer.userGroups)
+			.then(async allUserGroups => {
+				const userGroupInfos = allUserGroups.filter(g => !g.deleted)
+				// get and separate all enabled shared mail groups and shared team groups
+				const groupInfos = await loadAll(GroupInfoTypeRef, customer.teamGroups)
+				const sharedMailGroupInfos = groupInfos.filter(g => !g.deleted && g.groupType === GroupType.Mail)
+				let editor = new ContactFormEditor(c, createNew, newContactFormIdReceiver, userGroupInfos, sharedMailGroupInfos,
+					whitelabelDomain.domain)
+				editor.dialog.show()
+			}))
+	} else {
+		Dialog.error("whitelabelDomainNeeded_msg")
+	}
 }
 
 function getLanguageName(code: string): string {

--- a/src/settings/ContactFormViewer.js
+++ b/src/settings/ContactFormViewer.js
@@ -70,8 +70,8 @@ export class ContactFormViewer implements UpdatableSettingsViewer {
 		})
 		let participantMailGroupsField = null
 		loadGroupInfos(contactForm.participantGroupInfos)
-			.map(groupInfo => getGroupInfoDisplayName(groupInfo))
-			.then(mailGroupNames => {
+			.then(groupInfos => {
+				const mailGroupNames = groupInfos.map(groupInfo => getGroupInfoDisplayName(groupInfo))
 				if (mailGroupNames.length > 0) {
 					participantMailGroupsField = new TextField("responsiblePersons_label")
 						.setValue(mailGroupNames.join("; "))

--- a/src/settings/EditSecondFactorsForm.js
+++ b/src/settings/EditSecondFactorsForm.js
@@ -143,7 +143,7 @@ export class EditSecondFactorsForm {
 		let u2fSupportPromise = u2f.isSupported()
 		let userPromise = this._user.getAsync()
 		showProgressDialog("pleaseWait_msg", Promise.all([totpPromise, u2fSupportPromise, userPromise]))
-			.spread((totpKeys, u2fSupport, user) => {
+			.then(([totpKeys, u2fSupport, user]) => {
 				console.log("u2fSupport", u2fSupport)
 				const nameValue: Stream<string> = stream("")
 				const selectedType: Stream<string> = stream(SecondFactorType.totp)

--- a/src/settings/LocalAdminGroupInfoModel.js
+++ b/src/settings/LocalAdminGroupInfoModel.js
@@ -14,7 +14,6 @@ class LocalAdminGroupInfoModel {
 	groupInfos: GroupInfo[];
 
 	constructor() {
-
 		this._initialization = null
 		this.groupInfos = []
 	}
@@ -32,14 +31,14 @@ class LocalAdminGroupInfoModel {
 	}
 
 	_init(): Promise<GroupInfo[]> {
-		this._initialization = logins.getUserController().loadCustomer().then(customer => {
-			return loadAll(GroupInfoTypeRef, customer.teamGroups)
-				.filter(gi => gi.groupType === GroupType.LocalAdmin)
-				.then(groupInfos => {
-					this.groupInfos = groupInfos
-					return groupInfos
-				})
-		})
+		this._initialization = logins
+			.getUserController()
+			.loadCustomer()
+			.then(async customer => {
+				const groupInfos: Array<GroupInfo> = await loadAll(GroupInfoTypeRef, customer.teamGroups)
+				this.groupInfos = groupInfos.filter(gi => gi.groupType === GroupType.LocalAdmin)
+				return this.groupInfos
+			})
 		return this._initialization
 	}
 

--- a/src/settings/UserListView.js
+++ b/src/settings/UserListView.js
@@ -138,17 +138,14 @@ export class UserListView implements UpdatableSettingsViewer {
 		}
 	}
 
-	_loadAdmins(): Promise<void> {
+	async _loadAdmins(): Promise<void> {
 		let adminGroupMembership = logins.getUserController()
 		                                 .user
 		                                 .memberships
 		                                 .find(gm => gm.groupType === GroupType.Admin)
 		if (adminGroupMembership == null) return Promise.resolve()
-		return loadAll(GroupMemberTypeRef, adminGroupMembership.groupMember[0]).map(adminGroupMember => {
-			return adminGroupMember.userGroupInfo[1]
-		}).then(userGroupInfoIds => {
-			this._adminUserGroupInfoIds = userGroupInfoIds
-		})
+		const members = await loadAll(GroupMemberTypeRef, adminGroupMembership.groupMember[0])
+		this._adminUserGroupInfoIds = members.map((adminGroupMember) => adminGroupMember.userGroupInfo[1])
 	}
 
 	_setLoadedCompletely() {

--- a/src/settings/UserViewer.js
+++ b/src/settings/UserViewer.js
@@ -314,16 +314,18 @@ export class UserViewer {
 						return loadMultiple(ContactFormTypeRef, mailboxGroupRoot.participatingContactForms[0][0], mailboxGroupRoot.participatingContactForms.map(idTuple => idTuple[1]))
 					}
 					return []
-				}).map((cf: ContactForm) => {
-					let removeButton = new Button("remove_action", () => {
-						let match = cf.participantGroupInfos.find(id => isSameId(id, user.userGroup.groupInfo))
-						if (match) {
-							remove(cf.participantGroupInfos, match)
-						}
-						showProgressDialog("pleaseWait_msg", update(cf))
-					}, () => Icons.Cancel)
-					return new TableLine([cf.path], removeButton)
-				}).then(tableLines => {
+				}).then((forms) => {
+					const tableLines = forms.map((cf) => {
+						let removeButton = new Button("remove_action", () => {
+							let match = cf.participantGroupInfos.find(id => isSameId(id, user.userGroup.groupInfo))
+							if (match) {
+								remove(cf.participantGroupInfos, match)
+							}
+							showProgressDialog("pleaseWait_msg", update(cf))
+						}, () => Icons.Cancel)
+						return new TableLine([cf.path], removeButton)
+					})
+
 					if (this._contactFormsTable) {
 						this._contactFormsTable.updateEntries(tableLines)
 					}

--- a/src/subscription/giftcards/PurchaseGiftCardDialog.js
+++ b/src/subscription/giftcards/PurchaseGiftCardDialog.js
@@ -36,7 +36,7 @@ import {Icons} from "../../gui/base/icons/Icons"
 import {Icon} from "../../gui/base/Icon"
 import {GiftCardMessageEditorField} from "./GiftCardMessageEditorField"
 import {client} from "../../misc/ClientDetector"
-import {noOp} from "../../api/common/utils/Utils"
+import {filterInt, noOp} from "../../api/common/utils/Utils"
 import {isIOSApp} from "../../api/common/Env"
 import {formatPrice} from "../PriceUtils";
 
@@ -199,7 +199,7 @@ export function showPurchaseGiftCardDialog(): Promise<void> {
 			      logins.getUserController().loadCustomerInfo(),
 			      loadUpgradePrices()
 		      ]))
-		      .spread((giftCardInfo, customerInfo, prices) => {
+		      .then(([giftCardInfo, customerInfo, prices]) => {
 			      // User can't buy too many gift cards so we have to load their giftcards in order to check how many they ordered
 			      const loadGiftCardsPromise = customerInfo.giftCards
 				      ? locator.entityClient.loadAll(GiftCardTypeRef, customerInfo.giftCards.items)
@@ -230,8 +230,8 @@ export function showPurchaseGiftCardDialog(): Promise<void> {
 					      }
 					      let dialog
 					      const attrs: GiftCardPurchaseViewAttrs = {
-						      purchaseLimit: giftCardInfo.maxPerPeriod,
-						      purchasePeriodMonths: giftCardInfo.period,
+						      purchaseLimit: filterInt(giftCardInfo.maxPerPeriod),
+						      purchasePeriodMonths: filterInt(giftCardInfo.period),
 						      availablePackages: giftCardInfo.options,
 						      initiallySelectedPackage: Math.floor(giftCardInfo.options.length / 2),
 						      message: lang.get("defaultGiftCardMessage_msg"),

--- a/src/support/FaqModel.js
+++ b/src/support/FaqModel.js
@@ -36,7 +36,7 @@ export class FaqModel {
 			return Promise.all([
 				this.fetchFAQ("en"),
 				this.fetchFAQ(lang.code)
-			]).spread((defaultTranslations, currentLanguageTranslations) => {
+			]).then(([defaultTranslations, currentLanguageTranslations]) => {
 					if (defaultTranslations != null || currentLanguageTranslations != null) {
 						const faqLanguageViewModel = new LanguageViewModel()
 						faqLanguageViewModel.initWithTranslations(lang.code, lang.languageTag, defaultTranslations, currentLanguageTranslations)


### PR DESCRIPTION
Functions Promise.prototype.{each, map, filter, reduce, spread} (not to
be mistaken with "static" Promise.each, Promise.map etc) are not
type-safe in a sense that they are only defined for Promisees which
contain arrays but this behavior cannot be expressed for type-checked
so the result type of them is effectively `any`.

We remove them as they introduce dangerous gaps in type safety and also
as a part of departing from Bluebird.