### PR TITLE
update oxmsg version and adapt to changes, close #2727

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4443,8 +4443,8 @@
 			}
 		},
 		"oxmsg": {
-			"version": "github:tutao/oxmsg#d18421daaaca85de6a8c12ca927e4be96d71f61b",
-			"from": "github:tutao/oxmsg#d18421daaaca85de6a8c12ca927e4be96d71f61b",
+			"version": "github:tutao/oxmsg#e218f9fda176b3f990d13cb962f41fff8df4d58f",
+			"from": "github:tutao/oxmsg#e218f9fda176b3f990d13cb962f41fff8df4d58f",
 			"requires": {
 				"address-rfc2822": "^2.0.6",
 				"buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"qrcode-svg": "1.0.0",
 		"squire-rte": "1.9.0",
 		"systemjs": "6.8.3",
-		"oxmsg": "tutao/oxmsg#d18421daaaca85de6a8c12ca927e4be96d71f61b"
+		"oxmsg": "tutao/oxmsg#e218f9fda176b3f990d13cb962f41fff8df4d58f"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.10.5",

--- a/src/desktop/DesktopUtils.js
+++ b/src/desktop/DesktopUtils.js
@@ -11,7 +11,7 @@ import {uint8ArrayToHex} from "../api/common/utils/Encoding"
 import {cryptoFns} from "./CryptoFns"
 
 
-import {AttachmentType, Email, MessageEditorFormat} from "oxmsg"
+import {Attachment, Email, MessageEditorFormat} from "oxmsg"
 import {delay} from "../api/common/utils/PromiseUtils"
 import type {MailBundle} from "../mail/export/Bundler";
 import {legalizeFilenames} from "../api/common/utils/FileUtils"
@@ -188,7 +188,7 @@ export class DesktopUtils {
 			// attachment DataFiles cease to be Uint8Arrays and just because regular arrays, thus we have to remake them here.
 			// Oxmsg currently doesn't accept regular arrays for binary data, only Uint8Arrays, strings and booleans
 			// we could change the Oxmsg behaviour, it's kind of nice for it to be strict though.
-			email.attach(new Uint8Array(attachment.data), attachment.name, attachment.cid || "", AttachmentType.ATTACH_BY_VALUE)
+			email.attach(new Attachment(new Uint8Array(attachment.data), attachment.name, attachment.cid || ""))
 		}
 
 		return {name: `${subject}_export.msg`, content: email.msg()}


### PR DESCRIPTION
the changes to oxmsg include:
 - add CLSID to exported .msg files so that outlook knows how to handle them
 - changes to the public api to which i have adapted