### PR TITLE
Handle birthday parse exceptions

### DIFF
--- a/src/api/common/utils/BirthdayUtils.js
+++ b/src/api/common/utils/BirthdayUtils.js
@@ -1,9 +1,9 @@
 // @flow
 
-import {createBirthday} from "../../entities/tutanota/Birthday"
-import {ParsingError} from "../error/ParsingError"
-import {formatSortableDate} from "./DateUtils"
 import type {Birthday} from "../../entities/tutanota/Birthday"
+import {createBirthday} from "../../entities/tutanota/Birthday"
+import {formatSortableDate} from "./DateUtils"
+import {ParsingError} from "../error/ParsingError"
 
 /**
  * Converts the birthday object to iso Date format (yyyy-mm-dd) or iso Date without year (--mm-dd)
@@ -45,7 +45,7 @@ export function isoDateToBirthday(birthdayIso: string): Birthday {
 }
 
 
-function isValidBirthday(birthday: Birthday): boolean {
+export function isValidBirthday(birthday: Birthday): boolean {
 	const day = Number(birthday.day)
 	const month = Number(birthday.month)
 	const year = birthday.year ? Number(birthday.year) : null
@@ -53,7 +53,6 @@ function isValidBirthday(birthday: Birthday): boolean {
 		&& (month > 0 && month < 13)
 		&& (year === null || (year > 0 && year < 10000))
 }
-
 
 /**
  * returns new birthday format from old birthday format

--- a/src/contacts/model/ContactUtils.js
+++ b/src/contacts/model/ContactUtils.js
@@ -62,7 +62,7 @@ export function formatBirthdayWithMonthName(birthday: Birthday): string {
 /**
  * Returns the birthday of the contact as formatted string using default date formatter including date, month and year.
  * If birthday contains no year only month and day will be included.
- * If there is no birthday an empty string returns.
+ * If there is no birthday or an invalid birthday format an empty string returns.
  */
 export function formatBirthdayOfContact(contact: Contact): string {
 	if (contact.birthdayIso) {
@@ -70,10 +70,8 @@ export function formatBirthdayOfContact(contact: Contact): string {
 		try {
 			return formatBirthdayNumeric(isoDateToBirthday(isoDate))
 		} catch (e) {
-			console.log("error while formating contact birthday", e)
-			return ""
+			// cant format, cant do anything
 		}
-	} else {
-		return ""
 	}
+	return ""
 }

--- a/src/contacts/view/ContactViewer.js
+++ b/src/contacts/view/ContactViewer.js
@@ -3,9 +3,6 @@ import m from "mithril"
 import {lang} from "../../misc/LanguageViewModel"
 import {Button} from "../../gui/base/Button"
 import {ContactEditor} from "../ContactEditor"
-import {
-	formatBirthdayWithMonthName
-} from "../model/ContactUtils"
 import {TextField, Type} from "../../gui/base/TextField"
 import {erase} from "../../api/main/Entity"
 import {assertMainOrNode} from "../../api/common/Env"
@@ -15,17 +12,16 @@ import {Icons} from "../../gui/base/icons/Icons"
 import {NotFoundError} from "../../api/common/error/RestError"
 import {BootIcons} from "../../gui/base/icons/BootIcons"
 import {ContactSocialType, getContactSocialType, Keys} from "../../api/common/TutanotaConstants"
-import {isoDateToBirthday} from "../../api/common/utils/BirthdayUtils"
 import type {Contact} from "../../api/entities/tutanota/Contact"
 import type {ContactSocialId} from "../../api/entities/tutanota/ContactSocialId"
 import {locator} from "../../api/main/MainLocator"
 import {newMailEditorFromTemplate} from "../../mail/editor/MailEditor"
-import {neverNull} from "../../api/common/utils/Utils"
 import {logins} from "../../api/main/LoginController"
 import {NBSP} from "../../api/common/utils/StringUtils"
 import {ActionBar} from "../../gui/base/ActionBar"
 import {getContactAddressTypeLabel, getContactPhoneNumberTypeLabel, getContactSocialTypeLabel} from "./ContactGuiUtils";
 import {appendEmailSignature} from "../../mail/signature/Signature";
+import {formatBirthdayOfContact} from "../model/ContactUtils"
 
 assertMainOrNode()
 
@@ -52,6 +48,7 @@ export class ContactViewer {
 	socials: TextField[];
 	oncreate: Function;
 	onremove: Function;
+	formattedBirthday: ?string;
 
 	constructor(contact: Contact) {
 		this.contact = contact
@@ -114,6 +111,7 @@ export class ContactViewer {
 			return showURL
 		})
 
+		this.formattedBirthday = this._hasBirthday() ? formatBirthdayOfContact(this.contact) : null
 
 		this.view = () => {
 			return [
@@ -129,7 +127,7 @@ export class ContactViewer {
 									insertBetween([
 										this.contact.company ? m("span.company", this.contact.company) : null,
 										this.contact.role ? m("span.title", this.contact.role) : null,
-										this._hasBirthday() ? m("span.birthday", this._formatBirthday()) : null
+										this.formattedBirthday ? m("span.birthday", this.formattedBirthday) : null
 									], () => m("span", " | ")),
 									NBSP // alignment in case nothing is present here
 								])
@@ -256,13 +254,6 @@ export class ContactViewer {
 		new ContactEditor(this.contact).show()
 	}
 
-	_formatBirthday(): string {
-		if (this._hasBirthday()) {
-			return formatBirthdayWithMonthName(isoDateToBirthday(neverNull(this.contact.birthdayIso)))
-		} else {
-			return ""
-		}
-	}
 
 	_hasBirthday(): boolean {
 		return (!!this.contact.birthdayIso)


### PR DESCRIPTION
Incorrect birthdays are now silently not imported. Surprisingly, not
handling the exception broke the whole UI.

The vcard importer probably needs a rewrite as real parser.

fix #2708