### PR TITLE
clear up temporary directory on startup and quit

### DIFF
--- a/src/desktop/DesktopDownloadManager.js
+++ b/src/desktop/DesktopDownloadManager.js
@@ -13,7 +13,6 @@ import {looksExecutable, nonClobberingFilename} from "./PathUtils"
 import type {DesktopUtils} from "./DesktopUtils"
 import type {DownloadItem} from "electron"
 import {promises as fs} from "fs"
-import type {App} from "electron"
 
 
 export class DesktopDownloadManager {
@@ -152,7 +151,6 @@ export class DesktopDownloadManager {
 			}
 		}
 
-
 		item.on('done', (event, state) => {
 			if (state === 'completed') {
 				fileManagerLock()
@@ -170,18 +168,16 @@ export class DesktopDownloadManager {
 	/**
 	 * Get a directory under tutanota's temporary directory, will create it if it doesn't exist
 	 * @returns {Promise<string>}
-	 * @param app
 	 * @param subdirs
 	 */
 	async getTutanotaTempDirectory(...subdirs: string[]): Promise<string> {
 		const dirPath = this.getTutanotaTempPath(...subdirs)
-		await fs.mkdir(dirPath, {recursive: true})
+		await this._fs.mkdir(dirPath, {recursive: true})
 		return dirPath
 	}
 
 	/**
 	 * Get a path to a directory under tutanota's temporary directory. Will not create if it doesn't exist
-	 * @param app
 	 * @param subdirs
 	 * @returns {string}
 	 */
@@ -194,6 +190,7 @@ export class DesktopDownloadManager {
 		// Using sync version because this could get called on app shutdown and it may not complete if async
 		downcast(this._fs.rmdirSync)(this.getTutanotaTempPath(), {recursive: true})
 	}
+
 }
 
 function showDownloadErrorMessageBox(electron: $Exports<"electron">, message: string, filename: string) {
@@ -209,4 +206,3 @@ function showDownloadErrorMessageBox(electron: $Exports<"electron">, message: st
 			+ message
 	})
 }
-

--- a/src/desktop/DesktopDownloadManager.js
+++ b/src/desktop/DesktopDownloadManager.js
@@ -40,8 +40,8 @@ export class DesktopDownloadManager {
 
 	async downloadNative(sourceUrl: string, fileName: string, headers: {v: string, accessToken: string}): Promise<{statusCode: string, statusMessage: string, encryptedFileUri: string}> {
 		return new Promise(async (resolve, reject) => {
-			const downloadDirectory = await this.getTutanotaTempDirectory("download")
-			const encryptedFileUri = path.join(downloadDirectory, fileName)
+		const downloadDirectory = await this.getTutanotaTempDirectory("download")
+		const encryptedFileUri = path.join(downloadDirectory, fileName)
 			const fileStream = this._fs.createWriteStream(encryptedFileUri, {emitClose: true})
 			                       .on('finish', () => fileStream.close()) // .end() was called, contents is flushed -> release file desc
 			let cleanup = e => {
@@ -172,7 +172,7 @@ export class DesktopDownloadManager {
 	 */
 	async getTutanotaTempDirectory(...subdirs: string[]): Promise<string> {
 		const dirPath = this.getTutanotaTempPath(...subdirs)
-		await this._fs.mkdir(dirPath, {recursive: true})
+		await this._fs.promises.mkdir(dirPath, {recursive: true})
 		return dirPath
 	}
 

--- a/src/desktop/DesktopFileExport.js
+++ b/src/desktop/DesktopFileExport.js
@@ -8,16 +8,18 @@ import type {MailBundle} from "../mail/export/Bundler"
 import {Attachment, Email, MessageEditorFormat} from "oxmsg"
 import {ParsingError} from "../api/common/error/ParsingError"
 import {isValidGeneratedId} from "../api/common/utils/Encoding"
+import {getTutanotaTempDirectory} from "./DesktopDownloadManager"
+import type {App} from "electron"
+
+const EXPORT_DIR = "export"
 
 /**
  * Get the directory path into which temporary exports should be exported
- * @param tempDir: path to the tempdir, we have to inject this because we can't import app from electron in this file
  * @returns {Promise<string>}
+ * @param app: electron app for getting temp dir path
  */
-export async function getExportDirectoryPath(tempDir: string): Promise<string> {
-	const dirPath = path.join(tempDir, 'tutanota', 'msg_export')
-	await fs.mkdir(dirPath, {recursive: true})
-	return dirPath
+export async function getExportDirectoryPath(app: App): Promise<string> {
+	return getTutanotaTempDirectory(app, EXPORT_DIR)
 }
 
 /**
@@ -74,8 +76,8 @@ export async function makeMsgFile(bundle: MailBundle): Promise<{name: string, co
 }
 
 
-export async function msgFileExists(id: IdTuple, tempDir: string): Promise<boolean> {
-	const exportDir = await getExportDirectoryPath(tempDir)
+export async function msgFileExists(id: IdTuple, app: App): Promise<boolean> {
+	const exportDir = await getTutanotaTempDirectory(app, EXPORT_DIR)
 
 	// successful call to stat means the file exists. it should be valid because the only reason it's there is because we made it
 	return await fileExists(path.join(exportDir, mailIdToFileName(id, "msg")))

--- a/src/desktop/DesktopFileExport.js
+++ b/src/desktop/DesktopFileExport.js
@@ -8,18 +8,18 @@ import type {MailBundle} from "../mail/export/Bundler"
 import {Attachment, Email, MessageEditorFormat} from "oxmsg"
 import {ParsingError} from "../api/common/error/ParsingError"
 import {isValidGeneratedId} from "../api/common/utils/Encoding"
-import {getTutanotaTempDirectory} from "./DesktopDownloadManager"
-import type {App} from "electron"
+import type {DesktopDownloadManager} from "./DesktopDownloadManager"
 
 const EXPORT_DIR = "export"
 
 /**
  * Get the directory path into which temporary exports should be exported
  * @returns {Promise<string>}
+ * @param dl
  * @param app: electron app for getting temp dir path
  */
-export async function getExportDirectoryPath(app: App): Promise<string> {
-	return getTutanotaTempDirectory(app, EXPORT_DIR)
+export async function getExportDirectoryPath(dl: DesktopDownloadManager): Promise<string> {
+	return dl.getTutanotaTempDirectory(EXPORT_DIR)
 }
 
 /**
@@ -76,8 +76,8 @@ export async function makeMsgFile(bundle: MailBundle): Promise<{name: string, co
 }
 
 
-export async function msgFileExists(id: IdTuple, app: App): Promise<boolean> {
-	const exportDir = await getTutanotaTempDirectory(app, EXPORT_DIR)
+export async function msgFileExists(id: IdTuple, dl: DesktopDownloadManager): Promise<boolean> {
+	const exportDir = await dl.getTutanotaTempDirectory(EXPORT_DIR)
 
 	// successful call to stat means the file exists. it should be valid because the only reason it's there is because we made it
 	return await fileExists(path.join(exportDir, mailIdToFileName(id, "msg")))

--- a/src/desktop/DesktopMain.js
+++ b/src/desktop/DesktopMain.js
@@ -18,7 +18,7 @@ import {lang} from "../misc/LanguageViewModel"
 import en from "../translations/en"
 import {DesktopNetworkClient} from "./DesktopNetworkClient"
 import {DesktopCryptoFacade} from "./DesktopCryptoFacade"
-import {DesktopDownloadManager, getTutanotaTempPath} from "./DesktopDownloadManager"
+import {DesktopDownloadManager} from "./DesktopDownloadManager"
 import {DesktopTray} from "./tray/DesktopTray"
 import {log} from "./DesktopLog";
 import {UpdaterWrapperImpl} from "./UpdaterWrapper"
@@ -31,7 +31,6 @@ import net from "net"
 import child_process from "child_process"
 import {LocalShortcutManager} from "./electron-localshortcut/LocalShortcut"
 import {cryptoFns} from "./CryptoFns"
-import {downcast} from "../api/common/utils/Utils"
 
 mp()
 
@@ -86,10 +85,10 @@ if (process.argv.indexOf("-r") !== -1) {
 	startupInstance()
 }
 
-async function startupInstance() {
+function startupInstance() {
 	// Delete the temp directory on startup, because we may not always be able to do it on shutdown
 	// we want to await cause the next call will create it again
-	deleteTempDir()
+	dl.deleteTutanotaTempDirectory()
 
 	DesktopUtils.makeSingleInstance().then(willStay => {
 		if (!willStay) return
@@ -115,8 +114,8 @@ async function startupInstance() {
 			} else {
 				DesktopUtils.callWhenReady(() => handleMailto(url))
 			}
-		}).on('will-quit', async (e) => {
-			deleteTempDir()
+		}).on('will-quit', (e) => {
+			dl.deleteTutanotaTempDirectory()
 		})
 		// it takes a short while to get here,
 		// the event may already have fired
@@ -175,9 +174,3 @@ function handleMailto(mailtoArg?: string) {
 		ipc.sendRequest(w.id, 'createMailEditor', [[], "", "", "", mailtoArg])
 	}
 }
-
-function deleteTempDir() {
-	// TODO Flow doesn't know about the options param, we should update it and then remove this downcast
-	downcast(fs.rmdirSync)(getTutanotaTempPath(app), {recursive: true})
-}
-

--- a/src/desktop/DesktopMain.js
+++ b/src/desktop/DesktopMain.js
@@ -87,7 +87,6 @@ if (process.argv.indexOf("-r") !== -1) {
 
 function startupInstance() {
 	// Delete the temp directory on startup, because we may not always be able to do it on shutdown
-	// we want to await cause the next call will create it again
 	dl.deleteTutanotaTempDirectory()
 
 	DesktopUtils.makeSingleInstance().then(willStay => {

--- a/src/desktop/DesktopUtils.js
+++ b/src/desktop/DesktopUtils.js
@@ -161,8 +161,8 @@ function checkForAdminStatus(): Promise<boolean> {
 }
 
 function getLockFilePath() {
-	// don't get temp dir path from DesktopDownloadManager because we want the lockfile to persist while the app is open,
-	// and the tutanota temp dir may be deleted
+	// don't get temp dir path from DesktopDownloadManager because the path returned from there may be deleted at some point,
+	// we want to put the lockfile in root tmp so it persists
 	return path.join(app.getPath('temp'), 'tutanota_desktop_lockfile')
 }
 

--- a/src/desktop/DesktopUtils.js
+++ b/src/desktop/DesktopUtils.js
@@ -12,7 +12,6 @@ import {cryptoFns} from "./CryptoFns"
 
 
 import {delay} from "../api/common/utils/PromiseUtils"
-import {getTutanotaTempDirectory} from "./DesktopDownloadManager"
 
 export class DesktopUtils {
 	checkIsMailtoHandler(): Promise<boolean> {
@@ -81,8 +80,8 @@ export class DesktopUtils {
 	 * reads the lockfile and then writes the own version into the lockfile
 	 * @returns {Promise<boolean>} whether the lock was overridden by another version
 	 */
-	async singleInstanceLockOverridden(): Promise<boolean> {
-		const lockfilePath = await getLockFilePath()
+	singleInstanceLockOverridden(): Promise<boolean> {
+		const lockfilePath = getLockFilePath()
 		return fs.readFile(lockfilePath, 'utf8')
 		         .then(version => {
 			         return fs.writeFile(lockfilePath, app.getVersion(), 'utf8')
@@ -102,8 +101,8 @@ export class DesktopUtils {
 	 *
 	 * @returns {Promise<boolean>} whether the app was successful in getting the lock
 	 */
-	async makeSingleInstance(): Promise<boolean> {
-		const lockfilePath = await getLockFilePath()
+	makeSingleInstance(): Promise<boolean> {
+		const lockfilePath = getLockFilePath()
 		// first, put down a file in temp that contains our version.
 		// will overwrite if it already exists.
 		// errors are ignored and we fall back to a version agnostic single instance lock.
@@ -161,8 +160,10 @@ function checkForAdminStatus(): Promise<boolean> {
 	}
 }
 
-async function getLockFilePath(): Promise<string> {
-	return path.join(await getTutanotaTempDirectory(app), 'desktop_lockfile')
+function getLockFilePath() {
+	// don't get temp dir path from DesktopDownloadManager because we want the lockfile to persist while the app is open,
+	// and the tutanota temp dir may be deleted
+	return path.join(app.getPath('temp'), 'tutanota_desktop_lockfile')
 }
 
 /**

--- a/src/desktop/DesktopUtils.js
+++ b/src/desktop/DesktopUtils.js
@@ -11,8 +11,8 @@ import {uint8ArrayToHex} from "../api/common/utils/Encoding"
 import {cryptoFns} from "./CryptoFns"
 
 
-import {Attachment, Email, MessageEditorFormat} from "oxmsg"
 import {delay} from "../api/common/utils/PromiseUtils"
+import {getTutanotaTempDirectory} from "./DesktopDownloadManager"
 
 export class DesktopUtils {
 	checkIsMailtoHandler(): Promise<boolean> {
@@ -81,8 +81,8 @@ export class DesktopUtils {
 	 * reads the lockfile and then writes the own version into the lockfile
 	 * @returns {Promise<boolean>} whether the lock was overridden by another version
 	 */
-	singleInstanceLockOverridden(): Promise<boolean> {
-		const lockfilePath = getLockFilePath()
+	async singleInstanceLockOverridden(): Promise<boolean> {
+		const lockfilePath = await getLockFilePath()
 		return fs.readFile(lockfilePath, 'utf8')
 		         .then(version => {
 			         return fs.writeFile(lockfilePath, app.getVersion(), 'utf8')
@@ -102,8 +102,8 @@ export class DesktopUtils {
 	 *
 	 * @returns {Promise<boolean>} whether the app was successful in getting the lock
 	 */
-	makeSingleInstance(): Promise<boolean> {
-		const lockfilePath = getLockFilePath()
+	async makeSingleInstance(): Promise<boolean> {
+		const lockfilePath = await getLockFilePath()
 		// first, put down a file in temp that contains our version.
 		// will overwrite if it already exists.
 		// errors are ignored and we fall back to a version agnostic single instance lock.
@@ -161,8 +161,8 @@ function checkForAdminStatus(): Promise<boolean> {
 	}
 }
 
-function getLockFilePath() {
-	return path.join(app.getPath('temp'), 'tutanota_desktop_lockfile')
+async function getLockFilePath(): Promise<string> {
+	return path.join(await getTutanotaTempDirectory(app), 'desktop_lockfile')
 }
 
 /**

--- a/src/desktop/IPC.js
+++ b/src/desktop/IPC.js
@@ -276,8 +276,8 @@ export class IPC {
 				const getExportPath = async id => path.join(await getExportDirectoryPath(this._electron.app), mailIdToFileName(id, "msg"))
 				const files = await Promise.all(ids.map(getExportPath))
 				                           .then(files => files.filter(fileExists))
-
-				this._wm.get(windowId)?._browserWindow.webContents.startDrag({
+				const window = this._wm.get(windowId)
+				window && window._browserWindow.webContents.startDrag({
 					files,
 					icon: this._dragIcon
 				})
@@ -285,7 +285,8 @@ export class IPC {
 				return Promise.resolve()
 			}
 			case 'focusApplicationWindow': {
-				this._wm.get(windowId)?.browserWindow.focus()
+				const window = this._wm.get(windowId)
+				window && window.browserWindow.focus()
 				return Promise.resolve()
 			}
 			default:

--- a/src/login/LoginViewController.js
+++ b/src/login/LoginViewController.js
@@ -251,11 +251,9 @@ export class LoginViewController implements ILoginViewController {
 			})
 			.then(() => logins.loginComplete()).then(() => {
 			// don't wait for it, just invoke
-			if (isApp()) {
-				import("../native/common/FileApp")
-					.then(({fileApp}) => fileApp.clearFileData())
-					.catch((e) => console.log("Failed to clean file data", e))
-			}
+			import("../native/common/FileApp")
+				.then(({fileApp}) => fileApp.clearFileData())
+				.catch((e) => console.log("Failed to clean file data", e))
 		})
 			.then(() => {
 				if (logins.isGlobalAdminUserLoggedIn() && !isAdminClient()) {

--- a/src/login/LoginViewController.js
+++ b/src/login/LoginViewController.js
@@ -14,7 +14,7 @@ import {
 	TooManyRequestsError
 } from "../api/common/error/RestError"
 import {load, serviceRequestVoid, update} from "../api/main/Entity"
-import {assertMainOrNode, isAdminClient, isApp, LOGIN_TITLE, Mode} from "../api/common/Env"
+import {assertMainOrNode, isAdminClient, isApp, isDesktop, LOGIN_TITLE, Mode} from "../api/common/Env"
 import {CloseEventBusOption, Const} from "../api/common/TutanotaConstants"
 import {CustomerPropertiesTypeRef} from "../api/entities/sys/CustomerProperties"
 import {neverNull, noOp} from "../api/common/utils/Utils"
@@ -250,10 +250,12 @@ export class LoginViewController implements ILoginViewController {
 				}
 			})
 			.then(() => logins.loginComplete()).then(() => {
-			// don't wait for it, just invoke
-			import("../native/common/FileApp")
-				.then(({fileApp}) => fileApp.clearFileData())
-				.catch((e) => console.log("Failed to clean file data", e))
+				if (isApp() || isDesktop()) {
+					// don't wait for it, just invoke
+					import("../native/common/FileApp")
+						.then(({fileApp}) => fileApp.clearFileData())
+						.catch((e) => console.log("Failed to clean file data", e))
+				}
 		})
 			.then(() => {
 				if (logins.isGlobalAdminUserLoggedIn() && !isAdminClient()) {

--- a/test/client/desktop/DesktopDownloadManagerTest.js
+++ b/test/client/desktop/DesktopDownloadManagerTest.js
@@ -2,12 +2,8 @@
 import o from "ospec"
 import n from "../nodemocker"
 import {DesktopDownloadManager} from "../../../src/desktop/DesktopDownloadManager"
-import {lang} from "../../../src/misc/LanguageViewModel"
-// $FlowIgnore[untyped-import]
-import en from "../../../src/translations/en"
 
 const DEFAULT_DOWNLOAD_PATH = "/a/download/path/"
-lang.init({en})
 
 o.spec("DesktopDownloadManagerTest", function () {
 	let conf
@@ -138,13 +134,13 @@ o.spec("DesktopDownloadManagerTest", function () {
 			},
 			openSync: () => {
 			},
-			mkdir: () => Promise.resolve(),
 			writeFile: () => Promise.resolve(),
 			createWriteStream: () => new WriteStream(),
 			existsSync: (path) => path === DEFAULT_DOWNLOAD_PATH,
 			mkdirSync: () => {},
 			promises: {
-				unlink: () => Promise.resolve()
+				unlink: () => Promise.resolve(),
+				mkdir: () => Promise.resolve(),
 			}
 		}
 
@@ -165,7 +161,7 @@ o.spec("DesktopDownloadManagerTest", function () {
 		}
 	}
 
-	function makeMockedDownloadManager({electronMock, desktopUtilsMock, confMock, netMock, fsMock, langMock}) {
+	function makeMockedDownloadManager({electronMock, desktopUtilsMock, confMock, netMock, fsMock}) {
 		return new DesktopDownloadManager(confMock, netMock, desktopUtilsMock, fsMock, electronMock)
 	}
 


### PR DESCRIPTION
We do it at startup because on windows we won't receive before-quit, will-quit or quit events when the user shuts down or logs out without quitting the app first.

this commit also has some consolidation of tmp dir usage and minor tidying up

close #2770