### PR TITLE
Fix "batch does not have events for" error

### DIFF
--- a/src/api/worker/search/EventQueue.js
+++ b/src/api/worker/search/EventQueue.js
@@ -212,6 +212,9 @@ export class EventQueue {
 			findAllAndRemove(batchInThePast.events, (event) => isSameId(event.instanceId, elementId))
 			return batchInThePast.events.length === 0
 		}, startIndex)
+
+		// // We removed empty batches from the list but the one in the map will still stay.
+		this._lastOperationForEntity.set(elementId, this._eventQueue[startIndex])
 	}
 
 	start() {


### PR DESCRIPTION
In case of DELETE we have been removing all the batches between it and
previous DELETE/MOVE. We did not add the new DELETE because the old
one should be enough. However those operations inbetween can still be
"latest for entity", even if they are empty and since we don't add a
new DELETE to the queue we wouldn't operate latest entry in the map.

This commit sets previous batch as the latest one instead of the
removed batch

fix #2648