### PR TITLE
[desktop] use node.js url.pathToFileURL

### DIFF
--- a/src/desktop/PathUtils.js
+++ b/src/desktop/PathUtils.js
@@ -11,27 +11,6 @@ import {promises as fs} from "fs"
 export type ValidExtension = "msg"
 
 /**
- * @param pathToConvert absolute Path to a file
- * @returns {string} file:// URL that can be extended with query parameters and loaded with BrowserWindow.loadURL()
- */
-export function pathToFileURL(pathToConvert: string): string {
-	pathToConvert = pathToConvert
-		.trim()
-		.split(path.sep)
-		.map((fragment) => encodeURIComponent(fragment))
-		.join("/")
-	const extraSlashForWindows = process.platform === "win32" && pathToConvert !== ''
-		? "/"
-		: ""
-	let urlFromPath = url.format({
-		pathname: extraSlashForWindows + pathToConvert.trim(),
-		protocol: 'file:'
-	})
-
-	return urlFromPath.trim()
-}
-
-/**
  * compares a filename to a list of filenames and finds the first number-suffixed
  * filename not already contained in the list.
  * @returns {string} the basename appended with '-<first non-clashing positive number>.<ext>

--- a/test/client/desktop/ApplicationWindowTest.js
+++ b/test/client/desktop/ApplicationWindowTest.js
@@ -787,7 +787,7 @@ o.spec("ApplicationWindow Test", function () {
 		wcMock.getURL = () => "desktophtml"
 		o(w.getPath()).equals('')
 		wcMock.getURL = () => "desktophtml/meh/more"
-		downcast(w)._startFile = ''
+		downcast(w)._startFileURLString = ''
 		o(w.getPath()).equals("desktophtml/meh/more")
 	})
 

--- a/test/client/desktop/PathUtilsTest.js
+++ b/test/client/desktop/PathUtilsTest.js
@@ -1,35 +1,7 @@
 //@flow
 import o from "ospec"
-import path from 'path'
 import n from "../nodemocker"
-import {nonClobberingFilename, pathToFileURL} from "../../../src/desktop/PathUtils"
-
-function setEnv(platform: string) {
-	let sep = ''
-	switch (platform) {
-		case 'win32':
-			sep = '\\'
-			break
-		case 'darwin':
-		case 'linux':
-			sep = '/'
-			break
-		default:
-			throw new Error('invalid platform')
-	}
-
-	Object.defineProperty(process, 'platform', {
-		value: platform,
-		writable: false,
-		enumerable: true
-	})
-
-	Object.defineProperty((path: any), 'sep', {
-		value: sep,
-		writable: false,
-		enumerable: true
-	})
-}
+import {nonClobberingFilename} from "../../../src/desktop/PathUtils"
 
 o.spec("PathUtils", function () {
 	o.spec("nonClobberingFileName Test", function () {
@@ -229,46 +201,6 @@ o.spec("PathUtils", function () {
 
 			o(nonClobberingFilename([], ".."))
 				.equals(".._")
-		})
-	})
-
-	o.spec("pathToFileURL Test", function () {
-		let oldPlatform = process.platform
-
-		o.before(function () {
-			setEnv(oldPlatform)
-		})
-
-		o.after(function () {
-			setEnv(oldPlatform)
-		})
-
-		o("emptyPath", function () {
-			setEnv('linux')
-			o(pathToFileURL(''))
-				.equals('file://')
-
-			setEnv('darwin')
-			o(pathToFileURL(''))
-				.equals('file://')
-
-			setEnv('win32')
-			o(pathToFileURL(''))
-				.equals('file://')
-		})
-
-		o("normalPath", function () {
-			setEnv('win32')
-			o(pathToFileURL('C:\\home\\nig\\index.html'))
-				.equals('file:///C%3A/home/nig/index.html')
-
-			setEnv('darwin')
-			o(pathToFileURL('/Users/nig/Library/Application Support/index.html'))
-				.equals('file:///Users/nig/Library/Application%20Support/index.html')
-
-			setEnv('linux')
-			o(pathToFileURL('home/nig/index.html'))
-				.equals('file://home/nig/index.html')
 		})
 	})
 })


### PR DESCRIPTION
the function is used to produce a url (that can be extended with query parameters) to the desktop start file instead of a file path.

 fix #2791