### PR TITLE
Fix DELETE-CREATE combo in EventQueue again

### DIFF
--- a/src/api/worker/search/EventQueue.js
+++ b/src/api/worker/search/EventQueue.js
@@ -181,9 +181,14 @@ export class EventQueue {
 						const firstMoveBatch = this._eventQueue[firstMoveIndex]
 						const createEvent = getEventOfType(firstMoveBatch.events, OperationType.CREATE, elementId)
 						createEvent && remove(firstMoveBatch.events, createEvent)
+
+						// We removed empty batches from the list but the one in the map will still stay
+						// so we need to manually clean it up.
+						this._lastOperationForEntity.set(elementId, this._eventQueue[firstMoveIndex])
 					} else {
 						// add delete event
 						newBatch.events.push(newEvent)
+						// _lastOperationForEntity will be set after the batch is prepared as it's non-empty
 					}
 					// delete all other events
 					this.removeEventsForInstance(elementId, firstMoveIndex + 1)
@@ -212,9 +217,6 @@ export class EventQueue {
 			findAllAndRemove(batchInThePast.events, (event) => isSameId(event.instanceId, elementId))
 			return batchInThePast.events.length === 0
 		}, startIndex)
-
-		// // We removed empty batches from the list but the one in the map will still stay.
-		this._lastOperationForEntity.set(elementId, this._eventQueue[startIndex])
 	}
 
 	start() {

--- a/test/api/worker/search/EventQueueTest.js
+++ b/test/api/worker/search/EventQueueTest.js
@@ -380,6 +380,7 @@ o.spec("EventQueueTest", function () {
 		o("delete + create + delete + create == delete + create", async function () {
 			// This tests that create still works a
 			const deleteEvent1 = createUpdate(OperationType.DELETE, "list", "1", "u1")
+			const nonEmptyEventInBetween = createUpdate(OperationType.CREATE, "list2", "2", "u1.1")
 			const createEvent1 = createUpdate(OperationType.CREATE, "list", "1", "u2")
 
 			const deleteEvent2 = createUpdate(OperationType.DELETE, "list", "1", "u3")
@@ -387,6 +388,7 @@ o.spec("EventQueueTest", function () {
 
 
 			queue.add("batch-id-1", "group-id", [deleteEvent1])
+			queue.add("batch-id-1.1", "group-id", [nonEmptyEventInBetween])
 			queue.add("batch-id-2", "group-id", [createEvent1])
 			queue.add("batch-id-3", "group-id", [deleteEvent2])
 			queue.add("batch-id-4", "group-id", [createEvent2])
@@ -398,6 +400,7 @@ o.spec("EventQueueTest", function () {
 
 			o(processElement.calls.map(c => c.args)).deepEquals([
 				[{events: [expectedDelete], batchId: "batch-id-1", groupId: "group-id"}],
+				[{events: [nonEmptyEventInBetween], batchId: "batch-id-1.1", groupId: "group-id"}],
 				[{events: [expectedCreate], batchId: "batch-id-4", groupId: "group-id"}],
 			])
 		})


### PR DESCRIPTION
96b4ed7 introduced a fix for the DELETE-CREATE-DELETE-CREATE case in
EventQueue optimization. However it used the wrong index to set
lastOperationForEntity. This commit sets it only when we have to and
with the right index.

fix #2648