### PR TITLE
Improve functionality of CalendarEventPopup

### DIFF
--- a/src/api/common/utils/Utils.js
+++ b/src/api/common/utils/Utils.js
@@ -407,9 +407,9 @@ export function filterInt(value: string): number {
 	}
 }
 
-export function insideRect(point: {x: number, y: number}, rect: {x: number, y: number, width: number, height: number}): boolean {
-	return point.x >= rect.x && point.x < rect.x + rect.width
-		&& point.y >= rect.y && point.y < rect.y + rect.height
+export function insideRect(point: {x: number, y: number}, rect: {top: number, left: number, bottom: number, right: number}): boolean {
+	return point.x >= rect.left && point.x < rect.right
+		&& point.y >= rect.top && point.y < rect.bottom
 }
 
 export function objToError(o: Object): Error {

--- a/src/api/common/utils/Utils.js
+++ b/src/api/common/utils/Utils.js
@@ -407,6 +407,11 @@ export function filterInt(value: string): number {
 	}
 }
 
+export function insideRect(point: {x: number, y: number}, rect: {x: number, y: number, width: number, height: number}): boolean {
+	return point.x >= rect.x && point.x < rect.x + rect.width
+		&& point.y >= rect.y && point.y < rect.y + rect.height
+}
+
 export function objToError(o: Object): Error {
 	let errorType = ErrorNameToType[o.name]
 	let e = (errorType != null ? new errorType(o.message) : new Error(o.message): any)

--- a/src/calendar/view/CalendarEventPopup.js
+++ b/src/calendar/view/CalendarEventPopup.js
@@ -18,13 +18,14 @@ import {Keys} from "../../api/common/TutanotaConstants"
 import type {HtmlSanitizer} from "../../misc/HtmlSanitizer"
 
 export class CalendarEventPopup implements ModalComponent {
-	_calendarEvent: CalendarEvent;
-	_eventBubbleRect: ClientRect;
-	_viewModel: CalendarEventViewModel;
-	_onEditEvent: () => mixed;
+	_calendarEvent: CalendarEvent
+	_eventBubbleRect: ClientRect
+	_viewModel: CalendarEventViewModel
+	_onEditEvent: () => mixed
 	_shortcuts: Shortcut[]
-	_sanitizedDescription: string;
+	_sanitizedDescription: string
 
+	view: (Vnode<mixed>) => Children
 
 	constructor(viewModel: CalendarEventViewModel, calendarEvent: CalendarEvent, calendars: Map<Id, CalendarInfo>,
 	            mailboxDetail: MailboxDetail, eventBubbleRect: ClientRect,
@@ -74,63 +75,63 @@ export class CalendarEventPopup implements ModalComponent {
 					help: "delete_action"
 				})
 		}
+
+		this.view = (vnode: Vnode<any>) => {
+			return m(".abs.elevated-bg.plr.border-radius.dropdown-shadow", {
+					style: {
+						width: px(Math.min(window.innerWidth - DROPDOWN_MARGIN * 2, 400)), // minus margin, need to apply it now to not overflow later
+						opacity: "0", // see hack description below
+						margin: "1px" // because calendar event bubles have 1px border, we want to align
+					},
+					oncreate: ({dom}) => {
+					// This is a hack to get "natural" view size but render it without opacity first and then show dropdown with inferred
+						// size.
+					setTimeout(() => showDropdown(this._eventBubbleRect, dom, dom.offsetHeight, 400), 24)
+					},
+				},
+				[
+					m(".flex.flex-end", [
+						m(ButtonN, {
+							label: "edit_action",
+							click: () => {
+								this._onEditEvent()
+								this._close()
+							},
+							type: ButtonType.ActionLarge,
+							icon: () => Icons.Edit,
+							colors: ButtonColors.DrawerNav,
+						}),
+						!this._viewModel.isReadOnlyEvent()
+							? m(ButtonN, {
+								label: "delete_action",
+								click: () => deleteEvent(this._viewModel).then((confirmed) => {
+									if (confirmed) this._close()
+								}),
+								type: ButtonType.ActionLarge,
+								icon: () => Icons.Trash,
+								colors: ButtonColors.DrawerNav,
+							})
+							: null,
+						m(ButtonN, {
+							label: "close_alt",
+							click: () => this._close(),
+							type: ButtonType.ActionLarge,
+							icon: () => Icons.Cancel,
+							colors: ButtonColors.DrawerNav,
+						}),
+					]),
+					m(EventPreviewView, {
+						event: this._calendarEvent,
+						limitDescriptionHeight: true,
+						sanitizedDescription: this._sanitizedDescription
+					}),
+				],
+			)
+		}
 	}
 
 	show() {
 		modal.displayUnique(this, false)
-	}
-
-	view(vnode: Vnode<any>): Children {
-		return m(".abs.elevated-bg.plr.border-radius.dropdown-shadow", {
-				style: {
-					width: px(Math.min(window.innerWidth - DROPDOWN_MARGIN * 2, 400)), // minus margin, need to apply it now to not overflow later
-					opacity: "0", // see hack description below
-					margin: "1px" // because calendar event bubles have 1px border, we want to align
-				},
-				oncreate: ({dom}) => {
-					// This is a hack to get "natural" view size but render it without opacity first and then show dropdown with inferred
-					// size.
-					setTimeout(() => showDropdown(this._eventBubbleRect, dom, dom.offsetHeight, 400), 24)
-				},
-			},
-			[
-				m(".flex.flex-end", [
-					m(ButtonN, {
-						label: "edit_action",
-						click: () => {
-							this._onEditEvent()
-							this._close()
-						},
-						type: ButtonType.ActionLarge,
-						icon: () => Icons.Edit,
-						colors: ButtonColors.DrawerNav,
-					}),
-					!this._viewModel.isReadOnlyEvent()
-						? m(ButtonN, {
-							label: "delete_action",
-							click: () => deleteEvent(this._viewModel).then((confirmed) => {
-								if (confirmed) this._close()
-							}),
-							type: ButtonType.ActionLarge,
-							icon: () => Icons.Trash,
-							colors: ButtonColors.DrawerNav,
-						})
-						: null,
-					m(ButtonN, {
-						label: "close_alt",
-						click: () => this._close(),
-						type: ButtonType.ActionLarge,
-						icon: () => Icons.Cancel,
-						colors: ButtonColors.DrawerNav,
-					}),
-				]),
-				m(EventPreviewView, {
-					event: this._calendarEvent,
-					limitDescriptionHeight: true,
-					sanitizedDescription: this._sanitizedDescription
-				}),
-			],
-		)
 	}
 
 	_close() {

--- a/src/calendar/view/CalendarEventPopup.js
+++ b/src/calendar/view/CalendarEventPopup.js
@@ -81,10 +81,10 @@ export class CalendarEventPopup implements ModalComponent {
 					style: {
 						width: px(Math.min(window.innerWidth - DROPDOWN_MARGIN * 2, 400)), // minus margin, need to apply it now to not overflow later
 						opacity: "0", // see hack description below
-						margin: "1px" // because calendar event bubles have 1px border, we want to align
+						margin: "1px" // because calendar event bubbles have 1px border, we want to align
 					},
 					oncreate: ({dom}) => {
-					// This is a hack to get "natural" view size but render it without opacity first and then show dropdown with inferred
+						// This is a hack to get "natural" view size but render it without opacity first and then show dropdown with inferred
 						// size.
 					setTimeout(() => showDropdown(this._eventBubbleRect, dom, dom.offsetHeight, 400), 24)
 					},

--- a/src/calendar/view/EventPreviewView.js
+++ b/src/calendar/view/EventPreviewView.js
@@ -18,6 +18,10 @@ export type Attrs = {
 export class EventPreviewView implements MComponent<Attrs> {
 
 	view({attrs: {event, limitDescriptionHeight, sanitizedDescription}}: Vnode<Attrs>): Children {
+		const locationHref = event.location.startsWith("http://") || event.location.startsWith("https://")
+			? event.location
+			: `https://www.openstreetmap.org/search?query=${encodeURIComponent(event.location)}`
+
 		return m(".flex.col", [
 			m(".flex.col.smaller", [
 				m(".flex.pb-s.items-center", [renderSectionIndicator(BootIcons.Calendar), m(".h3.selectable", event.summary)]),
@@ -28,7 +32,8 @@ export class EventPreviewView implements MComponent<Attrs> {
 				),
 				event.location
 					? m(".flex.pb-s.items-center", [
-						renderSectionIndicator(Icons.Pin), m(".text-ellipsis.selectable", event.location)
+						renderSectionIndicator(Icons.Pin),
+						m("a", {href: locationHref}, m(".text-ellipsis.selectable.underline.click", event.location))
 					])
 					: null,
 				event.attendees.length

--- a/src/calendar/view/EventPreviewView.js
+++ b/src/calendar/view/EventPreviewView.js
@@ -20,13 +20,17 @@ export class EventPreviewView implements MComponent<Attrs> {
 	view({attrs: {event, limitDescriptionHeight, sanitizedDescription}}: Vnode<Attrs>): Children {
 		return m(".flex.col", [
 			m(".flex.col.smaller", [
-				m(".flex.pb-s.items-center", [renderSectionIndicator(BootIcons.Calendar), m(".h3", event.summary)]),
+				m(".flex.pb-s.items-center", [renderSectionIndicator(BootIcons.Calendar), m(".h3.selectable", event.summary)]),
 				m(".flex.pb-s.items-center", [
 						renderSectionIndicator(Icons.Time),
-						m(".align-self-center", formatEventDuration(event, getTimeZone(), false))
+						m(".align-self-center.selectable", formatEventDuration(event, getTimeZone(), false))
 					]
 				),
-				event.location ? m(".flex.pb-s.items-center", [renderSectionIndicator(Icons.Pin), m(".text-ellipsis", event.location)]) : null,
+				event.location
+					? m(".flex.pb-s.items-center", [
+						renderSectionIndicator(Icons.Pin), m(".text-ellipsis.selectable", event.location)
+					])
+					: null,
 				event.attendees.length
 					? m(".flex.pb-s", [
 						renderSectionIndicator(BootIcons.Contacts),
@@ -36,7 +40,7 @@ export class EventPreviewView implements MComponent<Attrs> {
 								style: {fill: theme.content_fg},
 								class: "mr-s"
 							}),
-							m(".span.line-break-anywhere", a.address.address),
+							m(".span.line-break-anywhere.selectable", a.address.address),
 						]))),
 					])
 					: null,
@@ -44,8 +48,8 @@ export class EventPreviewView implements MComponent<Attrs> {
 					? m(".flex.pb-s.items-start", [
 						renderSectionIndicator(Icons.AlignLeft, {marginTop: "2px"}),
 						limitDescriptionHeight
-							? m(".scroll.full-width", {style: {maxHeight: "100px"}}, m.trust(sanitizedDescription))
-							: m("", m.trust(sanitizedDescription))
+							? m(".scroll.full-width.selectable", {style: {maxHeight: "100px"}}, m.trust(sanitizedDescription))
+							: m(".selectable", m.trust(sanitizedDescription))
 					])
 					: null,
 			]),

--- a/src/calendar/view/EventPreviewView.js
+++ b/src/calendar/view/EventPreviewView.js
@@ -18,9 +18,16 @@ export type Attrs = {
 export class EventPreviewView implements MComponent<Attrs> {
 
 	view({attrs: {event, limitDescriptionHeight, sanitizedDescription}}: Vnode<Attrs>): Children {
-		const locationHref = event.location.startsWith("http://") || event.location.startsWith("https://")
-			? event.location
-			: `https://www.openstreetmap.org/search?query=${encodeURIComponent(event.location)}`
+
+		const location = event.location.trim()
+		const osmHref = `https://www.openstreetmap.org/search?query=${location}`
+		let url
+		try {
+			// if not a valid _absolute_ url then we get an exception
+			url = new URL(location)
+		} catch {
+			url = new URL(osmHref)
+		}
 
 		return m(".flex.col", [
 			m(".flex.col.smaller", [
@@ -33,7 +40,7 @@ export class EventPreviewView implements MComponent<Attrs> {
 				event.location
 					? m(".flex.pb-s.items-center", [
 						renderSectionIndicator(Icons.Pin),
-						m("a", {href: locationHref}, m(".text-ellipsis.selectable.underline.click", event.location))
+						m("a", {href: url.toString()}, m(".text-ellipsis.selectable.underline", event.location))
 					])
 					: null,
 				event.attendees.length

--- a/src/gui/base/Modal.js
+++ b/src/gui/base/Modal.js
@@ -7,7 +7,7 @@ import type {Shortcut} from "../../misc/KeyManager"
 import {keyManager} from "../../misc/KeyManager"
 import {windowFacade} from "../../misc/WindowFacade"
 import {remove} from "../../api/common/utils/ArrayUtils"
-import {insideRect} from "../../api/common/utils/Utils"
+import {downcast, insideRect} from "../../api/common/utils/Utils"
 
 assertMainOrNodeBoot()
 
@@ -52,10 +52,17 @@ class Modal {
 							this.visible = true
 							m.redraw()
 							if (wrapper.needsBg) this.addAnimation(vnode.dom, true)
-							vnode.dom.onclick = e => {
-								const childRect = vnode.children[0].dom.getBoundingClientRect()
-								if (!insideRect(e, childRect)) {
-									wrapper.component.backgroundClick(e)
+						},
+						onclick: (event: MouseEvent) => {
+							// flow only recognizes currentTarget as an EventTarget, but we know here that it's an HTMLElement
+							const element: HTMLElement = downcast(event.currentTarget)
+							// This layer div has a single child, the modal component
+							const child = element.firstElementChild
+							// child shouldn't be null but maybe the user click fast idk
+							if (child) {
+								const childRect = child.getBoundingClientRect()
+								if (!insideRect(event, childRect)) {
+									wrapper.component.backgroundClick(event)
 								}
 							}
 						},

--- a/src/mail/export/Exporter.js
+++ b/src/mail/export/Exporter.js
@@ -95,6 +95,7 @@ export function mailToEml(mail: MailBundle): string {
 		const filteredHeaders = mail.headers
 		                            .split("\n")
 		                            .filter(line => !line.match(/^\s*(Content-Type:|boundary=)/))
+		// We join the headers back together with \n, but the eml itself has \r\n line endings, so the headers are essentially one "line" of the eml
 		lines.push(filteredHeaders.join("\n"))
 	} else {
 		lines.push(


### PR DESCRIPTION
This pull request does things:

- Stops modal components from having backgroundClick called on them when they were the target of the click, so that the calendar event view popup can be clicked on without it going away.
- Make the text in the calendar event popup selectable, and make the location field clickable

in regards to the location field, if the field looks like a link then we will treat it as a link, otherwise it will link to OpenStreetMap. The URL detection could be improved maybe. I have a regex that's a bit more conservative about detecting possible URLs, but it seems like using inbuilt URL handling should be a safe bet here