### PR TITLE
[desktop] Fix updating system-wide Windows installation

### DIFF
--- a/flow/electron.js
+++ b/flow/electron.js
@@ -586,6 +586,7 @@ declare class AutoUpdater {
 	checkForUpdatesAndNotify(): Promise<any>;
 	checkForUpdates(): Promise<UpdateCheckResult>;
 	downloadUpdate(): Promise<Array<String>>; // paths of the dl'd assets
+	install(isSilent?: boolean, isForceRunAfter?: boolean): void;
 	quitAndInstall(isSilent?: boolean, isForceRunAfter?: boolean): void;
 	autoInstallOnAppQuit: boolean;
 	allowDowngrade: boolean;

--- a/test/client/desktop/ElectronUpdaterTest.js
+++ b/test/client/desktop/ElectronUpdaterTest.js
@@ -164,7 +164,7 @@ o.spec("ElectronUpdater Test", function () {
 		o(electron.app.emit.callCount).equals(1)
 		o(electron.app.emit.args[0]).equals('enable-force-quit')
 		o(autoUpdater.quitAndInstall.callCount).equals(1)
-		o(autoUpdater.quitAndInstall.args[0]).equals(true)
+		o(autoUpdater.quitAndInstall.args[0]).equals(false)
 		o(autoUpdater.quitAndInstall.args[1]).equals(true)
 	})
 
@@ -243,7 +243,7 @@ o.spec("ElectronUpdater Test", function () {
 		o(electron.app.emit.callCount).equals(1)
 		o(electron.app.emit.args[0]).equals('enable-force-quit')
 		o(autoUpdater.quitAndInstall.callCount).equals(1)
-		o(autoUpdater.quitAndInstall.args[0]).equals(true)
+		o(autoUpdater.quitAndInstall.args[0]).equals(false)
 		o(autoUpdater.quitAndInstall.args[1]).equals(true)
 	})
 
@@ -325,7 +325,7 @@ o.spec("ElectronUpdater Test", function () {
 		o(electron.app.emit.callCount).equals(1)
 		o(electron.app.emit.args[0]).equals('enable-force-quit')
 		o(autoUpdater.quitAndInstall.callCount).equals(1)
-		o(autoUpdater.quitAndInstall.args[0]).equals(true)
+		o(autoUpdater.quitAndInstall.args[0]).equals(false)
 		o(autoUpdater.quitAndInstall.args[1]).equals(true)
 		upd._stopPolling()
 	})


### PR DESCRIPTION
 This commit does two things:
  - it re-enables wizard for auto-update on Windows. We need it to
    successfully update system-wide.
  - it disables update-on-quit behavior on Windows because wizard in
    that case in unexpected.

fix #1413