### PR TITLE
Upgrade Electron to 12.0.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -486,6 +486,49 @@
 				"sumchecker": "^3.0.1"
 			}
 		},
+		"@electron/universal": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@electron/universal/-/universal-1.0.4.tgz",
+			"integrity": "sha512-ajZoumi4XwqwmZe8YVhu4XGkZBCPyWZsVCQONPTIe9TUlleSN+dic3YpXlaWcilx/HOzTdldTKtabNTeI0gDoA==",
+			"dev": true,
+			"requires": {
+				"@malept/cross-spawn-promise": "^1.1.0",
+				"asar": "^3.0.3",
+				"debug": "^4.3.1",
+				"dir-compare": "^2.4.0",
+				"fs-extra": "^9.0.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+					"dev": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"jsonfile": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^2.0.0"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				}
+			}
+		},
 		"@malept/cross-spawn-promise": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
@@ -568,6 +611,18 @@
 				"defer-to-connect": "^1.0.1"
 			}
 		},
+		"@types/cacheable-request": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+			"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+			"dev": true,
+			"requires": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "*",
+				"@types/node": "*",
+				"@types/responselike": "*"
+			}
+		},
 		"@types/debug": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
@@ -581,9 +636,9 @@
 			"dev": true
 		},
 		"@types/fs-extra": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.5.tgz",
-			"integrity": "sha512-wr3t7wIW1c0A2BIJtdVp4EflriVaVVAsCAIHVzzh8B+GiFv9X1xeJjCs4upRXtzp7kQ6lP5xvskjoD4awJ1ZeA==",
+			"version": "9.0.8",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.8.tgz",
+			"integrity": "sha512-bnlTVTwq03Na7DpWxFJ1dvnORob+Otb8xHyUqUWhqvz/Ksg8+JXPlR52oeMSZ37YEOa5PyccbgUNutiQdi13TA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -600,6 +655,21 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/http-cache-semantics": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+			"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+			"dev": true
+		},
+		"@types/keyv": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+			"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -613,10 +683,39 @@
 			"integrity": "sha512-vbxr0VZ8exFMMAjCW8rJwaya0dMCDyYW2ZRdTyjtrCvJoENMpdUHOT/eTzvgyA5ZnqRZ/sI0NwqAxNHKYokLJQ==",
 			"dev": true
 		},
+		"@types/plist": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.2.tgz",
+			"integrity": "sha512-ULqvZNGMv0zRFvqn8/4LSPtnmN4MfhlPNtJCTpKuIIxGVGZ2rYWzFXrvEBoh9CVyqSE7D6YFRJ1hydLHI6kbWw==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@types/node": "*",
+				"xmlbuilder": ">=11.0.1"
+			},
+			"dependencies": {
+				"xmlbuilder": {
+					"version": "15.1.1",
+					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+					"integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
 		"@types/resolve": {
 			"version": "1.17.1",
 			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
 			"integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -628,19 +727,26 @@
 			"integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
 			"dev": true
 		},
+		"@types/verror": {
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.4.tgz",
+			"integrity": "sha512-OjJdqx6QlbyZw9LShPwRW+Kmiegeg3eWNI41MQQKaG3vjdU2L9SRElntM51HmHBY1cu7izxQJ1lMYioQh3XMBg==",
+			"dev": true,
+			"optional": true
+		},
 		"@types/yargs": {
-			"version": "15.0.11",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.11.tgz",
-			"integrity": "sha512-jfcNBxHFYJ4nPIacsi3woz1+kvUO6s1CyeEhtnDHBjHUMNj5UlW2GynmnSgiJJEdNg9yW5C8lfoNRZrHGv5EqA==",
+			"version": "15.0.13",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
+			"integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
 			}
 		},
 		"@types/yargs-parser": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
+			"version": "20.2.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+			"integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
 			"dev": true
 		},
 		"@types/yauzl": {
@@ -768,61 +874,86 @@
 			}
 		},
 		"app-builder-bin": {
-			"version": "3.5.10",
-			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.10.tgz",
-			"integrity": "sha512-Jd+GW68lR0NeetgZDo47PdWBEPdnD+p0jEa7XaxjRC8u6Oo/wgJsfKUkORRgr2NpkD19IFKN50P6JYy04XHFLQ==",
+			"version": "3.5.12",
+			"resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.5.12.tgz",
+			"integrity": "sha512-lQARM2AielmFoBeIo6LZigAe+58Wwe07ZWkt+wVeDxzyieNmeWjlvz/V5dKzinydwdHd+CNswN86sww46yijjA==",
 			"dev": true
 		},
 		"app-builder-lib": {
-			"version": "22.9.1",
-			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.9.1.tgz",
-			"integrity": "sha512-KfXim/fiNwFW2SKffsjEMdAU7RbbEXn62x5YyXle1b4j9X/wEHW9iwox8De6y0hJdR+/kCC/49lI+VgNwLhV7A==",
+			"version": "22.10.5",
+			"resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.10.5.tgz",
+			"integrity": "sha512-/W8nlGamJCtKlQtsMWwU9vb+cX4pTNY+rJWCuc7oXUykVSMS50W7LhQusIjCelNfymUQ1XCu6cXEY/ylqhX12A==",
 			"dev": true,
 			"requires": {
 				"7zip-bin": "~5.0.3",
 				"@develar/schema-utils": "~2.6.5",
+				"@electron/universal": "1.0.4",
 				"async-exit-hook": "^2.0.1",
 				"bluebird-lst": "^1.0.9",
-				"builder-util": "22.9.1",
-				"builder-util-runtime": "8.7.2",
+				"builder-util": "22.10.5",
+				"builder-util-runtime": "8.7.3",
 				"chromium-pickle-js": "^0.2.0",
-				"debug": "^4.3.0",
-				"ejs": "^3.1.5",
-				"electron-publish": "22.9.1",
-				"fs-extra": "^9.0.1",
-				"hosted-git-info": "^3.0.5",
+				"debug": "^4.3.2",
+				"ejs": "^3.1.6",
+				"electron-publish": "22.10.5",
+				"fs-extra": "^9.1.0",
+				"hosted-git-info": "^3.0.8",
 				"is-ci": "^2.0.0",
-				"isbinaryfile": "^4.0.6",
-				"js-yaml": "^3.14.0",
+				"istextorbinary": "^5.12.0",
+				"js-yaml": "^4.0.0",
 				"lazy-val": "^1.0.4",
 				"minimatch": "^3.0.4",
-				"normalize-package-data": "^2.5.0",
+				"normalize-package-data": "^3.0.0",
 				"read-config-file": "6.0.0",
 				"sanitize-filename": "^1.6.3",
-				"semver": "^7.3.2",
+				"semver": "^7.3.4",
 				"temp-file": "^3.3.7"
 			},
 			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"builder-util-runtime": {
+					"version": "8.7.3",
+					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+					"integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.2",
+						"sax": "^1.2.4"
+					}
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"js-yaml": {
-					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+					"integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
 					"dev": true,
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"argparse": "^2.0.1"
 					}
 				},
 				"jsonfile": {
@@ -833,13 +964,28 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
+					}
+				},
+				"normalize-package-data": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.1.tgz",
+					"integrity": "sha512-D/ttLdxo71msR4FF3VgSwK4blHfE3/vGByz1NCeE7/Dh8reQOKNJJjk5L10mLq9jxa+ZHzT1/HLgxljzbXE7Fw==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^4.0.0",
+						"resolve": "^1.17.0",
+						"semver": "^7.3.2",
+						"validate-npm-package-license": "^3.0.1"
 					},
 					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
+						"hosted-git-info": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.0.tgz",
+							"integrity": "sha512-fqhGdjk4av7mT9fU/B01dUtZ+WZSc/XEXMoLXDVZukiQRXxeHSSz3AqbeWRJHtF8EQYHlAgB1NSAHU0Cm7aqZA==",
+							"dev": true,
+							"requires": {
+								"lru-cache": "^6.0.0"
+							}
 						}
 					}
 				},
@@ -853,9 +999,9 @@
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
@@ -1015,6 +1161,12 @@
 			"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
 			"dev": true
 		},
+		"binaryextensions": {
+			"version": "4.15.0",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-4.15.0.tgz",
+			"integrity": "sha512-MkUl3szxXolQ2scI1PM14WOT951KnaTNJ0eMKg7WzOI4kvSxyNo/Cygx4LOBNhwyINhAuSQpJW1rYD9aBSxGaw==",
+			"dev": true
+		},
 		"bl": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -1094,19 +1246,19 @@
 			"optional": true
 		},
 		"boxen": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-			"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-5.0.0.tgz",
+			"integrity": "sha512-5bvsqw+hhgUi3oYGK0Vf4WpIkyemp60WBInn7+WNfoISzAqk/HX4L7WNROq38E6UR/y3YADpv6pEm4BfkeEAdA==",
 			"dev": true,
 			"requires": {
 				"ansi-align": "^3.0.0",
-				"camelcase": "^5.3.1",
-				"chalk": "^3.0.0",
-				"cli-boxes": "^2.2.0",
-				"string-width": "^4.1.0",
-				"term-size": "^2.1.0",
-				"type-fest": "^0.8.1",
-				"widest-line": "^3.1.0"
+				"camelcase": "^6.2.0",
+				"chalk": "^4.1.0",
+				"cli-boxes": "^2.2.1",
+				"string-width": "^4.2.0",
+				"type-fest": "^0.20.2",
+				"widest-line": "^3.1.0",
+				"wrap-ansi": "^7.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -1125,9 +1277,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -1168,9 +1320,9 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
@@ -1197,9 +1349,9 @@
 					}
 				},
 				"type-fest": {
-					"version": "0.8.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 					"dev": true
 				}
 			}
@@ -1254,6 +1406,12 @@
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
 			"dev": true
 		},
+		"buffer-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+			"integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+			"dev": true
+		},
 		"buffer-fill": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -1267,22 +1425,22 @@
 			"dev": true
 		},
 		"builder-util": {
-			"version": "22.9.1",
-			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.9.1.tgz",
-			"integrity": "sha512-5hN/XOaYu4ZQUS6F+5CXE6jTo+NAnVqAxDuKGSaHWb9bejfv/rluChTLoY3/nJh7RFjkoyVjvFJv7zQDB1QmHw==",
+			"version": "22.10.5",
+			"resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.10.5.tgz",
+			"integrity": "sha512-/MkLhmyo1gU3xMwXJxccQaRj/9tm5eTd6ZyebTf8SYouY4r3hRser+LxhOm/f8Z9W6oJvfPe0jc9TFsxYfMcsg==",
 			"dev": true,
 			"requires": {
 				"7zip-bin": "~5.0.3",
 				"@types/debug": "^4.1.5",
-				"@types/fs-extra": "^9.0.1",
-				"app-builder-bin": "3.5.10",
+				"@types/fs-extra": "^9.0.7",
+				"app-builder-bin": "3.5.12",
 				"bluebird-lst": "^1.0.9",
-				"builder-util-runtime": "8.7.2",
+				"builder-util-runtime": "8.7.3",
 				"chalk": "^4.1.0",
-				"debug": "^4.3.0",
-				"fs-extra": "^9.0.1",
+				"debug": "^4.3.2",
+				"fs-extra": "^9.1.0",
 				"is-ci": "^2.0.0",
-				"js-yaml": "^3.14.0",
+				"js-yaml": "^4.0.0",
 				"source-map-support": "^0.5.19",
 				"stat-mode": "^1.0.0",
 				"temp-file": "^3.3.7"
@@ -1295,6 +1453,22 @@
 					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
+					}
+				},
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"builder-util-runtime": {
+					"version": "8.7.3",
+					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+					"integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.2",
+						"sax": "^1.2.4"
 					}
 				},
 				"chalk": {
@@ -1322,16 +1496,25 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -1341,13 +1524,12 @@
 					"dev": true
 				},
 				"js-yaml": {
-					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+					"integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
 					"dev": true,
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"argparse": "^2.0.1"
 					}
 				},
 				"jsonfile": {
@@ -1358,14 +1540,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"supports-color": {
@@ -1378,9 +1552,9 @@
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
@@ -1413,6 +1587,12 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+			"dev": true
+		},
+		"cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
 			"dev": true
 		},
 		"cacheable-request": {
@@ -1448,9 +1628,9 @@
 			}
 		},
 		"camelcase": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+			"integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
 			"dev": true
 		},
 		"caseless": {
@@ -1533,6 +1713,54 @@
 			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
 			"integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
 			"dev": true
+		},
+		"cli-truncate": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-1.1.0.tgz",
+			"integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"slice-ansi": "^1.0.0",
+				"string-width": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true,
+					"optional": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
 		},
 		"cliui": {
 			"version": "7.0.4",
@@ -1756,6 +1984,16 @@
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
+		"crc": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+			"integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"buffer": "^5.1.0"
+			}
+		},
 		"crc-32": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
@@ -1879,30 +2117,66 @@
 			"dev": true,
 			"optional": true
 		},
-		"dmg-builder": {
-			"version": "22.9.1",
-			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.9.1.tgz",
-			"integrity": "sha512-jc+DAirqmQrNT6KbDHdfEp8D1kD0DBTnsLhwUR3MX+hMBun5bT134LQzpdK0GKvd22GqF8L1Cz/NOgaVjscAXQ==",
+		"dir-compare": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-2.4.0.tgz",
+			"integrity": "sha512-l9hmu8x/rjVC9Z2zmGzkhOEowZvW7pmYws5CWHutg8u1JgvsKWMx7Q/UODeu4djLZ4FgW5besw5yvMQnBHzuCA==",
 			"dev": true,
 			"requires": {
-				"app-builder-lib": "22.9.1",
-				"builder-util": "22.9.1",
-				"fs-extra": "^9.0.1",
+				"buffer-equal": "1.0.0",
+				"colors": "1.0.3",
+				"commander": "2.9.0",
+				"minimatch": "3.0.4"
+			},
+			"dependencies": {
+				"colors": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+					"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+					"dev": true
+				},
+				"commander": {
+					"version": "2.9.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+					"dev": true,
+					"requires": {
+						"graceful-readlink": ">= 1.0.0"
+					}
+				}
+			}
+		},
+		"dmg-builder": {
+			"version": "22.10.5",
+			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.10.5.tgz",
+			"integrity": "sha512-58FEpfH8PEFqjbUNka4bYr52snRT8+LSXrP4gy6EZWOVICbOlmTOYj988pfoLam5C5iXb3odmyUQqwWOxlsEUw==",
+			"dev": true,
+			"requires": {
+				"app-builder-lib": "22.10.5",
+				"builder-util": "22.10.5",
+				"dmg-license": "^1.0.8",
+				"fs-extra": "^9.1.0",
 				"iconv-lite": "^0.6.2",
-				"js-yaml": "^3.14.0",
+				"js-yaml": "^4.0.0",
 				"sanitize-filename": "^1.6.3"
 			},
 			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"iconv-lite": {
@@ -1915,13 +2189,12 @@
 					}
 				},
 				"js-yaml": {
-					"version": "3.14.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+					"integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
 					"dev": true,
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"argparse": "^2.0.1"
 					}
 				},
 				"jsonfile": {
@@ -1932,22 +2205,32 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
+			}
+		},
+		"dmg-license": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.8.tgz",
+			"integrity": "sha512-47GOb6b4yVzpovXC34heXElpH++ICg9GuWBeOTaokUNLAoAdWpE4VehudYEEtu96j2jXsgQWYf78nW7r+0Y3eg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"@types/plist": "^3.0.1",
+				"@types/verror": "^1.10.3",
+				"ajv": "^6.10.0",
+				"cli-truncate": "^1.1.0",
+				"crc": "^3.8.0",
+				"iconv-corefoundation": "^1.1.5",
+				"plist": "^3.0.1",
+				"smart-buffer": "^4.0.2",
+				"verror": "^1.10.0"
 			}
 		},
 		"dompurify": {
@@ -1992,6 +2275,16 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"editions": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-6.1.0.tgz",
+			"integrity": "sha512-h6nWEyIocfgho9J3sTSuhU/WoFOu1hTX75rPBebNrbF38Y9QFDjCDizYXdikHTySW7Y3mSxli8bpDz9RAtc7rA==",
+			"dev": true,
+			"requires": {
+				"errlop": "^4.0.0",
+				"version-range": "^1.0.0"
+			}
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1999,53 +2292,45 @@
 			"dev": true
 		},
 		"ejs": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.5.tgz",
-			"integrity": "sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.6.tgz",
+			"integrity": "sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==",
 			"dev": true,
 			"requires": {
 				"jake": "^10.6.1"
 			}
 		},
 		"electron": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-11.3.0.tgz",
-			"integrity": "sha512-MhdS0gok3wZBTscLBbYrOhLaQybCSAfkupazbK1dMP5c+84eVMxJE/QGohiWQkzs0tVFIJsAHyN19YKPbelNrQ==",
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-12.0.1.tgz",
+			"integrity": "sha512-4bTfLSTmuFkMxq3RMyjd8DxuzbxI1Bde879XDrBA4kFWbKhZ3hfXqHXQz3129eCmcLre5odcNsWq7/xzyJilMA==",
 			"dev": true,
 			"requires": {
 				"@electron/get": "^1.0.1",
-				"@types/node": "^12.0.12",
+				"@types/node": "^14.6.2",
 				"extract-zip": "^1.0.3"
-			},
-			"dependencies": {
-				"@types/node": {
-					"version": "12.20.5",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.5.tgz",
-					"integrity": "sha512-5Oy7tYZnu3a4pnJ//d4yVvOImExl4Vtwf0D40iKUlU+XlUsyV9iyFWyCFlwy489b72FMAik/EFwRkNLjjOdSPg==",
-					"dev": true
-				}
 			}
 		},
 		"electron-builder": {
-			"version": "22.9.1",
-			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.9.1.tgz",
-			"integrity": "sha512-GXPt8l5Mxwm1QKYopUM6/Tdh9W3695G6Ax+IFyj5pQ51G4SD5L1uq4/RkPSsOgs3rP7jNSV6g6OfDzdtVufPdA==",
+			"version": "22.10.5",
+			"resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.10.5.tgz",
+			"integrity": "sha512-0q/289UUJUhRou6lZKDz/wzK6WprIQ6VXMTmaI+w9qXvSNugPC9UA5s2zXInOkjZOvO/xKnjeyiavrVSHYF3tA==",
 			"dev": true,
 			"requires": {
-				"@types/yargs": "^15.0.5",
-				"app-builder-lib": "22.9.1",
+				"@types/yargs": "^15.0.13",
+				"app-builder-lib": "22.10.5",
 				"bluebird-lst": "^1.0.9",
-				"builder-util": "22.9.1",
-				"builder-util-runtime": "8.7.2",
+				"builder-util": "22.10.5",
+				"builder-util-runtime": "8.7.3",
 				"chalk": "^4.1.0",
-				"dmg-builder": "22.9.1",
-				"fs-extra": "^9.0.1",
+				"dmg-builder": "22.10.5",
+				"fs-extra": "^9.1.0",
 				"is-ci": "^2.0.0",
 				"lazy-val": "^1.0.4",
 				"read-config-file": "6.0.0",
 				"sanitize-filename": "^1.6.3",
-				"update-notifier": "^4.1.1",
-				"yargs": "^16.0.3"
+				"update-notifier": "^5.1.0",
+				"yargs": "^16.2.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -2055,6 +2340,16 @@
 					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
+					}
+				},
+				"builder-util-runtime": {
+					"version": "8.7.3",
+					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+					"integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.2",
+						"sax": "^1.2.4"
 					}
 				},
 				"chalk": {
@@ -2082,16 +2377,25 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -2108,14 +2412,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"supports-color": {
@@ -2128,9 +2424,9 @@
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
@@ -2323,19 +2619,19 @@
 			}
 		},
 		"electron-publish": {
-			"version": "22.9.1",
-			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.9.1.tgz",
-			"integrity": "sha512-ducLjRJLEeU87FaTCWaUyDjCoLXHkawkltP2zqS/n2PyGke54ZIql0tBuUheht4EpR8AhFbVJ11spSn1gy8r6w==",
+			"version": "22.10.5",
+			"resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.10.5.tgz",
+			"integrity": "sha512-dHyuazv3P3j1Xyv7pdwTwAvxWab2pCb0G0Oa6qWQoCc4b1/mRGY00M7AvYW1cPuUijj9zYAf1HmXfM6MifaMlA==",
 			"dev": true,
 			"requires": {
-				"@types/fs-extra": "^9.0.1",
+				"@types/fs-extra": "^9.0.7",
 				"bluebird-lst": "^1.0.9",
-				"builder-util": "22.9.1",
-				"builder-util-runtime": "8.7.2",
+				"builder-util": "22.10.5",
+				"builder-util-runtime": "8.7.3",
 				"chalk": "^4.1.0",
-				"fs-extra": "^9.0.1",
+				"fs-extra": "^9.1.0",
 				"lazy-val": "^1.0.4",
-				"mime": "^2.4.6"
+				"mime": "^2.5.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -2345,6 +2641,16 @@
 					"dev": true,
 					"requires": {
 						"color-convert": "^2.0.1"
+					}
+				},
+				"builder-util-runtime": {
+					"version": "8.7.3",
+					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.3.tgz",
+					"integrity": "sha512-1Q2ReBqFblimF5g/TLg2+0M5Xzv0Ih5LxJ/BMWXvEy/e6pQKeeEpbkPMGsN6OiQgkygaZo5VXCXIjOkOQG5EoQ==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.3.2",
+						"sax": "^1.2.4"
 					}
 				},
 				"chalk": {
@@ -2372,16 +2678,25 @@
 					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"dev": true
 				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -2398,14 +2713,6 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
 					}
 				},
 				"supports-color": {
@@ -2418,41 +2725,123 @@
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
 		},
 		"electron-rebuild": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-2.0.3.tgz",
-			"integrity": "sha512-I8Oeey9afU+trFLd8/qRRiHC083CCoBnmw3q0qQaRFsg0OzMaeJQn7Nl6EYKPpntuQ/3yOqZQ7b3ObNuETN/Ig==",
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-2.3.5.tgz",
+			"integrity": "sha512-1sQ1DRtQGpglFhc3urD4olMJzt/wxlbnAAsf+WY2xHf5c50ZovivZvCXSpVgTOP9f4TzOMvelWyspyfhxQKHzQ==",
 			"dev": true,
 			"requires": {
-				"@malept/cross-spawn-promise": "^1.1.0",
+				"@malept/cross-spawn-promise": "^1.1.1",
 				"colors": "^1.3.3",
 				"debug": "^4.1.1",
 				"detect-libc": "^1.0.3",
 				"fs-extra": "^9.0.1",
-				"node-abi": "^2.19.1",
+				"got": "^11.7.0",
+				"lzma-native": "^6.0.1",
+				"node-abi": "^2.19.2",
 				"node-gyp": "^7.1.0",
 				"ora": "^5.1.0",
+				"tar": "^6.0.5",
 				"yargs": "^16.0.0"
 			},
 			"dependencies": {
+				"@sindresorhus/is": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+					"integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
+					"dev": true
+				},
+				"@szmarczak/http-timer": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+					"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+					"dev": true,
+					"requires": {
+						"defer-to-connect": "^2.0.0"
+					}
+				},
+				"cacheable-request": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+					"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+					"dev": true,
+					"requires": {
+						"clone-response": "^1.0.2",
+						"get-stream": "^5.1.0",
+						"http-cache-semantics": "^4.0.0",
+						"keyv": "^4.0.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
+						"responselike": "^2.0.0"
+					}
+				},
+				"decompress-response": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+					"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+					"dev": true,
+					"requires": {
+						"mimic-response": "^3.1.0"
+					}
+				},
+				"defer-to-connect": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+					"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+					"dev": true
+				},
 				"fs-extra": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
 					"dev": true,
 					"requires": {
 						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
 						"jsonfile": "^6.0.1",
-						"universalify": "^1.0.0"
+						"universalify": "^2.0.0"
 					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"got": {
+					"version": "11.8.2",
+					"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+					"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
+					"dev": true,
+					"requires": {
+						"@sindresorhus/is": "^4.0.0",
+						"@szmarczak/http-timer": "^4.0.5",
+						"@types/cacheable-request": "^6.0.1",
+						"@types/responselike": "^1.0.0",
+						"cacheable-lookup": "^5.0.3",
+						"cacheable-request": "^7.0.1",
+						"decompress-response": "^6.0.0",
+						"http2-wrapper": "^1.0.0-beta.5.2",
+						"lowercase-keys": "^2.0.0",
+						"p-cancelable": "^2.0.0",
+						"responselike": "^2.0.0"
+					}
+				},
+				"json-buffer": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+					"dev": true
 				},
 				"jsonfile": {
 					"version": "6.1.0",
@@ -2462,20 +2851,48 @@
 					"requires": {
 						"graceful-fs": "^4.1.6",
 						"universalify": "^2.0.0"
-					},
-					"dependencies": {
-						"universalify": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-							"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-							"dev": true
-						}
+					}
+				},
+				"keyv": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+					"integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+					"dev": true,
+					"requires": {
+						"json-buffer": "3.0.1"
+					}
+				},
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+					"dev": true
+				},
+				"mimic-response": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+					"dev": true
+				},
+				"p-cancelable": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
+					"integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
+					"dev": true
+				},
+				"responselike": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+					"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+					"dev": true,
+					"requires": {
+						"lowercase-keys": "^2.0.0"
 					}
 				},
 				"universalify": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
 				}
 			}
@@ -2581,6 +2998,12 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
 			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+			"dev": true
+		},
+		"errlop": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/errlop/-/errlop-4.1.0.tgz",
+			"integrity": "sha512-vul6gGBuVt0M2TPi1/WrcL86+Hb3Q2Tpu3TME3sbVhZrYf7J1ZMHCodI25RQKCVurh56qTfvgM0p3w5cT4reSQ==",
 			"dev": true
 		},
 		"error-ex": {
@@ -2921,9 +3344,9 @@
 			}
 		},
 		"filelist": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.1.tgz",
-			"integrity": "sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
+			"integrity": "sha512-z7O0IS8Plc39rTCq6i6iHxk43duYOn8uFJiWSewIq0Bww1RNybVHSCjahmcC87ZqAm4OTvFzlzeGu3XAzG1ctQ==",
 			"dev": true,
 			"requires": {
 				"minimatch": "^3.0.4"
@@ -3071,12 +3494,12 @@
 			}
 		},
 		"fs-minipass": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+			"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 			"dev": true,
 			"requires": {
-				"minipass": "^3.0.0"
+				"minipass": "^2.6.0"
 			}
 		},
 		"fs.realpath": {
@@ -3096,7 +3519,10 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
 			"integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"icu4c-data": "^0.67.2"
+			}
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -3275,18 +3701,18 @@
 			}
 		},
 		"global-dirs": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
-			"integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+			"integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
 			"dev": true,
 			"requires": {
-				"ini": "1.3.7"
+				"ini": "2.0.0"
 			},
 			"dependencies": {
 				"ini": {
-					"version": "1.3.7",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-					"integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+					"integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
 					"dev": true
 				}
 			}
@@ -3362,6 +3788,12 @@
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
 		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+			"dev": true
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -3405,9 +3837,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-			"integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+			"integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
 			"dev": true,
 			"requires": {
 				"lru-cache": "^6.0.0"
@@ -3450,6 +3882,26 @@
 				"sshpk": "^1.7.0"
 			}
 		},
+		"http2-wrapper": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+			"dev": true,
+			"requires": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			}
+		},
+		"iconv-corefoundation": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.5.tgz",
+			"integrity": "sha512-hI4m7udfV04OcjleOmDaR4gwXnH4xumxN+ZmywHDiKf2CmAzsT9SVYe7Y4pdnQbyZfXwAQyrElykbE5PrPRfmQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"cli-truncate": "^1.1.0"
+			}
+		},
 		"iconv-lite": {
 			"version": "0.4.23",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
@@ -3459,10 +3911,25 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"icu4c-data": {
+			"version": "0.67.2",
+			"resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.67.2.tgz",
+			"integrity": "sha512-OIRiop+k1IVf4TBLEOj910duoO9NKwtJLwp++qWT6KT5gRziHNt+5gwhcGuTqRy++RTK2gLoAIbk8KYCNxW++g==",
+			"dev": true
+		},
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
+		"ignore-walk": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+			"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
 		},
 		"import-lazy": {
 			"version": "2.1.0",
@@ -3565,13 +4032,13 @@
 			}
 		},
 		"is-installed-globally": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
-			"integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+			"integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
 			"dev": true,
 			"requires": {
-				"global-dirs": "^2.0.1",
-				"is-path-inside": "^3.0.1"
+				"global-dirs": "^3.0.0",
+				"is-path-inside": "^3.0.2"
 			}
 		},
 		"is-interactive": {
@@ -3587,9 +4054,9 @@
 			"dev": true
 		},
 		"is-npm": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
-			"integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-5.0.0.tgz",
+			"integrity": "sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==",
 			"dev": true
 		},
 		"is-number": {
@@ -3605,9 +4072,9 @@
 			"dev": true
 		},
 		"is-path-inside": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true
 		},
 		"is-reference": {
@@ -3645,12 +4112,6 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
-		"isbinaryfile": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.6.tgz",
-			"integrity": "sha512-ORrEy+SNVqUhrCaal4hA4fBzhggQQ+BaLntyPOdoEiwlKZW9BZiJXjg3RMiruE4tPEI3pyVPpySHQF/dKWperg==",
-			"dev": true
-		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3662,6 +4123,17 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 			"dev": true
+		},
+		"istextorbinary": {
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-5.12.0.tgz",
+			"integrity": "sha512-wLDRWD7qpNTYubk04+q3en1+XZGS4vYWK0+SxNSXJLaITMMEK+J3o/TlOMyULeH1qozVZ9uUkKcyMA8odyxz8w==",
+			"dev": true,
+			"requires": {
+				"binaryextensions": "^4.15.0",
+				"editions": "^6.1.0",
+				"textextensions": "^5.11.0"
+			}
 		},
 		"jake": {
 			"version": "10.8.2",
@@ -3957,6 +4429,26 @@
 			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
 			"integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ=="
 		},
+		"lzma-native": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-6.0.1.tgz",
+			"integrity": "sha512-O6oWF0xe1AFvOCjU8uOZBZ/lhjaMNwHfVNaqVMqmoQXlRwBcFWpCAToiZOdXcKVMdo/5s/D0a2QgA5laMErxHQ==",
+			"dev": true,
+			"requires": {
+				"node-addon-api": "^1.6.0",
+				"node-pre-gyp": "^0.11.0",
+				"readable-stream": "^2.3.5",
+				"rimraf": "^2.7.1"
+			},
+			"dependencies": {
+				"node-addon-api": {
+					"version": "1.7.2",
+					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+					"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+					"dev": true
+				}
+			}
+		},
 		"magic-string": {
 			"version": "0.25.7",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -4027,9 +4519,9 @@
 			"dev": true
 		},
 		"mime": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-			"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+			"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -4073,22 +4565,30 @@
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"minipass": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-			"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+			"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 			"dev": true,
 			"requires": {
-				"yallist": "^4.0.0"
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true
+				}
 			}
 		},
 		"minizlib": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+			"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 			"dev": true,
 			"requires": {
-				"minipass": "^3.0.0",
-				"yallist": "^4.0.0"
+				"minipass": "^2.9.0"
 			}
 		},
 		"mithril": {
@@ -4125,12 +4625,6 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
-		"mute-stream": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-			"dev": true
-		},
 		"nanoid": {
 			"version": "3.1.20",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
@@ -4142,10 +4636,32 @@
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
 			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
 		},
+		"needle": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+			"integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.2.6",
+				"iconv-lite": "^0.4.4",
+				"sax": "^1.2.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
+		},
 		"node-abi": {
-			"version": "2.19.3",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-			"integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
+			"integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
 			"requires": {
 				"semver": "^5.4.1"
 			}
@@ -4179,32 +4695,22 @@
 				"which": "^2.0.2"
 			},
 			"dependencies": {
-				"request": {
-					"version": "2.88.2",
-					"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-					"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+				"nopt": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+					"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
 					"dev": true,
 					"requires": {
-						"aws-sign2": "~0.7.0",
-						"aws4": "^1.8.0",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.6",
-						"extend": "~3.0.2",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.3.2",
-						"har-validator": "~5.1.3",
-						"http-signature": "~1.2.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.19",
-						"oauth-sign": "~0.9.0",
-						"performance-now": "^2.1.0",
-						"qs": "~6.5.2",
-						"safe-buffer": "^5.1.2",
-						"tough-cookie": "~2.5.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.3.2"
+						"abbrev": "1"
+					}
+				},
+				"rimraf": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"semver": {
@@ -4215,6 +4721,47 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
+				}
+			}
+		},
+		"node-pre-gyp": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
+			"integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
+			"dev": true,
+			"requires": {
+				"detect-libc": "^1.0.2",
+				"mkdirp": "^0.5.1",
+				"needle": "^2.2.1",
+				"nopt": "^4.0.1",
+				"npm-packlist": "^1.1.6",
+				"npmlog": "^4.0.2",
+				"rc": "^1.2.7",
+				"rimraf": "^2.6.1",
+				"semver": "^5.3.0",
+				"tar": "^4"
+			},
+			"dependencies": {
+				"tar": {
+					"version": "4.4.13",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.2",
+						"yallist": "^3.0.3"
+					}
+				},
+				"yallist": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+					"dev": true
 				}
 			}
 		},
@@ -4236,6 +4783,14 @@
 				"mime-types": "^2.1.24",
 				"source-map": "^0.5.6",
 				"source-map-fast": "npm:source-map@0.7.3"
+			},
+			"dependencies": {
+				"source-map-fast": {
+					"version": "npm:source-map@0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				}
 			}
 		},
 		"noop-logger": {
@@ -4244,12 +4799,13 @@
 			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
 		},
 		"nopt": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
-			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+			"integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
 			"dev": true,
 			"requires": {
-				"abbrev": "1"
+				"abbrev": "1",
+				"osenv": "^0.1.4"
 			}
 		},
 		"normalize-package-data": {
@@ -4284,6 +4840,15 @@
 			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
 			"dev": true
 		},
+		"npm-bundled": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+			"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+			"dev": true,
+			"requires": {
+				"npm-normalize-package-bin": "^1.0.1"
+			}
+		},
 		"npm-conf": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
@@ -4293,6 +4858,23 @@
 			"requires": {
 				"config-chain": "^1.1.11",
 				"pify": "^3.0.0"
+			}
+		},
+		"npm-normalize-package-bin": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+			"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+			"dev": true
+		},
+		"npm-packlist": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+			"integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+			"dev": true,
+			"requires": {
+				"ignore-walk": "^3.0.1",
+				"npm-bundled": "^1.0.1",
+				"npm-normalize-package-bin": "^1.0.1"
 			}
 		},
 		"npmlog": {
@@ -4366,17 +4948,17 @@
 			}
 		},
 		"ora": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/ora/-/ora-5.1.0.tgz",
-			"integrity": "sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+			"integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
 			"dev": true,
 			"requires": {
+				"bl": "^4.0.3",
 				"chalk": "^4.1.0",
 				"cli-cursor": "^3.1.0",
-				"cli-spinners": "^2.4.0",
+				"cli-spinners": "^2.5.0",
 				"is-interactive": "^1.0.0",
 				"log-symbols": "^4.0.0",
-				"mute-stream": "0.0.8",
 				"strip-ansi": "^6.0.0",
 				"wcwidth": "^1.0.1"
 			},
@@ -4445,6 +5027,28 @@
 						"has-flag": "^4.0.0"
 					}
 				}
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"osenv": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
 			}
 		},
 		"ospec": {
@@ -4751,6 +5355,12 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
+		"quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"dev": true
+		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -4870,6 +5480,34 @@
 				"rc": "^1.2.8"
 			}
 		},
+		"request": {
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"dev": true,
+			"requires": {
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.2",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"tough-cookie": "~2.5.0",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.3.2"
+			}
+		},
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4885,6 +5523,12 @@
 				"is-core-module": "^2.1.0",
 				"path-parse": "^1.0.6"
 			}
+		},
+		"resolve-alpn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
+			"integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
+			"dev": true
 		},
 		"responselike": {
 			"version": "1.0.2",
@@ -4906,9 +5550,9 @@
 			}
 		},
 		"rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
@@ -5181,16 +5825,36 @@
 				"simple-concat": "^1.0.0"
 			}
 		},
+		"slice-ansi": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+			"integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"smart-buffer": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+			"integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+			"dev": true,
+			"optional": true
+		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
-		},
-		"source-map-fast": {
-			"version": "npm:source-map@0.7.3",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-			"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
 			"dev": true
 		},
 		"source-map-support": {
@@ -5360,9 +6024,9 @@
 			"integrity": "sha512-UcTY+FEA1B7e+bpJk1TI+a9Na6LG7wFEqW7ED16cLqLuQfI/9Ri0rsXm3tKlIgNoHyLHZycjdAOijzNbzelgwA=="
 		},
 		"tar": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.5.tgz",
-			"integrity": "sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.0.tgz",
+			"integrity": "sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==",
 			"dev": true,
 			"requires": {
 				"chownr": "^2.0.0",
@@ -5378,6 +6042,34 @@
 					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
 					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
 					"dev": true
+				},
+				"fs-minipass": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"minipass": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+					"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+					"dev": true,
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
 				},
 				"mkdirp": {
 					"version": "1.0.4",
@@ -5432,12 +6124,6 @@
 				"fs-extra": "^8.1.0"
 			}
 		},
-		"term-size": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-			"integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-			"dev": true
-		},
 		"terser": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.5.1.tgz",
@@ -5467,6 +6153,12 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
 			"integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
+		},
+		"textextensions": {
+			"version": "5.12.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.12.0.tgz",
+			"integrity": "sha512-IYogUDaP65IXboCiPPC0jTLLBzYlhhw2Y4b0a2trPgbHNGGGEfuHE6tds+yDcCf4mpNDaGISFzwSSezcXt+d6w==",
+			"dev": true
 		},
 		"to-fast-properties": {
 			"version": "2.0.0",
@@ -5603,22 +6295,23 @@
 			"dev": true
 		},
 		"update-notifier": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
-			"integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-5.1.0.tgz",
+			"integrity": "sha512-ItnICHbeMh9GqUy31hFPrD1kcuZ3rpxDZbf4KUDavXwS0bW5m7SLbDQpGX3UYr072cbrF5hFUs3r5tUsPwjfHw==",
 			"dev": true,
 			"requires": {
-				"boxen": "^4.2.0",
-				"chalk": "^3.0.0",
+				"boxen": "^5.0.0",
+				"chalk": "^4.1.0",
 				"configstore": "^5.0.1",
 				"has-yarn": "^2.1.0",
 				"import-lazy": "^2.1.0",
 				"is-ci": "^2.0.0",
-				"is-installed-globally": "^0.3.1",
-				"is-npm": "^4.0.0",
+				"is-installed-globally": "^0.4.0",
+				"is-npm": "^5.0.0",
 				"is-yarn-global": "^0.3.0",
-				"latest-version": "^5.0.0",
-				"pupa": "^2.0.1",
+				"latest-version": "^5.1.0",
+				"pupa": "^2.1.1",
+				"semver": "^7.3.4",
 				"semver-diff": "^3.1.1",
 				"xdg-basedir": "^4.0.0"
 			},
@@ -5633,9 +6326,9 @@
 					}
 				},
 				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -5662,6 +6355,15 @@
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
+				},
+				"semver": {
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
 				},
 				"supports-color": {
 					"version": "7.2.0",
@@ -5742,6 +6444,21 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
+		"version-compare": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/version-compare/-/version-compare-1.1.0.tgz",
+			"integrity": "sha512-zVKtPOJTC9x23lzS4+4D7J+drq80BXVYAmObnr5zqxxFVH7OffJ1lJlAS7LYsQNV56jx/wtbw0UV7XHLrvd6kQ==",
+			"dev": true
+		},
+		"version-range": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/version-range/-/version-range-1.1.0.tgz",
+			"integrity": "sha512-R1Ggfg2EXamrnrV3TkZ6yBNgITDbclB3viwSjbZ3+eK0VVNK4ajkYJTnDz5N0bIMYDtK9MUBvXJUnKO5RWWJ6w==",
+			"dev": true,
+			"requires": {
+				"version-compare": "^1.0.0"
+			}
+		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -5801,9 +6518,9 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
 		"keytar": "7.2.0",
 		"luxon": "^1.22.0",
 		"mithril": "2.0.4",
+		"node-abi": "^2.21.0",
+		"oxmsg": "tutao/oxmsg#a201b436f34e6b795359597b3a454cacc1aaff22",
 		"qrcode-svg": "1.0.0",
 		"squire-rte": "1.9.0",
-		"systemjs": "6.8.3",
-		"oxmsg": "tutao/oxmsg#a201b436f34e6b795359597b3a454cacc1aaff22"
+		"systemjs": "6.8.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.10.5",
@@ -50,11 +51,11 @@
 		"chokidar": "3.3.1",
 		"commander": "5.0.0-2",
 		"core-js": "2.6.10",
-		"electron": "11.3.0",
-		"electron-builder": "22.9.1",
+		"electron": "12.0.1",
+		"electron-builder": "22.10.5",
 		"electron-notarize": "1.0.0",
 		"electron-packager": "15.1.0",
-		"electron-rebuild": "2.0.3",
+		"electron-rebuild": "2.3.5",
 		"electron-updater": "4.3.5",
 		"express": "4.17.1",
 		"express-ws": "^4.0.0",


### PR DESCRIPTION
This is the first release that introduces the Ozone abstraction layer from Chromium, which can render natively on Wayland, making it possible to use the app in high-density displays with window managers like Sway.

Enable with `--enable-features=UseOzonePlatform --ozone-platform=wayland`

`node-abi` is added to the list of `dependencies` to force `npm` to resolve it transitively to the latest version.