### PR TITLE
fix horizontal overflow of event bubbles in week view

### DIFF
--- a/src/calendar/view/CalendarDayEventsView.js
+++ b/src/calendar/view/CalendarDayEventsView.js
@@ -120,7 +120,7 @@ export class CalendarDayEventsView implements MComponent<Attrs> {
 	}
 
 	_renderColumns(attrs: Attrs, columns: Array<Array<CalendarEvent>>): ChildArray {
-		const columnWidth = neverNull(this._dayDom).scrollWidth / columns.length
+		const columnWidth = neverNull(this._dayDom).clientWidth / columns.length
 		return columns.map((column, index) => {
 			return column.map(event => {
 				return this._renderEvent(attrs, event, index, columns, Math.floor(columnWidth))


### PR DESCRIPTION
fix #2847

We use clientWidth instead of scrollWidth of the columns, because scrollWidth includes overflow, meaning that its the max of either the width of the column or of it's widest element, meaning the bubbles wouldn't be able to become narrower