### PR TITLE
use single view for DNS records, display dot at the end of CNAME and MX record values

### DIFF
--- a/src/api/common/TutanotaConstants.js
+++ b/src/api/common/TutanotaConstants.js
@@ -287,6 +287,7 @@ export const DnsRecordType = Object.freeze({
 	DNS_RECORD_TYPE_CNAME_DKIM: "2",
 	DNS_RECORD_TYPE_TXT_DMARC: "3",
 	DNS_RECORD_TYPE_CNAME_MTA_STS: "4",
+	DNS_RECORD_TYPE_TXT_VERIFY: "5",
 })
 export type DnsRecordTypeEnum = $Values<typeof DnsRecordType>;
 
@@ -295,7 +296,8 @@ export const DnsRecordTypeToName = Object.freeze({
 	"1": "TXT",
 	"2": "CNAME",
 	"3": "TXT",
-	"4": "CNAME"
+	"4": "CNAME",
+	"5": "TXT"
 })
 
 export const SessionState = Object.freeze({

--- a/src/settings/CheckDomainDnsStatusDialog.js
+++ b/src/settings/CheckDomainDnsStatusDialog.js
@@ -3,64 +3,25 @@ import m from "mithril"
 import {lang} from "../misc/LanguageViewModel"
 import {assertMainOrNode} from "../api/common/Env"
 import {Dialog, DialogType} from "../gui/base/Dialog"
-import {CustomDomainCheckResult, DnsRecordType} from "../api/common/TutanotaConstants"
-import {showProgressDialog} from "../gui/ProgressDialog"
 import {DomainDnsStatus} from "./DomainDnsStatus"
-import {createDnsRecordTable} from "./emaildomain/AddDomainWizard"
+import {renderCheckResult} from "./emaildomain/VerifyDnsRecordsPage"
 
 assertMainOrNode()
 
 /**
- * @pre currentStatus.status.isLoaded() == true
+ * @pre domainStatus.status.isLoaded() == true
  */
-export function showDnsCheckDialog(currentStatus: DomainDnsStatus) {
-	let renderCheckResult = function (): ChildArray {
-		let result = currentStatus.getLoadedCustomDomainCheckReturn()
-		if (result.checkResult === CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_OK) {
-			let array = []
-			if (result.missingRecords.length > 0 || result.invalidRecords.length > 0) {
-				array.push(m(".i.mt-m.mb-s", lang.get("skipDnsRecordsInfo_msg")))
-
-				if (result.missingRecords.filter(r => r.type !== DnsRecordType.DNS_RECORD_TYPE_TXT_DMARC).length > 0) {
-					array.push(m(".mt-m.mb-s", lang.get("setDnsRecords_msg")))
-					array.push(createDnsRecordTable(result.missingRecords.filter(r => r.type !== DnsRecordType.DNS_RECORD_TYPE_TXT_DMARC)))
-				}
-
-				if (result.invalidRecords.length > 0) {
-					array.push(m(".mt-m.mb-s", lang.get("deleteDnsRecords_msg")))
-					array.push(createDnsRecordTable(result.invalidRecords))
-				}
-
-				let recommendedDmarc = result.missingRecords.find(r => r.type === DnsRecordType.DNS_RECORD_TYPE_TXT_DMARC)
-				if (recommendedDmarc) {
-					array.push(m(".mt-m.mb-s", lang.get("recommendedDmarcRecord_msg")))
-					array.push(createDnsRecordTable([recommendedDmarc]))
-				}
-
-				array.push(m("span.small.mt-m", lang.get("moreInfo_msg") + " "))
-				array.push(m("span.small", m(`a[href=${lang.getInfoLink("domainInfo_link")}][target=_blank]`, lang.getInfoLink("domainInfo_link"))))
-			}
-			return array
-		} else {
-			let errorMessageMap = {}
-			errorMessageMap[CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_DNS_LOOKUP_FAILED] = "customDomainErrorDnsLookupFailure_msg"
-			errorMessageMap[CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_DOMAIN_NOT_FOUND] = "customDomainErrorDomainNotFound_msg"
-			errorMessageMap[CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_NAMESERVER_NOT_FOUND] = "customDomainErrorNameserverNotFound_msg"
-			return [lang.get(errorMessageMap[result.checkResult])]
-		}
-	}
-
+export function showDnsCheckDialog(domainStatus: DomainDnsStatus) {
 	let dialog = Dialog.showActionDialog({
 		type: DialogType.EditLarger,
 		title: () => lang.get("checkDnsRecords_action"),
 		okActionTextId: "checkAgain_action",
 		cancelActionTextId: "close_alt",
-		child: () => renderCheckResult(),
+		child: () => renderCheckResult(domainStatus),
 		okAction: () => {
-			showProgressDialog("pleaseWait_msg", currentStatus.loadCurrentStatus()).then(() => {
-				if (currentStatus.areAllRecordsFine()) {
+			domainStatus.loadCurrentStatus().then(() => {
+				if (domainStatus.areRecordsFine()) {
 					dialog.close()
-					Dialog.error("dnsRecordsOk_msg")
 				} else {
 					m.redraw()
 				}

--- a/src/settings/CheckDomainDnsStatusDialog.js
+++ b/src/settings/CheckDomainDnsStatusDialog.js
@@ -17,7 +17,7 @@ export function showDnsCheckDialog(domainStatus: DomainDnsStatus) {
 		title: () => lang.get("checkDnsRecords_action"),
 		okActionTextId: "checkAgain_action",
 		cancelActionTextId: "close_alt",
-		child: () => renderCheckResult(domainStatus),
+		child: () => renderCheckResult(domainStatus, true),
 		okAction: () => {
 			domainStatus.loadCurrentStatus().then(() => {
 				if (domainStatus.areRecordsFine()) {
@@ -27,7 +27,5 @@ export function showDnsCheckDialog(domainStatus: DomainDnsStatus) {
 				}
 			})
 		},
-	}).setCloseHandler(() => {
-		dialog.close()
 	})
 }

--- a/src/settings/DomainDnsStatus.js
+++ b/src/settings/DomainDnsStatus.js
@@ -30,6 +30,27 @@ export class DomainDnsStatus {
 		return this.status.getLoaded()
 	}
 
+	/**
+	 * Only checks for the required records (MX and spf) to be fine.
+	 * We have this less strict check because one can already use the custom domain (with limitations) even if certain records like dmarc are not yet set properly.
+	 * We want to allow finishing the dialogs succesfully even if just these basic check pass.
+	 * @returns {boolean} true if records are fine.
+	 */
+	areRecordsFine(): boolean {
+		if (!this.status.isLoaded()
+			|| this.status.getLoaded().checkResult !== CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_OK) {
+			return false
+		}
+		const requiredCorrectTypes = [DnsRecordType.DNS_RECORD_TYPE_MX, DnsRecordType.DNS_RECORD_TYPE_TXT_SPF]
+		const requiredMissingRecords = this.status.getLoaded().missingRecords.filter(r => requiredCorrectTypes.includes(r.type))
+		return !requiredMissingRecords.length
+	}
+
+	/**
+	 * Checks that ALL records are fine. Even the ones that are only recommended.
+	 * We need this check on top of areRecordsFine() because we want to display if some records are not yet set correctly even if the domain can already be used.
+	 * @returns {boolean} true if all records are fine.
+	 */
 	areAllRecordsFine(): boolean {
 		return this.status.isLoaded()
 			&& this.status.getLoaded().checkResult === CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_OK

--- a/src/settings/emaildomain/AddDomainWizard.js
+++ b/src/settings/emaildomain/AddDomainWizard.js
@@ -94,7 +94,7 @@ export type ValidatedDnSRecord =
 		helpInfo: string[]
 	}
 
-export function createDnsRecordTableN(records: ValidatedDnSRecord[], refreshButtonAttrs: ButtonAttrs): Children {
+export function createDnsRecordTableN(records: ValidatedDnSRecord[], refreshButtonAttrs: ?ButtonAttrs): Children {
 
 	return m(TableN, {
 		columnHeading: [

--- a/src/settings/emaildomain/VerifyDnsRecordsPage.js
+++ b/src/settings/emaildomain/VerifyDnsRecordsPage.js
@@ -88,7 +88,7 @@ function _getDisplayableRecordValue(record: DnsRecord): string {
 	return record.value
 }
 
-export function renderCheckResult(domainStatus: DomainDnsStatus): ChildArray {
+export function renderCheckResult(domainStatus: DomainDnsStatus, hideRefreshButton: boolean = false): ChildArray {
 	const result = domainStatus.getLoadedCustomDomainCheckReturn()
 	if (result.checkResult === CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_OK) {
 		let array = []
@@ -120,11 +120,14 @@ export function renderCheckResult(domainStatus: DomainDnsStatus): ChildArray {
 			return validatedRecord
 		})
 		array.push(m(".mt-m.mb-s", lang.get("setDnsRecords_msg")))
-		array.push(createDnsRecordTableN(validatedRecords, {
-			label: "refresh_action",
-			icon: () => BootIcons.Progress,
-			click: () => _updateDnsStatus(domainStatus)
-		}))
+		const refreshButtonAttrs = hideRefreshButton
+			? null
+			: {
+				label: "refresh_action",
+				icon: () => BootIcons.Progress,
+				click: () => _updateDnsStatus(domainStatus)
+			}
+		array.push(createDnsRecordTableN(validatedRecords, refreshButtonAttrs))
 		array.push(m("span.small.mt-m", lang.get("moreInfo_msg") + " "))
 		array.push(m("span.small", m(`a[href=${lang.getInfoLink("domainInfo_link")}][target=_blank]`, lang.getInfoLink("domainInfo_link"))))
 

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -352,7 +352,7 @@ export default {
 		"deleteContacts_msg": "Are you sure you want to delete the selected contact(s)?",
 		"deleteContact_msg": "Are you sure you want to delete this contact?",
 		"deleteCredentials_action": "Delete credentials",
-		"deleteDnsRecords_msg": "Please delete or fix the following DNS records:",
+		"deleteDnsRecords_msg": "Please delete or fix the following DNS records:", // TODO delete
 		"deleteEmails_action": "Delete the selected emails",
 		"deleteEventConfirmation_msg": "Are you sure you want to delete this event?",
 		"deleteSharedCalendarConfirm_msg": "The calendar \"{calendar}\" is shared with other users.",
@@ -371,7 +371,7 @@ export default {
 		"discardChanges_action": "Discard changes",
 		"display_action": "Display",
 		"dnsRecordHostOrName_label": "Host/Name",
-		"dnsRecordsOk_msg": "All DNS records are fine!",
+		"dnsRecordsOk_msg": "All DNS records are fine!", // TODO remove key from phrase
 		"dnsRecordValueOrPointsTo_label": "Value/Points to",
 		"domainSetup_title": "Custom domain setup",
 		"domain_label": "Domain",
@@ -966,7 +966,7 @@ export default {
 		"receivingMailboxAlreadyUsed_msg": "The selected receiving mailbox is already used for a different contact form.",
 		"receivingMailbox_label": "Receiving mailbox",
 		"recipients_label": "Recipients",
-		"recommendedDmarcRecord_msg": "We recommend to set the following TXT entry for DMARC, but you may also choose your own configuration:",
+		"recommendedDmarcRecord_msg": "We recommend to set the following TXT entry for DMARC, but you may also choose your own configuration:", // TODO remove
 		"recommendedDNSValue_label": "Recommended value",
 		"recoverAccountAccess_action": "Lost account access",
 		"recoverResetFactors_action": "Reset second factor",
@@ -1129,7 +1129,7 @@ export default {
 		"signingNeeded_msg": "Signing needed!",
 		"signupOneFreeAccountConfirm_msg": "Only one Free account is allowed per person. Please confirm that you do not own any other Tutanota Free accounts.",
 		"sign_action": "Sign",
-		"skipDnsRecordsInfo_msg": "Please set the DNS records for your custom email domain. As long as they are not correctly configured you may not be able to send and receive emails. However, you may postpone this step until you have initially setup your email addresses.",
+		"skipDnsRecordsInfo_msg": "Please set the DNS records for your custom email domain. As long as they are not correctly configured you may not be able to send and receive emails. However, you may postpone this step until you have initially setup your email addresses.", //TODO remove
 		"skip_action": "Skip",
 		"smsError_msg": "Could not send text message.",
 		"smsResent_msg": "If no text message has arrived, you can resend it now.",


### PR DESCRIPTION
After a discussion with @jowlo we decided not to make the change on the server but on the client. I also did some refactoring to have a single view for DNS records now.

fixes #2820 and fixes #2877