### PR TITLE
Fix broken links for invites from Outlook

### DIFF
--- a/src/calendar/CalendarEventViewModel.js
+++ b/src/calendar/CalendarEventViewModel.js
@@ -33,7 +33,7 @@ import {
 	getTimeZone,
 	hasCapabilityOnGroup,
 	incrementByRepeatPeriod,
-	incrementSequence,
+	incrementSequence, prepareCalendarDescription,
 	timeString,
 	timeStringInZone
 } from "./CalendarUtils"
@@ -249,7 +249,7 @@ export class CalendarEventViewModel {
 			this.repeat = null
 		}
 		this.location(existingEvent.location)
-		this.note = existingEvent.description
+		this.note = prepareCalendarDescription(existingEvent.description)
 
 		this._calendarModel.loadAlarms(existingEvent.alarmInfos, this._userController.user).then((alarms) => {
 			alarms.forEach((alarm) => this.addAlarm(downcast(alarm.alarmInfo.trigger)))

--- a/src/calendar/CalendarUtils.js
+++ b/src/calendar/CalendarUtils.js
@@ -762,4 +762,25 @@ export function findPrivateCalendar(calendarInfo: Map<Id, CalendarInfo>): ?Calen
 	return null
 }
 
+/**
+ * Prepare calendar event description to be shown to the user. Must be called *before* sanitizing.
+ *
+ * It is needed to fix special format of links from Outlook which otherwise disappear during sanitizing.
+ * They look like this:
+ * ```
+ * text<https://example.com>
+ * ```
+ */
+export function prepareCalendarDescription(description: string): string {
+	return description.replace(/<(http|https):\/\/[A-z0-9$-_.+!*‘(),\/?]+>/gi, (possiblyLink) => {
+		try {
+			const withoutBrackets = possiblyLink.slice(1, -1)
+			const url = new URL(withoutBrackets)
+			return `<a href="${url.toString()}">${withoutBrackets}</a>`
+		} catch (e) {
+			return possiblyLink
+		}
+	})
+}
+
 export const DEFAULT_HOUR_OF_DAY = 6

--- a/src/calendar/view/CalendarEventPopup.js
+++ b/src/calendar/view/CalendarEventPopup.js
@@ -16,6 +16,7 @@ import {UserError} from "../../api/main/UserError"
 import {DROPDOWN_MARGIN, showDropdown} from "../../gui/base/DropdownN"
 import {Keys} from "../../api/common/TutanotaConstants"
 import type {HtmlSanitizer} from "../../misc/HtmlSanitizer"
+import {prepareCalendarDescription} from "../CalendarUtils"
 
 export class CalendarEventPopup implements ModalComponent {
 	_calendarEvent: CalendarEvent
@@ -35,9 +36,11 @@ export class CalendarEventPopup implements ModalComponent {
 		this._eventBubbleRect = eventBubbleRect
 		this._onEditEvent = onEditEvent
 		this._viewModel = viewModel
+
+		const preparedDescription = prepareCalendarDescription(calendarEvent.description)
 		// We receive the HtmlSanitizer from outside and do the sanitization inside, so that we don't have to just assume it was already done
-		this._sanitizedDescription = calendarEvent.description
-			? htmlSanitizer.sanitize(calendarEvent.description, {blockExternalContent: true}).text
+		this._sanitizedDescription = preparedDescription
+			? htmlSanitizer.sanitize(preparedDescription, {blockExternalContent: true}).text
 			: ""
 
 		if (calendarEvent._ownerGroup == null) {
@@ -86,7 +89,7 @@ export class CalendarEventPopup implements ModalComponent {
 					oncreate: ({dom}) => {
 						// This is a hack to get "natural" view size but render it without opacity first and then show dropdown with inferred
 						// size.
-					setTimeout(() => showDropdown(this._eventBubbleRect, dom, dom.offsetHeight, 400), 24)
+						setTimeout(() => showDropdown(this._eventBubbleRect, dom, dom.offsetHeight, 400), 24)
 					},
 				},
 				[

--- a/test/client/calendar/CalendarUtilsTest.js
+++ b/test/client/calendar/CalendarUtilsTest.js
@@ -4,7 +4,7 @@ import {
 	getCalendarMonth,
 	getStartOfWeek,
 	getWeekNumber,
-	hasCapabilityOnGroup
+	hasCapabilityOnGroup, prepareCalendarDescription
 } from "../../../src/calendar/CalendarUtils"
 import {lang} from "../../../src/misc/LanguageViewModel"
 import {createGroupMembership} from "../../../src/api/entities/sys/GroupMembership"
@@ -280,6 +280,33 @@ o.spec("calendar utils tests", function () {
 			o(hasCapabilityOnGroup(user, group, ShareCapability.Invite)).equals(false)
 			o(hasCapabilityOnGroup(user, group, ShareCapability.Write)).equals(false)
 			o(hasCapabilityOnGroup(user, group, ShareCapability.Read)).equals(false)
+		})
+	})
+
+	o.spec("prepareCalendarDescription", function () {
+		o("angled link replaced with a proper link", function () {
+			o(prepareCalendarDescription("JoinBlahBlah<https://the-link.com/path>"))
+				.equals(`JoinBlahBlah<a href="https://the-link.com/path">https://the-link.com/path</a>`)
+		})
+
+		o("normal HTML link is not touched", function () {
+			o(prepareCalendarDescription(`JoinBlahBlah<a href="https://the-link.com/path">a link</a>`))
+				.equals(`JoinBlahBlah<a href="https://the-link.com/path">a link</a>`)
+		})
+
+		o("non-HTTP/HTTPS link is not allowed", function () {
+			o(prepareCalendarDescription(`JoinBlahBlah<protocol://the-link.com/path>`))
+				.equals(`JoinBlahBlah<protocol://the-link.com/path>`)
+		})
+
+		o("link with additional text is not allowed", function () {
+			o(prepareCalendarDescription("JoinBlahBlah<https://the-link.com/path and some other text>"))
+				.equals(`JoinBlahBlah<https://the-link.com/path and some other text>`)
+		})
+
+		o("non-closed tag is not allowed", function () {
+			o(prepareCalendarDescription("JoinBlahBlah<https://the-link.com/path and some other text"))
+				.equals(`JoinBlahBlah<https://the-link.com/path and some other text`)
 		})
 	})
 })


### PR DESCRIPTION
 fix #2741

Outlook has special format for links and it is removed by our
sanitizer. We try to find such places and replace them with proper
HTML.