### PR TITLE
add override of electrons' per-url zoom factor retention

### DIFF
--- a/flow/electron.js
+++ b/flow/electron.js
@@ -400,7 +400,7 @@ declare module 'electron' {
 		constructor(any): BrowserWindow;
 		on(BrowserWindowEvent, (Event, ...Array<any>) => mixed): BrowserWindow;
 		once(BrowserWindowEvent, (Event, ...Array<any>) => mixed): BrowserWindow;
-		emit(BrowserWindowEvent): void;
+		emit(BrowserWindowEvent, ...Array<any>): void;
 		focus(): void;
 		hide(): void;
 		close(): void;
@@ -479,7 +479,7 @@ declare module 'electron' {
 
 	declare export type DragInfo = {files: string[] | string, icon?: NativeImage | string}
 
-	declare export type WebContentsEvent = {sender: WebContents, preventDefault: ()=>void}
+	declare export type WebContentsEvent = {+sender: WebContents, +preventDefault: ()=>void}
 
 	declare export class WebContents {
 		on(WebContentsEventType, (WebContentsEvent, ...Array<any>) => void): WebContents;
@@ -742,6 +742,8 @@ export type BrowserWindowEvent
 	| 'sheet-end'
 	| 'new-window-for-tab'
 	| 'did-start-navigation' // passed through from webContents
+	| 'did-navigate' // passed through from webContents
+	| 'zoom-changed' // passed through from webContents
 
 // https://github.com/electron/electron/blob/master/docs/api/web-contents.md#instance-events
 export type WebContentsEventType

--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -110,11 +110,8 @@ export class ApplicationWindow {
 	hide: (() => void) = () => this._browserWindow.hide()
 	center: (() => void) = () => this._browserWindow.center()
 	showInactive: (() => void) = () => this._browserWindow.showInactive()
+	focus: () => void = () => this._browserWindow.focus()
 	isFocused: (() => boolean) = () => this._browserWindow.isFocused()
-
-	get browserWindow(): BrowserWindow {
-		return this._browserWindow
-	}
 
 	show() {
 		if (!this._browserWindow) {
@@ -296,7 +293,7 @@ export class ApplicationWindow {
 	}
 
 	setContextMenuHandler(handler: (ContextMenuParams) => void) {
-		const wc = this.browserWindow.webContents
+		const wc = this._browserWindow.webContents
 		wc.on('context-menu', (e, params) => handler(params))
 	}
 

--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -226,16 +226,9 @@ export class ApplicationWindow {
 		    .on('remote-get-builtin', e => e.preventDefault())
 		    .on('remote-get-current-web-contents', e => e.preventDefault())
 		    .on('remote-get-current-window', e => e.preventDefault())
-		    .on('zoom-changed', (ev: WebContentsEvent, direction: "in" | "out") => {
-			    const wc = ev.sender
-			    let newFactor = ((wc.getZoomFactor() * 100) + (direction === "out" ? -10 : 10)) / 100
-			    if (newFactor > 3) {
-				    newFactor = 3
-			    } else if (newFactor < 0.5) {
-				    newFactor = 0.5
-			    }
-			    wc.setZoomFactor(newFactor)
-		    })
+		    .on('did-navigate', () => this._browserWindow.emit('did-navigate'))
+		    .on('did-navigate-in-page', () => this._browserWindow.emit('did-navigate'))
+		    .on('zoom-changed', (ev: WebContentsEvent, direction: "in" | "out") => this._browserWindow.emit('zoom-changed', ev, direction))
 		    .on('update-target-url', (ev, url) => {
 			    this._ipc.sendRequest(this.id, 'updateTargetUrl', [url, appFileUrl])
 		    })
@@ -302,7 +295,7 @@ export class ApplicationWindow {
 		).then(() => this.show())
 	}
 
-	setContextMenuHandler(handler: (ContextMenuParams)=>void) {
+	setContextMenuHandler(handler: (ContextMenuParams) => void) {
 		const wc = this.browserWindow.webContents
 		wc.on('context-menu', (e, params) => handler(params))
 	}
@@ -464,7 +457,7 @@ export class ApplicationWindow {
 		return {
 			fullscreen: this._browserWindow.isFullScreen(),
 			rect: this._browserWindow.getBounds(),
-			scale: this._browserWindow.webContents.zoomFactor
+			scale: 1, // turns out we can't really trust wc.getZoomFactor
 		}
 	}
 }

--- a/src/desktop/DesktopDownloadManager.js
+++ b/src/desktop/DesktopDownloadManager.js
@@ -110,7 +110,7 @@ export class DesktopDownloadManager {
 		await this._handleDownloadItem(downloadItem)
 		const writePromise = downloadItem.savePath
 			? write({canceled: false, filePath: downloadItem.savePath})
-			: this._electron.dialog.showSaveDialog(win.browserWindow, {defaultPath: path.join(this._electron.app.getPath('downloads'), filename)})
+			: this._electron.dialog.showSaveDialog(null, {defaultPath: path.join(this._electron.app.getPath('downloads'), filename)})
 			      .then(write)
 		return writePromise.then(() => downloadItem.emit('done', undefined, 'completed'))
 		                   .catch(e => {downloadItem.emit('done', e, 'cancelled')})

--- a/src/desktop/DesktopUtils.js
+++ b/src/desktop/DesktopUtils.js
@@ -9,6 +9,7 @@ import {downcast, noOp} from "../api/common/utils/Utils"
 import {log} from "./DesktopLog"
 import {uint8ArrayToHex} from "../api/common/utils/Encoding"
 import {cryptoFns} from "./CryptoFns"
+import type {Rectangle} from "electron"
 
 
 import {delay} from "../api/common/utils/PromiseUtils"
@@ -246,4 +247,11 @@ async function _unregisterOnWin() {
 
 export function readJSONSync(absolutePath: string): {[string]: mixed} {
 	return JSON.parse(readFileSync(absolutePath, {encoding: "utf8"}))
+}
+
+export function isRectContainedInRect(closestRect: Rectangle, lastBounds: Rectangle): boolean {
+	return lastBounds.x >= closestRect.x - 10
+		&& lastBounds.y >= closestRect.y - 10
+		&& lastBounds.width + lastBounds.x <= closestRect.width + 10
+		&& lastBounds.height + lastBounds.y <= closestRect.height + 10
 }

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -19,6 +19,8 @@ import {fileExists} from "./PathUtils"
 import type {MailExportMode} from "../mail/export/Exporter"
 import {BuildConfigKey, DesktopConfigEncKey} from "./config/ConfigKeys"
 import type {SseInfo} from "./sse/DesktopSseClient"
+import {isRectContainedInRect} from "./DesktopUtils"
+import {downcast} from "../api/common/utils/Utils"
 
 export type WindowBounds = {|
 	rect: Rectangle,
@@ -37,6 +39,7 @@ export class WindowManager {
 	+dl: DesktopDownloadManager
 	+_newWindowFactory: (noAutoLogin?: boolean) => Promise<ApplicationWindow>
 	+_dragIcons: {[MailExportMode]: NativeImage}
+	_currentBounds: WindowBounds
 
 	constructor(conf: DesktopConfig, tray: DesktopTray, notifier: DesktopNotifier, electron: $Exports<"electron">,
 	            localShortcut: LocalShortcutManager, dl: DesktopDownloadManager) {
@@ -50,6 +53,12 @@ export class WindowManager {
 			"eml": this._tray.getIconByName("eml.png"),
 			"msg": this._tray.getIconByName("msg.png"),
 		}
+		// this is the global default for window placement & scale
+		this._currentBounds = {
+			scale: 1,
+			fullscreen: false,
+			rect: {height: 600, width: 800, x: 200, y: 200}
+		}
 	}
 
 	/**
@@ -60,10 +69,11 @@ export class WindowManager {
 	}
 
 	async newWindow(showWhenReady: boolean, noAutoLogin?: boolean): Promise<ApplicationWindow> {
+		await this.loadStartingBounds()
 		const w: ApplicationWindow = await this._newWindowFactory(noAutoLogin)
 		windows.unshift(w)
 		w.on('close', ev => {
-			this.saveBounds(w)
+			this.saveBounds(w.getBounds())
 		}).on('closed', ev => {
 			windows.splice(windows.indexOf(w), 1)
 			this._tray.update(this._notifier)
@@ -79,17 +89,22 @@ export class WindowManager {
 				w.setUserInfo(null)
 			}
 			this._tray.update(this._notifier)
+		}).on('zoom-changed', (ev: Event, direction: "in" | "out") => {
+			let scale = ((this._currentBounds.scale * 100) + (direction === "out" ? -5 : 5)) / 100
+			if (scale > 3) scale = 3
+			else if (scale < 0.5) scale = 0.5
+			this._currentBounds.scale = scale
+			windows.forEach(w => w.setZoomFactor(scale))
+			const w = this.getEventSender(downcast(ev))
+			if(!w) return
+			this.saveBounds(w.getBounds())
+		}).on('did-navigate', () => {
+			// electron likes to override the zoom factor when the URL changes.
+			windows.forEach(w => w.setZoomFactor(this._currentBounds.scale))
 		}).once('ready-to-show', async () => {
 			this._tray.update(this._notifier)
-			const startingBounds: ?WindowBounds = await this.getStartingBounds()
-			if (startingBounds) {
-				w.setBounds(startingBounds)
-			} else {
-				w.center()
-			}
-			if (showWhenReady) {
-				w.show()
-			}
+			w.setBounds(this._currentBounds)
+			if (showWhenReady) w.show()
 		})
 
 		w.setContextMenuHandler((params) => this._contextMenu.open(params))
@@ -173,28 +188,34 @@ export class WindowManager {
 			|| this.newWindow(true, true)
 	}
 
-	saveBounds(w: ApplicationWindow): void {
-		const lastBounds = w.getBounds()
-		if (this.isRectContainedInRect(screen.getDisplayMatching(lastBounds.rect).bounds, lastBounds.rect)) {
-			log.debug("saving bounds:", lastBounds)
-			this._conf.setVar('lastBounds', lastBounds)
-		}
+	/**
+	 * Set window size & location in the WindowManager and save them and the manager's window scale to config.
+	 * The WindowManagers scale will be retained even if passed bounds has a different scale.
+	 * @param bounds {WindowBounds} the bounds containing the size & location to save
+	 */
+	saveBounds(bounds: WindowBounds): void {
+		const displayRect = screen.getDisplayMatching(bounds.rect).bounds
+		if (!isRectContainedInRect(displayRect, bounds.rect)) return
+		this._currentBounds.fullscreen = bounds.fullscreen
+		this._currentBounds.rect = bounds.rect
+		this._conf.setVar('lastBounds', this._currentBounds)
 	}
 
-	async getStartingBounds(): Promise<?WindowBounds> {
-		const lastBounds: WindowBounds = await this._conf.getVar("lastBounds")
-		if (!lastBounds || !this.isRectContainedInRect(screen.getDisplayMatching(lastBounds.rect).bounds, lastBounds.rect)) {
-			return null
-		} else {
-			return Object.assign({scale: 1, fullscreen: false, rect: {height: 600, width: 800, x: 200, y: 200}}, lastBounds)
-		}
-	}
-
-	isRectContainedInRect(closestRect: Rectangle, lastBounds: Rectangle): boolean {
-		return lastBounds.x >= closestRect.x - 10
-			&& lastBounds.y >= closestRect.y - 10
-			&& lastBounds.width + lastBounds.x <= closestRect.width + 10
-			&& lastBounds.height + lastBounds.y <= closestRect.height + 10
+	/**
+	 * load lastBounds from config.
+	 * if there are none or they don't match a screen, save default bounds to config
+	 */
+	async loadStartingBounds(): Promise<void> {
+		const loadedBounds: WindowBounds = await this._conf.getVar("lastBounds")
+		if(!loadedBounds) this.saveBounds(this._currentBounds)
+		const lastBounds = loadedBounds || this._currentBounds
+		const displayRect = screen.getDisplayMatching(lastBounds.rect).bounds
+		// we may have loaded bounds that are not in bounds of the screen
+		// if ie the resolution changed, more/less screens, ...
+		const result = isRectContainedInRect(displayRect, lastBounds.rect)
+			? Object.assign(this._currentBounds, lastBounds)
+			: this._currentBounds
+		this.saveBounds(result)
 	}
 
 	async _newWindow(electron: $Exports<"electron">, localShortcut: LocalShortcutManager, noAutoLogin: ?boolean): Promise<ApplicationWindow> {

--- a/src/desktop/IPC.js
+++ b/src/desktop/IPC.js
@@ -273,7 +273,7 @@ export class IPC {
 			}
 			case 'focusApplicationWindow': {
 				const window = this._wm.get(windowId)
-				window && window.browserWindow.focus()
+				window && window.focus()
 				return Promise.resolve()
 			}
 			case 'checkFileExistsInExportDirectory': {

--- a/src/desktop/config/DesktopConfig.js
+++ b/src/desktop/config/DesktopConfig.js
@@ -64,9 +64,8 @@ export class DesktopConfig {
 			downcast<MigrationKind>(buildConfig["configMigrationFunction"]),
 			populatedConfig,
 		)
-		await fs.mkdirSync(path.join(this._app.getPath('userData')), {recursive: true})
-		const json = JSON.stringify(desktopConfig, null, 2)
-		await fs.writeFileSync(this._desktopConfigPath, json)
+		await fs.promises.mkdir(path.join(this._app.getPath('userData')), {recursive: true})
+		await writeJSON(this._desktopConfigPath, desktopConfig)
 		this._desktopConfig.resolve(desktopConfig)
 	}
 
@@ -94,8 +93,7 @@ export class DesktopConfig {
 		}
 
 		const deviceKey = await this._deviceKeyProvider.getDeviceKey()
-		const decryptedValue = this._cryptoFacade.aesDecryptObject(deviceKey, downcast<string>(encryptedValue))
-		return decryptedValue
+		return this._cryptoFacade.aesDecryptObject(deviceKey, downcast<string>(encryptedValue))
 	}
 
 	async _setEncryptedVar(key: DesktopConfigEncKeyEnum, value: any) {
@@ -127,8 +125,7 @@ export class DesktopConfig {
 
 	async _saveAndNotify(key: AllConfigKeysEnum, value: any, oldValue: any): Promise<void> {
 		const desktopConfig = await this._desktopConfig.promise
-		const json = JSON.stringify(desktopConfig, null, 2)
-		fs.writeFileSync(this._desktopConfigPath, json)
+		await writeJSON(this._desktopConfigPath, desktopConfig)
 		this._notifyChangeListeners(key, value, oldValue)
 	}
 
@@ -193,7 +190,12 @@ export class DesktopConfig {
 	}
 }
 
-async function readJSON(path: string): Promise<mixed> {
-	const text: string = fs.readFileSync(path, "utf8")
+async function readJSON(path: string): Promise<any> {
+	const text: string = await fs.promises.readFile(path, "utf8")
 	return JSON.parse(text)
+}
+
+async function writeJSON(path: string, obj: any): Promise<void> {
+	const json = JSON.stringify(obj, null, 2)
+	return fs.promises.writeFile(path, json)
 }

--- a/test/client/desktop/ApplicationWindowTest.js
+++ b/test/client/desktop/ApplicationWindowTest.js
@@ -277,6 +277,8 @@ o.spec("ApplicationWindow Test", function () {
 			'remote-get-builtin',
 			'remote-get-current-web-contents',
 			'remote-get-current-window',
+			'did-navigate',
+			'did-navigate-in-page',
 			'zoom-changed',
 			'update-target-url'
 		])("webContents registered callbacks dont match")
@@ -716,7 +718,7 @@ o.spec("ApplicationWindow Test", function () {
 		})
 
 		w.setBounds({rect: {width: 1, height: 1, x: 1, y: 1}, fullscreen: false, scale: 2})
-		o(w.getBounds()).deepEquals({rect: {width: 1, height: 1, x: 1, y: 1}, fullscreen: false, scale: 2})
+		o(w.getBounds()).deepEquals({rect: {width: 1, height: 1, x: 1, y: 1}, fullscreen: false, scale: 1})
 
 		w.setBounds({rect: {width: 0, height: 0, x: 0, y: 0}, fullscreen: true, scale: 1})
 		o(w.getBounds()).deepEquals({rect: {width: 1, height: 1, x: 1, y: 1}, fullscreen: true, scale: 1})
@@ -729,7 +731,7 @@ o.spec("ApplicationWindow Test", function () {
 			o(w.getBounds()).deepEquals({
 				rect: {width: 0, height: 0, x: 0, y: -10},
 				fullscreen: false,
-				scale: 0.5
+				scale: 1
 			})
 			done()
 		}, 250)


### PR DESCRIPTION
 add override of electrons' per-url zoom factor retention

electron started to exhibit chromiums' zoom factor retention
which is saved in electron.app.getPath('userData')/Preferences
* %APPDATA%/tutanota-desktop/Preferences on win32
* ~/.config/tutanota-desktop/Preferences on linux
* ~/Library/Application Support/tutanota-desktop/Preferences on darwin

this conflicts with our own zoom handling logic.
it is saved per url and at different times apparently depending
on things like whether a window is open at the time of shutdown
or not.

this commit overrides this behaviour by maintaining the current
zoom factor in the window manager and resetting it whenever
any WebContents navigated.

also reduces the step size of scale adjustment from 10% to 5%.

fix #2917, #2317