### PR TITLE
Fix iOS build on Apple M1

### DIFF
--- a/app-ios/tutanota.xcodeproj/project.pbxproj
+++ b/app-ios/tutanota.xcodeproj/project.pbxproj
@@ -2084,6 +2084,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = JKCH89Z3M9;
+				EXCLUDED_ARCHS = arm64;
 				HEADER_SEARCH_PATHS = (
 					"\"$(TARGET_BUILD_DIR)/usr/local/lib/include\"",
 					"\"$(BUILT_PRODUCTS_DIR)\"",


### PR DESCRIPTION
Hi,

I had some problems when linking `libcrypto.a` on Apple M1.

This PR fixes this issue by excluding the `arm64` arch from debug builds.