### PR TITLE
show suggestions for bubble text field in overlay dropdown

### DIFF
--- a/src/calendar/view/CalendarEventEditDialog.js
+++ b/src/calendar/view/CalendarEventEditDialog.js
@@ -365,7 +365,7 @@ export function showCalendarEventDialog(date: Date, calendars: Map<Id, CalendarI
 			return m(".calendar-edit-container.pb", [
 					renderHeading(),
 					renderChangesMessage(),
-					m(".mb", m(ExpanderPanelN, {
+					m(".mb.rel", m(ExpanderPanelN, {
 							expanded: attendeesExpanded,
 						},
 						[
@@ -538,7 +538,7 @@ function makeBubbleTextField(viewModel: CalendarEventViewModel, contactModel: Co
 		},
 	}, contactModel)
 
-	const invitePeopleValueTextField = new BubbleTextField("addGuest_label", bubbleHandler, {marginLeft: 0}, () => renderConfidentialButton(viewModel))
+	const invitePeopleValueTextField = new BubbleTextField("addGuest_label", bubbleHandler, () => renderConfidentialButton(viewModel))
 	return invitePeopleValueTextField
 }
 

--- a/src/gui/base/Expander.js
+++ b/src/gui/base/Expander.js
@@ -29,31 +29,31 @@ export class ExpanderButtonN implements MComponent<ExpanderAttrs> {
 		const a = vnode.attrs
 		return m(".flex.limit-width", [ // .limit-width does not work without .flex in IE11
 			m("button.expander.bg-transparent.pt-s.hover-ul.limit-width", {
-					style: a.style,
-					onclick: (event: MouseEvent) => {
-						a.expanded(!a.expanded())
-						event.stopPropagation()
+				style: a.style,
+				onclick: (event: MouseEvent) => {
+					a.expanded(!a.expanded())
+					event.stopPropagation()
+				},
+				oncreate: vnode => addFlash(vnode.dom),
+				onremove: (vnode) => removeFlash(vnode.dom),
+				"aria-expanded": String(!!a.expanded()),
+			}, m(".flex.items-center", [ // TODO remove wrapper after Firefox 52 has been deployed widely https://bugzilla.mozilla.org/show_bug.cgi?id=984869
+				(a.showWarning) ? m(Icon, {
+					icon: Icons.Warning,
+					style: {
+						fill: a.color ? a.color : theme.content_button,
+					}
+				}) : null,
+				m("small.b.text-ellipsis", {style: {color: a.color || theme.content_button}}, lang.getMaybeLazy(a.label).toUpperCase()),
+				m(Icon, {
+					icon: BootIcons.Expand,
+					class: "flex-center items-center",
+					style: {
+						fill: a.color ? a.color : theme.content_button,
+						'margin-right': px(-4), // icon is has 4px whitespace to the right,
+						transform: `rotateZ(${a.expanded() ? 180 : 0}deg)`,
+						transition: `transform ${DefaultAnimationTime}ms`
 					},
-					oncreate: vnode => addFlash(vnode.dom),
-					onremove: (vnode) => removeFlash(vnode.dom),
-					"aria-expanded": String(!!a.expanded()),
-				}, m(".flex.items-center", [ // TODO remove wrapper after Firefox 52 has been deployed widely https://bugzilla.mozilla.org/show_bug.cgi?id=984869
-					(a.showWarning) ? m(Icon, {
-						icon: Icons.Warning,
-						style: {
-							fill: a.color ? a.color : theme.content_button,
-						}
-					}) : null,
-					m("small.b.text-ellipsis", {style: {color: a.color || theme.content_button}}, lang.getMaybeLazy(a.label).toUpperCase()),
-					m(Icon, {
-						icon: BootIcons.Expand,
-						class: "flex-center items-center",
-						style: {
-							fill: a.color ? a.color : theme.content_button,
-							'margin-right': px(-4), // icon is has 4px whitespace to the right,
-							transform: `rotateZ(${a.expanded() ? 180 : 0}deg)`,
-							transition: `transform ${DefaultAnimationTime}ms`
-						},
 				}),
 			])),
 		])

--- a/src/mail/editor/MailEditor.js
+++ b/src/mail/editor/MailEditor.js
@@ -395,8 +395,8 @@ export class MailEditor implements MComponent<MailEditorAttrs> {
 			onload: (ev) => {
 			}
 		}, [
-			m(this.recipientFields.to.component),
-			m(ExpanderPanelN, {expanded: a.areDetailsExpanded},
+			m(".rel", m(this.recipientFields.to.component)),
+			m(".rel", m(ExpanderPanelN, {expanded: a.areDetailsExpanded},
 				m(".details", [
 					m(this.recipientFields.cc.component),
 					m(this.recipientFields.bcc.component),
@@ -412,7 +412,7 @@ export class MailEditor implements MComponent<MailEditorAttrs> {
 
 					]),
 				])
-			),
+			)),
 			isConfidential
 				? m(".external-recipients.overflow-hidden", {
 					oncreate: vnode => animate(vnode.dom, true),

--- a/src/mail/editor/MailEditorViewModel.js
+++ b/src/mail/editor/MailEditorViewModel.js
@@ -190,7 +190,7 @@ export class MailEditorRecipientField implements RecipientInfoBubbleFactory {
 		this.field = fieldType
 
 		const handler = new RecipientInfoBubbleHandler(this, contactModel)
-		this.component = new BubbleTextField(_getRecipientFieldLabelTranslationKey(this.field), handler, {}, injectionsRight, disabled)
+		this.component = new BubbleTextField(_getRecipientFieldLabelTranslationKey(this.field), handler, injectionsRight, disabled)
 
 		// we want to fill in the field with existing recipients from the model
 		this.component.bubbles = this._modelRecipients().map(recipient => this.createBubble(recipient.name, recipient.mailAddress, recipient.contact))

--- a/src/sharing/view/GroupSharingDialog.js
+++ b/src/sharing/view/GroupSharingDialog.js
@@ -193,7 +193,7 @@ function showAddParticipantDialog(model: GroupSharingModel, texts: GroupSharingT
 		title: () => lang.get("addParticipant_action"),
 		child: () => [
 			m(".pt", texts.addMemberMessage(customGroupName || realGroupName)),
-			m(invitePeopleValueTextField),
+			m(".rel", m(invitePeopleValueTextField)),
 			m(DropDownSelectorN, {
 				label: "permissions_label",
 				items: [


### PR DESCRIPTION
resolves #2949

I decided to make the suggestions dropdown with position `absolute` so that it does not move around when scrolling (as it would the case with `fixed`). I decided not to put position 'relative' to the parent element, i.e. the BubbleTextField for the following reason:
In some use cases there is an ancestor element with overflow set to `hidden` which means the dropdown would not be shown. However, we avoid this problem by putting position `relative` on a parent of the overflow-hidden element.