### PR TITLE
Disable template popup in mobile

### DIFF
--- a/src/mail/editor/MailEditor.js
+++ b/src/mail/editor/MailEditor.js
@@ -525,7 +525,7 @@ function createMailEditorDialog(model: SendMailModel, blockExternalContent: bool
 	}
 
 
-	const templatePopupModel = logins.isInternalUserLoggedIn() && !isApp()
+	const templatePopupModel = logins.isInternalUserLoggedIn() && client.isDesktopDevice()
 		? new TemplatePopupModel(locator.eventController, logins, locator.entityClient)
 		: null
 

--- a/src/mail/editor/MailEditor.js
+++ b/src/mail/editor/MailEditor.js
@@ -525,7 +525,7 @@ function createMailEditorDialog(model: SendMailModel, blockExternalContent: bool
 	}
 
 
-	const templatePopupModel = logins.isInternalUserLoggedIn()
+	const templatePopupModel = logins.isInternalUserLoggedIn() && !isApp()
 		? new TemplatePopupModel(locator.eventController, logins, locator.entityClient)
 		: null
 

--- a/src/templates/view/TemplatePopup.js
+++ b/src/templates/view/TemplatePopup.js
@@ -32,7 +32,6 @@ import {getSharedGroupName, hasCapabilityOnGroup} from "../../sharing/GroupUtils
 import {createInitialTemplateListIfAllowed} from "../TemplateGroupUtils"
 import {getConfirmation} from "../../gui/base/GuiUtils"
 import {ScrollSelectList} from "../../gui/ScrollSelectList"
-import {isApp} from "../../api/common/Env"
 
 export const TEMPLATE_POPUP_HEIGHT = 340;
 export const TEMPLATE_POPUP_TWO_COLUMN_MIN_WIDTH = 600;
@@ -91,11 +90,9 @@ export class TemplatePopup implements ModalComponent {
 		this._rect = rect
 		this._onSelect = onSelect
 		this._initialWindowWidth = window.innerWidth
-		this._resizeListener =
-			isApp()
-				? noOp
-				: () => this._close()
-
+		this._resizeListener = () => {
+			this._close()
+		}
 		this._searchBarValue = stream(initialSearchString)
 		this._templateModel = templateModel
 

--- a/src/templates/view/TemplatePopup.js
+++ b/src/templates/view/TemplatePopup.js
@@ -32,6 +32,7 @@ import {getSharedGroupName, hasCapabilityOnGroup} from "../../sharing/GroupUtils
 import {createInitialTemplateListIfAllowed} from "../TemplateGroupUtils"
 import {getConfirmation} from "../../gui/base/GuiUtils"
 import {ScrollSelectList} from "../../gui/ScrollSelectList"
+import {isApp} from "../../api/common/Env"
 
 export const TEMPLATE_POPUP_HEIGHT = 340;
 export const TEMPLATE_POPUP_TWO_COLUMN_MIN_WIDTH = 600;
@@ -90,9 +91,11 @@ export class TemplatePopup implements ModalComponent {
 		this._rect = rect
 		this._onSelect = onSelect
 		this._initialWindowWidth = window.innerWidth
-		this._resizeListener = () => {
-			this._close()
-		}
+		this._resizeListener =
+			isApp()
+				? noOp
+				: () => this._close()
+
 		this._searchBarValue = stream(initialSearchString)
 		this._templateModel = templateModel
 


### PR DESCRIPTION
For now we will not have templates enable in the apps. We may choose to add it later but it would require further changes to/an alternate version of the template popup as it is not suited for mobile