### PR TITLE
Add ctrl-enter as send shortcut

### DIFF
--- a/src/mail/editor/MailEditor.js
+++ b/src/mail/editor/MailEditor.js
@@ -569,6 +569,7 @@ function createMailEditorDialog(model: SendMailModel, blockExternalContent: bool
 		{key: Keys.ESC, exec() { closeButtonAttrs.click(newMouseEvent(), domCloseButton) }, help: "close_alt"},
 		{key: Keys.S, ctrl: true, exec: () => { save() }, help: "save_action"},
 		{key: Keys.S, ctrl: true, shift: true, exec: send, help: "send_action"},
+		{key: Keys.RETURN, ctrl: true, exec: send, help: "send_action"}
 	]
 
 	dialog = Dialog.largeDialogN(headerBarAttrs, MailEditor, mailEditorAttrs,)


### PR DESCRIPTION
Add <kbd>Ctrl</kbd>+<kbd>Enter</kbd> as a shortcut to send mails while in the mail editor view

See [reddit](https://www.reddit.com/r/tutanota/comments/n62p81/feature_request_shortcut_to_send_current_email/) or common expectations (like here on github)