### PR TITLE
Create global theme management singleton

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,6 @@ import "./gui/main-styles"
 import {assertMainOrNodeBoot, bootFinished, isApp, isDesktop, isTutanotaDomain} from "./api/common/Env"
 import {logins} from "./api/main/LoginController"
 import {downcast, neverNull} from "./api/common/utils/Utils"
-import {themeId} from "./gui/theme"
 import {routeChange} from "./misc/RouteChange"
 import {windowFacade} from "./misc/WindowFacade"
 import {Const} from "./api/common/TutanotaConstants"
@@ -17,6 +16,7 @@ import {deviceConfig} from "./misc/DeviceConfig"
 import {Logger, replaceNativeLogger} from "./api/common/Logger"
 import {init as initSW} from "./serviceworker/ServiceWorkerClient"
 import {applicationPaths} from "./ApplicationPaths"
+import {themeManager} from "./gui/theme"
 
 assertMainOrNodeBoot()
 bootFinished()
@@ -40,7 +40,7 @@ window.tutao = {
 	root,
 	logins,
 	currentView,
-	themeId,
+	themeManager,
 	Const,
 	locator: window.tutao ? window.tutao.locator : null // locator is not restored on hot reload otherwise
 }

--- a/src/calendar/CalendarUpdateDistributor.js
+++ b/src/calendar/CalendarUpdateDistributor.js
@@ -6,7 +6,6 @@ import {CalendarMethod, ConversationType, getAttendeeStatus, MailMethod, mailMet
 import {calendarAttendeeStatusSymbol, formatEventDuration, getTimeZone} from "./CalendarUtils"
 import type {CalendarEvent} from "../api/entities/tutanota/CalendarEvent"
 import {stringToUtf8Uint8Array, uint8ArrayToBase64} from "../api/common/utils/Encoding"
-import {defaultTheme} from "../gui/theme"
 import {assertNotNull, noOp} from "../api/common/utils/Utils"
 import type {SendMailModel} from "../mail/editor/SendMailModel"
 import type {Mail} from "../api/entities/tutanota/Mail"
@@ -16,6 +15,7 @@ import type {CalendarEventAttendee} from "../api/entities/tutanota/CalendarEvent
 import {createCalendarEventAttendee} from "../api/entities/tutanota/CalendarEventAttendee"
 import {isTutanotaMailAddress} from "../api/common/RecipientInfo"
 import {createMailAddress} from "../api/entities/tutanota/MailAddress"
+import {themeManager} from "../gui/theme"
 
 export interface CalendarUpdateDistributor {
 	sendInvite(existingEvent: CalendarEvent, sendMailModel: SendMailModel): Promise<void>;
@@ -191,7 +191,7 @@ function makeInviteEmailBody(sender: string, event: CalendarEvent, message: stri
 	const logo = isTutanotaMailAddress(sender)
 		? `
   <img style="width: 200px; max-height: 38px; display: block; background-color: white; padding: 4px 8px; border-radius: 4px; margin: 16px auto 0"
-  src="data:image/svg+xml;base64,${uint8ArrayToBase64(stringToUtf8Uint8Array(defaultTheme.logo))}"
+  src="data:image/svg+xml;base64,${uint8ArrayToBase64(stringToUtf8Uint8Array(themeManager.getDefaultTheme().logo))}"
   alt="logo"/>
 `
 		: ""

--- a/src/gui/styles.js
+++ b/src/gui/styles.js
@@ -3,7 +3,7 @@ import {Cat, log, timer} from "../misc/Log"
 import {size} from "./size"
 import {assertMainOrNodeBoot, isAdminClient} from "../api/common/Env"
 import {windowFacade} from "../misc/WindowFacade"
-import {theme, themeId} from "./theme"
+import {theme, themeManager} from "./theme"
 import {neverNull} from "../api/common/utils/Utils"
 import {client} from "../misc/ClientDetector"
 
@@ -27,7 +27,7 @@ class Styles {
 			this.bodyWidth = width
 			this.bodyHeight = height
 		})
-		themeId.map(() => {
+		themeManager.themeIdChangedStream.map(() => {
 			this._updateDomStyles()
 		})
 	}

--- a/src/login/LoginView.js
+++ b/src/login/LoginView.js
@@ -7,7 +7,6 @@ import {lang} from "../misc/LanguageViewModel"
 import type {DeferredObject} from "../api/common/utils/Utils"
 import {defer, neverNull} from "../api/common/utils/Utils"
 import {deviceConfig} from "../misc/DeviceConfig"
-import {setThemeId, themeId} from "../gui/theme"
 import {ExpanderButtonN, ExpanderPanelN} from "../gui/base/Expander"
 import {BootIcons} from "../gui/base/icons/BootIcons"
 import {base64ToUint8Array, base64UrlToBase64, utf8Uint8ArrayToString} from "../api/common/utils/Encoding"
@@ -24,6 +23,7 @@ import {UserError} from "../api/main/UserError"
 import {showUserError} from "../misc/ErrorHandlerImpl"
 import {LoginForm} from "./LoginForm"
 import {CredentialsSelector} from "./CredentialsSelector"
+import {themeManager} from "../gui/theme"
 
 assertMainOrNode()
 
@@ -76,7 +76,7 @@ export class LoginView {
 
 		if (window.location.href.includes('signup')) {
 			if (window.location.hash.includes('theme=blue')) {
-				setThemeId('blue')
+				themeManager.setThemeId('blue')
 			}
 			this.permitAutoLogin = false
 			this._signup()
@@ -169,13 +169,13 @@ export class LoginView {
 							label: "switchColorTheme_action",
 							type: ButtonType.Secondary,
 							click: () => {
-								switch (themeId()) {
+								switch (themeManager.themeId) {
 									case 'light':
-										return setThemeId('dark')
+										return themeManager.setThemeId('dark')
 									case 'dark':
-										return setThemeId('blue')
+										return themeManager.setThemeId('blue')
 									default:
-										return setThemeId('light')
+										return themeManager.setThemeId('light')
 								}
 							}
 						})
@@ -212,7 +212,7 @@ export class LoginView {
 	}
 
 	_switchThemeLinkVisible(): boolean {
-		return (themeId() !== 'custom')
+		return (themeManager.themeId !== 'custom')
 	}
 
 	_recoverLoginVisible(): boolean {

--- a/src/login/LoginViewController.js
+++ b/src/login/LoginViewController.js
@@ -26,7 +26,6 @@ import {deviceConfig} from "../misc/DeviceConfig"
 import {client} from "../misc/ClientDetector"
 import {secondFactorHandler} from "../misc/SecondFactorHandler"
 import {showProgressDialog} from "../gui/ProgressDialog"
-import {themeId} from "../gui/theme"
 import {CancelledError} from "../api/common/error/CancelledError"
 import {notifications} from "../gui/Notifications"
 import {isMailAddress} from "../misc/FormatValidator"
@@ -41,6 +40,7 @@ import {ButtonType} from "../gui/base/ButtonN"
 import {isNotificationCurrentlyActive, loadOutOfOfficeNotification} from "../api/main/OutOfOfficeNotificationUtils"
 import type {OutOfOfficeNotification} from "../api/entities/tutanota/OutOfOfficeNotification"
 import {showMoreStorageNeededOrderDialog} from "../misc/SubscriptionDialogs"
+import {themeManager} from "../gui/theme"
 
 assertMainOrNode()
 
@@ -67,7 +67,7 @@ export class LoginViewController implements ILoginViewController {
 		if (isApp()) {
 			worker.initialized.then(() => {
 
-				themeId.map((theme) => {
+				themeManager.themeIdChangedStream.map((theme) => {
 					import("../native/main/SystemApp").then(({changeColorTheme}) => changeColorTheme(theme))
 				})
 			})

--- a/src/misc/DeviceConfig.js
+++ b/src/misc/DeviceConfig.js
@@ -16,7 +16,7 @@ export const defaultThemeId: ThemeId = 'light'
 /**
  * Device config for internal user auto login. Only one config per device is stored.
  */
-class DeviceConfig {
+export class DeviceConfig {
 	_version: number;
 	_credentials: Credentials[];
 	_scheduledAlarmUsers: Id[];

--- a/src/settings/AppearanceSettingsViewer.js
+++ b/src/settings/AppearanceSettingsViewer.js
@@ -6,7 +6,6 @@ import type {DropDownSelectorAttrs} from "../gui/base/DropDownSelectorN"
 import {DropDownSelectorN} from "../gui/base/DropDownSelectorN"
 import stream from "mithril/stream/stream.js"
 import {deviceConfig} from "../misc/DeviceConfig"
-import {setThemeId, themeId} from "../gui/theme"
 import type {TimeFormatEnum, WeekStartEnum} from "../api/common/TutanotaConstants"
 import {TimeFormat, WeekStart} from "../api/common/TutanotaConstants"
 import {logins} from "../api/main/LoginController"
@@ -20,6 +19,7 @@ import {getHourCycle} from "../misc/Formatter"
 import {Mode} from "../api/common/Env"
 import type {LanguageCode} from "../misc/LanguageViewModel"
 import type {ThemeId} from "../gui/theme"
+import {themeManager} from "../gui/theme"
 
 
 export class AppearanceSettingsViewer implements UpdatableSettingsViewer {
@@ -49,9 +49,12 @@ export class AppearanceSettingsViewer implements UpdatableSettingsViewer {
 
 		const themeDropDownAttrs: DropDownSelectorAttrs<ThemeId> = {
 			label: "switchColorTheme_action",
-			items: [{name: lang.get("light_label"), value: "light"}, {name: lang.get("dark_label"), value: "dark"}, {name: lang.get("blue_label"), value: "blue"}],
-			selectedValue: themeId,
-			selectionChangedHandler: (value) => setThemeId(value)
+			items: [
+				{name: lang.get("light_label"), value: "light"}, {name: lang.get("dark_label"), value: "dark"},
+				{name: lang.get("blue_label"), value: "blue"}
+			],
+			selectedValue: stream(themeManager.themeId),
+			selectionChangedHandler: (value) => themeManager.setThemeId(value)
 		}
 
 		const userSettingsGroupRoot = logins.getUserController().userSettingsGroupRoot
@@ -91,7 +94,7 @@ export class AppearanceSettingsViewer implements UpdatableSettingsViewer {
 		return m(".fill-absolute.scroll.plr-l.pb-xl", [
 			m(".h4.mt-l", lang.get('settingsForDevice_label')),
 			m(DropDownSelectorN, languageDropDownAttrs),
-			themeId() === 'custom' ? null : m(DropDownSelectorN, themeDropDownAttrs),
+			(themeManager.themeId === 'custom') ? null : m(DropDownSelectorN, themeDropDownAttrs),
 			m(".h4.mt-l", lang.get('userSettings_label')),
 			m(DropDownSelectorN, hourFormatDropDownAttrs),
 			m(DropDownSelectorN, weekStartDropDownAttrs),

--- a/src/settings/EditCustomColorsDialog.js
+++ b/src/settings/EditCustomColorsDialog.js
@@ -5,7 +5,7 @@ import {assertMainOrNode} from "../api/common/Env"
 import {Dialog} from "../gui/base/Dialog"
 import {ButtonType} from "../gui/base/ButtonN"
 import type {Theme} from "../gui/theme"
-import {defaultTheme, theme, updateCustomTheme} from "../gui/theme"
+import {theme, themeManager} from "../gui/theme"
 import type {DialogHeaderBarAttrs} from "../gui/base/DialogHeaderBar"
 import {update} from "../api/main/Entity"
 import {Keys} from "../api/common/TutanotaConstants"
@@ -20,7 +20,7 @@ assertMainOrNode()
 let COLOR_FORMAT = new RegExp("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
 
 export function show(themeToEdit: Theme, onThemeChanged: (Theme) => mixed) {
-	const colorFieldsAttrs = Object.keys(defaultTheme)
+	const colorFieldsAttrs = Object.keys(themeManager.getDefaultTheme())
 	                               .filter(name => name !== "logo")
 	                               .sort((a, b) => a.localeCompare(b))
 	                               .map(colorName => {
@@ -116,13 +116,13 @@ function _getDefaultColorLine(field: TextFieldAttrs): Child {
 	if (!field.value().trim() || colorValue) {
 		let colorName = (field: any).label()
 		return m(".small.flex-space-between", [
-			m("", lang.get("defaultColor_label", {"{1}": defaultTheme[colorName]})),
+			m("", lang.get("defaultColor_label", {"{1}": themeManager.getDefaultTheme()[colorName]})),
 			m("", {
 				style: {
 					width: '100px',
 					height: '10px',
 					"margin-top": "2px",
-					"background-color": defaultTheme[colorName]
+					"background-color": themeManager.getDefaultTheme()[colorName]
 				}
 			})
 		])

--- a/src/settings/whitelabel/WhitelabelSettingsViewer.js
+++ b/src/settings/whitelabel/WhitelabelSettingsViewer.js
@@ -15,7 +15,6 @@ import {HttpMethod} from "../../api/common/EntityFunctions"
 import type {WhitelabelConfig} from "../../api/entities/sys/WhitelabelConfig"
 import {WhitelabelConfigTypeRef} from "../../api/entities/sys/WhitelabelConfig"
 import type {Theme} from "../../gui/theme"
-import {updateCustomTheme} from "../../gui/theme"
 import {progressIcon} from "../../gui/base/Icon"
 import {showProgressDialog} from "../../gui/ProgressDialog"
 import type {Booking} from "../../api/entities/sys/Booking"
@@ -43,6 +42,7 @@ import {WhitelabelCustomMetaTagsSettings} from "./WhitelabelCustomMetaTagsSettin
 import {WhitelabelStatusSettings} from "./WhitelabelStatusSettings"
 import {WhitelabelNotificationEmailSettings} from "./WhitelabelNotificationEmailSettings"
 import {WhitelabelGermanLanguageFileSettings} from "./WhitelabelGermanLanguageFileSettings"
+import {themeManager} from "../../gui/theme"
 
 assertMainOrNode()
 
@@ -142,7 +142,7 @@ export class WhitelabelSettingsViewer implements UpdatableSettingsViewer {
 		const onThemeChanged = (theme) => {
 			neverNull(this._whitelabelConfig).jsonTheme = JSON.stringify(theme)
 			update(neverNull(this._whitelabelConfig))
-			updateCustomTheme(theme)
+			themeManager.updateCustomTheme(theme)
 		}
 
 		const whitelabelThemeSettingsAttrs = {


### PR DESCRIPTION
We were managing themes via top level functions that operate on globals, which was confusing and error prone. Now we have a single point of access

We keep the global theme singleton for convenience

 fix #3030