### PR TITLE
fix display of large event names in preview

### DIFF
--- a/src/calendar/view/EventPreviewView.js
+++ b/src/calendar/view/EventPreviewView.js
@@ -1,16 +1,16 @@
 //@flow
 import type {CalendarEvent} from "../../api/entities/tutanota/CalendarEvent"
 import m from "mithril"
+import type {AllIconsEnum} from "../../gui/base/Icon"
 import {Icon} from "../../gui/base/Icon"
 import {theme} from "../../gui/theme"
 import {BootIcons} from "../../gui/base/icons/BootIcons"
 import {Icons} from "../../gui/base/icons/Icons"
 import {iconForAttendeeStatus} from "./CalendarEventEditDialog"
 import {formatEventDuration, getTimeZone} from "../date/CalendarUtils"
-import {attendeeStatusByCode, getAttendeeStatus} from "../../api/common/TutanotaConstants"
+import {getAttendeeStatus} from "../../api/common/TutanotaConstants"
 import {memoized} from "../../api/common/utils/Utils"
 import type {CalendarEventAttendee} from "../../api/entities/tutanota/CalendarEventAttendee"
-import type {AllIconsEnum} from "../../gui/base/Icon"
 
 export type Attrs = {
 	event: CalendarEvent,
@@ -32,7 +32,14 @@ export class EventPreviewView implements MComponent<Attrs> {
 
 		return m(".flex.col", [
 			m(".flex.col.smaller", [
-				m(".flex.pb-s.items-center", [this._renderSectionIndicator(BootIcons.Calendar), m(".h3.selectable.text-break", event.summary)]),
+				m(".flex.pb-s.items-center", [
+					this._renderSectionIndicator(BootIcons.Calendar),
+					m(".h3.selectable.text-wrap.scroll-no-overlay", {
+						style: {
+							maxHeight: "3em",
+						}
+					}, event.summary)
+				]),
 				m(".flex.pb-s.items-center", [
 						this._renderSectionIndicator(Icons.Time),
 						m(".align-self-center.selectable", formatEventDuration(event, getTimeZone(), false))
@@ -58,7 +65,11 @@ export class EventPreviewView implements MComponent<Attrs> {
 					? m(".flex.pb-s.items-start", [
 						this._renderSectionIndicator(Icons.AlignLeft, {marginTop: "2px"}),
 						limitDescriptionHeight
-							? m(".scroll.visible-scrollbar.full-width.selectable", {style: {maxHeight: "100px"}}, m.trust(sanitizedDescription))
+							? m(".scroll-no-overlay.full-width.selectable.text-wrap", {
+								style: {
+									maxHeight: "100px"
+								}
+							}, m.trust(sanitizedDescription))
 							: m(".selectable", m.trust(sanitizedDescription))
 					])
 					: null,

--- a/src/calendar/view/EventPreviewView.js
+++ b/src/calendar/view/EventPreviewView.js
@@ -34,7 +34,7 @@ export class EventPreviewView implements MComponent<Attrs> {
 			m(".flex.col.smaller", [
 				m(".flex.pb-s.items-center", [
 					this._renderSectionIndicator(BootIcons.Calendar),
-					m(".h3.selectable.text-wrap.scroll-no-overlay", {
+					m(".h3.selectable.text-break.scroll-no-overlay", {
 						style: {
 							maxHeight: "3em",
 						}
@@ -65,7 +65,7 @@ export class EventPreviewView implements MComponent<Attrs> {
 					? m(".flex.pb-s.items-start", [
 						this._renderSectionIndicator(Icons.AlignLeft, {marginTop: "2px"}),
 						limitDescriptionHeight
-							? m(".scroll-no-overlay.full-width.selectable.text-wrap", {
+							? m(".scroll-no-overlay.full-width.selectable.text-break", {
 								style: {
 									maxHeight: "100px"
 								}

--- a/src/gui/main-styles.js
+++ b/src/gui/main-styles.js
@@ -270,8 +270,7 @@ styles.registerStyle('main', () => {
 		// common setting
 		'.text-ellipsis': {overflow: 'hidden', 'text-overflow': 'ellipsis', 'min-width': 0, 'white-space': 'nowrap'},
 		'.min-width-0': {'min-width': 0},
-		'.text-break': {overflow: 'hidden', 'word-break': 'break-word'},
-		'.text-wrap': {overflow: 'hidden', 'word-wrap': 'break-word'},
+		'.text-break': {overflow: 'hidden', 'overflow-wrap': 'break-word'},
 		'.break-word-links a': {'word-wrap': 'break-word'},
 		'.text-prewrap': {'white-space': 'pre-wrap'},
 		'.text-preline': {'white-space': 'pre-line'},

--- a/src/gui/main-styles.js
+++ b/src/gui/main-styles.js
@@ -271,6 +271,7 @@ styles.registerStyle('main', () => {
 		'.text-ellipsis': {overflow: 'hidden', 'text-overflow': 'ellipsis', 'min-width': 0, 'white-space': 'nowrap'},
 		'.min-width-0': {'min-width': 0},
 		'.text-break': {overflow: 'hidden', 'word-break': 'break-word'},
+		'.text-wrap': {overflow: 'hidden', 'word-wrap': 'break-word'},
 		'.break-word-links a': {'word-wrap': 'break-word'},
 		'.text-prewrap': {'white-space': 'pre-wrap'},
 		'.text-preline': {'white-space': 'pre-line'},


### PR DESCRIPTION
We now will show up to two lines of text for the title, and any more will be scrollable.

Also, disable horizontal scrolling for the description field and use `word-wrap: break-word` instead. 

![Screenshot from 2021-05-17 14-17-35](https://user-images.githubusercontent.com/22109738/118487543-1c327180-b71b-11eb-970d-01fa465f1f47.png)

fix #2899