### PR TITLE
Defer rendering mail body until viewSlider animation is over.

### DIFF
--- a/src/gui/base/ViewSlider.js
+++ b/src/gui/base/ViewSlider.js
@@ -257,8 +257,8 @@ export class ViewSlider implements IViewSlider {
 	}
 
 
-	focus(viewColumn: ViewColumn) {
-		this._busy.then(() => {
+	focus(viewColumn: ViewColumn): Promise<void> {
+		return this._busy.then(() => {
 			// hide the foreground column if the column is in foreground
 			if (this.focusedColumn.isInForeground) {
 				this._busy = this._slideForegroundColumn(this.focusedColumn, false)

--- a/src/mail/view/MailViewer.js
+++ b/src/mail/view/MailViewer.js
@@ -119,6 +119,7 @@ import {ActionBanner} from "../../gui/base/icons/ActionBanner"
 import type {Link} from "../../misc/HtmlSanitizer"
 import {stringifyFragment} from "../../gui/HtmlUtils"
 import {IndexingNotSupportedError} from "../../api/common/error/IndexingNotSupportedError"
+import {delay} from "../../api/common/utils/PromiseUtils"
 
 assertMainOrNode()
 
@@ -176,8 +177,11 @@ export class MailViewer {
 	_entityClient: EntityClient;
 	_mailModel: MailModel;
 	_contactModel: ContactModel;
+	_delayBodyRenderingUntil: Promise<*>
 
-	constructor(mail: Mail, showFolder: boolean, entityClient: EntityClient, mailModel: MailModel, contactModel: ContactModel) {
+	constructor(mail: Mail, showFolder: boolean, entityClient: EntityClient, mailModel: MailModel, contactModel: ContactModel,
+	            delayBodyRenderingUntil: Promise<*>) {
+		this._delayBodyRenderingUntil = delayBodyRenderingUntil
 		if (isDesktop()) {
 			import("../../native/common/NativeWrapper").then(({nativeApp}) =>
 				nativeApp.invokeNative(new Request('sendSocketMessage', [{mailAddress: mail.sender.address}])))
@@ -252,6 +256,13 @@ export class MailViewer {
 			this._entityClient.load(ConversationEntryTypeRef, mail.conversationEntry)
 			    .catch(NotFoundError, e => console.log("could load conversation entry as it has been moved/deleted already", e))
 		})
+
+		let delayIsOver = false
+		delayBodyRenderingUntil
+			.then(() => {
+				delayIsOver = true
+				m.redraw()
+			})
 
 		this.view = () => {
 			const dateTime = formatDateWithWeekday(this.mail.receivedDate) + " • " + formatTime(this.mail.receivedDate)
@@ -354,7 +365,7 @@ export class MailViewer {
 									}
 								},
 							},
-							this.renderMailBodySection()
+							delayIsOver ? this.renderMailBodySection() : null
 						)
 					],
 				),
@@ -866,6 +877,9 @@ export class MailViewer {
 		                                                .catch(e => false)
 		const isAllowedAndAuthenticatedExternalSender = isAllowListedExternalSender
 			&& mail.authStatus === MailAuthenticationStatus.AUTHENTICATED
+
+		// We should not try to sanitize body while we still animate because it's a heavy operation.
+		await this._delayBodyRenderingUntil
 
 		const sanitizeResult = await this.setSanitizedMailBodyFromMail(mail, !isAllowedAndAuthenticatedExternalSender)
 

--- a/src/search/view/SearchResultDetailsViewer.js
+++ b/src/search/view/SearchResultDetailsViewer.js
@@ -55,7 +55,7 @@ export class SearchResultDetailsViewer {
 	showEntity(entity: Object, entitySelected: boolean): void {
 		if (isSameTypeRef(MailTypeRef, entity._type)) {
 			let mail = ((entity: any): Mail)
-			this._viewer = new MailViewer(mail, true, locator.entityClient, locator.mailModel, locator.contactModel)
+			this._viewer = new MailViewer(mail, true, locator.entityClient, locator.mailModel, locator.contactModel, Promise.resolve())
 			this._viewerEntityId = mail._id
 			if (entitySelected && mail.unread && !mail._errors) {
 				mail.unread = false


### PR DESCRIPTION
This avoids big frame losses by separating re-layouts. ViewSlider
animations trigger layout and showing/scaling mail body does too.