### PR TITLE
Handle SecurityError when using ServiceWorker and localStorage

### DIFF
--- a/flow/core_missing.js
+++ b/flow/core_missing.js
@@ -1,0 +1,52 @@
+// @flow
+
+/**
+ * Declarations of browser APIs that aren't declared by flow
+ */
+
+/** DOMException that can be thrown by the browser
+ * https://developer.mozilla.org/en-US/docs/Web/API/DOMException/DOMException
+ *
+ * flow doesn't declare it for some reason
+ */
+declare class DOMException {
+
+	constructor(message?: string, name?: string): DOMException;
+
+	+message: string;
+
+	// possible name values:
+	// https://developer.mozilla.org/en-US/docs/Web/API/DOMException#error_names
+	+name: "SecurityError";
+
+	/** @deprecated use {@code DOMException.name} instead */
+	+code: number;
+
+	// Legacy constants for values of DOMException.code
+	+ABORT_ERR: number;
+	+DATA_CLONE_ERR: number;
+	+DOMSTRING_SIZE_ERR: number;
+	+HIERARCHY_REQUEST_ERR: number;
+	+INDEX_SIZE_ERR: number;
+	+INUSE_ATTRIBUTE_ERR: number;
+	+INVALID_ACCESS_ERR: number;
+	+INVALID_CHARACTER_ERR: number;
+	+INVALID_MODIFICATION_ERR: number;
+	+INVALID_NODE_TYPE_ERR: number;
+	+INVALID_STATE_ERR: number;
+	+NAMESPACE_ERR: number;
+	+NETWORK_ERR: number;
+	+NOT_FOUND_ERR: number;
+	+NOT_SUPPORTED_ERR: number;
+	+NO_DATA_ALLOWED_ERR: number;
+	+NO_MODIFICATION_ALLOWED_ERR: number;
+	+QUOTA_EXCEEDED_ERR: number;
+	+SECURITY_ERR: number;
+	+SYNTAX_ERR: number;
+	+TIMEOUT_ERR: number;
+	+TYPE_MISMATCH_ERR: number;
+	+URL_MISMATCH_ERR: number;
+	+VALIDATION_ERR: number;
+	+WRONG_DOCUMENT_ERR: number;
+}
+

--- a/src/api/common/utils/Utils.js
+++ b/src/api/common/utils/Utils.js
@@ -516,3 +516,7 @@ export function mapNullable<T, U>(val: ?T, action: T => U): U | null {
 		? action(val)
 		: null
 }
+
+export function isSecurityError(e: any): boolean {
+	return e instanceof DOMException && (e.name === "SecurityError" || e.code === e.SECURITY_ERR)
+}

--- a/src/misc/ClientDetector.js
+++ b/src/misc/ClientDetector.js
@@ -164,8 +164,12 @@ class ClientDetector {
 	}
 
 	localStorage(): boolean {
-		return typeof localStorage !== "undefined"
-
+		try {
+			return typeof localStorage !== "undefined"
+		} catch (e) {
+			// DOMException is thrown if all cookies are disabled
+			return false
+		}
 	}
 
 	/**

--- a/src/misc/DeviceConfig.js
+++ b/src/misc/DeviceConfig.js
@@ -146,6 +146,7 @@ export class DeviceConfig {
 			localStorage.setItem(LocalStorageKey, JSON.stringify(this))
 		} catch (e) {
 			// may occur in Safari < 11 in incognito mode because it throws a QuotaExceededError
+			// DOMException will occurr if all cookies are disabled
 			console.log("could not store config", e)
 		}
 	}

--- a/src/serviceworker/ServiceWorkerClient.js
+++ b/src/serviceworker/ServiceWorkerClient.js
@@ -86,6 +86,18 @@ export function init() {
 					             }
 				             )
 			             })
+			             .catch(e => {
+				             console.warn("Failed to register the service worker:", e.message)
+
+				             // We get a rejection when trying to register the service worker in firefox with security settings like
+				             // "Delete cookies and site data and site data when Firefox is closed" enabled
+				             // Ignore this case but still allow other cases to show an error dialog
+				             const isSecurityError = e instanceof DOMException && e.name === "SecurityError" || e.code === e.SECURITY_ERR
+
+				             if (!isSecurityError) {
+					             throw e
+				             }
+			             })
 		}
 	} else {
 		console.log("ServiceWorker is not supported")

--- a/src/serviceworker/ServiceWorkerClient.js
+++ b/src/serviceworker/ServiceWorkerClient.js
@@ -4,7 +4,7 @@ import {lang} from "../misc/LanguageViewModel"
 import {windowFacade} from "../misc/WindowFacade"
 import m from "mithril"
 import {handleUncaughtError} from "../misc/ErrorHandler"
-import {objToError} from "../api/common/utils/Utils";
+import {isSecurityError, objToError} from "../api/common/utils/Utils";
 
 assertMainOrNodeBoot()
 
@@ -92,9 +92,7 @@ export function init() {
 				             // We get a rejection when trying to register the service worker in firefox with security settings like
 				             // "Delete cookies and site data and site data when Firefox is closed" enabled
 				             // Ignore this case but still allow other cases to show an error dialog
-				             const isSecurityError = e instanceof DOMException && e.name === "SecurityError" || e.code === e.SECURITY_ERR
-
-				             if (!isSecurityError) {
+				             if (!isSecurityError(e)) {
 					             throw e
 				             }
 			             })


### PR DESCRIPTION
We handle SecurityErrors when trying to register the ServiceWorker, as these can be thrown when specific browser settings are enabled

fix #3107