### PR TITLE
Fix loading calendar events for the next month

### DIFF
--- a/src/calendar/view/CalendarView.js
+++ b/src/calendar/view/CalendarView.js
@@ -295,13 +295,15 @@ export class CalendarView implements CurrentView {
 		this._calendarInfos = locator.calendarModel.loadOrCreateCalendarInfo(progressMonitor).tap(m.redraw)
 
 		this.selectedDate.map((d) => {
-			const previousMonthDate = new Date(d)
-			previousMonthDate.setMonth(d.getMonth() - 1)
+			const thisMonthStart = getMonth(d, getTimeZone()).start
 
-			const nextMonthDate = new Date(d)
-			nextMonthDate.setMonth(d.getMonth() + 1)
+			const previousMonthDate = new Date(thisMonthStart)
+			previousMonthDate.setMonth(thisMonthStart.getMonth() - 1)
 
-			this._loadMonthIfNeeded(d)
+			const nextMonthDate = new Date(thisMonthStart)
+			nextMonthDate.setMonth(thisMonthStart.getMonth() + 1)
+
+			this._loadMonthIfNeeded(thisMonthStart)
 			    .then(() => progressMonitor.workDone(1))
 			    .then(() => this._loadMonthIfNeeded(nextMonthDate))
 			    .then(() => progressMonitor.workDone(1))


### PR DESCRIPTION
The issue was that we've been calculating previous/next month based on
the current date and not on the start of the month. This means that on
31st of the month we would do dateOn31st+oneMonth and we would skip the
next month entirely. This is tricky to reproduce because calendar must
be opened directly on the date.

fix #3136