### PR TITLE
Fix attaching files on mobile

### DIFF
--- a/src/mail/editor/MailEditorViewModel.js
+++ b/src/mail/editor/MailEditorViewModel.js
@@ -39,8 +39,10 @@ import type {ContactModel} from "../../contacts/model/ContactModel"
 
 export function chooseAndAttachFile(model: SendMailModel, boundingRect: ClientRect, fileTypes?: Array<string>): Promise<?$ReadOnlyArray<FileReference | DataFile>> {
 	return showFileChooserForAttachments(boundingRect, fileTypes)
-		.then(files => {
-			model.attachFiles((files: any))
+		.then(async files => {
+			if (files) {
+				model.attachFiles(files)
+			}
 			return files
 		}).catch(UserError, showUserError)
 }

--- a/src/native/common/FileApp.js
+++ b/src/native/common/FileApp.js
@@ -3,6 +3,7 @@ import {nativeApp} from "./NativeWrapper"
 import {Request} from "../../api/common/WorkerProtocol"
 import {uint8ArrayToBase64} from "../../api/common/utils/Encoding"
 import type {MailBundle} from "../../mail/export/Bundler";
+import {promiseMap} from "../../api/common/utils/PromiseUtils"
 
 
 export const fileApp = {
@@ -48,7 +49,7 @@ function openFileChooser(boundingRect: ClientRect): Promise<Array<FileReference>
 	}
 
 	return nativeApp.invokeNative(new Request("openFileChooser", [srcRect, false]))
-	                .then((response) => response.map(uriToFileRef))
+	                .then((response: Array<string>) => promiseMap(response, uriToFileRef))
 }
 
 function openFolderChooser(): Promise<Array<string>> {


### PR DESCRIPTION
Promise.prototype.map() was replaced by Array.prototype.map() and was
not type-checked.

 fix #3138