### PR TITLE
show current index date when field is empty in DatePickerDialog

### DIFF
--- a/src/gui/date/DatePicker.js
+++ b/src/gui/date/DatePicker.js
@@ -4,7 +4,7 @@ import stream from "mithril/stream/stream.js"
 import {Icons} from "../base/icons/Icons"
 import {client} from "../../misc/ClientDetector"
 import {formatDate, formatDateWithWeekdayAndYear, formatMonthWithFullYear} from "../../misc/Formatter"
-import type {TranslationKey} from "../../misc/LanguageViewModel"
+import type {TranslationKey, TranslationText} from "../../misc/LanguageViewModel"
 import {lang} from "../../misc/LanguageViewModel"
 import {px} from "../size"
 import {theme} from "../theme"
@@ -37,10 +37,10 @@ export class DatePicker implements MComponent<void> {
 	_showingDropdown: boolean;
 	_disabled: boolean;
 	_label: TranslationKey | lazy<string>
-	_nullSelectionHelpLabel: TranslationKey
+	_nullSelectionHelpLabel: TranslationText
 	_domInput: ?HTMLElement
 
-	constructor(startOfTheWeekOffset: number, labelTextIdOrTextFunction: TranslationKey | lazy<string>, nullSelectionTextId: TranslationKey = "emptyString_msg", disabled: boolean = false, dateStream?: Stream<?Date>) {
+	constructor(startOfTheWeekOffset: number, labelTextIdOrTextFunction: TranslationKey | lazy<string>, nullSelectionTextId: TranslationText = "emptyString_msg", disabled: boolean = false, dateStream?: Stream<?Date>) {
 		this.date = dateStream ? dateStream : stream(null)
 		const initDate = this.date()
 		this._dateString = stream(initDate ? formatDate(initDate) : "")
@@ -79,7 +79,7 @@ export class DatePicker implements MComponent<void> {
 			} else if (this.date() != null) {
 				return formatDateWithWeekdayAndYear(neverNull(this.date()))
 			} else {
-				return lang.get(this._nullSelectionHelpLabel)
+				return lang.getMaybeLazy(this._nullSelectionHelpLabel)
 			}
 		}
 

--- a/src/gui/date/DatePickerDialog.js
+++ b/src/gui/date/DatePickerDialog.js
@@ -6,6 +6,7 @@ import {lang} from "../../misc/LanguageViewModel"
 import {DatePicker} from "./DatePicker"
 import {px} from "../size"
 import {client} from "../../misc/ClientDetector"
+import {formatDateWithWeekdayAndYear} from "../../misc/Formatter"
 
 assertMainOrNode()
 
@@ -13,15 +14,16 @@ assertMainOrNode()
  * Shows a dialog in which the user can select a start date and an end date. Start and end date does not need to be selected, then they are null and regarded as unlimited.
  */
 export function showDatePickerDialog<T>(startOfTheWeekOffset: number, start: ?Date, end: ?Date): Promise<{start: ?Date, end: ?Date}> {
-	let dateStart = new DatePicker(startOfTheWeekOffset, "dateFrom_label", "unlimited_label")
+	const helpLabel = (date) => date != null ? () => formatDateWithWeekdayAndYear(date) : "unlimited_label"
+	const dateStart = new DatePicker(startOfTheWeekOffset, "dateFrom_label", helpLabel(start))
 	if (start) {
 		dateStart.setDate(start)
 	}
-	let dateEnd = new DatePicker(startOfTheWeekOffset, "dateTo_label", "unlimited_label")
+	const dateEnd = new DatePicker(startOfTheWeekOffset, "dateTo_label", helpLabel(end))
 	if (end) {
 		dateEnd.setDate(end)
 	}
-	let form = {
+	const form = {
 		view: () => m(".flex-space-between",
 			client.isDesktopDevice() ? {style: {height: px(305)}} : {}, [
 				m(".pr-s.flex-grow.max-width-200.flex-space-between.flex-column", m(dateStart)),


### PR DESCRIPTION
fix #3110

If one of the date fields was empty we were showing "unlimited", but it would actually be interpreted as "whatever it already is" now we only show "unlimited" when the user actually has indexed their entire mailbox