### PR TITLE
Don't focus subject bar when toggling formatting toolbar

### DIFF
--- a/src/mail/editor/MailEditor.js
+++ b/src/mail/editor/MailEditor.js
@@ -294,7 +294,13 @@ export class MailEditor implements MComponent<MailEditorAttrs> {
 			? m(ButtonN, {
 				label: 'showRichTextToolbar_action',
 				icon: () => Icons.FontSize,
-				click: () => a.doShowToolbar(!a.doShowToolbar()),
+				click: (event) => {
+					a.doShowToolbar(!a.doShowToolbar())
+
+					// Stop the subject bar from being focused
+					event.stopPropagation()
+					this.editor.focus()
+				},
 				isSelected: a.doShowToolbar,
 				noRecipientInfoBubble: true
 			})


### PR DESCRIPTION
This will now focus the editor whenever you toggle the formatting
toolbar, even if the editor wasn't already focused. This is
most likely what you want 9 times out of 10 anyway.

fix #3036