### PR TITLE
[desktop] seed prng when loading it, close #3155

### DIFF
--- a/src/api/worker/WorkerImpl.js
+++ b/src/api/worker/WorkerImpl.js
@@ -25,7 +25,6 @@ import type {WebsocketCounterData} from "../entities/sys/WebsocketCounterData"
 import type {ProgressMonitorId} from "../common/utils/ProgressMonitor";
 import type {WebsocketLeaderStatus} from "../entities/sys/WebsocketLeaderStatus"
 import type {User} from "../entities/sys/User"
-import linkifyHtml from "linkify/html"
 import {urlify} from "./Urlifier"
 
 
@@ -402,7 +401,7 @@ export class WorkerImpl {
 	 * @param entropy
 	 * @returns {Promise.<void>}
 	 */
-	addEntropy(entropy: {source: EntropySrcEnum, entropy: number, data: number}[]): Promise<void> {
+	addEntropy(entropy: {source: EntropySrcEnum, entropy: number, data: number | Array<number>}[]): Promise<void> {
 		try {
 			return random.addEntropy(entropy)
 		} finally {

--- a/src/api/worker/crypto/Randomizer.js
+++ b/src/api/worker/crypto/Randomizer.js
@@ -15,7 +15,7 @@ class Randomizer {
 		this.random = new sjcl.prng(6)
 	}
 
-	addEntropy(entropyCache: Array<{source: EntropySrcEnum, entropy: number, data: number}>): Promise<void> {
+	addEntropy(entropyCache: Array<{source: EntropySrcEnum, entropy: number, data: number | Array<number>}>): Promise<void> {
 		entropyCache.forEach(entry => {
 			this.random.addEntropy(entry.data, entry.entropy, entry.source)
 		})

--- a/src/desktop/CryptoFns.js
+++ b/src/desktop/CryptoFns.js
@@ -12,6 +12,21 @@ import {decryptAndMapToInstance} from "../api/worker/crypto/InstanceMapper"
 import {EntropySrc} from "../api/common/TutanotaConstants"
 import {random} from "../api/worker/crypto/Randomizer"
 
+{
+	// the prng throws if it doesn't have enough entropy
+	// it may be called very early, so we need to seed it
+	// we do it here because it's the first place in the dep. chain that knows it's
+	// in node but the last one that knows the prng implementation
+	const entropy = crypto.randomBytes(128)
+	random.addEntropy([
+		{
+			source: EntropySrc.random,
+			entropy: 128 * 8,
+			data: Array.from(entropy)
+		}
+	]).then()
+}
+
 export interface CryptoFunctions {
 	aes128Decrypt(key: Aes128Key, encryptedBytes: Uint8Array, usePadding: boolean): Uint8Array;
 

--- a/src/desktop/CryptoFns.js
+++ b/src/desktop/CryptoFns.js
@@ -17,14 +17,18 @@ import {random} from "../api/worker/crypto/Randomizer"
 	// it may be called very early, so we need to seed it
 	// we do it here because it's the first place in the dep. chain that knows it's
 	// in node but the last one that knows the prng implementation
-	const entropy = crypto.randomBytes(128)
-	random.addEntropy([
-		{
-			source: EntropySrc.random,
-			entropy: 128 * 8,
-			data: Array.from(entropy)
-		}
-	]).then()
+	const seed = () => {
+		const entropy = crypto.randomBytes(128)
+		random.addEntropy([
+			{
+				source: EntropySrc.random,
+				entropy: 128 * 8,
+				data: Array.from(entropy)
+			}
+		]).then()
+	}
+	seed()
+	// TODO: add entropy periodically
 }
 
 export interface CryptoFunctions {

--- a/src/desktop/DesktopCryptoFacade.js
+++ b/src/desktop/DesktopCryptoFacade.js
@@ -8,10 +8,8 @@ import {
 	utf8Uint8ArrayToString
 } from "../api/common/utils/Encoding"
 import type {CryptoFunctions} from "./CryptoFns"
+import {cryptoFns} from "./CryptoFns"
 import {IV_BYTE_LENGTH} from "../api/worker/crypto/Aes"
-import crypto from "crypto"
-import {random} from "../api/worker/crypto/Randomizer"
-import {EntropySrc} from "../api/common/TutanotaConstants"
 
 
 export class DesktopCryptoFacade {
@@ -21,7 +19,6 @@ export class DesktopCryptoFacade {
 	constructor(fs: $Exports<"fs">, cryptoFns: CryptoFunctions) {
 		this.fs = fs
 		this.cryptoFns = cryptoFns
-		this._addEntropy()
 	}
 
 	aesEncryptObject(encryptionKey: Aes256Key, object: number | string | boolean | $ReadOnlyArray<*> | {}): string {
@@ -100,11 +97,7 @@ export class DesktopCryptoFacade {
 		return this.cryptoFns.aes256RandomKey()
 	}
 
-	_addEntropy() {
-		const valueList = crypto.randomBytes(16 * 32)
-		for (let i = 0; i < valueList.length; i++) {
-			// 8 because we have byte values
-			random.addEntropy([{source: EntropySrc.random, entropy: 8, data: valueList[i]}])
-		}
+	randomBytes(count: number): Uint8Array {
+		return cryptoFns.randomBytes(count)
 	}
 }

--- a/src/desktop/DesktopMain.js
+++ b/src/desktop/DesktopMain.js
@@ -32,11 +32,11 @@ import child_process from "child_process"
 import {LocalShortcutManager} from "./electron-localshortcut/LocalShortcut"
 import {cryptoFns} from "./CryptoFns"
 import {DesktopConfigMigrator} from "./config/migrations/DesktopConfigMigrator"
+import type {DeviceKeyProvider} from "./DeviceKeyProviderImpl"
 import {DeviceKeyProviderImpl} from "./DeviceKeyProviderImpl"
 import {AlarmSchedulerImpl} from "../calendar/date/AlarmScheduler"
 import {SchedulerImpl} from "../misc/Scheduler"
 import {DateProviderImpl} from "../calendar/date/CalendarUtils"
-import type {DeviceKeyProvider} from "./DeviceKeyProviderImpl"
 
 mp()
 
@@ -75,12 +75,18 @@ if (opts.registerAsMailHandler && opts.unregisterAsMailHandler) {
 	//register as mailto handler, then quit
 	DesktopUtils.registerAsMailtoHandler(false)
 	            .then(() => app.exit(0))
-	            .catch(() => app.exit(1))
+	            .catch(e => {
+		            log.error("there was a problem with registering as default mail app:", e)
+		            app.exit(1)
+	            })
 } else if (opts.unregisterAsMailHandler) {
 	//unregister as mailto handler, then quit
 	DesktopUtils.unregisterAsMailtoHandler(false)
 	            .then(() => app.exit(0))
-	            .catch(() => app.exit(1))
+	            .catch(e => {
+		            log.error("there was a problem with unregistering as default mail app:", e)
+		            app.exit(1)
+	            })
 } else {
 	createComponents().then(startupInstance)
 }

--- a/test/client/desktop/DesktopCryptoFacadeTest.js
+++ b/test/client/desktop/DesktopCryptoFacadeTest.js
@@ -3,9 +3,7 @@ import n from "../nodemocker"
 import o from "ospec"
 import {DesktopCryptoFacade} from "../../../src/desktop/DesktopCryptoFacade"
 import {stringToUtf8Uint8Array, uint8ArrayToBase64} from "../../../src/api/common/utils/Encoding"
-import {aes128Encrypt, aes128RandomKey, IV_BYTE_LENGTH} from "../../../src/api/worker/crypto/Aes"
 import {keyToBase64, uint8ArrayToBitArray} from "../../../src/api/worker/crypto/CryptoUtils"
-import {random} from "../../../src/api/worker/crypto/Randomizer"
 import {arrayEquals} from "../../../src/api/common/utils/ArrayUtils"
 import {downcast} from "../../../src/api/common/utils/Utils"
 import type {CryptoFunctions} from "../../../src/desktop/CryptoFns"
@@ -64,8 +62,8 @@ o.spec("DesktopCryptoFacadeTest", () => {
 			throw new Error("stub!")
 		},
 
-		randomBytes(bytes: number): Uint8Array {
-			return Buffer.alloc(bytes, 4)
+		randomBytes(nbrOfBytes: number): Uint8Array {
+			return Buffer.alloc(nbrOfBytes, 4)
 		},
 		decryptAndMapToInstance<T>(model: TypeModel, instance: Object, sk: ?Aes128Key): Promise<T> {
 			return Promise.resolve(instance)


### PR DESCRIPTION
registering / unregistering as mailto handler on windows
calls tutanota recursively with a command line argument.
this nested instance needs random bytes very early in the
run and the used prng throws if it's not seeded.

this caused the registry write to fail silently,
leading to #3155

this commit seeds the prng with node.crypto.randomBytes
after importing it and adds some logging so the nested
instances leave info as to what happened in the logs should
they error out.