### PR TITLE
remove old Component type, separate f1 help gui from keymanager

### DIFF
--- a/flow/libs.js
+++ b/flow/libs.js
@@ -1,12 +1,14 @@
-
 declare type QueryValue = string | boolean | Array<QueryValue>
 
+/** Top-level components accept route and query parameters as attrs */
+type TopLevelComponentAttrs = {[string]: QueryValue}
+
 declare type RouteResolverMatch = {
-	onmatch(args: {[string]: QueryValue}, requestedPath: string): ?(Component | Promise<?Component>);
+	onmatch(args: {[string]: QueryValue}, requestedPath: string): $Promisable<?MComponent<TopLevelComponentAttrs>>;
 }
 
 declare type RouteResolverRender = {
-	render(vnode: Object): VirtualElement | Array<VirtualElement>;
+	render(vnode: Vnode<TopLevelComponentAttrs>): VirtualElement | Array<VirtualElement>;
 }
 
 declare type RouteResolver = (RouteResolverMatch & RouteResolverRender) | RouteResolverMatch | RouteResolverRender
@@ -38,7 +40,7 @@ type Attrs = $ReadOnly<{[?string]: any}>
 
 declare interface Mithril {
 	// We would like to write a definition which allows omitting Attrs if all keys are optional
-	(component: string | MComponent<any> | Class<MComponent<any>>, children?: Children): Vnode<any>;
+	(component: string | MComponent<void> | Class<MComponent<void>>, children?: Children): Vnode<any>;
 
 	<AttrsT: Attrs>(
 		component: string | Class<MComponent<AttrsT>> | MComponent<AttrsT>,

--- a/flow/libs.js
+++ b/flow/libs.js
@@ -1,7 +1,3 @@
-// Declared at the top level to not import it in all places
-declare interface Component {
-	view(vnode: Vnode<any>): VirtualElement | VirtualElement[];
-}
 
 declare type QueryValue = string | boolean | Array<QueryValue>
 
@@ -15,21 +11,25 @@ declare type RouteResolverRender = {
 
 declare type RouteResolver = (RouteResolverMatch & RouteResolverRender) | RouteResolverMatch | RouteResolverRender
 
+/**
+ * mithril component lifecycle methods: https://mithril.js.org/lifecycle-methods.html
+ */
 interface Lifecycle<Attrs> {
 	// The oninit hook is called before a vnode is touched by the virtual DOM engine.
-	+oninit?: (vnode: Vnode<Attrs>) => any;
+	+oninit?: (vnode: Vnode<Attrs>) => void;
 	// The oncreate hook is called after a DOM element is created and attached to the document.
-	+oncreate?: (vnode: VnodeDOM<Attrs>) => any;
-	// The onbeforeupdate hook is called before a vnode is diffed in a update. If a Promise is returned, Mithril only detaches the DOM element after the promise completes.
-	// Change to the correct return type after updating to Flow 0.85 or newer
-	// see https://github.com/facebook/flow/issues/6284
-	+onbeforeremove?: (vnode: VnodeDOM<Attrs>) => any;
-	// The onremove hook is called before a DOM element is removed from the document.
-	+onremove?: (vnode: VnodeDOM<Attrs>) => any;
+	+oncreate?: (vnode: VnodeDOM<Attrs>) => void;
 	// The onbeforeremove hook is called before a DOM element is detached from the document.
+	// If a Promise is returned, Mithril only detaches the DOM element after the promise completes.
+	+onbeforeremove?: (vnode: VnodeDOM<Attrs>) => void | Promise<void>;
+	// The onremove hook is called before a DOM element is removed from the document.
+	+onremove?: (vnode: VnodeDOM<Attrs>) => void;
+	// The onbeforeupdate hook is called before a vnode is diffed in a update.
+	// if it returns false, Mithril prevents a diff from happening to the vnode,
+	// and consequently to the vnode's children.
 	+onbeforeupdate?: (vnode: Vnode<Attrs>, old: VnodeDOM<Attrs>) => boolean | void;
 	// The onupdate hook is called after a DOM element is updated, while attached to the document.
-	+onupdate?: (vnode: VnodeDOM<Attrs>) => any;
+	+onupdate?: (vnode: VnodeDOM<Attrs>) => void;
 }
 
 type LifecycleAttrs<T> = T & Lifecycle<T>
@@ -38,10 +38,10 @@ type Attrs = $ReadOnly<{[?string]: any}>
 
 declare interface Mithril {
 	// We would like to write a definition which allows omitting Attrs if all keys are optional
-	(component: string | Component | MComponent<void> | Class<MComponent<void>>, children?: Children): Vnode<any>;
+	(component: string | MComponent<any> | Class<MComponent<any>>, children?: Children): Vnode<any>;
 
 	<AttrsT: Attrs>(
-		component: string | Component | Class<MComponent<AttrsT>> | MComponent<AttrsT>,
+		component: string | Class<MComponent<AttrsT>> | MComponent<AttrsT>,
 		attributes: AttrsT,
 		children?: Children
 	): Vnode<any>;
@@ -65,7 +65,7 @@ declare interface Mithril {
 
 declare module 'mithril' {
 	declare interface Router {
-		(root: HTMLElement, defaultRoute: string, routes: {[string]: Component | RouteResolver}): void;
+		(root: HTMLElement, defaultRoute: string, routes: {[string]: MComponent<mixed> | RouteResolver}): void;
 
 		set(path: string, data?: ?{[string]: mixed},
 		    options?: {replace?: boolean, state?: ?Object, title?: ?string}): void;
@@ -78,7 +78,7 @@ declare module 'mithril' {
 
 		prefix: string;
 
-		Link: MComponent<any>;
+		Link: MComponent<mixed>;
 	}
 
 	declare export default Mithril;
@@ -271,6 +271,7 @@ interface Attributes {
 
 type $Attrs<+T> = $ReadOnly<T>
 
+// Declared at the top level to not import it in all places
 interface MComponent<+Attrs> extends Lifecycle<Attrs> {
 	/** Creates a view out of virtual elements. */
 	view(vnode: Vnode<Attrs>): ?Children;

--- a/src/app.js
+++ b/src/app.js
@@ -203,7 +203,7 @@ import("./translations/en").then((en) => lang.init(en.default)).then(() => {
 
 	// append catch all at the end because mithril will stop at the first match
 	resolvers["/:path"] = {
-		onmatch: (args: {[string]: QueryValue}, requestedPath: string): Promise<MComponent<void>> => {
+		onmatch: (args: {[string]: QueryValue}, requestedPath: string): $Promisable<?MComponent<TopLevelComponentAttrs>> => {
 			return Promise.all([import("./gui/base/InfoView"), import("./gui/base/ButtonN")])
 			              .then(([{InfoView}, {ButtonType, ButtonN}]) => {
 				              return {

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,7 @@ window.Promise = Promise.config({
 	warnings: false
 })
 
-let currentView: ?Component = null
+let currentView: ?MComponent<mixed> = null
 
 window.tutao = {
 	client,
@@ -203,7 +203,7 @@ import("./translations/en").then((en) => lang.init(en.default)).then(() => {
 
 	// append catch all at the end because mithril will stop at the first match
 	resolvers["/:path"] = {
-		onmatch: (args: {[string]: QueryValue}, requestedPath: string): Promise<Component> => {
+		onmatch: (args: {[string]: QueryValue}, requestedPath: string): Promise<MComponent<void>> => {
 			return Promise.all([import("./gui/base/InfoView"), import("./gui/base/ButtonN")])
 			              .then(([{InfoView}, {ButtonType, ButtonN}]) => {
 				              return {

--- a/src/calendar/view/CalendarMonthView.js
+++ b/src/calendar/view/CalendarMonthView.js
@@ -6,15 +6,19 @@ import {px, size} from "../../gui/size"
 import type {WeekStartEnum} from "../../api/common/TutanotaConstants"
 import {EventTextTimeOption, WeekStart} from "../../api/common/TutanotaConstants"
 import {CalendarEventBubble} from "./CalendarEventBubble"
+import type {CalendarDay} from "../date/CalendarUtils"
 import {
-	CALENDAR_EVENT_HEIGHT, getAllDayDateForTimezone,
-	getCalendarMonth, getDateIndicator,
+	CALENDAR_EVENT_HEIGHT,
+	getAllDayDateForTimezone,
+	getCalendarMonth,
+	getDateIndicator,
 	getDiffInDays,
 	getEventColor,
 	getEventEnd,
 	getStartOfDayWithZone,
 	getStartOfNextDayWithZone,
-	getStartOfTheWeekOffset, getTimeZone,
+	getStartOfTheWeekOffset,
+	getTimeZone,
 	getWeekNumber,
 	layOutEvents
 } from "../date/CalendarUtils"
@@ -31,7 +35,6 @@ import {Icon} from "../../gui/base/Icon"
 import {Icons} from "../../gui/base/icons/Icons"
 import {PageView} from "../../gui/base/PageView"
 import type {CalendarEvent} from "../../api/entities/tutanota/CalendarEvent"
-import type {CalendarDay} from "../date/CalendarUtils"
 import {logins} from "../../api/main/LoginController"
 
 type CalendarMonthAttrs = {

--- a/src/contacts/ContactAggregateEditor.js
+++ b/src/contacts/ContactAggregateEditor.js
@@ -32,8 +32,8 @@ export class ContactAggregateEditor implements MComponent<AggregateEditorAttrs<*
 		if (animate) this.animate(vnode.dom, true)
 	}
 
-	onbeforeremove(vnode: Vnode<AggregateEditorAttrs<*>>): Promise<*> {
-		return this.animate(vnode.dom, false)
+	async onbeforeremove(vnode: Vnode<AggregateEditorAttrs<*>>): Promise<void> {
+		await this.animate(vnode.dom, false)
 	}
 
 	view(vnode: Vnode<AggregateEditorAttrs<*>>): Children {

--- a/src/gui/base/BubbleTextField.js
+++ b/src/gui/base/BubbleTextField.js
@@ -85,7 +85,7 @@ export class BubbleTextField<T> {
 	suggestionAnimation: Promise<void>;
 	bubbleHandler: BubbleHandler<T, Suggestion>;
 	view: (Vnode<T>) => Children;
-	oncreate: (VnodeDOM<T>) => mixed;
+	oncreate: (VnodeDOM<T>) => void;
 
 	_textField: TextField;
 	_domSuggestions: HTMLElement;

--- a/src/gui/base/Dialog.js
+++ b/src/gui/base/Dialog.js
@@ -1,6 +1,7 @@
 // @flow
 import m from "mithril"
 import stream from "mithril/stream/stream.js"
+import type {ModalComponent} from "./Modal"
 import {modal} from "./Modal"
 import {alpha, animations, DefaultAnimationTime, opacity, transform} from "../animation/Animations"
 import {ease} from "../animation/Easing"
@@ -27,9 +28,8 @@ import {dialogAttrs} from "../AriaUtils"
 import {styles} from "../styles"
 import type {MaybeLazy} from "../../api/common/utils/Utils"
 import {getAsLazy, mapLazily} from "../../api/common/utils/Utils"
-import type {ModalComponent} from "./Modal"
-import {DialogInjectionRight} from "./DialogInjectionRight"
 import type {DialogInjectionRightAttrs} from "./DialogInjectionRight"
+import {DialogInjectionRight} from "./DialogInjectionRight"
 
 assertMainOrNode()
 
@@ -48,7 +48,7 @@ export type DialogTypeEnum = $Values<typeof DialogType>;
 
 type ActionDialogProps = {|
 	title: lazy<string> | string,
-	child: Component | lazy<Children>,
+	child: MComponent<mixed> | lazy<Children>,
 	validator?: ?validator,
 	okAction: null | (Dialog) => mixed,
 	allowCancel?: MaybeLazy<boolean>,
@@ -71,7 +71,7 @@ export class Dialog implements ModalComponent {
 	_focusedBeforeShown: ?HTMLElement
 	_injectionRightAttrs: ?DialogInjectionRightAttrs<*>
 
-	constructor(dialogType: DialogTypeEnum, childComponent: MComponent<any>) {
+	constructor(dialogType: DialogTypeEnum, childComponent: MComponent<mixed>) {
 		this.visible = false
 		this._focusOnLoadFunction = this._defaultFocusOnLoad
 		this._wasFocusOnLoadCalled = false
@@ -435,7 +435,7 @@ export class Dialog implements ModalComponent {
 	}
 
 	// used in admin client
-	static save(title: lazy<string>, saveAction: action, child: Component): Promise<void> {
+	static save(title: lazy<string>, saveAction: action, child: MComponent<mixed>): Promise<void> {
 		return new Promise(resolve => {
 			let saveDialog: Dialog
 			const closeAction = () => {
@@ -673,7 +673,7 @@ export class Dialog implements ModalComponent {
 	/**
 	 * @deprecated useLargeDialogN instead
 	 */
-	static largeDialog(headerBarAttrs: DialogHeaderBarAttrs, child: (Component | Class<MComponent<void>>)): Dialog {
+	static largeDialog(headerBarAttrs: DialogHeaderBarAttrs, child: MComponent<mixed>): Dialog {
 		return new Dialog(DialogType.EditLarge, {
 			view: () => {
 				return m("", [

--- a/src/gui/base/Dialog.js
+++ b/src/gui/base/Dialog.js
@@ -48,7 +48,7 @@ export type DialogTypeEnum = $Values<typeof DialogType>;
 
 type ActionDialogProps = {|
 	title: lazy<string> | string,
-	child: MComponent<mixed> | lazy<Children>,
+	child: MComponent<void> | lazy<Children>,
 	validator?: ?validator,
 	okAction: null | (Dialog) => mixed,
 	allowCancel?: MaybeLazy<boolean>,
@@ -71,7 +71,7 @@ export class Dialog implements ModalComponent {
 	_focusedBeforeShown: ?HTMLElement
 	_injectionRightAttrs: ?DialogInjectionRightAttrs<*>
 
-	constructor(dialogType: DialogTypeEnum, childComponent: MComponent<mixed>) {
+	constructor(dialogType: DialogTypeEnum, childComponent: MComponent<void>) {
 		this.visible = false
 		this._focusOnLoadFunction = this._defaultFocusOnLoad
 		this._wasFocusOnLoadCalled = false
@@ -435,7 +435,7 @@ export class Dialog implements ModalComponent {
 	}
 
 	// used in admin client
-	static save(title: lazy<string>, saveAction: action, child: MComponent<mixed>): Promise<void> {
+	static save(title: lazy<string>, saveAction: action, child: MComponent<void>): Promise<void> {
 		return new Promise(resolve => {
 			let saveDialog: Dialog
 			const closeAction = () => {
@@ -673,7 +673,7 @@ export class Dialog implements ModalComponent {
 	/**
 	 * @deprecated useLargeDialogN instead
 	 */
-	static largeDialog(headerBarAttrs: DialogHeaderBarAttrs, child: MComponent<mixed>): Dialog {
+	static largeDialog(headerBarAttrs: DialogHeaderBarAttrs, child: MComponent<void>): Dialog {
 		return new Dialog(DialogType.EditLarge, {
 			view: () => {
 				return m("", [

--- a/src/gui/base/Header.js
+++ b/src/gui/base/Header.js
@@ -27,7 +27,7 @@ export const LogoutUrl: string = location.hash.startsWith("#mail")
 
 assertMainOrNode()
 
-export interface CurrentView extends Component {
+export interface CurrentView extends MComponent<void> {
 	+headerView?: () => Children;
 	+headerRightView?: () => Children;
 	+getViewSlider?: () => ?IViewSlider;

--- a/src/gui/base/MultiSelectionBar.js
+++ b/src/gui/base/MultiSelectionBar.js
@@ -7,7 +7,7 @@ import {Button} from "./Button"
 type MultiSelectionBarAttrs = {
 	selectNoneHandler: () => void,
 	selectedEntiesLength: number,
-	content: Component
+	content: MComponent<mixed>
 }
 
 export class MultiSelectionBar {

--- a/src/gui/base/MultiSelectionBar.js
+++ b/src/gui/base/MultiSelectionBar.js
@@ -7,7 +7,7 @@ import {Button} from "./Button"
 type MultiSelectionBarAttrs = {
 	selectNoneHandler: () => void,
 	selectedEntiesLength: number,
-	content: MComponent<mixed>
+	content: MComponent<void>
 }
 
 export class MultiSelectionBar {

--- a/src/gui/base/NotificationOverlay.js
+++ b/src/gui/base/NotificationOverlay.js
@@ -11,7 +11,7 @@ import {ButtonN, ButtonType} from "./ButtonN"
 assertMainOrNode()
 
 type NotificationOverlayAttrs = {|
-	message: Component,
+	message: MComponent<mixed>,
 	buttons: Array<ButtonAttrs>
 |}
 
@@ -32,7 +32,7 @@ class NotificationOverlay implements MComponent<NotificationOverlayAttrs> {
 /**
  * @param buttons The postpone button is automatically added and does not have to be passed from outside
  */
-export function show(message: Component, closeButtonAttrs: $Shape<ButtonAttrs>, buttons: Array<ButtonAttrs>) {
+export function show(message: MComponent<mixed>, closeButtonAttrs: $Shape<ButtonAttrs>, buttons: Array<ButtonAttrs>) {
 	notificationQueue.push({message, buttons, closeButtonAttrs})
 	if (notificationQueue.length > 1) {
 		// another notification is already visible. Next notification will be shown when closing current notification

--- a/src/gui/base/NotificationOverlay.js
+++ b/src/gui/base/NotificationOverlay.js
@@ -11,7 +11,7 @@ import {ButtonN, ButtonType} from "./ButtonN"
 assertMainOrNode()
 
 type NotificationOverlayAttrs = {|
-	message: MComponent<mixed>,
+	message: MComponent<void>,
 	buttons: Array<ButtonAttrs>
 |}
 

--- a/src/gui/base/Overlay.js
+++ b/src/gui/base/Overlay.js
@@ -24,7 +24,7 @@ export type PositionRect = {
 type AnimationProvider = (dom: HTMLElement) => DomMutation
 
 type OverlayAttrs = {
-	component: Component,
+	component: MComponent<mixed>,
 	position: lazy<PositionRect>,
 	createAnimation?: AnimationProvider,
 	closeAnimation?: AnimationProvider,
@@ -34,7 +34,7 @@ type OverlayAttrs = {
 const overlays: Array<[OverlayAttrs, ?HTMLElement, number]> = []
 let key = 0
 
-export function displayOverlay(position: lazy<PositionRect>, component: Component, createAnimation?: AnimationProvider,
+export function displayOverlay(position: lazy<PositionRect>, component: MComponent<mixed>, createAnimation?: AnimationProvider,
                                closeAnimation?: AnimationProvider, shadowClass: string = "dropdown-shadow"): () => Promise<void> {
 	const newAttrs = {
 		position,
@@ -60,7 +60,7 @@ export function displayOverlay(position: lazy<PositionRect>, component: Componen
 	}
 }
 
-export const overlay = {
+export const overlay: MComponent<OverlayAttrs> = {
 	view: (): Children => m("#overlay", {
 		style: {
 			display: overlays.length > 0 ? "" : 'none' // display: null not working for IE11
@@ -82,7 +82,7 @@ export const overlay = {
 				'z-index': position.zIndex ? position.zIndex : LayerType.Overlay,
 				'margin-top': (requiresStatusBarHack() ? "20px" : 'env(safe-area-inset-top)') // insets for iPhone X
 			},
-			oncreate: (vnode: Vnode<any>) => {
+			oncreate: (vnode: Vnode<OverlayAttrs>) => {
 				overlayAttrs[1] = vnode.dom
 				if (attrs.createAnimation) {
 					animations.add(vnode.dom, attrs.createAnimation(vnode.dom))

--- a/src/gui/base/Overlay.js
+++ b/src/gui/base/Overlay.js
@@ -24,7 +24,7 @@ export type PositionRect = {
 type AnimationProvider = (dom: HTMLElement) => DomMutation
 
 type OverlayAttrs = {
-	component: MComponent<mixed>,
+	component: MComponent<void>,
 	position: lazy<PositionRect>,
 	createAnimation?: AnimationProvider,
 	closeAnimation?: AnimationProvider,
@@ -34,7 +34,7 @@ type OverlayAttrs = {
 const overlays: Array<[OverlayAttrs, ?HTMLElement, number]> = []
 let key = 0
 
-export function displayOverlay(position: lazy<PositionRect>, component: MComponent<mixed>, createAnimation?: AnimationProvider,
+export function displayOverlay(position: lazy<PositionRect>, component: MComponent<void>, createAnimation?: AnimationProvider,
                                closeAnimation?: AnimationProvider, shadowClass: string = "dropdown-shadow"): () => Promise<void> {
 	const newAttrs = {
 		position,
@@ -60,7 +60,7 @@ export function displayOverlay(position: lazy<PositionRect>, component: MCompone
 	}
 }
 
-export const overlay: MComponent<OverlayAttrs> = {
+export const overlay: MComponent<void> = {
 	view: (): Children => m("#overlay", {
 		style: {
 			display: overlays.length > 0 ? "" : 'none' // display: null not working for IE11

--- a/src/gui/base/ViewColumn.js
+++ b/src/gui/base/ViewColumn.js
@@ -16,8 +16,8 @@ export const ColumnType = {
 
 type Attrs = {rightBorder?: boolean}
 
-export class ViewColumn {
-	component: Component;
+export class ViewColumn implements MComponent<Attrs> {
+	component: MComponent<mixed>;
 	columnType: ColumnTypeEnum;
 	minWidth: number;
 	maxWidth: number;
@@ -39,7 +39,7 @@ export class ViewColumn {
 	 * @param maxWidth The maximum allowed width for the view column.
 	 * @param title A function that returns the translated title text for a column.
 	 */
-	constructor(component: Component, columnType: ColumnTypeEnum, minWidth: number, maxWidth: number, title: ?lazy<string>, ariaLabel: ?lazy<string>) {
+	constructor(component: MComponent<mixed>, columnType: ColumnTypeEnum, minWidth: number, maxWidth: number, title: ?lazy<string>, ariaLabel: ?lazy<string>) {
 		this.component = component
 		this.columnType = columnType
 		this.minWidth = minWidth

--- a/src/gui/base/ViewColumn.js
+++ b/src/gui/base/ViewColumn.js
@@ -17,7 +17,7 @@ export const ColumnType = {
 type Attrs = {rightBorder?: boolean}
 
 export class ViewColumn implements MComponent<Attrs> {
-	component: MComponent<mixed>;
+	component: MComponent<void>;
 	columnType: ColumnTypeEnum;
 	minWidth: number;
 	maxWidth: number;
@@ -39,7 +39,7 @@ export class ViewColumn implements MComponent<Attrs> {
 	 * @param maxWidth The maximum allowed width for the view column.
 	 * @param title A function that returns the translated title text for a column.
 	 */
-	constructor(component: MComponent<mixed>, columnType: ColumnTypeEnum, minWidth: number, maxWidth: number, title: ?lazy<string>, ariaLabel: ?lazy<string>) {
+	constructor(component: MComponent<void>, columnType: ColumnTypeEnum, minWidth: number, maxWidth: number, title: ?lazy<string>, ariaLabel: ?lazy<string>) {
 		this.component = component
 		this.columnType = columnType
 		this.minWidth = minWidth

--- a/src/gui/base/ViewSlider.js
+++ b/src/gui/base/ViewSlider.js
@@ -103,7 +103,7 @@ export class ViewSlider implements IViewSlider {
 					}))
 				),
 				styles.isUsingBottomNavigation() ? m(BottomNav) : null,
-				this._getColumnsForOverlay().map(m),
+				this._getColumnsForOverlay().map((c) => m(c, {})),
 				this._createModalBackground(),
 			])
 		}

--- a/src/gui/base/ViewSliderN.js
+++ b/src/gui/base/ViewSliderN.js
@@ -297,7 +297,7 @@ export const ColumnType = {
 }
 
 export class ViewColumnN {
-	component: Component | Class<MComponent<void>>;
+	component: Class<MComponent<void>>;
 	columnType: ColumnTypeEnum;
 	minWidth: number;
 	maxWidth: number;
@@ -315,7 +315,7 @@ export class ViewColumnN {
 	 * @param maxWidth The maximum allowed width for the view column.
 	 * @param title A function that returns the translated title text for a column.
 	 */
-	constructor(component: Component | Class<MComponent<void>>, columnType: ColumnTypeEnum, minWidth: number, maxWidth: number, title: ?lazy<string>) {
+	constructor(component: Class<MComponent<void>>, columnType: ColumnTypeEnum, minWidth: number, maxWidth: number, title: ?lazy<string>) {
 		this.component = component
 		this.columnType = columnType
 		this.minWidth = minWidth

--- a/src/gui/date/DatePicker.js
+++ b/src/gui/date/DatePicker.js
@@ -3,11 +3,7 @@ import m from "mithril"
 import stream from "mithril/stream/stream.js"
 import {Icons} from "../base/icons/Icons"
 import {client} from "../../misc/ClientDetector"
-import {
-	formatDate,
-	formatDateWithWeekdayAndYear,
-	formatMonthWithFullYear
-} from "../../misc/Formatter"
+import {formatDate, formatDateWithWeekdayAndYear, formatMonthWithFullYear} from "../../misc/Formatter"
 import type {TranslationKey} from "../../misc/LanguageViewModel"
 import {lang} from "../../misc/LanguageViewModel"
 import {px} from "../size"
@@ -20,8 +16,8 @@ import {DateTime} from "luxon"
 import {getAllDayDateLocal} from "../../api/common/utils/CommonCalendarUtils"
 import {TextFieldN} from "../base/TextFieldN"
 import {Keys} from "../../api/common/TutanotaConstants"
-import {getCalendarMonth, getDateIndicator} from "../../calendar/date/CalendarUtils"
 import type {CalendarDay} from "../../calendar/date/CalendarUtils"
+import {getCalendarMonth, getDateIndicator} from "../../calendar/date/CalendarUtils"
 import {parseDate} from "../../misc/DateParser"
 
 /**
@@ -33,7 +29,7 @@ import {parseDate} from "../../misc/DateParser"
  * That is why we only use the picker on mobile devices. They provide native picker components
  * and allow opening the picker by forwarding the click event to the input.
  */
-export class DatePicker implements Component {
+export class DatePicker implements MComponent<void> {
 	invalidDate: boolean;
 	date: Stream<?Date>;
 	_dateString: Stream<string>;

--- a/src/gui/dialogs/ShortcutDialog.js
+++ b/src/gui/dialogs/ShortcutDialog.js
@@ -1,0 +1,67 @@
+// @flow
+
+import {lang} from "../../misc/LanguageViewModel"
+import m from "mithril"
+import stream from "mithril/stream/stream.js"
+import {Dialog} from "../base/Dialog"
+import {Keys} from "../../api/common/TutanotaConstants"
+import {TextFieldN} from "../base/TextFieldN"
+import type {Shortcut} from "../../misc/KeyManager"
+import {ButtonType} from "../base/ButtonN"
+
+let isOpen = false
+
+function makeShortcutName(shortcut: Shortcut): string {
+	return ((shortcut.meta) ? Keys.META.name + " + " : "")
+		+ ((shortcut.ctrl) ? Keys.CTRL.name + " + " : "")
+		+ ((shortcut.shift) ? Keys.SHIFT.name + " + " : "")
+		+ ((shortcut.alt) ? Keys.ALT.name + " + " : "")
+		+ shortcut.key.name
+}
+
+export function showShortcutDialog(attrs: ShortcutDialogAttrs) {
+	if (isOpen) return
+	let dialog
+
+	const close = () => {
+		isOpen = false
+		dialog.close()
+	}
+
+	const headerAttrs = {
+		left: [{label: 'close_alt', click: close, type: ButtonType.Secondary}],
+		middle: () => lang.get("keyboardShortcuts_title")
+	}
+
+	isOpen = true
+	dialog = Dialog.largeDialogN(headerAttrs, ShortcutDialog, attrs)
+	               .addShortcut({key: Keys.ESC, exec: close, help: "close_alt"})
+	               .show()
+}
+
+export type ShortcutDialogAttrs = {
+	shortcuts: Stream<Array<Shortcut>>
+}
+
+/**
+ * The Dialog that shows the currently active Keyboard shortcuts when you press F1
+ *
+ *
+ */
+class ShortcutDialog implements MComponent<ShortcutDialogAttrs> {
+	view(vnode: Vnode<ShortcutDialogAttrs>) {
+		vnode.attrs.shortcuts.map(m.redraw)
+		const shortcuts = vnode.attrs.shortcuts()
+
+		const textFieldAttrs = shortcuts
+			.filter(shortcut => shortcut.enabled == null || shortcut.enabled())
+			.map(shortcut => ({
+					label: () => makeShortcutName(shortcut),
+					value: stream(lang.get(shortcut.help)),
+					disabled: true
+				})
+			)
+
+		return m("div.pb", textFieldAttrs.map(t => m(TextFieldN, t)))
+	}
+}

--- a/src/login/LoginViewController.js
+++ b/src/login/LoginViewController.js
@@ -254,7 +254,7 @@ export class LoginViewController implements ILoginViewController {
 	_remindActiveOutOfOfficeNotification(): Promise<void> {
 		return loadOutOfOfficeNotification().then((notification) => {
 			if (notification && isNotificationCurrentlyActive(notification, new Date())) {
-				const notificationMessage: Component = {
+				const notificationMessage: MComponent<void> = {
 					view: () => {
 						return m("", lang.get("outOfOfficeReminder_label"))
 					}

--- a/src/mail/view/MailListView.js
+++ b/src/mail/view/MailListView.js
@@ -41,7 +41,7 @@ assertMainOrNode()
 
 const className = "mail-list"
 
-export class MailListView implements Component {
+export class MailListView implements MComponent<void> {
 	listId: Id;
 	mailView: MailView;
 	list: List<Mail, MailRow>;

--- a/src/search/SearchBar.js
+++ b/src/search/SearchBar.js
@@ -79,7 +79,7 @@ export type SearchBarState = {
 	selected: ?Entry
 }
 
-export class SearchBar implements Component {
+export class SearchBar implements MComponent<SearchBarAttrs> {
 	view: Function;
 	_domInput: HTMLInputElement;
 	_domWrapper: HTMLElement;

--- a/src/serviceworker/ServiceWorkerClient.js
+++ b/src/serviceworker/ServiceWorkerClient.js
@@ -9,7 +9,7 @@ import {isSecurityError, objToError} from "../api/common/utils/Utils";
 assertMainOrNodeBoot()
 
 function showUpdateOverlay(onUpdate: () => void) {
-	const notificationMessage: Component = {
+	const notificationMessage: MComponent<void> = {
 		view: () => {
 			return m("span", [
 				lang.get("updateFound_label"),

--- a/src/settings/SettingsView.js
+++ b/src/settings/SettingsView.js
@@ -314,7 +314,7 @@ export class SettingsView implements CurrentView {
 				))
 	}
 
-	_getCurrentViewer(): Component {
+	_getCurrentViewer(): MComponent<void> {
 		if (!this._currentViewer) {
 			this.detailsViewer = null
 			this._currentViewer = this._selectedFolder.viewerCreator()

--- a/src/sharing/view/GroupSharingDialog.js
+++ b/src/sharing/view/GroupSharingDialog.js
@@ -186,7 +186,7 @@ function showAddParticipantDialog(model: GroupSharingModel, texts: GroupSharingT
 			return buttonAttrs
 		}
 	}, locator.contactModel, SHOW_CONTACT_SUGGESTIONS_MAX)
-	const invitePeopleValueTextField: BubbleTextField<RecipientInfo> = new BubbleTextField("shareWithEmailRecipient_label", bubbleHandler)
+	const invitePeopleValueTextField = new BubbleTextField<RecipientInfo>("shareWithEmailRecipient_label", bubbleHandler)
 	const capability: Stream<ShareCapabilityEnum> = stream(ShareCapability.Read)
 	const realGroupName = getSharedGroupName(model.info, false)
 	const customGroupName = getSharedGroupName(model.info, true)

--- a/src/subscription/BuyOptionBox.js
+++ b/src/subscription/BuyOptionBox.js
@@ -24,7 +24,7 @@ export type BuyOptionBoxAttr = {|
 	// lazy<ButtonAttrs> because you can't do actionButton instanceof ButtonAttrs since ButtonAttrs doesn't exist in the javascript side
 	// there is a strange interaction between the HTMLEditor in HTML mode and the ButtonN when you pass the ButtonN in via a component
 	// that doesn't occur when you pass in the attrs
-	actionButton: ?(Component | lazy<ButtonAttrs>),
+	actionButton: ?(MComponent<mixed> | lazy<ButtonAttrs>),
 	price?: string,
 	priceHint?: TranslationKey | lazy<string>,
 	helpLabel: TranslationKey | lazy<string>,

--- a/src/subscription/BuyOptionBox.js
+++ b/src/subscription/BuyOptionBox.js
@@ -24,7 +24,7 @@ export type BuyOptionBoxAttr = {|
 	// lazy<ButtonAttrs> because you can't do actionButton instanceof ButtonAttrs since ButtonAttrs doesn't exist in the javascript side
 	// there is a strange interaction between the HTMLEditor in HTML mode and the ButtonN when you pass the ButtonN in via a component
 	// that doesn't occur when you pass in the attrs
-	actionButton: ?(MComponent<mixed> | lazy<ButtonAttrs>),
+	actionButton: ?(MComponent<void> | lazy<ButtonAttrs>),
 	price?: string,
 	priceHint?: TranslationKey | lazy<string>,
 	helpLabel: TranslationKey | lazy<string>,

--- a/src/subscription/SubscriptionUtils.js
+++ b/src/subscription/SubscriptionUtils.js
@@ -125,15 +125,15 @@ export function isDowngrade(targetSubscription: SubscriptionTypeEnum, currentSub
 }
 
 export type SubscriptionActionButtons = {|
-	Free: Component,
-	Premium: Component,
-	PremiumBusiness: Component,
-	Teams: Component,
-	TeamsBusiness: Component,
-	Pro: Component,
+	Free: MComponent<mixed>,
+	Premium: MComponent<mixed>,
+	PremiumBusiness: MComponent<mixed>,
+	Teams: MComponent<mixed>,
+	TeamsBusiness: MComponent<mixed>,
+	Pro: MComponent<mixed>,
 |}
 
-export function getActionButtonBySubscription(actionButtons: SubscriptionActionButtons, subscription: SubscriptionTypeEnum): Component {
+export function getActionButtonBySubscription(actionButtons: SubscriptionActionButtons, subscription: SubscriptionTypeEnum): MComponent<mixed> {
 	switch (subscription) {
 		case SubscriptionType.Free:
 			return actionButtons.Free

--- a/src/subscription/SubscriptionUtils.js
+++ b/src/subscription/SubscriptionUtils.js
@@ -125,15 +125,15 @@ export function isDowngrade(targetSubscription: SubscriptionTypeEnum, currentSub
 }
 
 export type SubscriptionActionButtons = {|
-	Free: MComponent<mixed>,
-	Premium: MComponent<mixed>,
-	PremiumBusiness: MComponent<mixed>,
-	Teams: MComponent<mixed>,
-	TeamsBusiness: MComponent<mixed>,
-	Pro: MComponent<mixed>,
+	Free: MComponent<void>,
+	Premium: MComponent<void>,
+	PremiumBusiness: MComponent<void>,
+	Teams: MComponent<void>,
+	TeamsBusiness: MComponent<void>,
+	Pro: MComponent<void>,
 |}
 
-export function getActionButtonBySubscription(actionButtons: SubscriptionActionButtons, subscription: SubscriptionTypeEnum): MComponent<mixed> {
+export function getActionButtonBySubscription(actionButtons: SubscriptionActionButtons, subscription: SubscriptionTypeEnum): MComponent<void> {
 	switch (subscription) {
 		case SubscriptionType.Free:
 			return actionButtons.Free

--- a/src/subscription/SwitchSubscriptionDialog.js
+++ b/src/subscription/SwitchSubscriptionDialog.js
@@ -107,7 +107,7 @@ export function showSwitchDialog(customer: Customer, customerInfo: CustomerInfo,
 		})
 }
 
-function createSubscriptionPlanButton(dialog: Dialog, targetSubscription: SubscriptionTypeEnum, currentSubscriptionInfo: CurrentSubscriptionInfo): Component {
+function createSubscriptionPlanButton(dialog: Dialog, targetSubscription: SubscriptionTypeEnum, currentSubscriptionInfo: CurrentSubscriptionInfo): MComponent<void> {
 	return {
 		view: () => {
 			return m(ButtonN, {

--- a/src/subscription/UpgradeSubscriptionPage.js
+++ b/src/subscription/UpgradeSubscriptionPage.js
@@ -71,7 +71,7 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 }
 
 
-function createUpgradeButton(data: UpgradeSubscriptionData, showNextPage: () => void, subscriptionType: SubscriptionTypeEnum): Component {
+function createUpgradeButton(data: UpgradeSubscriptionData, showNextPage: () => void, subscriptionType: SubscriptionTypeEnum): MComponent<void> {
 	return {
 		view: () => {
 			return m(ButtonN, {

--- a/src/support/SupportDialog.js
+++ b/src/support/SupportDialog.js
@@ -68,7 +68,7 @@ export function showSupportDialog() {
 		value: searchValue
 	}
 
-	const child: Component = {
+	const child: MComponent<void> = {
 		view: () => {
 			return [
 				m(".pt"),

--- a/src/support/SupportDialog.js
+++ b/src/support/SupportDialog.js
@@ -1,6 +1,4 @@
 //@flow
-
-
 import {Dialog} from "../gui/base/Dialog"
 import type {DialogHeaderBarAttrs} from "../gui/base/DialogHeaderBar"
 import type {ButtonAttrs} from "../gui/base/ButtonN"


### PR DESCRIPTION
makes sure that lifecycle methods on mithril component classes don't return promises to make issues like #3225 less likely
 
lifecycle methods passed to m on plain objects are not checked yet