### PR TITLE
Fix attachments of response #3252

### DIFF
--- a/src/mail/view/MailGuiUtils.js
+++ b/src/mail/view/MailGuiUtils.js
@@ -214,5 +214,5 @@ export async function loadInlineImages(worker: WorkerClient, attachments: Array<
 }
 
 export function getReferencedAttachments(attachments: Array<TutanotaFile>, referencedCids: Array<string>): Array<TutanotaFile> {
-	return attachments.filter(file => referencedCids.filter(rcid => file.cid === rcid))
+	return attachments.filter(file => referencedCids.find(rcid => file.cid === rcid))
 }


### PR DESCRIPTION
`filter` returns an empty array, which is truthy, so the old implementation just returned a clone of the original array.