### PR TITLE
[build] don't prepend "translation" to translation chunks

### DIFF
--- a/dist.js
+++ b/dist.js
@@ -238,12 +238,7 @@ async function buildWebapp(version) {
 			return getChunkName(id, {getModuleInfo})
 		},
 		chunkFileNames: (chunkInfo) => {
-			// I would love to test chunkInfo.name but it will be just "en", not "translation-en" for some reason
-			if (chunkInfo.facadeModuleId && chunkInfo.facadeModuleId.includes("src/translations/")) {
-				return "translation-[name]-[hash].js"
-			} else {
 				return "[name]-[hash].js"
-			}
 		}
 	})
 	const chunks = output.output.map(c => c.fileName)


### PR DESCRIPTION
We already generate the translation chunks as "translation-xx-xxxxx.js", so we don't have to then append "translation" to the front. When generating `sw.js` we tell it to add the file beginning with "translation-en" to it's list of files to cache, which doesn't exist because all of the translation files begin with "translation-translation"

fix #3268