### PR TITLE
Enable spawning multiple build servers

### DIFF
--- a/buildSrc/Builder.js
+++ b/buildSrc/Builder.js
@@ -98,6 +98,8 @@ function debugModels() {
 }
 
 export async function build({desktop, stage, host}, {devServerPort, watchFolders}, log) {
+	log("Building app")
+
 	const {version} = JSON.parse(await fs.readFile("package.json", "utf8"))
 	await prepareAssets(stage, host, version)
 	const start = Date.now()

--- a/make.js
+++ b/make.js
@@ -39,7 +39,7 @@ const flowPromise = new Promise((resolve, reject) => {
 runBuild()
 
 function runBuild() {
-	const buildServerClient = new BuildServerClient()
+	const buildServerClient = new BuildServerClient("make")
 	buildServerClient.buildWithServer({
 		forceRestart: opts.clean,
 		builder: path.resolve("./buildSrc/Builder.js"),

--- a/packages/tutanota-build-server/src/BuildServer.js
+++ b/packages/tutanota-build-server/src/BuildServer.js
@@ -62,7 +62,7 @@ export class BuildServer {
 	 * @param devServerPort if set, a dev server will be listening on this port
 	 * @param builderPath absolute path to the builder which will be used by the server
 	 * @param preserveLogs boolean, logs will not be deleted on server shutdown if set to true
-	 * @param directory absolute path to directory in which the build server will create its log file and socket
+	 * @param directory absolute path to directory in which the build server will create its log file and socket. This will identify a given build server
 	 * @param watchFolders directories to watch for file changes that re-trigger the last build
 	 * @param webRoot absolute path to directory to be used as webRoot by devServer
 	 * @param spaRedirect boolean, if true the devServer will redirect any requests to '/?r=<requestedURL>'
@@ -71,7 +71,7 @@ export class BuildServer {
 		this.devServerPort = devServerPort
 		this.builderPath = builderPath
 		this.preserveLogs = preserveLogs || false
-		this.directory = directory || path.join(os.tempdir, 'tutanota-build-server')
+		this.directory = directory
 		this.watchFolders = watchFolders
 		this.webRoot = webRoot
 		this.spaRedirect = spaRedirect || true

--- a/test/test.js
+++ b/test/test.js
@@ -4,44 +4,51 @@ import {BuildServerClient} from "@tutao/tutanota-build-server"
 import flow from "flow-bin"
 import path from "path"
 
-let project
-if (process.argv.indexOf("api") !== -1) {
-	project = "api"
-} else if (process.argv.indexOf("client") !== -1) {
-	project = "client"
-} else {
-	console.error("must provide 'api' or 'client' to run the tests")
-	process.exit(1)
-}
-const clean = process.argv.includes("-c")
+run()
 
-spawn(flow, ["--quiet"], {stdio: "inherit"})
+async function run() {
+	let project
+	if (process.argv.indexOf("api") !== -1) {
+		project = "api"
+	} else if (process.argv.indexOf("client") !== -1) {
+		project = "client"
+	} else {
+		console.error("must provide 'api' or 'client' to run the tests")
+		process.exit(1)
+	}
+	const clean = process.argv.includes("-c")
 
-const buildServerClient = new BuildServerClient()
-buildServerClient.buildWithServer({
-	forceRestart: clean,
-	builder: path.resolve("TestBuilder.js"),
-	watchFolders: [path.resolve("api"), path.resolve("client"), path.resolve("../src")],
-	buildOpts: {}
-})
-.then(
-	async () => {
+
+	spawn(flow, ["--quiet"], {stdio: "inherit"})
+
+	try {
+		const buildServerClient = new BuildServerClient("test")
+		await buildServerClient.buildWithServer({
+			forceRestart: clean,
+			builder: path.resolve("TestBuilder.js"),
+			watchFolders: [path.resolve("api"), path.resolve("client"), path.resolve("../src")],
+			buildOpts: {}
+		})
 		console.log("build finished!")
 		const code = await runTest(project)
 		process.exit(code)
-	},
-	(e) => {
+	} catch (e) {
 		console.error("Build failed", e)
 		process.exit(1)
 	}
-)
-
+}
 
 function runTest(project) {
 	return new Promise((resolve) => {
-		let testRunner = child_process.fork(`../build/test/bootstrapTests-${project}.js`)
+		let testRunner = child_process.fork(`./build/bootstrapTests-${project}.js`)
 		testRunner.on('exit', (code) => {
 			resolve(code)
 		})
 	})
+}
+
+async function directoryExists(filePath) {
+	return fs.stat(filePath)
+	         .then(stats => stats.isDirectory())
+	         .catch(() => false)
 }


### PR DESCRIPTION
And we spawn different build servers for make.js and test.js,
as well as splitting their output directories

fix #3233