### PR TITLE
don't permanently delete mail when hitting enter key

### DIFF
--- a/src/gui/base/Dialog.js
+++ b/src/gui/base/Dialog.js
@@ -365,7 +365,7 @@ export class Dialog implements ModalComponent {
 	 * Simpler version of {@link Dialog#confirmMultiple} with just two options: no and yes (or another confirmation).
 	 * @return Promise, which is resolved with user selection - true for confirm, false for cancel.
 	 */
-	static confirm(messageIdOrMessageFunction: TranslationKey | lazy<string>, confirmId: TranslationKey = "ok_action", enableConfirmShortcut: boolean = true): Promise<boolean> {
+	static confirm(messageIdOrMessageFunction: TranslationKey | lazy<string>, confirmId: TranslationKey = "ok_action"): Promise<boolean> {
 		return new Promise(resolve => {
 			const closeAction = conf => {
 				dialog.close()
@@ -375,7 +375,7 @@ export class Dialog implements ModalComponent {
 				{label: "cancel_action", click: () => closeAction(false), type: ButtonType.Secondary},
 				{label: confirmId, click: () => closeAction(true), type: ButtonType.Primary},
 			]
-			const dialog = Dialog.confirmMultiple(messageIdOrMessageFunction, buttonAttrs, resolve, enableConfirmShortcut)
+			const dialog = Dialog.confirmMultiple(messageIdOrMessageFunction, buttonAttrs, resolve)
 		})
 	}
 
@@ -410,14 +410,6 @@ export class Dialog implements ModalComponent {
 			  exec: () => closeAction(false),
 			  help: "cancel_action"
 		  })
-		if (enableConfirmShortcut) {
-			dialog.addShortcut({
-				key: Keys.RETURN,
-				shift: false,
-				exec: () => closeAction(true),
-				help: "ok_action",
-			})
-		}
 
 		dialog.show()
 		return dialog

--- a/src/mail/view/MailGuiUtils.js
+++ b/src/mail/view/MailGuiUtils.js
@@ -30,7 +30,7 @@ export function showDeleteConfirmationDialog(mails: $ReadOnlyArray<Mail>): Promi
 		}
 	}
 	if (confirmationTextId != null) {
-		return Dialog.confirm(confirmationTextId, "ok_action", false)
+		return Dialog.confirm(confirmationTextId, "ok_action")
 	} else {
 		return Promise.resolve(true)
 	}

--- a/src/mail/view/MailGuiUtils.js
+++ b/src/mail/view/MailGuiUtils.js
@@ -30,7 +30,7 @@ export function showDeleteConfirmationDialog(mails: $ReadOnlyArray<Mail>): Promi
 		}
 	}
 	if (confirmationTextId != null) {
-		return Dialog.confirm(confirmationTextId)
+		return Dialog.confirm(confirmationTextId, "ok_action", false)
 	} else {
 		return Promise.resolve(true)
 	}


### PR DESCRIPTION
Until now we hard code the enter key to trigger confirmation in a confirmation dialog regardless of which button is selected. Sometimes this isn't ideal as you don't want it to be too easy to do dangerous operations, so I've added functionality that can opt in to disable it. I would also be for just disabling it always

fix #3200