### PR TITLE
remove tutanota links for non-admin whitelabel users

### DIFF
--- a/src/api/common/utils/Utils.js
+++ b/src/api/common/utils/Utils.js
@@ -526,10 +526,14 @@ export function isCustomizationEnabledForCustomer(customer: Customer, feature: F
 /**
  * If val is non null, returns the result of val passed to action, else null
  */
-export function mapNullable<T, U>(val: ?T, action: T => U): U | null {
-	return val != null
-		? action(val)
-		: null
+export function mapNullable<T, U>(val: ?T, action: T => ?U): U | null  {
+	if (val != null) {
+		const result = action(val)
+		if (result != null) {
+			return result
+		}
+	}
+	return null
 }
 
 export function isSecurityError(e: any): boolean {

--- a/src/api/main/LoginController.js
+++ b/src/api/main/LoginController.js
@@ -4,6 +4,7 @@ import {assertMainOrNodeBoot, getHttpOrigin} from "../common/Env"
 import type {FeatureTypeEnum} from "../common/TutanotaConstants"
 import type {IUserController, UserControllerInitData} from "./UserController"
 import type {WorkerClient} from "./WorkerClient"
+import {getWhitelabelCustomizations} from "../../misc/WhitelabelCustomizations"
 
 assertMainOrNodeBoot()
 
@@ -40,6 +41,10 @@ export interface LoginController {
 
 	loadCustomizations(): Promise<void>;
 
+	determineIfWhitelabel(): Promise<void>;
+
+	isWhitelabel(): boolean;
+
 	logout(sync: boolean): Promise<void>;
 }
 
@@ -47,6 +52,7 @@ export class LoginControllerImpl implements LoginController {
 	_userController: ?IUserController
 	customizations: ?NumberString[]
 	waitForLogin: {resolve: Function, reject: Function, promise: Promise<void>} = defer()
+	_isWhitelabel: boolean = !!getWhitelabelCustomizations(window)
 
 	_getWorker(): Promise<WorkerClient> {
 		return import("./MainLocator")
@@ -181,6 +187,14 @@ export class LoginControllerImpl implements LoginController {
 			console.log("No session to delete")
 			return Promise.resolve()
 		}
+	}
+
+	async determineIfWhitelabel(): Promise<void> {
+		this._isWhitelabel = await this.getUserController().isWhitelabelAccount()
+	}
+
+	isWhitelabel(): boolean {
+		return this._isWhitelabel
 	}
 
 }

--- a/src/gui/base/GuiUtils.js
+++ b/src/gui/base/GuiUtils.js
@@ -2,7 +2,7 @@
 import type {Country} from "../../api/common/CountryList"
 import {Countries} from "../../api/common/CountryList"
 import {DropDownSelector} from "./DropDownSelector"
-import type {TranslationKey} from "../../misc/LanguageViewModel"
+import type {InfoLink, TranslationKey} from "../../misc/LanguageViewModel"
 import {lang} from "../../misc/LanguageViewModel"
 import type {ButtonAttrs, ButtonTypeEnum} from "./ButtonN"
 import {ButtonColors, ButtonType} from "./ButtonN"
@@ -12,6 +12,7 @@ import {attachDropdown} from "./DropdownN"
 import type {MaybeLazy} from "../../api/common/utils/Utils"
 import {assertNotNull, mapLazily, noOp} from "../../api/common/utils/Utils"
 import {Dialog} from "./Dialog"
+import {logins} from "../../api/main/LoginController"
 import type {AllIconsEnum} from "./Icon"
 
 // TODO Use DropDownSelectorN
@@ -142,4 +143,16 @@ export function makeListSelectionChangedScrollHandler(scrollDom: HTMLElement, en
 			scrollDom.scrollTop = selectedBottom - scrollWindowHeight
 		}
 	}
+}
+
+/**
+ * Executes the passed function if the user is allowed to see `tutanota.com` links.
+ * @param render receives the resolved link
+ * @returns {Children|null}
+ */
+export function ifAllowedTutanotaLinks(linkId: InfoLink, render: (string) => Children): Children | null {
+	if (logins.getUserController().isGlobalAdmin() || !logins.isWhitelabel()) {
+		return render(lang.getInfoLink(linkId))
+	}
+	return null
 }

--- a/src/gui/base/InfoBanner.js
+++ b/src/gui/base/InfoBanner.js
@@ -11,6 +11,7 @@ import {ButtonN, ButtonType} from "./ButtonN"
 import {NavButtonN} from "./NavButtonN"
 import {mapNullable} from "../../api/common/utils/Utils"
 import {Icons} from "./icons/Icons"
+import {ifAllowedTutanotaLinks} from "./GuiUtils"
 
 const WARNING_RED = "#ca0606"
 
@@ -82,16 +83,17 @@ export class InfoBanner implements MComponent<InfoBannerAttrs> {
 		}))
 	}
 
-	renderHelpLink(helpLink: InfoLink): Children {
-		return m(".button-content",
-			{style: {marginRight: "-10px"}},
-			m(NavButtonN, {
-				icon: () => Icons.QuestionMark,
-				href: lang.getInfoLink(helpLink),
-				small: true,
-				hideLabel: true,
-				centred: true,
-				label: "help_label"
-			}))
+	renderHelpLink(helpLink: InfoLink): ?Children {
+		return ifAllowedTutanotaLinks(helpLink, link => {
+			return m(".button-content",
+				{style: {marginRight: "-10px"}},
+				m(NavButtonN, {
+					icon: () => Icons.QuestionMark,
+					href: link,
+					small: true,
+					hideLabel: true,
+					centred: true,
+				label: "help_label"}))
+		})
 	}
 }

--- a/src/login/LoginViewController.js
+++ b/src/login/LoginViewController.js
@@ -223,12 +223,15 @@ export class LoginViewController implements ILoginViewController {
 					return locator.mailModel.init()
 				}
 			})
-			.then(() => logins.loginComplete()).then(() => {
+			.then(() => logins.loginComplete()).then(async () => {
 			if (isApp() || isDesktop()) {
 				// don't wait for it, just invoke
 				import("../native/common/FileApp")
 					.then(({fileApp}) => fileApp.clearFileData())
 					.catch((e) => console.log("Failed to clean file data", e))
+
+				await logins.determineIfWhitelabel()
+
 				return this._maybeSetCustomTheme()
 			}
 		})

--- a/src/mail/view/MailViewer.js
+++ b/src/mail/view/MailViewer.js
@@ -119,7 +119,7 @@ import {isNewMailActionAvailable} from "../../gui/nav/NavFunctions"
 import {locator} from "../../api/main/MainLocator"
 import {exportMails} from "../export/Exporter"
 import {BannerType, InfoBanner} from "../../gui/base/InfoBanner"
-import {getCoordsOfMouseOrTouchEvent, createMoreSecondaryButtonAttrs} from "../../gui/base/GuiUtils"
+import {getCoordsOfMouseOrTouchEvent, createMoreSecondaryButtonAttrs, ifAllowedTutanotaLinks} from "../../gui/base/GuiUtils"
 import type {Link} from "../../misc/HtmlSanitizer"
 import {stringifyFragment} from "../../gui/HtmlUtils"
 import {IndexingNotSupportedError} from "../../api/common/error/IndexingNotSupportedError"
@@ -778,7 +778,8 @@ export class MailViewer {
 				style: {marginBottom: "-10px"},
 			}, [
 				m("div", lang.get("phishingReport_msg")),
-				m("a.mt-s", {href: lang.getInfoLink("phishing_link"), target: "_blank"}, lang.get("whatIsPhishing_msg")),
+				ifAllowedTutanotaLinks("phishing_link",
+					link => m("a.mt-s", {href: link, target: "_blank"}, lang.get("whatIsPhishing_msg"))),
 				m(".flex-wrap.flex-end", [
 					m(ButtonN, {
 						label: "reportPhishing_action",

--- a/src/settings/DesktopSettingsViewer.js
+++ b/src/settings/DesktopSettingsViewer.js
@@ -22,6 +22,7 @@ import type {NativeWrapper} from "../native/common/NativeWrapper"
 import type {DesktopConfigKeyEnum} from "../desktop/config/ConfigKeys"
 import {typeof DesktopConfigKey} from "../desktop/config/ConfigKeys"
 import {getCurrentSpellcheckLanguageLabel, showSpellcheckLanguageDialog} from "../gui/dialogs/SpellcheckLanguageDialog"
+import {ifAllowedTutanotaLinks} from "../gui/base/GuiUtils"
 import type {UpdatableSettingsViewer} from "./SettingsView"
 
 assertMainOrNode()
@@ -85,12 +86,11 @@ export class DesktopSettingsViewer implements UpdatableSettingsViewer {
 		const setRunInBackgroundAttrs: DropDownSelectorAttrs<boolean> = {
 			label: "runInBackground_action",
 			helpLabel: () => {
-				const lnk = lang.getInfoLink("runInBackground_link")
-				return [
+				return ifAllowedTutanotaLinks("runInBackground_link", link => [
 					m("span", lang.get("runInBackground_msg") + " "),
 					m("span", lang.get("moreInfo_msg") + " "),
-					m("span.text-break", [m(`a[href=${lnk}][target=_blank]`, lnk)])
-				]
+					m("span.text-break", [m(`a[href=${link}][target=_blank]`, link)])
+				])
 			},
 			items: [
 				{name: lang.get("yes_label"), value: true},

--- a/src/settings/EditSecondFactorsForm.js
+++ b/src/settings/EditSecondFactorsForm.js
@@ -36,6 +36,7 @@ import type {EntityUpdateData} from "../api/main/EventController"
 import {isUpdateForTypeRef} from "../api/main/EventController"
 import type {User} from "../api/entities/sys/User"
 import {getEtId, isSameId} from "../api/common/utils/EntityUtils";
+import {ifAllowedTutanotaLinks} from "../gui/base/GuiUtils"
 import {ofClass} from "../api/common/utils/PromiseUtils"
 
 assertMainOrNode()
@@ -64,7 +65,6 @@ export class EditSecondFactorsForm {
 	}
 
 	view(): Children {
-		const lnk = lang.getInfoLink('2FA_link')
 		const secondFactorTableAttrs: TableAttrs = {
 			columnHeading: ["name_label", "type_label"],
 			columnWidths: [ColumnWidth.Largest, ColumnWidth.Largest],
@@ -83,7 +83,7 @@ export class EditSecondFactorsForm {
 			isTutanotaDomain()
 				? [
 					m("span.small", lang.get("moreInfo_msg") + " "),
-					m("span.small.text-break", [m(`a[href=${lnk}][target=_blank]`, lnk)])
+					ifAllowedTutanotaLinks("2FA_link", link => m("span.small.text-break", [m(`a[href=${link}][target=_blank]`, link)]))
 				]
 				: null
 		]

--- a/src/settings/LoginSettingsViewer.js
+++ b/src/settings/LoginSettingsViewer.js
@@ -1,7 +1,7 @@
 // @flow
 import m from "mithril"
 import stream from "mithril/stream/stream.js"
-import {assertMainOrNode, isTutanotaDomain} from "../api/common/Env"
+import {assertMainOrNode} from "../api/common/Env"
 import type {TextFieldAttrs} from "../gui/base/TextFieldN"
 import {TextFieldN} from "../gui/base/TextFieldN"
 import {lang} from "../misc/LanguageViewModel"
@@ -26,6 +26,7 @@ import type {ExpanderAttrs} from "../gui/base/Expander"
 import {ExpanderButtonN, ExpanderPanelN} from "../gui/base/Expander"
 import type {TableAttrs, TableLineAttrs} from "../gui/base/TableN"
 import {ColumnWidth, TableN} from "../gui/base/TableN"
+import {ifAllowedTutanotaLinks} from "../gui/base/GuiUtils"
 import type {UpdatableSettingsViewer} from "./SettingsView"
 import {ofClass, promiseMap} from "../api/common/utils/PromiseUtils"
 
@@ -96,16 +97,10 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 		const recoveryCodeFieldAttrs: TextFieldAttrs = {
 			label: "recoveryCode_label",
 			helpLabel: () => {
-				if (isTutanotaDomain()) {
-					const lnk = lang.getInfoLink("recoverCode_link")
-					return [
-						m("span", lang.get("moreInfo_msg") + " "),
-						m("span.text-break", [m(`a[href=${lnk}][target=_blank]`, lnk)])
-					]
-				} else {
-					return ""
-				}
-
+				return ifAllowedTutanotaLinks("recoverCode_link", link => [
+					m("span", lang.get("moreInfo_msg") + " "),
+					m("span.text-break", [m(`a[href=${link}][target=_blank]`, link)])
+				])
 			},
 			value: this._stars,
 			disabled: true,

--- a/src/settings/SettingsExpander.js
+++ b/src/settings/SettingsExpander.js
@@ -3,6 +3,7 @@ import type {InfoLink, TranslationKey} from "../misc/LanguageViewModel"
 import {lang} from "../misc/LanguageViewModel"
 import m from "mithril"
 import {ExpanderButtonN, ExpanderPanelN} from "../gui/base/Expander"
+import {ifAllowedTutanotaLinks} from "../gui/base/GuiUtils"
 
 
 export type SettingsExpanderAttrs = {|
@@ -33,7 +34,9 @@ export class SettingsExpander implements MComponent<SettingsExpanderAttrs> {
 			]),
 			m(ExpanderPanelN, {expanded}, vnode.children),
 			infoMsg ? m("small", lang.getMaybeLazy(infoMsg)) : null,
-			infoLinkId ? m("small.text-break", [m(`a[href=${lang.getInfoLink(infoLinkId)}][target=_blank]`, lang.getInfoLink(infoLinkId))]) : null
+			infoLinkId
+				? ifAllowedTutanotaLinks(infoLinkId, link => m("small.text-break", [m(`a[href=${link}][target=_blank]`, link)]))
+				: null
 		];
 	}
 }


### PR DESCRIPTION
fix #3150

This makes sure that the logged in user is either not in whitelabel mode or a global admin before displaying most `tutanota.com` links.

Another improvement would be disabling the FAQ search completely, since all those will come from our domain. This would make #3182 unnecessary.