### PR TITLE
don't handle spellchecking on mac ourselves

### DIFF
--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -47,8 +47,12 @@ export class WindowManager {
 	constructor(conf: DesktopConfig, tray: DesktopTray, notifier: DesktopNotifier, electron: $Exports<"electron">,
 	            localShortcut: LocalShortcutManager, dl: DesktopDownloadManager, themeManager: ThemeManager) {
 		this._conf = conf
-		conf.getVar(DesktopConfigKey.spellcheck).then(l => this._setSpellcheckLang(l))
-		conf.on(DesktopConfigKey.spellcheck, l => this._setSpellcheckLang(l))
+
+		if (process.platform !== "darwin") {
+			conf.getVar(DesktopConfigKey.spellcheck).then(l => this._setSpellcheckLang(l))
+			conf.on(DesktopConfigKey.spellcheck, l => this._setSpellcheckLang(l))
+		}
+
 		this._tray = tray
 		this._notifier = notifier
 		this.dl = dl

--- a/src/settings/DesktopSettingsViewer.js
+++ b/src/settings/DesktopSettingsViewer.js
@@ -211,7 +211,7 @@ export class DesktopSettingsViewer implements UpdatableSettingsViewer {
 		return [
 			m("#user-settings.fill-absolute.scroll.plr-l.pb-xl", [
 				m(".h4.mt-l", lang.get('desktopSettings_label')),
-				m(TextFieldN, spellcheckLanguageAttrs),
+				env.platformId !== 'darwin' ? m(DropDownSelectorN, spellcheckLanguageAttrs) : null,
 				env.platformId === 'linux' ? null : m(DropDownSelectorN, setDefaultMailtoHandlerAttrs),
 				env.platformId === 'darwin' ? null : m(DropDownSelectorN, setRunInBackgroundAttrs),
 				m(DropDownSelectorN, setRunOnStartupAttrs),


### PR DESCRIPTION
electron handles spellchecking through native apis on mac, so we don't need to any configuration of our own

fix #3251