### PR TITLE
[desktop] properly handle findInPage rejections

### DIFF
--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -21,6 +21,7 @@ import {log} from "./DesktopLog"
 import {parseUrlOrNull} from "./PathUtils"
 import type {LocalShortcutManager} from "./electron-localshortcut/LocalShortcut"
 import {ThemeManager} from "./ThemeManager"
+import {CancelledError} from "../api/common/error/CancelledError"
 
 const MINIMUM_WINDOW_SIZE: number = 350
 
@@ -57,7 +58,7 @@ export class ApplicationWindow {
 	_findingInPage: boolean = false;
 	_skipNextSearchBarBlur: boolean = false;
 	_lastSearchRequest: ?[string, {forward: boolean, matchCase: boolean}] = null;
-	_lastSearchPromiseReject: (?string) => void;
+	_lastSearchPromiseReject: (?Error) => void;
 	_shortcuts: Array<LocalShortcut>;
 	id: number;
 
@@ -363,13 +364,13 @@ export class ApplicationWindow {
 		return this._browserWindow.webContents.getURL().substring(this._startFileURLString.length)
 	}
 
-	findInPage([searchTerm, options]: [string, {forward: boolean, matchCase: boolean}]): Promise<FindInPageResult> {
+	findInPage([searchTerm, options]: [string, {forward: boolean, matchCase: boolean}]): Promise<?FindInPageResult> {
 		this._findingInPage = true
 		if (searchTerm !== '') {
 			this._lastSearchRequest = [searchTerm, options]
 			this._browserWindow.webContents.findInPage(searchTerm, options)
 			return new Promise((resolve, reject) => {
-				this._lastSearchPromiseReject("outdated request")
+				this._lastSearchPromiseReject(new CancelledError("search request was superseded"))
 				this._lastSearchPromiseReject = reject
 				this._browserWindow.webContents
 					// the last listener might not have fired yet
@@ -378,16 +379,15 @@ export class ApplicationWindow {
 						this._lastSearchPromiseReject = noOp
 						resolve(res)
 					})
+			}).catch(e => {
+				// findInPage might reject if requests come too quickly
+				// if it's rejecting for another reason we'll have logs
+				if (!(e instanceof CancelledError)) log.debug("findInPage reject: ", e)
+				return null
 			})
 		} else {
 			this.stopFindInPage()
-			return Promise.resolve({
-				requestId: -1,
-				activeMatchOrdinal: 0,
-				matches: 0,
-				selectionArea: {height: 0, width: 0, x: 0, y: 0},
-				finalUpdate: true
-			})
+			return Promise.resolve(null)
 		}
 	}
 

--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -370,7 +370,11 @@ export class ApplicationWindow {
 			this._lastSearchRequest = [searchTerm, options]
 			this._browserWindow.webContents.findInPage(searchTerm, options)
 			return new Promise((resolve, reject) => {
+				// if the last search request is still ongoing, this will reject that requests' promise
+				// we obviously don't care about that requests' result since we are already handling a new one
+				// if the last request is done, this is a noOp
 				this._lastSearchPromiseReject(new CancelledError("search request was superseded"))
+				// make sure we can cancel this promise if we get a new search request before this one is done.
 				this._lastSearchPromiseReject = reject
 				this._browserWindow.webContents
 					// the last listener might not have fired yet

--- a/src/desktop/IPC.js
+++ b/src/desktop/IPC.js
@@ -133,14 +133,9 @@ export class IPC {
 			case 'findInPage':
 				return this.initialized(windowId).then(() => {
 					const w = this._wm.get(windowId)
-					if (w) {
-						// findInPage might reject if requests come too quickly
-						// if it's rejecting for another reason we'll have logs
-						return w.findInPage(downcast(args))
-						        .catch(e => log.debug("findInPage reject:", e))
-					} else {
-						return {numberOfMatches: 0, currentMatch: 0}
-					}
+					return w != null
+						? w.findInPage(downcast(args))
+						: null
 				})
 			case 'stopFindInPage':
 				return this.initialized(windowId).then(() => {

--- a/src/gui/SearchInPageOverlay.js
+++ b/src/gui/SearchInPageOverlay.js
@@ -12,6 +12,7 @@ import {transform} from "./animation/Animations"
 import {nativeApp} from "../native/common/NativeWrapper.js"
 import {ButtonN, ButtonType} from "./base/ButtonN"
 import {Keys} from "../api/common/TutanotaConstants"
+import type {FindInPageResult} from "electron"
 
 assertMainOrNode()
 
@@ -103,19 +104,25 @@ export class SearchInPageOverlay {
 				matchCase: this._matchCase,
 				findNext,
 			}
-		])).then(r => this.applyNextResult(r.activeMatchOrdinal, r.matches))
+		])).then(r => this.applyNextResult(r))
 	}
 
-	applyNextResult(activeMatchOrdinal: number, matches: number): void {
-		if (matches === 1) {
-			/* the search bar loses focus without any events when there
-			*  are no results except for the search bar itself. this enables
-			*  us to retain focus. */
-			this._domInput.blur()
-			this._domInput.focus()
+	applyNextResult(result: ?FindInPageResult): void {
+		if (result == null) {
+			this._numberOfMatches = 0
+			this._currentMatch = 0
+		} else {
+			const {activeMatchOrdinal, matches} = result
+			if (matches === 1) {
+				/* the search bar loses focus without any events when there
+				*  are no results except for the search bar itself. this enables
+				*  us to retain focus. */
+				this._domInput.blur()
+				this._domInput.focus()
+			}
+			this._numberOfMatches = matches - 1
+			this._currentMatch = activeMatchOrdinal - 1
 		}
-		this._numberOfMatches = matches - 1
-		this._currentMatch = activeMatchOrdinal - 1
 		m.redraw()
 	}
 

--- a/src/native/main/NativeWrapperCommands.js
+++ b/src/native/main/NativeWrapperCommands.js
@@ -77,10 +77,9 @@ const openFindInPage = (): Promise<void> => {
 	})
 }
 
-const applySearchResultToOverlay = (result: any): Promise<void> => {
+const applySearchResultToOverlay = (msg: any): Promise<void> => {
 	return import('../../gui/SearchInPageOverlay.js').then(module => {
-		const {activeMatchOrdinal, matches} = result.args[0]
-		module.searchInPageOverlay.applyNextResult(activeMatchOrdinal, matches)
+		module.searchInPageOverlay.applyNextResult(msg.args[0])
 		return Promise.resolve()
 	})
 }


### PR DESCRIPTION
* handle CancelledError as an expected error
* log other rejections
* return null in any rejection case and for no results instead of mock result object
* 
close #3362