### PR TITLE
[ios] fix memory leak when scheduling alarms

### DIFF
--- a/app-ios/tutanota/Sources/Files/TUTFileUtil.m
+++ b/app-ios/tutanota/Sources/Files/TUTFileUtil.m
@@ -85,7 +85,7 @@ static NSString * const FILES_ERROR_DOMAIN = @"tutanota_files";
 		[fileURL getResourceValue:&fileSizeValue
 						   forKey:NSURLFileSizeKey
 							error:&fileSizeError];
-		if (fileSizeValue) {
+		if (fileSizeValue != nil) {
 			completion(fileSizeValue, nil);
 		} else {
 			completion(nil, [NSError errorWithDomain:FILES_ERROR_DOMAIN


### PR DESCRIPTION
We call `TUTUserPreferenceFacade.storeAlarms` in a loop, which calls `NSJSONSerialization.dataWithJSONObject`, which for some reason isn't releasing everything it allocates.

So we now only call `storeAlarms` once after scheduling/unscheduling all the new notifications.

also it goes way more faster now

fix #3363