### PR TITLE
[desktop] handle relative settings URLs in windows

### DIFF
--- a/src/mail/view/MailViewer.js
+++ b/src/mail/view/MailViewer.js
@@ -1792,15 +1792,11 @@ export class MailViewer {
 
 /**
  * support and invoice mails can contain links to the settings page.
- * in the desktop app, all normal anchor links are opened with the default browser.
- * this fails for relative links because the desktop app prepends file://C:/ or file:///
- * and we prevent any files being opened from links in mails.
+ * we don't want normal mails to be able to link places in the app, though.
  * */
-function isSettingsLink({href, origin}: HTMLAnchorElement, mail: Mail): boolean {
-	console.log(href, origin)
-	//Electron in windows appends /<drive letter>:/ to relative urls, so we should match with or without
-	const isSettingsHref = href.startsWith(origin) && !!href.slice(origin.length).match(/^(\/[A-Z]:)?\/settings\//)
-	return isSettingsHref && isTutanotaTeamMail(mail)
+function isSettingsLink(anchor: HTMLAnchorElement, mail: Mail): boolean {
+	const href = anchor.getAttribute("href")
+	return (href != null) && href.startsWith("/settings/") && isTutanotaTeamMail(mail)
 }
 
 type CreateMailViewerOptions = {

--- a/src/mail/view/MailViewer.js
+++ b/src/mail/view/MailViewer.js
@@ -1508,9 +1508,7 @@ export class MailViewer {
 				}
 			}
 			// Navigate to the settings menu if they are linked within an email.
-			else if (anchorElement
-				&& isTutanotaTeamMail(this.mail)
-				&& startsWith(anchorElement.href, (anchorElement.origin + "/settings/"))) {
+			else if (anchorElement && isSettingsLink(anchorElement, this.mail)) {
 				let newRoute = anchorElement.href.substr(anchorElement.href.indexOf("/settings/"))
 				m.route.set(newRoute)
 				event.preventDefault()
@@ -1581,12 +1579,12 @@ export class MailViewer {
 		locator.fileController.downloadAndOpen(file, open)
 		       .catch(ofClass(FileOpenError, (e) => {
 			       console.warn("FileOpenError", e)
-			              Dialog.message("canNotOpenFileOnDevice_msg")
+			       Dialog.message("canNotOpenFileOnDevice_msg")
 		       }))
 		       .catch(e => {
 			       const msg = e || "unknown error"
 			       console.error("could not open file:", msg)
-			              return Dialog.message("errorDuringFileOpen_msg")
+			       return Dialog.message("errorDuringFileOpen_msg")
 		       })
 	}
 
@@ -1790,6 +1788,19 @@ export class MailViewer {
 
 		return {inlineImageCids, links, externalContent}
 	}
+}
+
+/**
+ * support and invoice mails can contain links to the settings page.
+ * in the desktop app, all normal anchor links are opened with the default browser.
+ * this fails for relative links because the desktop app prepends file://C:/ or file:///
+ * and we prevent any files being opened from links in mails.
+ * */
+function isSettingsLink({href, origin}: HTMLAnchorElement, mail: Mail): boolean {
+	console.log(href, origin)
+	//Electron in windows appends /<drive letter>:/ to relative urls, so we should match with or without
+	const isSettingsHref = href.startsWith(origin) && !!href.slice(origin.length).match(/^(\/[A-Z]:)?\/settings\//)
+	return isSettingsHref && isTutanotaTeamMail(mail)
 }
 
 type CreateMailViewerOptions = {


### PR DESCRIPTION
*  the mail's `/settings/invoice` href is interpreted as an
absolute path, the root of which is `https://mail.tutanota.com/`
in browsers (correct) and the file system root in
electron (wrong).
* changing it to a relative path, e.g. `../../settings/invoice`
would _theoretically_ work, but relies on the link being displayed
in the correct location relative to the settings page.
Practically, any link navigation in the desktop clients that's
pointing to the file system is prevented by us, because we don't
want the shell to open/execute random files from links that got sent by mail.
* the `file:///C:/settings/invoice` link is generated from the mail's
`/settings/invoice` href by electron before dispatching the onclick event.

this commit allows for relative navigation from Tutanota Team
mails if the href contains a drive letter between origin and
the settings path.

fix #3333