### PR TITLE
don't send promises over the worker saving/updating/sending drafts

### DIFF
--- a/src/api/common/RecipientInfo.js
+++ b/src/api/common/RecipientInfo.js
@@ -21,12 +21,6 @@ export function isExternal(recipientInfo: RecipientInfo): boolean {
 	return recipientInfo.type === RecipientInfoType.EXTERNAL
 }
 
-export function isExternalSecureRecipient(recipientInfo: RecipientInfo): boolean {
-	return isExternal(recipientInfo) &&
-		recipientInfo.contact != null && recipientInfo.contact.presharedPassword != null
-		&& recipientInfo.contact.presharedPassword.trim() !== ""
-}
-
 export function isTutanotaMailAddress(mailAddress: string): boolean {
 	var tutanotaDomains = TUTANOTA_MAIL_ADDRESS_DOMAINS
 	for (var i = 0; i < tutanotaDomains.length; i++) {
@@ -35,4 +29,21 @@ export function isTutanotaMailAddress(mailAddress: string): boolean {
 		}
 	}
 	return false
+}
+
+// We need this type because we cannot pass RecipientInfo across the worker, since they (may) contain Promises
+export type RecipientDetails = {
+	name: string,
+	mailAddress: string,
+	isExternal: boolean,
+	password: ?string,
+}
+
+export function makeRecipientDetails(name: string, mailAddress: string, type: RecipientInfoTypeEnum, contact: ?Contact): RecipientDetails {
+	return {
+		name,
+		mailAddress,
+		isExternal: type === RecipientInfoType.EXTERNAL,
+		password: contact?.presharedPassword ?? contact?.autoTransmitPassword
+	}
 }

--- a/src/api/main/WorkerClient.js
+++ b/src/api/main/WorkerClient.js
@@ -48,7 +48,6 @@ import type {Mail} from "../entities/tutanota/Mail"
 import type {EntityRestInterface} from "../worker/rest/EntityRestClient"
 import type {NewSessionData} from "../worker/facades/LoginFacade"
 import {logins} from "./LoginController"
-import type {RecipientInfo} from "../common/RecipientInfo"
 import type {WebsocketLeaderStatus} from "../entities/sys/WebsocketLeaderStatus"
 import {createWebsocketLeaderStatus} from "../entities/sys/WebsocketLeaderStatus"
 import type {Country} from "../common/CountryList"
@@ -57,6 +56,9 @@ import type {GiftCardRedeemGetReturn} from "../entities/sys/GiftCardRedeemGetRet
 import {TypeRef} from "../common/utils/TypeRef"
 import {addSearchIndexDebugEntry} from "../../misc/IndexerDebugLogger"
 import type {TypeModel} from "../common/EntityTypes"
+import type {DraftRecipient} from "../entities/tutanota/DraftRecipient"
+import type {EncryptedMailAddress} from "../entities/tutanota/EncryptedMailAddress"
+import type {RecipientDetails} from "../common/RecipientInfo"
 
 assertMainOrNode()
 
@@ -237,23 +239,23 @@ export class WorkerClient implements EntityRestInterface {
 		return this._postRequest(new Request('createMailFolder', arguments))
 	}
 
-	createMailDraft(subject: string, body: string, senderAddress: string, senderName: string, toRecipients: $ReadOnlyArray<RecipientInfo>,
-	                ccRecipients: $ReadOnlyArray<RecipientInfo>, bccRecipients: $ReadOnlyArray<RecipientInfo>,
+	createMailDraft(subject: string, body: string, senderAddress: string, senderName: string, toRecipients: $ReadOnlyArray<DraftRecipient>,
+	                ccRecipients: $ReadOnlyArray<DraftRecipient>, bccRecipients: $ReadOnlyArray<DraftRecipient>,
 	                conversationType: ConversationTypeEnum, previousMessageId: ?Id,
 	                attachments: ?$ReadOnlyArray<TutanotaFile | DataFile | FileReference>,
-	                confidential: boolean, replyTos: $ReadOnlyArray<RecipientInfo>, method: MailMethodEnum
+	                confidential: boolean, replyTos: $ReadOnlyArray<EncryptedMailAddress>, method: MailMethodEnum
 	): Promise<Mail> {
 		return this._postRequest(new Request('createMailDraft', arguments))
 	}
 
-	updateMailDraft(subject: string, body: string, senderAddress: string, senderName: string, toRecipients: $ReadOnlyArray<RecipientInfo>,
-	                ccRecipients: $ReadOnlyArray<RecipientInfo>, bccRecipients: $ReadOnlyArray<RecipientInfo>,
+	updateMailDraft(subject: string, body: string, senderAddress: string, senderName: string, toRecipients: $ReadOnlyArray<DraftRecipient>,
+	                ccRecipients: $ReadOnlyArray<DraftRecipient>, bccRecipients: $ReadOnlyArray<DraftRecipient>,
 	                attachments: ?$ReadOnlyArray<TutanotaFile | DataFile | FileReference>, confidential: boolean, draft: Mail): Promise<Mail> {
 		return this._postRequest(new Request('updateMailDraft', arguments))
 	}
 
-	sendMailDraft(draft: Mail, recipientInfos: $ReadOnlyArray<RecipientInfo>, language: string): Promise<void> {
-		return this._postRequest(new Request('sendMailDraft', [draft, recipientInfos, language]))
+	sendMailDraft(draft: Mail, recipients: $ReadOnlyArray<RecipientDetails>, language: string): Promise<void> {
+		return this._postRequest(new Request('sendMailDraft', [draft, recipients, language]))
 	}
 
 	downloadFileContent(file: TutanotaFile): Promise<DataFile> {

--- a/src/mail/model/MailUtils.js
+++ b/src/mail/model/MailUtils.js
@@ -47,6 +47,8 @@ import {createPublicKeyData} from "../../api/entities/sys/PublicKeyData"
 import type {WorkerClient} from "../../api/main/WorkerClient"
 import {fullNameToFirstAndLastName, mailAddressToFirstAndLastName} from "../../misc/parsing/MailAddressParser";
 import {ofClass} from "../../api/common/utils/PromiseUtils"
+import type {DraftRecipient} from "../../api/entities/tutanota/DraftRecipient"
+import {createDraftRecipient} from "../../api/entities/tutanota/DraftRecipient"
 
 assertMainOrNode()
 
@@ -137,10 +139,10 @@ export function resolveRecipientInfo(worker: WorkerClient, recipientInfo: Recipi
 		return Promise.resolve(recipientInfo)
 	} else {
 		return getRecipientKeyData(worker, recipientInfo.mailAddress)
-		                .then((keyData) => {
-			                recipientInfo.type = keyData == null ? RecipientInfoType.EXTERNAL : RecipientInfoType.INTERNAL
-			                return recipientInfo
-		                })
+			.then((keyData) => {
+				recipientInfo.type = keyData == null ? RecipientInfoType.EXTERNAL : RecipientInfoType.INTERNAL
+				return recipientInfo
+			})
 	}
 }
 
@@ -403,4 +405,18 @@ export function getExistingRuleForType(props: TutanotaProperties, cleanValue: st
 
 export function canDoDragAndDropExport(): boolean {
 	return isDesktop()
+}
+
+/**
+ * Lossily convert a RecipientInfo to a DraftRecipient
+ */
+export function recipientInfoToDraftRecipient({name, mailAddress}: RecipientInfo): DraftRecipient {
+	return createDraftRecipient({name, mailAddress})
+}
+
+/**
+ * Lossily convert a RecipientInfo to an EncryptedMailAddress
+ */
+export function recipientInfoToEncryptedMailAddress({name, mailAddress}: RecipientInfo): EncryptedMailAddress {
+	return createEncryptedMailAddress({name, address: mailAddress})
 }


### PR DESCRIPTION
This turned out to be fairly large. We pass RecipientInfos, which may have Promises inside of them, over the worker boundary. This is no good, but for some reason worked when we had bluebird, but not anymore

This commit also contains some refactorings to use async/await

fix #3399