### PR TITLE
Fix reconnecting websocket

### DIFF
--- a/src/api/worker/EventBusClient.js
+++ b/src/api/worker/EventBusClient.js
@@ -291,9 +291,7 @@ export class EventBusClient {
 				break;
 		}
 
-		if (this._socket && typeof this._socket == "function") { // close is undefined in node tests
-			this._socket.close()
-		}
+		this._socket?.close()
 	}
 
 	_unsubscribeFromOldWebsocket() {


### PR DESCRIPTION
Check for socket in _close() was broken with Flow update (it was
checking if socket is a function which is never the case). This code is
not needed because the function is stubbed in tests anyway.

 fix #3411