### PR TITLE
fix search list duplication

### DIFF
--- a/src/api/common/utils/ArrayUtils.js
+++ b/src/api/common/utils/ArrayUtils.js
@@ -417,3 +417,18 @@ export function partition<T>(array: Array<T>, predicate: T => boolean): [Array<T
 
 	return [left, right]
 }
+
+export function compare<T>(a1: Array<T>, a2: Array<T>, comp: (T, T) => boolean = (a, b) => a === b): boolean {
+	if (a1.length !== a2.length) {
+		return false
+	}
+
+	for (let i = 0; i < a1.length; ++i) {
+		if (!comp(a1[i], a2[1])) {
+			return false
+		}
+	}
+
+	return true
+}
+

--- a/src/api/common/utils/ArrayUtils.js
+++ b/src/api/common/utils/ArrayUtils.js
@@ -27,6 +27,10 @@ export function numberRange(min: number, max: number): Array<number> {
  * It is valid to compare Uint8Array to Array<T>, don't restrict it to be one type
  */
 export function arrayEquals<T, A: Uint8Array | Array<T>>(a1: A, a2: A): boolean {
+	if (a1 === a2) {
+		return true
+	}
+
 	if (a1.length === a2.length) {
 		for (let i = 0; i < a1.length; i++) {
 			if (a1[i] !== a2[i]) {
@@ -417,18 +421,3 @@ export function partition<T>(array: Array<T>, predicate: T => boolean): [Array<T
 
 	return [left, right]
 }
-
-export function compare<T>(a1: Array<T>, a2: Array<T>, comp: (T, T) => boolean = (a, b) => a === b): boolean {
-	if (a1.length !== a2.length) {
-		return false
-	}
-
-	for (let i = 0; i < a1.length; ++i) {
-		if (!comp(a1[i], a2[1])) {
-			return false
-		}
-	}
-
-	return true
-}
-

--- a/src/gui/base/List.js
+++ b/src/gui/base/List.js
@@ -11,7 +11,7 @@ import {debounceStart, defer, mapLazily, neverNull} from "../../api/common/utils
 import {assertMainOrNode} from "../../api/common/Env"
 import ColumnEmptyMessageBox from "./ColumnEmptyMessageBox"
 import {progressIcon} from "./Icon"
-import {animations, transform} from "./../animation/Animations"
+import {animations, transform} from "../animation/Animations"
 import {ease} from "../animation/Easing"
 import {DefaultAnimationTime, opacity} from "../animation/Animations"
 import {windowFacade} from "../../misc/WindowFacade"

--- a/src/search/SearchBar.js
+++ b/src/search/SearchBar.js
@@ -469,7 +469,7 @@ export class SearchBar implements MComponent<SearchBarAttrs> {
 		const limit = isSameTypeRef(MailTypeRef, restriction.type)
 			? this._isQuickSearch() ? MAX_SEARCH_PREVIEW_RESULTS : PageSize
 			: null
-		locator.search.search(query, restriction, useSuggestions ? 10 : 0, limit)
+		locator.search.search({query: query || "", restriction, minSuggestionCount: useSuggestions ? 10 : 0, maxResults: limit})
 		       .then(result => this._loadAndDisplayResult(query, result, limit))
 		       .finally(() => cb())
 	})

--- a/src/search/SearchBar.js
+++ b/src/search/SearchBar.js
@@ -469,7 +469,7 @@ export class SearchBar implements MComponent<SearchBarAttrs> {
 		const limit = isSameTypeRef(MailTypeRef, restriction.type)
 			? this._isQuickSearch() ? MAX_SEARCH_PREVIEW_RESULTS : PageSize
 			: null
-		locator.search.search({query: query || "", restriction, minSuggestionCount: useSuggestions ? 10 : 0, maxResults: limit})
+		locator.search.search({query: query ?? "", restriction, minSuggestionCount: useSuggestions ? 10 : 0, maxResults: limit})
 		       .then(result => this._loadAndDisplayResult(query, result, limit))
 		       .finally(() => cb())
 	})

--- a/src/search/model/SearchModel.js
+++ b/src/search/model/SearchModel.js
@@ -8,7 +8,7 @@ import type {WorkerClient} from "../../api/main/WorkerClient"
 import type {SearchIndexStateInfo, SearchRestriction, SearchResult} from "../../api/worker/search/SearchTypes"
 import {isSameTypeRef} from "../../api/common/utils/TypeRef";
 import {ofClass} from "../../api/common/utils/PromiseUtils"
-import {compare} from "../../api/common/utils/ArrayUtils"
+import {arrayEquals} from "../../api/common/utils/ArrayUtils"
 
 assertMainOrNode()
 
@@ -46,9 +46,7 @@ export class SearchModel {
 	}
 
 	async search(searchQuery: SearchQuery): Promise<?SearchResult> {
-		console.log("search:", searchQuery, this._lastQuery, this._lastQuery && compareSearchQuery(searchQuery, this._lastQuery))
-		if (this._lastQuery && compareSearchQuery(searchQuery, this._lastQuery)) {
-			console.log("its the same")
+		if (this._lastQuery && areSearchQueriesEqual(searchQuery, this._lastQuery)) {
 			return this._lastSearchPromise
 		}
 
@@ -113,7 +111,7 @@ export class SearchModel {
 	}
 }
 
-function compareSearchQuery(a: SearchQuery, b: SearchQuery) {
+function areSearchQueriesEqual(a: SearchQuery, b: SearchQuery) {
 	return a.query === b.query
 		&& compareSearchRestriction(a.restriction, b.restriction)
 		&& a.minSuggestionCount === b.minSuggestionCount
@@ -121,9 +119,10 @@ function compareSearchQuery(a: SearchQuery, b: SearchQuery) {
 }
 
 function compareSearchRestriction(a: SearchRestriction, b: SearchRestriction): boolean {
-	const isSameAttributeIds = a.attributeIds != null && b.attributeIds != null
-		? compare(a.attributeIds, b.attributeIds)
-		: true
+
+
+	const isSameAttributeIds = a.attributeIds === b.attributeIds
+		|| (!!a.attributeIds && !!b.attributeIds && arrayEquals(a.attributeIds, b.attributeIds))
 
 	return isSameTypeRef(a.type, b.type)
 		&& a.start === b.start

--- a/src/search/model/SearchModel.js
+++ b/src/search/model/SearchModel.js
@@ -46,7 +46,7 @@ export class SearchModel {
 	}
 
 	async search(searchQuery: SearchQuery): Promise<?SearchResult> {
-		if (this._lastQuery && areSearchQueriesEqual(searchQuery, this._lastQuery)) {
+		if (this._lastQuery && searchQueryEquals(searchQuery, this._lastQuery)) {
 			return this._lastSearchPromise
 		}
 
@@ -107,19 +107,18 @@ export class SearchModel {
 			return false
 		}
 
-		return !compareSearchRestriction(restriction, result.restriction)
+		return !searchRestrictionEquals(restriction, result.restriction)
 	}
 }
 
-function areSearchQueriesEqual(a: SearchQuery, b: SearchQuery) {
+function searchQueryEquals(a: SearchQuery, b: SearchQuery) {
 	return a.query === b.query
-		&& compareSearchRestriction(a.restriction, b.restriction)
+		&& searchRestrictionEquals(a.restriction, b.restriction)
 		&& a.minSuggestionCount === b.minSuggestionCount
 		&& a.maxResults === b.maxResults
 }
 
-function compareSearchRestriction(a: SearchRestriction, b: SearchRestriction): boolean {
-
+function searchRestrictionEquals(a: SearchRestriction, b: SearchRestriction): boolean {
 
 	const isSameAttributeIds = a.attributeIds === b.attributeIds
 		|| (!!a.attributeIds && !!b.attributeIds && arrayEquals(a.attributeIds, b.attributeIds))

--- a/src/search/view/SearchListView.js
+++ b/src/search/view/SearchListView.js
@@ -20,14 +20,8 @@ import {logins} from "../../api/main/LoginController"
 import {hasMoreResults} from "../model/SearchModel"
 import {Dialog} from "../../gui/base/Dialog"
 import {flat, groupBy} from "../../api/common/utils/ArrayUtils"
-import {
-	elementIdPart,
-	GENERATED_MAX_ID,
-	isSameId,
-	listIdPart,
-	sortCompareByReverseId
-} from "../../api/common/utils/EntityUtils";
 import type {ListElement} from "../../api/common/utils/EntityUtils"
+import {elementIdPart, GENERATED_MAX_ID, isSameId, listIdPart, sortCompareByReverseId} from "../../api/common/utils/EntityUtils";
 import {archiveMails, moveToInbox, showDeleteConfirmationDialog} from "../../mail/view/MailGuiUtils";
 import {MailRow} from "../../mail/view/MailRow";
 import {isSameTypeRef, TypeRef} from "../../api/common/utils/TypeRef";
@@ -133,8 +127,8 @@ export class SearchListView {
 					return Promise.resolve([])
 				}
 				return this._loadSearchResults(this._searchResult, startId !== GENERATED_MAX_ID, startId, count)
-				           .then(results => results.map(instance => new SearchResultListEntry(instance)))
-				           .finally(m.redraw)
+					           .then(results => results.map(instance => new SearchResultListEntry(instance)))
+					           .finally(m.redraw)
 			},
 			loadSingle: (elementId) => {
 				if (this._searchResult) {
@@ -246,26 +240,26 @@ export class SearchListView {
 
 		const grouped = groupBy(toLoad, listIdPart)
 		return promiseMap(grouped, ([listId, ids]) => loadMultiple(type, listId, ids.map(elementIdPart)))
-		              .then(flat)
-		              .then((loaded) => {
-			              // Filter not found instances from the current result as well so we don’t loop trying to load them
-			              if (loaded.length < toLoad.length) {
-				              const resultLength = currentResult.results.length
-				              console.log(`Could not load some results: ${loaded.length} out of ${toLoad.length}`)
-				              // loop backwards to remove correct elements by index
-				              for (let i = toLoad.length - 1; i >= 0; i--) {
-					              const toLoadId = toLoad[i]
-					              if (loaded.find((l) => isSameId(l._id, toLoadId)) == null) {
-						              currentResult.results.splice(startIndex + i, 1)
-						              if (loaded.length === toLoad.length) {
-							              break
-						              }
-					              }
-				              }
-				              console.log(`Fixed results, before ${resultLength}, after: ${currentResult.results.length}`)
-			              }
-			              return loaded
-		              })
+			.then(flat)
+			.then((loaded) => {
+				// Filter not found instances from the current result as well so we don’t loop trying to load them
+				if (loaded.length < toLoad.length) {
+					const resultLength = currentResult.results.length
+					console.log(`Could not load some results: ${loaded.length} out of ${toLoad.length}`)
+					// loop backwards to remove correct elements by index
+					for (let i = toLoad.length - 1; i >= 0; i--) {
+						const toLoadId = toLoad[i]
+						if (loaded.find((l) => isSameId(l._id, toLoadId)) == null) {
+							currentResult.results.splice(startIndex + i, 1)
+							if (loaded.length === toLoad.length) {
+								break
+							}
+						}
+					}
+					console.log(`Fixed results, before ${resultLength}, after: ${currentResult.results.length}`)
+				}
+				return loaded
+			})
 	}
 
 	isEntitySelected(id: Id): boolean {

--- a/src/search/view/SearchView.js
+++ b/src/search/view/SearchView.js
@@ -481,11 +481,11 @@ export class SearchView implements CurrentView {
 		// using hasOwnProperty to distinguish case when url is like '/search/mail/query='
 		if (args.hasOwnProperty('query')) {
 			if (locator.search.isNewSearch(args.query, restriction)) {
-				locator.search.search(args.query, restriction, 0, maxResults)
+				locator.search.search({query: args.query, restriction, minSuggestionCount: 0, maxResults})
 			}
 		} else if (lastQuery && locator.search.isNewSearch(lastQuery, restriction)) {
 			// If query is not set for some reason (e.g. switching search type), use the last query value
-			locator.search.search(lastQuery, restriction, 0, maxResults)
+			locator.search.search({query: lastQuery, restriction, minSuggestionCount: 0, maxResults})
 		}
 		// update the filters
 		if (isSameTypeRef(restriction.type, MailTypeRef)) {


### PR DESCRIPTION
if we try to search again for the exact same query, then we will just return the promise from the previous search query.

Will need to be confirmed that this is the right way to go by someone who groks the search implementation

 fix #1972