### PR TITLE
Update Electron to 13.3.0

### DIFF
--- a/flow/electron.js
+++ b/flow/electron.js
@@ -6,7 +6,7 @@ type Record<A, B> = {[A]: B}
 
 // Little hack, we can"t override properties with event name (like on() or once()) but we need some other generic things
 declare class EventEmitterStub {
-	emit(event: string, ...args:Array<any>): boolean;
+	emit(event: string, ...args: Array<any>): boolean;
 	removeAllListeners(event?: string): this;
 }
 
@@ -485,9 +485,538 @@ declare module 'electron' {
 		enabled: boolean;
 	}
 
+	declare type DefaultFontFamily = {
+		/**
+		 * Defaults to `Times New Roman`.
+		 */
+		standard?: string;
+		/**
+		 * Defaults to `Times New Roman`.
+		 */
+		serif?: string;
+		/**
+		 * Defaults to `Arial`.
+		 */
+		sansSerif?: string;
+		/**
+		 * Defaults to `Courier New`.
+		 */
+		monospace?: string;
+		/**
+		 * Defaults to `Script`.
+		 */
+		cursive?: string;
+		/**
+		 * Defaults to `Impact`.
+		 */
+		fantasy?: string;
+	}
+
+
+	declare type WebPreferences = {
+		/**
+		 * Whether to enable DevTools. If it is set to `false`, can not use
+		 * `BrowserWindow.webContents.openDevTools()` to open DevTools. Default is `true`.
+		 */
+		devTools?: boolean;
+		/**
+		 * Whether node integration is enabled. Default is `false`.
+		 */
+		nodeIntegration?: boolean;
+		/**
+		 * Whether node integration is enabled in web workers. Default is `false`. More
+		 * about this can be found in Multithreading.
+		 */
+		nodeIntegrationInWorker?: boolean;
+		/**
+		 * Experimental option for enabling Node.js support in sub-frames such as iframes
+		 * and child windows. All your preloads will load for every iframe, you can use
+		 * `process.isMainFrame` to determine if you are in the main frame or not.
+		 */
+		nodeIntegrationInSubFrames?: boolean;
+		/**
+		 * Specifies a script that will be loaded before other scripts run in the page.
+		 * This script will always have access to node APIs no matter whether node
+		 * integration is turned on or off. The value should be the absolute file path to
+		 * the script. When node integration is turned off, the preload script can
+		 * reintroduce Node global symbols back to the global scope. See example here.
+		 */
+		preload?: string;
+		/**
+		 * If set, this will sandbox the renderer associated with the window, making it
+		 * compatible with the Chromium OS-level sandbox and disabling the Node.js engine.
+		 * This is not the same as the `nodeIntegration` option and the APIs available to
+		 * the preload script are more limited. Read more about the option here.
+		 */
+		sandbox?: boolean;
+		/**
+		 * Whether to enable the `remote` module. Default is `false`.
+		 */
+		enableRemoteModule?: boolean;
+		/**
+		 * Sets the session used by the page. Instead of passing the Session object
+		 * directly, you can also choose to use the `partition` option instead, which
+		 * accepts a partition string. When both `session` and `partition` are provided,
+		 * `session` will be preferred. Default is the default session.
+		 */
+		session?: Session;
+		/**
+		 * Sets the session used by the page according to the session's partition string.
+		 * If `partition` starts with `persist:`, the page will use a persistent session
+		 * available to all pages in the app with the same `partition`. If there is no
+		 * `persist:` prefix, the page will use an in-memory session. By assigning the same
+		 * `partition`, multiple pages can share the same session. Default is the default
+		 * session.
+		 */
+		partition?: string;
+		/**
+		 * When specified, web pages with the same `affinity` will run in the same renderer
+		 * process. Note that due to reusing the renderer process, certain `webPreferences`
+		 * options will also be shared between the web pages even when you specified
+		 * different values for them, including but not limited to `preload`, `sandbox` and
+		 * `nodeIntegration`. So it is suggested to use exact same `webPreferences` for web
+		 * pages with the same `affinity`. _Deprecated_
+		 */
+		affinity?: string;
+		/**
+		 * The default zoom factor of the page, `3.0` represents `300%`. Default is `1.0`.
+		 */
+		zoomFactor?: number;
+		/**
+		 * Enables JavaScript support. Default is `true`.
+		 */
+		javascript?: boolean;
+		/**
+		 * When `false`, it will disable the same-origin policy (usually using testing
+		 * websites by people), and set `allowRunningInsecureContent` to `true` if this
+		 * options has not been set by user. Default is `true`.
+		 */
+		webSecurity?: boolean;
+		/**
+		 * Allow an https page to run JavaScript, CSS or plugins from http URLs. Default is
+		 * `false`.
+		 */
+		allowRunningInsecureContent?: boolean;
+		/**
+		 * Enables image support. Default is `true`.
+		 */
+		images?: boolean;
+		/**
+		 * Make TextArea elements resizable. Default is `true`.
+		 */
+		textAreasAreResizable?: boolean;
+		/**
+		 * Enables WebGL support. Default is `true`.
+		 */
+		webgl?: boolean;
+		/**
+		 * Whether plugins should be enabled. Default is `false`.
+		 */
+		plugins?: boolean;
+		/**
+		 * Enables Chromium's experimental features. Default is `false`.
+		 */
+		experimentalFeatures?: boolean;
+		/**
+		 * Enables scroll bounce (rubber banding) effect on macOS. Default is `false`.
+		 */
+		scrollBounce?: boolean;
+		/**
+		 * A list of feature strings separated by `,`, like `CSSVariables,KeyboardEventKey`
+		 * to enable. The full list of supported feature strings can be found in the
+		 * RuntimeEnabledFeatures.json5 file.
+		 */
+		enableBlinkFeatures?: string;
+		/**
+		 * A list of feature strings separated by `,`, like `CSSVariables,KeyboardEventKey`
+		 * to disable. The full list of supported feature strings can be found in the
+		 * RuntimeEnabledFeatures.json5 file.
+		 */
+		disableBlinkFeatures?: string;
+		/**
+		 * Sets the default font for the font-family.
+		 */
+		defaultFontFamily?: DefaultFontFamily;
+		/**
+		 * Defaults to `16`.
+		 */
+		defaultFontSize?: number;
+		/**
+		 * Defaults to `13`.
+		 */
+		defaultMonospaceFontSize?: number;
+		/**
+		 * Defaults to `0`.
+		 */
+		minimumFontSize?: number;
+		/**
+		 * Defaults to `ISO-8859-1`.
+		 */
+		defaultEncoding?: string;
+		/**
+		 * Whether to throttle animations and timers when the page becomes background. This
+		 * also affects the Page Visibility API. Defaults to `true`.
+		 */
+		backgroundThrottling?: boolean;
+		/**
+		 * Whether to enable offscreen rendering for the browser window. Defaults to
+		 * `false`. See the offscreen rendering tutorial for more details.
+		 */
+		offscreen?: boolean;
+		/**
+		 * Whether to run Electron APIs and the specified `preload` script in a separate
+		 * JavaScript context. Defaults to `true`. The context that the `preload` script
+		 * runs in will only have access to its own dedicated `document` and `window`
+		 * globals, as well as its own set of JavaScript builtins (`Array`, `Object`,
+		 * `JSON`, etc.), which are all invisible to the loaded content. The Electron API
+		 * will only be available in the `preload` script and not the loaded page. This
+		 * option should be used when loading potentially untrusted remote content to
+		 * ensure the loaded content cannot tamper with the `preload` script and any
+		 * Electron APIs being used.  This option uses the same technique used by Chrome
+		 * Content Scripts.  You can access this context in the dev tools by selecting the
+		 * 'Electron Isolated Context' entry in the combo box at the top of the Console
+		 * tab.
+		 */
+		contextIsolation?: boolean;
+		/**
+		 * If true, values returned from `webFrame.executeJavaScript` will be sanitized to
+		 * ensure JS values can't unsafely cross between worlds when using
+		 * `contextIsolation`. Defaults to `true`. _Deprecated_
+		 */
+		worldSafeExecuteJavaScript?: boolean;
+		/**
+		 * Whether to use native `window.open()`. Defaults to `false`. Child windows will
+		 * always have node integration disabled unless `nodeIntegrationInSubFrames` is
+		 * true. **Note:** This option is currently experimental.
+		 */
+		nativeWindowOpen?: boolean;
+		/**
+		 * Whether to enable the `<webview>` tag. Defaults to `false`. **Note:** The
+		 * `preload` script configured for the `<webview>` will have node integration
+		 * enabled when it is executed so you should ensure remote/untrusted content is not
+		 * able to create a `<webview>` tag with a possibly malicious `preload` script. You
+		 * can use the `will-attach-webview` event on webContents to strip away the
+		 * `preload` script and to validate or alter the `<webview>`'s initial settings.
+		 */
+		webviewTag?: boolean;
+		/**
+		 * A list of strings that will be appended to `process.argv` in the renderer
+		 * process of this app.  Useful for passing small bits of data down to renderer
+		 * process preload scripts.
+		 */
+		additionalArguments?: string[];
+		/**
+		 * Whether to enable browser style consecutive dialog protection. Default is
+		 * `false`.
+		 */
+		safeDialogs?: boolean;
+		/**
+		 * The message to display when consecutive dialog protection is triggered. If not
+		 * defined the default message would be used, note that currently the default
+		 * message is in English and not localized.
+		 */
+		safeDialogsMessage?: string;
+		/**
+		 * Whether to disable dialogs completely. Overrides `safeDialogs`. Default is
+		 * `false`.
+		 */
+		disableDialogs?: boolean;
+		/**
+		 * Whether dragging and dropping a file or link onto the page causes a navigation.
+		 * Default is `false`.
+		 */
+		navigateOnDragDrop?: boolean;
+		/**
+		 * Autoplay policy to apply to content in the window, can be
+		 * `no-user-gesture-required`, `user-gesture-required`,
+		 * `document-user-activation-required`. Defaults to `no-user-gesture-required`.
+		 */
+		autoplayPolicy?: ('no-user-gesture-required' | 'user-gesture-required' | 'document-user-activation-required');
+		/**
+		 * Whether to prevent the window from resizing when entering HTML Fullscreen.
+		 * Default is `false`.
+		 */
+		disableHtmlFullscreenWindowResize?: boolean;
+		/**
+		 * An alternative title string provided only to accessibility tools such as screen
+		 * readers. This string is not directly visible to users.
+		 */
+		accessibleTitle?: string;
+		/**
+		 * Whether to enable the builtin spellchecker. Default is `true`.
+		 */
+		spellcheck?: boolean;
+		/**
+		 * Whether to enable the WebSQL api. Default is `true`.
+		 */
+		enableWebSQL?: boolean;
+		/**
+		 * Enforces the v8 code caching policy used by blink. Accepted values are
+		 */
+		v8CacheOptions?: ('none' | 'code' | 'bypassHeatCheck' | 'bypassHeatCheckAndEagerCompile');
+		/**
+		 * Whether to enable preferred size mode. The preferred size is the minimum size
+		 * needed to contain the layout of the document—without requiring scrolling.
+		 * Enabling this will cause the `preferred-size-changed` event to be emitted on the
+		 * `WebContents` when the preferred size changes. Default is `false`.
+		 */
+		enablePreferredSizeMode?: boolean;
+	}
+
+	/** Docs: https://electronjs.org/docs/api/structures/point */
+	declare type Point = {
+		x: number;
+		y: number;
+	}
+
+	declare type BrowserWindowConstructorOptions = {
+		/**
+		 * Window's width in pixels. Default is `800`.
+		 */
+		width?: number;
+		/**
+		 * Window's height in pixels. Default is `600`.
+		 */
+		height?: number;
+		/**
+		 * (**required** if y is used) Window's left offset from screen. Default is to
+		 * center the window.
+		 */
+		x?: number;
+		/**
+		 * (**required** if x is used) Window's top offset from screen. Default is to
+		 * center the window.
+		 */
+		y?: number;
+		/**
+		 * The `width` and `height` would be used as web page's size, which means the
+		 * actual window's size will include window frame's size and be slightly larger.
+		 * Default is `false`.
+		 */
+		useContentSize?: boolean;
+		/**
+		 * Show window in the center of the screen.
+		 */
+		center?: boolean;
+		/**
+		 * Window's minimum width. Default is `0`.
+		 */
+		minWidth?: number;
+		/**
+		 * Window's minimum height. Default is `0`.
+		 */
+		minHeight?: number;
+		/**
+		 * Window's maximum width. Default is no limit.
+		 */
+		maxWidth?: number;
+		/**
+		 * Window's maximum height. Default is no limit.
+		 */
+		maxHeight?: number;
+		/**
+		 * Whether window is resizable. Default is `true`.
+		 */
+		resizable?: boolean;
+		/**
+		 * Whether window is movable. This is not implemented on Linux. Default is `true`.
+		 */
+		movable?: boolean;
+		/**
+		 * Whether window is minimizable. This is not implemented on Linux. Default is
+		 * `true`.
+		 */
+		minimizable?: boolean;
+		/**
+		 * Whether window is maximizable. This is not implemented on Linux. Default is
+		 * `true`.
+		 */
+		maximizable?: boolean;
+		/**
+		 * Whether window is closable. This is not implemented on Linux. Default is `true`.
+		 */
+		closable?: boolean;
+		/**
+		 * Whether the window can be focused. Default is `true`. On Windows setting
+		 * `focusable: false` also implies setting `skipTaskbar: true`. On Linux setting
+		 * `focusable: false` makes the window stop interacting with wm, so the window will
+		 * always stay on top in all workspaces.
+		 */
+		focusable?: boolean;
+		/**
+		 * Whether the window should always stay on top of other windows. Default is
+		 * `false`.
+		 */
+		alwaysOnTop?: boolean;
+		/**
+		 * Whether the window should show in fullscreen. When explicitly set to `false` the
+		 * fullscreen button will be hidden or disabled on macOS. Default is `false`.
+		 */
+		fullscreen?: boolean;
+		/**
+		 * Whether the window can be put into fullscreen mode. On macOS, also whether the
+		 * maximize/zoom button should toggle full screen mode or maximize window. Default
+		 * is `true`.
+		 */
+		fullscreenable?: boolean;
+		/**
+		 * Use pre-Lion fullscreen on macOS. Default is `false`.
+		 */
+		simpleFullscreen?: boolean;
+		/**
+		 * Whether to show the window in taskbar. Default is `false`.
+		 */
+		skipTaskbar?: boolean;
+		/**
+		 * Whether the window is in kiosk mode. Default is `false`.
+		 */
+		kiosk?: boolean;
+		/**
+		 * Default window title. Default is `"Electron"`. If the HTML tag `<title>` is
+		 * defined in the HTML file loaded by `loadURL()`, this property will be ignored.
+		 */
+		title?: string;
+		/**
+		 * The window icon. On Windows it is recommended to use `ICO` icons to get best
+		 * visual effects, you can also leave it undefined so the executable's icon will be
+		 * used.
+		 */
+		icon?: (NativeImage) | (string);
+		/**
+		 * Whether window should be shown when created. Default is `true`.
+		 */
+		show?: boolean;
+		/**
+		 * Whether the renderer should be active when `show` is `false` and it has just
+		 * been created.  In order for `document.visibilityState` to work correctly on
+		 * first load with `show: false` you should set this to `false`.  Setting this to
+		 * `false` will cause the `ready-to-show` event to not fire.  Default is `true`.
+		 */
+		paintWhenInitiallyHidden?: boolean;
+		/**
+		 * Specify `false` to create a Frameless Window. Default is `true`.
+		 */
+		frame?: boolean;
+		/**
+		 * Specify parent window. Default is `null`.
+		 */
+		parent?: BrowserWindow;
+		/**
+		 * Whether this is a modal window. This only works when the window is a child
+		 * window. Default is `false`.
+		 */
+		modal?: boolean;
+		/**
+		 * Whether clicking an inactive window will also click through to the web contents.
+		 * Default is `false` on macOS. This option is not configurable on other platforms.
+		 */
+		acceptFirstMouse?: boolean;
+		/**
+		 * Whether to hide cursor when typing. Default is `false`.
+		 */
+		disableAutoHideCursor?: boolean;
+		/**
+		 * Auto hide the menu bar unless the `Alt` key is pressed. Default is `false`.
+		 */
+		autoHideMenuBar?: boolean;
+		/**
+		 * Enable the window to be resized larger than screen. Only relevant for macOS, as
+		 * other OSes allow larger-than-screen windows by default. Default is `false`.
+		 */
+		enableLargerThanScreen?: boolean;
+		/**
+		 * Window's background color as a hexadecimal value, like `#66CD00` or `#FFF` or
+		 * `#80FFFFFF` (alpha in #AARRGGBB format is supported if `transparent` is set to
+		 * `true`). Default is `#FFF` (white).
+		 */
+		backgroundColor?: string;
+		/**
+		 * Whether window should have a shadow. Default is `true`.
+		 */
+		hasShadow?: boolean;
+		/**
+		 * Set the initial opacity of the window, between 0.0 (fully transparent) and 1.0
+		 * (fully opaque). This is only implemented on Windows and macOS.
+		 */
+		opacity?: number;
+		/**
+		 * Forces using dark theme for the window, only works on some GTK+3 desktop
+		 * environments. Default is `false`.
+		 */
+		darkTheme?: boolean;
+		/**
+		 * Makes the window transparent. Default is `false`. On Windows, does not work
+		 * unless the window is frameless.
+		 */
+		transparent?: boolean;
+		/**
+		 * The type of window, default is normal window. See more about this below.
+		 */
+		type?: string;
+		/**
+		 * Specify how the material appearance should reflect window activity state on
+		 * macOS. Must be used with the `vibrancy` property. Possible values are:
+		 */
+		visualEffectState?: ('followWindow' | 'active' | 'inactive');
+		/**
+		 * The style of window title bar. Default is `default`. Possible values are:
+		 */
+		titleBarStyle?: ('default' | 'hidden' | 'hiddenInset' | 'customButtonsOnHover');
+		/**
+		 * Set a custom position for the traffic light buttons in frameless windows.
+		 */
+		trafficLightPosition?: Point;
+		/**
+		 * Whether frameless window should have rounded corners on macOS. Default is
+		 * `true`.
+		 */
+		roundedCorners?: boolean;
+		/**
+		 * Shows the title in the title bar in full screen mode on macOS for `hiddenInset`
+		 * titleBarStyle. Default is `false`.
+		 *
+		 * @deprecated
+		 */
+		fullscreenWindowTitle?: boolean;
+		/**
+		 * Use `WS_THICKFRAME` style for frameless windows on Windows, which adds standard
+		 * window frame. Setting it to `false` will remove window shadow and window
+		 * animations. Default is `true`.
+		 */
+		thickFrame?: boolean;
+		/**
+		 * Add a type of vibrancy effect to the window, only on macOS. Can be
+		 * `appearance-based`, `light`, `dark`, `titlebar`, `selection`, `menu`, `popover`,
+		 * `sidebar`, `medium-light`, `ultra-dark`, `header`, `sheet`, `window`, `hud`,
+		 * `fullscreen-ui`, `tooltip`, `content`, `under-window`, or `under-page`. Please
+		 * note that `appearance-based`, `light`, `dark`, `medium-light`, and `ultra-dark`
+		 * are deprecated and have been removed in macOS Catalina (10.15).
+		 */
+		vibrancy?: ('appearance-based' | 'light' | 'dark' | 'titlebar' | 'selection' | 'menu' | 'popover' | 'sidebar' | 'medium-light' | 'ultra-dark' | 'header' | 'sheet' | 'window' | 'hud' | 'fullscreen-ui' | 'tooltip' | 'content' | 'under-window' | 'under-page');
+		/**
+		 * Controls the behavior on macOS when option-clicking the green stoplight button
+		 * on the toolbar or by clicking the Window > Zoom menu item. If `true`, the window
+		 * will grow to the preferred width of the web page when zoomed, `false` will cause
+		 * it to zoom to the width of the screen. This will also affect the behavior when
+		 * calling `maximize()` directly. Default is `false`.
+		 */
+		zoomToPageWidth?: boolean;
+		/**
+		 * Tab group name, allows opening the window as a native tab on macOS 10.12+.
+		 * Windows with the same tabbing identifier will be grouped together. This also
+		 * adds a native new tab button to your window's tab bar and allows your `app` and
+		 * window to receive the `new-window-for-tab` event.
+		 */
+		tabbingIdentifier?: string;
+		/**
+		 * Settings of web page's features.
+		 */
+		webPreferences?: WebPreferences;
+	}
+
 	declare export class BrowserWindow {
 		// https://github.com/electron/electron/blob/master/docs/api/browser-window.md#new-browserwindowoptions
-		constructor(any): BrowserWindow;
+		constructor(BrowserWindowConstructorOptions): BrowserWindow;
 		on(BrowserWindowEvent, (Event, ...Array<any>) => mixed): BrowserWindow;
 		once(BrowserWindowEvent, (Event, ...Array<any>) => mixed): BrowserWindow;
 		emit(BrowserWindowEvent, ...Array<any>): void;
@@ -693,7 +1222,49 @@ declare module 'electron' {
 
 	declare export type DragInfo = {files: string[] | string, icon?: NativeImage | string}
 
-	declare export type WebContentsEvent = {+sender: WebContents, +preventDefault: ()=>void}
+	declare export type WebContentsEvent = {+sender: WebContents, +preventDefault: () => void}
+
+	/** stub! https://www.electronjs.org/docs/latest/api/structures/referrer/ */
+	declare export type Referrer = {}
+
+	/** stub! https://www.electronjs.org/docs/latest/api/structures/post-body/ */
+	declare export type PostBody = {}
+
+	/** https://www.electronjs.org/docs/latest/api/web-contents/#contentssetwindowopenhandlerhandler */
+	declare export type NewWindowOpenDetails$Disposition =
+		| "default"
+		| "foreground-tab"
+		| "background-tab"
+		| "new-window"
+		| "save-to-disk"
+		| "other"
+
+	/** https://www.electronjs.org/docs/latest/api/web-contents/#contentssetwindowopenhandlerhandler */
+	declare export type NewWindowOpenDetails = {
+		/** The resolved version of the URL passed to window.open(). e.g. opening a window with */
+		url: string,
+		/** Name of the window provided in window.open() */
+		frameName: string,
+		/** Comma separated list of window features provided to window.open(). */
+		features: string,
+		/** Can be default, foreground-tab, background-tab, new-window, save-to-disk or other. */
+		disposition: NewWindowOpenDetails$Disposition,
+		/**
+		 * The referrer that will be passed to the new window. May or may not result in the Referer header being sent, depending on
+		 *  the referrer policy.
+		 */
+		referrer: Referrer,
+		/**
+		 * The post data that will be sent to the new window, along with the appropriate headers that will be set. If no post data is to be
+		 * sent, the value will be null. Only defined when the window is being created by a form that set target=_blank.
+		 */
+		postBody?: ?PostBody,
+	}
+
+	/** https://www.electronjs.org/docs/latest/api/web-contents/#contentssetwindowopenhandlerhandler */
+	declare export type NewWindowOpenReturn =
+		| {action: 'deny'}
+		| {action: 'allow', overrideBrowserWindowOptions?: BrowserWindowConstructorOptions}
 
 	declare export class WebContents {
 		on(WebContentsEventType, (WebContentsEvent, ...Array<any>) => void): WebContents;
@@ -726,6 +1297,7 @@ declare module 'electron' {
 		undo(): void;
 		redo(): void;
 		startDrag(item: DragInfo): void;
+		setWindowOpenHandler(handler: (NewWindowOpenDetails) => NewWindowOpenReturn): void;
 	}
 
 	declare export class WebFrame {
@@ -932,7 +1504,7 @@ If the size is unknown, it returns 0.
 		| 'fullscreen'
 		| 'openExternal';
 	declare export type ElectronSessionEvent =
-		|'will-download'
+		| 'will-download'
 		| 'spellcheck-dictionary-initialized'
 		| 'spellcheck-dictionary-download-begin'
 		| 'spellcheck-dictionary-download-success'

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 				"body-parser": "1.19.0",
 				"chokidar": "3.5.2",
 				"commander": "5.0.0-2",
-				"electron": "11.4.11",
+				"electron": "13.3.0",
 				"electron-builder": "22.11.11",
 				"electron-notarize": "1.0.1",
 				"electron-packager": "15.3.0",
@@ -2764,13 +2764,14 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "11.4.11",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
+			"integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
 			"dev": true,
 			"hasInstallScript": true,
-			"license": "MIT",
 			"dependencies": {
 				"@electron/get": "^1.0.1",
-				"@types/node": "^12.0.12",
+				"@types/node": "^14.6.2",
 				"extract-zip": "^1.0.3"
 			},
 			"bin": {
@@ -3242,9 +3243,10 @@
 			}
 		},
 		"node_modules/electron/node_modules/@types/node": {
-			"version": "12.20.18",
-			"dev": true,
-			"license": "MIT"
+			"version": "14.17.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.14.tgz",
+			"integrity": "sha512-rsAj2u8Xkqfc332iXV12SqIsjVi07H479bOP4q94NAcjzmAvapumEhuVIt53koEf7JFrpjgNKjBga5Pnn/GL8A==",
+			"dev": true
 		},
 		"node_modules/email-addresses": {
 			"version": "4.0.0",
@@ -9165,16 +9167,20 @@
 			}
 		},
 		"electron": {
-			"version": "11.4.11",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
+			"integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
 			"dev": true,
 			"requires": {
 				"@electron/get": "^1.0.1",
-				"@types/node": "^12.0.12",
+				"@types/node": "^14.6.2",
 				"extract-zip": "^1.0.3"
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.20.18",
+					"version": "14.17.14",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.14.tgz",
+					"integrity": "sha512-rsAj2u8Xkqfc332iXV12SqIsjVi07H479bOP4q94NAcjzmAvapumEhuVIt53koEf7JFrpjgNKjBga5Pnn/GL8A==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"body-parser": "1.19.0",
 		"chokidar": "3.5.2",
 		"commander": "5.0.0-2",
-		"electron": "11.4.11",
+		"electron": "13.3.0",
 		"electron-builder": "22.11.11",
 		"electron-notarize": "1.0.1",
 		"electron-packager": "15.3.0",


### PR DESCRIPTION
The only breaking change in 12 and 13 which affects us is that
new-window event is deprecated. I also copied some missing type
definitions for Electron.

Close #3348 