### PR TITLE
fix scrolling in template list after filtering

### DIFF
--- a/src/templates/model/TemplatePopupModel.js
+++ b/src/templates/model/TemplatePopupModel.js
@@ -50,7 +50,6 @@ export class TemplatePopupModel {
 	_allTemplates: SortedArray<EmailTemplate>
 	+searchResults: Stream<$ReadOnlyArray<EmailTemplate>>
 	+selectedTemplate: Stream<?EmailTemplate>
-	_templateListId: Id
 	initialized: LazyLoaded<TemplatePopupModel>
 	+_eventController: EventController;
 	+_entityEventReceived: EntityEventsListener;
@@ -59,7 +58,6 @@ export class TemplatePopupModel {
 	_groupInstances: Array<TemplateGroupInstance>
 
 	_selectedContentLanguage: LanguageCode
-	_selectedContent: ?EmailTemplateContent
 
 	_searchFilter: TemplateSearchFilter
 

--- a/src/templates/view/TemplatePopup.js
+++ b/src/templates/view/TemplatePopup.js
@@ -360,7 +360,6 @@ export class TemplatePopup implements ModalComponent {
 			items: this._templateModel.searchResults(),
 			selectedItem: this._templateModel.selectedTemplate,
 			emptyListMessage: () => this._templateModel.isLoaded() ? "nothingFound_label" : "loadingTemplates_label",
-			itemHeight: TEMPLATE_LIST_ENTRY_HEIGHT,
 			width: TEMPLATE_LIST_ENTRY_WIDTH,
 			renderItem: (template) => m(TemplatePopupResultRow, {template: template}),
 			onItemDoubleClicked: (template) => {


### PR DESCRIPTION
use element.scrollIntoView function instead of manual positioning, fix scrolling after filtering templates, fixes #3229