### PR TITLE
stop overflow in calendar event popup

### DIFF
--- a/src/calendar/view/CalendarEventPopup.js
+++ b/src/calendar/view/CalendarEventPopup.js
@@ -26,6 +26,8 @@ export class CalendarEventPopup implements ModalComponent {
 	_onEditEvent: () => mixed
 	_shortcuts: Shortcut[]
 	_sanitizedDescription: string
+	_headerDom: ?HTMLElement = null
+	_popupDom: ?HTMLElement = null
 
 	view: (Vnode<mixed>) => Children
 
@@ -85,16 +87,24 @@ export class CalendarEventPopup implements ModalComponent {
 					style: {
 						width: px(Math.min(window.innerWidth - DROPDOWN_MARGIN * 2, 400)), // minus margin, need to apply it now to not overflow later
 						opacity: "0", // see hack description below
-					margin: "1px" // because calendar event bubbles have 1px border, we want to align
+						margin: "1px" // because calendar event bubbles have 1px border, we want to align
 					},
 					oncreate: ({dom}) => {
 						// This is a hack to get "natural" view size but render it without opacity first and then show dropdown with inferred
 						// size.
 						setTimeout(() => showDropdown(this._eventBubbleRect, dom, dom.offsetHeight, 400), 24)
+
+						// We need to redraw so that we can set max-height of the body based on the newly created dom elements
+						setTimeout(() => m.redraw(), 26)
+						this._popupDom = dom
 					},
 				},
 				[
-					m(".flex.flex-end", [
+					m(".flex.flex-end", {
+						oncreate: vnode => {
+							this._headerDom = vnode.dom
+						},
+					}, [
 						m(ButtonN, {
 							label: "edit_action",
 							click: () => {
@@ -124,13 +134,25 @@ export class CalendarEventPopup implements ModalComponent {
 							colors: ButtonColors.DrawerNav,
 						}),
 					]),
-					m(EventPreviewView, {
+					m("", {
+						style: {
+							maxHeight: this.contentMaxHeight(),
+							overflow: "scroll"
+						}
+					}, m(EventPreviewView, {
 						event: this._calendarEvent,
-						limitDescriptionHeight: true,
 						sanitizedDescription: this._sanitizedDescription
-					}),
+					})),
 				],
 			)
+		}
+	}
+
+	contentMaxHeight(): string {
+		if (this._popupDom && this._headerDom) {
+			return px(this._popupDom.offsetHeight - this._headerDom.offsetHeight)
+		} else {
+			return "none"
 		}
 	}
 

--- a/src/calendar/view/EventPreviewView.js
+++ b/src/calendar/view/EventPreviewView.js
@@ -14,7 +14,6 @@ import type {CalendarEventAttendee} from "../../api/entities/tutanota/CalendarEv
 
 export type Attrs = {
 	event: CalendarEvent,
-	limitDescriptionHeight: boolean,
 	sanitizedDescription: string,
 }
 
@@ -26,7 +25,7 @@ export class EventPreviewView implements MComponent<Attrs> {
 		this._getLocationUrl = memoized(getLocationUrl)
 	}
 
-	view({attrs: {event, limitDescriptionHeight, sanitizedDescription}}: Vnode<Attrs>): Children {
+	view({attrs: {event, sanitizedDescription}}: Vnode<Attrs>): Children {
 
 		const url = this._getLocationUrl(event.location.trim())
 
@@ -34,11 +33,7 @@ export class EventPreviewView implements MComponent<Attrs> {
 			m(".flex.col.smaller", [
 				m(".flex.pb-s.items-center", [
 					this._renderSectionIndicator(BootIcons.Calendar),
-					m(".h3.selectable.text-break.scroll-no-overlay", {
-						style: {
-							maxHeight: "3em",
-						}
-					}, event.summary)
+					m(".h3.selectable.text-break", event.summary)
 				]),
 				m(".flex.pb-s.items-center", [
 						this._renderSectionIndicator(Icons.Time),
@@ -64,13 +59,7 @@ export class EventPreviewView implements MComponent<Attrs> {
 				!!event.description
 					? m(".flex.pb-s.items-start", [
 						this._renderSectionIndicator(Icons.AlignLeft, {marginTop: "2px"}),
-						limitDescriptionHeight
-							? m(".scroll-no-overlay.full-width.selectable.text-break", {
-								style: {
-									maxHeight: "100px"
-								}
-							}, m.trust(sanitizedDescription))
-							: m(".selectable", m.trust(sanitizedDescription))
+						m(".full-width.selectable.text-break", m.trust(sanitizedDescription))
 					])
 					: null,
 			]),


### PR DESCRIPTION
Now the popup will just limit the total height of it's body and will scroll instead of overflowing. Individual sections no longer limit their heights

fix #3453