### PR TITLE
[android] Update Android compileSdk and libraries

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-	compileSdkVersion 29
+	compileSdkVersion 31
 	buildToolsVersion '29.0.2'
 	defaultConfig {
 		applicationId "de.tutao.tutanota"
@@ -10,7 +10,6 @@ android {
 		versionCode 387020
 		versionName "3.87.2"
 		testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
 
 		javaCompileOptions {
 			annotationProcessorOptions {
@@ -72,10 +71,6 @@ task copyResourcesToClasses(type: Copy) {
 
 preBuild.dependsOn copyResourcesToClasses
 
-//task unitTest(dependsOn: [copyResourcesToClasses, 'testDebugUnitTest']) {
-//
-//}
-
 tasks.withType(Test) {
 	testLogging {
 		exceptionFormat "full"
@@ -85,9 +80,10 @@ tasks.withType(Test) {
 }
 
 dependencies {
-	def room_version = "2.2.3"
-	def lifecycle_version = "2.2.0"
-	def appcompat_version = "1.1.0"
+	def room_version = "2.3.0"
+	def lifecycle_version = "2.3.1"
+	def activity_version = "1.3.1"
+
 
 	implementation fileTree(dir: 'libs', include: ['*.jar'])
 	androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
@@ -95,18 +91,17 @@ dependencies {
 	})
 	implementation 'commons-io:commons-io:2.5'
 	implementation 'org.jdeferred:jdeferred-core:1.2.4'
-	implementation 'androidx.core:core:1.1.0'
+	implementation 'androidx.core:core:1.6.0'
+	implementation "androidx.activity:activity:$activity_version"
 
 	implementation "androidx.room:room-runtime:$room_version"
-	annotationProcessor "androidx.room:room-compiler:$room_version" // For Kotlin use kapt instead of annotationProcessor
+	// For Kotlin use kapt instead of annotationProcessor
+	annotationProcessor "androidx.room:room-compiler:$room_version"
 
 	implementation "androidx.lifecycle:lifecycle-livedata:$lifecycle_version"
 
 
-
-
-
-	testImplementation 'junit:junit:4.12'
+	testImplementation 'junit:junit:4.13.1'
 	testImplementation "org.robolectric:robolectric:3.3.2"
 	testImplementation "org.mockito:mockito-core:2.28.2"
 	androidTestImplementation 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'

--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,8 @@
                 android:name=".MainActivity"
                 android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale"
                 android:launchMode="singleInstance"
-                android:theme="@style/SplashTheme">
+                android:theme="@style/SplashTheme"
+                android:exported="true">
             <!--Main intent for launching from home screen-->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app-android/app/src/main/java/de/tutao/tutanota/AndroidKeyStoreFacade.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/AndroidKeyStoreFacade.java
@@ -1,20 +1,14 @@
 package de.tutao.tutanota;
 
 import android.content.Context;
-import android.os.Build;
-import android.security.KeyPairGeneratorSpec;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.util.Log;
 
-import androidx.annotation.RequiresApi;
-
 import java.io.IOException;
-import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.Key;
-import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -24,14 +18,12 @@ import java.security.PublicKey;
 import java.security.UnrecoverableEntryException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
-import java.util.Calendar;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.KeyGenerator;
 import javax.crypto.NoSuchPaddingException;
-import javax.security.auth.x500.X500Principal;
 
 
 public class AndroidKeyStoreFacade {
@@ -43,13 +35,10 @@ public class AndroidKeyStoreFacade {
 	private static final String RSA_ALGORITHM = "RSA/ECB/PKCS1Padding";
 	private static final String ANDROID_OPEN_SSL_PROVIDER = "AndroidOpenSSL";
 
-	private final Context context;
 	private volatile KeyStore keyStore;
-	private Crypto crypto;
-
+	private final Crypto crypto;
 
 	public AndroidKeyStoreFacade(Context context) {
-		this.context = context;
 		this.crypto = new Crypto(context);
 	}
 
@@ -109,29 +98,6 @@ public class AndroidKeyStoreFacade {
 		}
 	}
 
-	private void generateAsymmetricKeyPair() throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
-		Calendar start = Calendar.getInstance();
-		Calendar end = Calendar.getInstance();
-		end.add(Calendar.YEAR, 50);
-
-		KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(context)
-				.setAlias(ASYMMETRIC_KEY_ALIAS)
-				.setSubject(new X500Principal("CN=" + ASYMMETRIC_KEY_ALIAS))
-				.setSerialNumber(BigInteger.TEN)
-				.setStartDate(start.getTime())
-				.setEndDate(end.getTime())
-				.setKeySize(2048)
-				.build();
-		Log.d(TAG, "Generating device key");
-		KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", AndroidKeyStore);
-		kpg.initialize(spec);
-		long startTime = System.currentTimeMillis();
-		kpg.generateKeyPair();
-		long endTime = System.currentTimeMillis();
-		Log.d(TAG, "Generation of key took (ms): " + (endTime - startTime));
-	}
-
-	@RequiresApi(23)
 	private void generateSymmetricKey() throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
 		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES", AndroidKeyStore);
 		keyGenerator.init(new KeyGenParameterSpec.Builder(SYMMETRIC_KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)

--- a/app-android/app/src/main/java/de/tutao/tutanota/Contact.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/Contact.java
@@ -1,19 +1,17 @@
 package de.tutao.tutanota;
 
+import static android.provider.ContactsContract.CommonDataKinds.Email;
+import static android.provider.ContactsContract.Contacts;
+
 import android.Manifest;
 import android.content.ContentResolver;
 import android.database.Cursor;
-import android.os.Build;
-import android.provider.ContactsContract;
 
 import org.jdeferred.DoneFilter;
 import org.jdeferred.Promise;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-import static android.provider.ContactsContract.*;
-import static android.provider.ContactsContract.CommonDataKinds.*;
 
 /**
  * Created by mpfau on 4/12/17.

--- a/app-android/app/src/main/java/de/tutao/tutanota/Crypto.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/Crypto.java
@@ -78,16 +78,14 @@ public class Crypto {
 	public static final int AES_KEY_LENGTH_BYTES = AES_KEY_LENGTH / 8;
 
 	private final static String TAG = "tutao.Crypto";
-	private SecureRandom randomizer;
+	private final SecureRandom randomizer;
 
 	private static final Integer ANDROID_6_SDK_VERSION = 23;
 
 	private final Context context;
 
 	static {
-		for (int i = 0; i < FIXED_IV.length; i++) {
-			FIXED_IV[i] = (byte) 0x88;
-		}
+		Arrays.fill(FIXED_IV, (byte) 0x88);
 	}
 
 	public static final String HMAC_256 = "HmacSHA256";
@@ -432,9 +430,9 @@ public class Crypto {
 		}
 	}
 
-	public class EncryptedFileInfo {
-		private String uri;
-		private long unencSize;
+	public static final class EncryptedFileInfo {
+		private final String uri;
+		private final long unencSize;
 
 		public EncryptedFileInfo(String uri, long unencSize) {
 			this.unencSize = unencSize;

--- a/app-android/app/src/main/java/de/tutao/tutanota/EncryptionUtils.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/EncryptionUtils.java
@@ -6,7 +6,7 @@ import java.util.Date;
 public class EncryptionUtils {
 	public static Date decryptDate(String encryptedData, Crypto crypto, byte[] sessionKey) throws CryptoError {
 		byte[] decBytes = crypto.aesDecrypt(sessionKey, encryptedData);
-		return new Date(Long.valueOf(new String(decBytes, StandardCharsets.UTF_8)));
+		return new Date(Long.parseLong(new String(decBytes, StandardCharsets.UTF_8)));
 	}
 
 	public static String decryptString(String encryptedData, Crypto crypto, byte[] sessionKey) throws CryptoError {

--- a/app-android/app/src/main/java/de/tutao/tutanota/JsRequest.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/JsRequest.java
@@ -1,5 +1,7 @@
 package de.tutao.tutanota;
 
+import androidx.annotation.NonNull;
+
 public enum JsRequest {
 	updatePushIdentifier("updatePushIdentifier"),
 	notify("notify"),
@@ -18,6 +20,7 @@ public enum JsRequest {
 		name = s;
 	}
 
+	@NonNull
 	public String toString() {
 		return this.name;
 	}

--- a/app-android/app/src/main/java/de/tutao/tutanota/TutaoCipherInputStream.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/TutaoCipherInputStream.java
@@ -14,7 +14,7 @@ public class TutaoCipherInputStream extends FilterInputStream {
 	private static final int UPDATE_BUFFER_SIZE = 4096;
 
 	private final Cipher cipher;
-	private byte[] temp;
+	private final byte[] temp;
 
 	private boolean finished = false;
 

--- a/app-android/app/src/main/java/de/tutao/tutanota/Utils.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/Utils.java
@@ -1,8 +1,8 @@
 package de.tutao.tutanota;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.Cursor;
-import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.OpenableColumns;
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 
 public class Utils {
@@ -44,28 +45,20 @@ public class Utils {
 
 
 	public static byte[] readFile(File file) throws IOException {
-		FileInputStream in = new FileInputStream(file);
-		try {
-			byte[] bytes = IOUtils.toByteArray(in);
-			return bytes;
-		} finally {
-			in.close();
+		try (FileInputStream in = new FileInputStream(file)) {
+			return IOUtils.toByteArray(in);
 		}
 	}
 
-	public static void writeFile(File outputFile, byte[] bytes)
-			throws FileNotFoundException, IOException {
-		if (!outputFile.getParentFile().exists()) {
+	public static void writeFile(File outputFile, byte[] bytes) throws IOException {
+		if (!Objects.requireNonNull(outputFile.getParentFile()).exists()) {
 			outputFile.getParentFile().mkdirs();
 		}
 		if (!outputFile.exists()) {
 			outputFile.createNewFile();
 		}
-		FileOutputStream out = new FileOutputStream(outputFile);
-		try {
+		try (FileOutputStream out = new FileOutputStream(outputFile)) {
 			IOUtils.write(bytes, out);
-		} finally {
-			out.close();
 		}
 	}
 
@@ -73,6 +66,7 @@ public class Utils {
 		return Uri.fromFile(file).toString();
 	}
 
+	@SuppressLint("Range")
 	public static FileInfo getFileInfo(Context context, Uri fileUri) throws FileNotFoundException {
 		String scheme = fileUri.getScheme();
 		if (scheme == null || scheme.equals("file")) {
@@ -103,13 +97,12 @@ public class Utils {
 
 	public static byte[] merge(byte[]... arrays) {
 		int length = 0;
-		for (int i = 0; i < arrays.length; i++) {
-			length += arrays[i].length;
+		for (byte[] bytes : arrays) {
+			length += bytes.length;
 		}
 		byte[] merged = new byte[length];
 		int position = 0;
-		for (int i = 0; i < arrays.length; i++) {
-			byte[] array = arrays[i];
+		for (byte[] array : arrays) {
 			System.arraycopy(array, 0, merged, position, array.length);
 			position += array.length;
 		}
@@ -148,7 +141,7 @@ public class Utils {
 		int argb = parseColor(color);
 		int r = (argb >> 16) & 0xff;  // extract red
 		int g = (argb >> 8) & 0xff;   // extract green
-		int b = (argb >> 0) & 0xff;   // extract blue
+		int b = (argb) & 0xff;   // extract blue
 
 		// Counting the perceptive luminance
 		// human eye favors green color...

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmInfo.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmInfo.java
@@ -23,7 +23,7 @@ public final class AlarmInfo {
         return new AlarmInfo(trigger, alarmIdentifier);
     }
 
-    public AlarmInfo(String trigger, String identifier) {
+    public AlarmInfo(@NonNull String trigger, String identifier) {
         this.trigger = trigger;
         this.identifier = Objects.requireNonNull(identifier);
     }
@@ -32,11 +32,13 @@ public final class AlarmInfo {
         return new String(crypto.aesDecrypt(sessionKey, this.trigger), StandardCharsets.UTF_8);
     }
 
-    public String getTrigger() {
+    @NonNull
+	public String getTrigger() {
         return trigger;
     }
 
-    public String getIdentifier() {
+    @NonNull
+	public String getIdentifier() {
         return identifier;
     }
 

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotification.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotification.java
@@ -24,21 +24,24 @@ import de.tutao.tutanota.OperationType;
 @Entity(primaryKeys = "identifier")
 @TypeConverters(AlarmNotification.OperationTypeConverter.class)
 public class AlarmNotification {
-	private OperationType operation;
-	private String summary;
-	private String eventStart;
-	private String eventEnd;
+	private final OperationType operation;
+	private final String summary;
+	private final String eventStart;
+	private final String eventEnd;
 	@Embedded
 	@NonNull
-	private AlarmInfo alarmInfo;
+	private final AlarmInfo alarmInfo;
 	@Embedded
-	private RepeatRule repeatRule;
+	private final RepeatRule repeatRule;
 	@Embedded(prefix = "key")
-	private NotificationSessionKey notificationSessionKey;
-	private String user;
+	private final NotificationSessionKey notificationSessionKey;
+	private final String user;
 
-	public AlarmNotification(OperationType operation, String summary, String eventStart, String eventEnd,
-							 AlarmInfo alarmInfo,
+	public AlarmNotification(OperationType operation,
+							 String summary,
+							 String eventStart,
+							 String eventEnd,
+							 @NonNull AlarmInfo alarmInfo,
 							 RepeatRule repeatRule,
 							 @Nullable NotificationSessionKey notificationSessionKey, // in case of a delete operation there is no session key
 							 String user) {
@@ -106,6 +109,7 @@ public class AlarmNotification {
 		return repeatRule;
 	}
 
+	@NonNull
 	public AlarmInfo getAlarmInfo() {
 		return alarmInfo;
 	}

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotificationsManager.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotificationsManager.java
@@ -27,26 +27,24 @@ public class AlarmNotificationsManager {
 	public static final long TIME_IN_THE_FUTURE_LIMIT_MS = TimeUnit.DAYS.toMillis(14);
 
 	private static final String TAG = "AlarmNotificationsMngr";
-	private final AndroidKeyStoreFacade keyStoreFacade;
 	private final SseStorage sseStorage;
 	private final Crypto crypto;
 	private final SystemAlarmFacade systemAlarmFacade;
 	private final PushKeyResolver pushKeyResolver;
 	private final LocalNotificationsFacade localNotificationsFacade;
 
-	public AlarmNotificationsManager(AndroidKeyStoreFacade androidKeyStoreFacade, SseStorage sseStorage, Crypto crypto, SystemAlarmFacade systemAlarmFacade,
+	public AlarmNotificationsManager(SseStorage sseStorage, Crypto crypto, SystemAlarmFacade systemAlarmFacade,
 									 LocalNotificationsFacade localNotificationsFacade) {
-		keyStoreFacade = androidKeyStoreFacade;
 		this.sseStorage = sseStorage;
 		this.crypto = crypto;
 		this.systemAlarmFacade = systemAlarmFacade;
-		this.pushKeyResolver = new PushKeyResolver(keyStoreFacade, sseStorage);
+		this.pushKeyResolver = new PushKeyResolver(sseStorage);
 		this.localNotificationsFacade = localNotificationsFacade;
 	}
 
 	public void reScheduleAlarms() {
 		PushKeyResolver pushKeyResolver =
-				new PushKeyResolver(keyStoreFacade, sseStorage);
+				new PushKeyResolver(sseStorage);
 		List<AlarmNotification> alarmInfos = sseStorage.readAlarmNotifications();
 		for (AlarmNotification alarmNotification : alarmInfos) {
 			byte[] sessionKey = this.resolveSessionKey(alarmNotification, pushKeyResolver);
@@ -214,12 +212,10 @@ public class AlarmNotificationsManager {
 
 
 	private static class PushKeyResolver {
-		private AndroidKeyStoreFacade keyStoreFacade;
 		private final SseStorage sseStorage;
 		private final Map<String, byte[]> pushIdentifierToResolvedSessionKey = new HashMap<>();
 
-		private PushKeyResolver(AndroidKeyStoreFacade keyStoreFacade, SseStorage sseStorage) {
-			this.keyStoreFacade = keyStoreFacade;
+		private PushKeyResolver(SseStorage sseStorage) {
 			this.sseStorage = sseStorage;
 		}
 

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmTrigger.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmTrigger.java
@@ -10,7 +10,7 @@ public enum AlarmTrigger {
     THREE_DAYS("3D"),
     ONE_WEEK("1W");
 
-    private String value;
+    private final String value;
 
     AlarmTrigger(String value) {
         this.value = value;

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/RepeatRule.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/RepeatRule.java
@@ -16,9 +16,9 @@ public final class RepeatRule {
 	private final String interval;
 	private final String timeZone;
 	@Nullable
-	private String endType;
+	private final String endType;
 	@Nullable
-	private String endValue;
+	private final String endValue;
 
 	static RepeatRule fromJson(JSONObject jsonObject) throws JSONException {
 		return new RepeatRule(

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/SystemAlarmFacade.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/SystemAlarmFacade.java
@@ -4,7 +4,6 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.util.Log;
 
 import java.util.Date;

--- a/app-android/app/src/main/java/de/tutao/tutanota/data/AlarmInfoDao.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/data/AlarmInfoDao.java
@@ -1,15 +1,14 @@
 package de.tutao.tutanota.data;
 
+import static androidx.room.OnConflictStrategy.REPLACE;
+
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.Query;
 
 import java.util.List;
 
-import de.tutao.tutanota.alarms.AlarmInfo;
 import de.tutao.tutanota.alarms.AlarmNotification;
-
-import static androidx.room.OnConflictStrategy.REPLACE;
 
 @Dao
 public interface AlarmInfoDao {

--- a/app-android/app/src/main/java/de/tutao/tutanota/data/PushIdentifierKey.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/data/PushIdentifierKey.java
@@ -27,6 +27,7 @@ public class PushIdentifierKey {
 		return deviceEncPushIdentifierKey;
 	}
 
+	@NonNull
 	@Override
 	public String toString() {
 		return "PushIdentifierKey{" +

--- a/app-android/app/src/main/java/de/tutao/tutanota/data/SseInfo.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/data/SseInfo.java
@@ -51,12 +51,13 @@ public final class SseInfo {
 		}
 	}
 
-	public SseInfo(String pushIdentifier, Collection<String> userIds, String sseOrigin) {
+	public SseInfo(@NonNull String pushIdentifier, Collection<String> userIds, String sseOrigin) {
 		this.pushIdentifier = pushIdentifier;
 		this.userIds = userIds;
 		this.sseOrigin = sseOrigin;
 	}
 
+	@NonNull
 	public String getPushIdentifier() {
 		return pushIdentifier;
 	}

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/LocalNotificationsFacade.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/LocalNotificationsFacade.java
@@ -17,6 +17,7 @@ import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.core.app.NotificationCompat;
@@ -25,6 +26,7 @@ import androidx.core.app.NotificationManagerCompat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import de.tutao.tutanota.BuildConfig;
@@ -43,7 +45,7 @@ public class LocalNotificationsFacade {
 	private static final int SUMMARY_NOTIFICATION_ID = 45;
 	private static final String PERSISTENT_NOTIFICATION_CHANNEL_ID = "service_intent";
 
-	private Context context;
+	private final Context context;
 
 	public LocalNotificationsFacade(Context context) {
 		this.context = context;
@@ -124,14 +126,15 @@ public class LocalNotificationsFacade {
 
 			int notificationId = makeNotificationId(notificationInfo.getAddress());
 
-
+			@ColorInt
+			int redColor = context.getResources().getColor(R.color.red, context.getTheme());
 			NotificationCompat.Builder notificationBuilder =
 					new NotificationCompat.Builder(context, EMAIL_NOTIFICATION_CHANNEL_ID)
-							.setLights(context.getResources().getColor(R.color.red), 1000, 1000);
+							.setLights(redColor, 1000, 1000);
 			ArrayList<String> addresses = new ArrayList<>();
 			addresses.add(notificationInfo.getAddress());
 			notificationBuilder.setContentTitle(title)
-					.setColor(context.getResources().getColor(R.color.red))
+					.setColor(redColor)
 					.setContentText(notificationContent(notificationInfo.getAddress()))
 					.setNumber(counterPerAlias.counter)
 					.setSmallIcon(R.drawable.ic_status)
@@ -163,7 +166,7 @@ public class LocalNotificationsFacade {
 				this.context,
 				/*requestCode*/1,
 				new Intent(DownloadManager.ACTION_VIEW_DOWNLOADS),
-				/*flags*/0
+				/*flags*/PendingIntent.FLAG_IMMUTABLE
 		);
 		Notification notification = new Notification.Builder(this.context, channel.getId())
 				.setContentIntent(pendingIntent)
@@ -195,12 +198,14 @@ public class LocalNotificationsFacade {
 		NotificationCompat.Builder builder = new NotificationCompat.Builder(context, EMAIL_NOTIFICATION_CHANNEL_ID)
 				.setBadgeIconType(NotificationCompat.BADGE_ICON_SMALL);
 
+		@ColorInt
+		int red = context.getResources().getColor(R.color.red, context.getTheme());
 		Notification notification = builder.setContentTitle(title)
 				.setContentText(notificationContent(notificationInfo.getAddress()))
 				.setSmallIcon(R.drawable.ic_status)
 				.setGroup(NOTIFICATION_EMAIL_GROUP)
 				.setGroupSummary(true)
-				.setColor(context.getResources().getColor(R.color.red))
+				.setColor(red)
 				.setNumber(summaryCounter)
 				.setStyle(inboxStyle)
 				.setContentIntent(intentOpenMailbox(notificationInfo, true))
@@ -280,7 +285,7 @@ public class LocalNotificationsFacade {
 
 	@NonNull
 	private String notificationContent(String address) {
-		return aliasNotification.get(address).counter + " " + address;
+		return Objects.requireNonNull(aliasNotification.get(address)).counter + " " + address;
 	}
 
 	private int makeNotificationId(String address) {
@@ -328,13 +333,15 @@ public class LocalNotificationsFacade {
 	public static void showAlarmNotification(Context context, long when, String summary, Intent intent) {
 		String contentText = String.format("%tR %s", when, summary);
 		NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+		@ColorInt
+		int red = context.getResources().getColor(R.color.red, context.getTheme());
 		notificationManager.notify((int) System.currentTimeMillis(),
 				new NotificationCompat.Builder(context, ALARM_NOTIFICATION_CHANNEL_ID)
 						.setSmallIcon(R.drawable.ic_status)
 						.setContentTitle(context.getString(R.string.reminder_label))
 						.setContentText(contentText)
 						.setDefaults(NotificationCompat.DEFAULT_ALL)
-						.setColor(context.getResources().getColor(R.color.red))
+						.setColor(red)
 						.setContentIntent(openCalendarIntent(context, intent))
 						.setAutoCancel(true)
 						.build());

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/LooperThread.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/LooperThread.java
@@ -7,7 +7,7 @@ import android.util.Log;
 final class LooperThread extends Thread {
 
 	private volatile Handler handler;
-	private Runnable initRunnable;
+	private final Runnable initRunnable;
 
 	LooperThread(Runnable initRunnable) {
 		this.initRunnable = initRunnable;

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushMessage.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushMessage.java
@@ -53,7 +53,7 @@ final class PushMessage {
 	final static class NotificationInfo {
 		private final String address;
 		private final int counter;
-		private String userId;
+		private final String userId;
 
 		// We pass in mailAddressKey because of the incompatibility between the entity passed with SSE message and the one inside MissedNotification
 		public static NotificationInfo fromJson(JSONObject jsonObject, String mailAddressKey) throws JSONException {

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.java
@@ -28,7 +28,6 @@ public final class PushNotificationService extends LifecycleJobService {
 
 	private volatile JobParameters jobParameters;
 	private LocalNotificationsFacade localNotificationsFacade;
-	private AlarmNotificationsManager alarmNotificationsManager;
 	private SseClient sseClient;
 
 	public static Intent startIntent(Context context, String sender) {
@@ -46,7 +45,7 @@ public final class PushNotificationService extends LifecycleJobService {
 		SseStorage sseStorage = new SseStorage(appDatabase, keyStoreFacade);
 
 		localNotificationsFacade = new LocalNotificationsFacade(this);
-		alarmNotificationsManager = new AlarmNotificationsManager(keyStoreFacade, sseStorage, new Crypto(this),
+		AlarmNotificationsManager alarmNotificationsManager = new AlarmNotificationsManager(sseStorage, new Crypto(this),
 				new SystemAlarmFacade(this), localNotificationsFacade);
 		TutanotaNotificationsHandler tutanotaNotificationsHandler = new TutanotaNotificationsHandler(localNotificationsFacade, sseStorage,
 				alarmNotificationsManager);

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.java
@@ -17,7 +17,6 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/SseStorage.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/SseStorage.java
@@ -1,32 +1,13 @@
 package de.tutao.tutanota.push;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
-import android.util.Log;
-
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 import androidx.lifecycle.LiveData;
 
-import org.apache.commons.io.IOUtils;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyStoreException;
 import java.security.UnrecoverableEntryException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import de.tutao.tutanota.AndroidKeyStoreFacade;
 import de.tutao.tutanota.CryptoError;
@@ -34,7 +15,6 @@ import de.tutao.tutanota.Utils;
 import de.tutao.tutanota.alarms.AlarmNotification;
 import de.tutao.tutanota.data.AppDatabase;
 import de.tutao.tutanota.data.PushIdentifierKey;
-import de.tutao.tutanota.data.SseInfo;
 import de.tutao.tutanota.data.User;
 
 

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/TutanotaNotificationsHandler.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/TutanotaNotificationsHandler.java
@@ -1,6 +1,5 @@
 package de.tutao.tutanota.push;
 
-import android.text.TextUtils;
 import android.util.Log;
 
 import androidx.annotation.NonNull;

--- a/app-android/app/src/test/java/de/tutao/tutanota/AlarmNotificationsManagerTest.java
+++ b/app-android/app/src/test/java/de/tutao/tutanota/AlarmNotificationsManagerTest.java
@@ -61,7 +61,7 @@ public class AlarmNotificationsManagerTest {
 		sseStorage = mock(SseStorage.class);
 		keyStoreFacade = mock(AndroidKeyStoreFacade.class);
 		crypto = mock(Crypto.class);
-		manager = new AlarmNotificationsManager(keyStoreFacade, sseStorage, crypto, systemAlarmFacade, mock(LocalNotificationsFacade.class));
+		manager = new AlarmNotificationsManager(sseStorage, crypto, systemAlarmFacade, mock(LocalNotificationsFacade.class));
 
 		when(crypto.aesDecrypt(any(), anyString())).thenAnswer((Answer<byte[]>) invocation -> ((String) invocation.getArgument(1)).getBytes());
 		when(sseStorage.getPushIdentifierSessionKey(pushIdentifierElementId)).thenReturn(pushIdentifierKey);

--- a/app-android/build.gradle
+++ b/app-android/build.gradle
@@ -1,22 +1,23 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    repositories {
-        jcenter()
+	repositories {
         google()
+        mavenCentral()
+        gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.2'
 
-        // NOTE: Do not place your application dependencies here; they belong
+		// NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
 }
 

--- a/app-android/gradle/wrapper/gradle-wrapper.properties
+++ b/app-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
close #3470

Some code cleanups are done to fix the warnings.

jcenter is removed as it is deprecated.

Activity result/permission warnings are suppressed because we can't
access requestCode with new API and we need it to identify the
request.

Some PendingIntent warnings are left as-is because FLAG_MUTABLE is not
available on older SDKs and there doesn't seem to be compat
replacement.