### PR TITLE
[desktop] improve handling of local config

### DIFF
--- a/src/api/common/Logger.js
+++ b/src/api/common/Logger.js
@@ -98,6 +98,9 @@ export function replaceNativeLogger(global: any, loggerInstance: Logger, force: 
 			error(...args) {
 				globalConsole.error(...args)
 				loggerInstance.logError(...args)
+			},
+			trace(...args) {
+				globalConsole.trace(...args)
 			}
 		}
 	}

--- a/src/api/common/utils/ArrayUtils.js
+++ b/src/api/common/utils/ArrayUtils.js
@@ -217,30 +217,52 @@ export function removeAll(array: Array<any>, elements: Array<any>) {
 }
 
 /**
- * Group an array based on the given separator, but each group will have only unique items
+ * Group an array based on the given discriminator, but each group will have only unique items
  */
-export function groupByAndMapUniquely<T, R, E>(iterable: Iterable<T>, separator: T => R, mapper: T => E): Map<R, Set<E>> {
+export function groupByAndMapUniquely<T, R, E>(iterable: Iterable<T>, discriminator: T => R, mapper: T => E): Map<R, Set<E>> {
 	const map = new Map()
 	for (let el of iterable) {
-		const key = separator(el)
+		const key = discriminator(el)
 		getFromMap(map, key, () => new Set()).add(mapper(el))
 	}
 	return map
 }
 
-export function groupByAndMap<T, R, E>(iterable: Iterable<T>, separator: (T) => R, mapper: (T) => E): Map<R, Array<E>> {
+/**
+ * convert an Array of T's into a Map of Arrays of E's by
+ * * grouping them based on a discriminator
+ * * mapping them from T to E
+ * @param iterable the array to split into groups
+ * @param discriminator a function that produces the keys to group the elements by
+ * @param mapper a function that maps the array elements before they get added to the group
+ * @returns {Map<R, Array<E>>}
+ */
+export function groupByAndMap<T, R, E>(iterable: Iterable<T>, discriminator: (T) => R, mapper: (T) => E): Map<R, Array<E>> {
 	const map = new Map()
 	for (let el of iterable) {
-		const key = separator(el)
+		const key = discriminator(el)
 		getFromMap(map, key, () => []).push(mapper(el))
 	}
 	return map
 }
 
-export function groupBy<T, R>(iterable: Iterable<T>, separator: (T) => R): Map<R, Array<T>> {
-	return groupByAndMap(iterable, separator, identity)
+/**
+ * Group array elements based on keys produced by a discriminator
+ * @param iterable the array to split into groups
+ * @param discriminator a function that produces the keys to group the elements by
+ * @returns {NodeJS.Global.Map<R, Array<T>>}
+ */
+export function groupBy<T, R>(iterable: Iterable<T>, discriminator: (T) => R): Map<R, Array<T>> {
+	return groupByAndMap(iterable, discriminator, identity)
 }
 
+/**
+ * split an array into chunks of a given size.
+ * the last chunk will be smaller if there are less than chunkSize elements left.
+ * @param chunkSize
+ * @param array
+ * @returns {Array<Array<T>>}
+ */
 export function splitInChunks<T>(chunkSize: number, array: Array<T>): Array<Array<T>> {
 	if (chunkSize < 1) {
 		return []

--- a/src/desktop/DesktopMonkeyPatch.js
+++ b/src/desktop/DesktopMonkeyPatch.js
@@ -39,10 +39,12 @@ process.on('exit', () => {
 const oldLog = console.log
 const oldError = console.error
 const oldWarn = console.warn
+const oldTrace = console.trace
 
 ;(console: any).log = (...args) => oldLog(`[${new Date().toISOString()}]`, ...args)
 ;(console: any).error = (...args) => oldError(`[${new Date().toISOString()}]`, ...args)
 ;(console: any).warn = (...args) => oldWarn(`[${new Date().toISOString()}]`, ...args)
+;(console: any).trace = (...args) => oldTrace(`[${new Date().toISOString()}]`, ...args)
 
 if (process.platform === "win32") {
 	try {

--- a/src/desktop/config/ConfigFile.js
+++ b/src/desktop/config/ConfigFile.js
@@ -1,37 +1,72 @@
 // @flow
-import fs from "fs"
 
-let accessPromise: Promise<any> = Promise.resolve()
-
-export function readJSON(path: string): Promise<any> {
-	accessPromise = accessPromise
-		.then(() => fs.promises.readFile(path, "utf8"))
-		.then(t => JSON.parse(t))
-		.catch(e => {
-			// catch needed to make future reads/writes work
-			console.error("failed to read config!", e)
-		})
-	return accessPromise
-}
+const instances: {[string]: ConfigFile} = {}
 
 /**
- * asynchronously write an object to a file.
- * multiple writes are handled in a fifo manner to prevent race conditions that could
- * cause the file to contain invalid json
- * deliberately not using async to make sure the chain of writes doesn't branch.
- *
- * @param path path to the file the json object should be stored in
- * @param obj the object to serialize
- * @returns {Promise<void>} resolves when the object has been written
+ * get an instance of ConfigFile pointing at a certain path
+ * @param p {string} path to file the configFile should write to
+ * @param fsthe fs object returned by "import fs from ''fs"
  */
-export function writeJSON(path: string, obj: any): Promise<void> {
-	accessPromise = accessPromise
-		.then(() => JSON.stringify(obj, null, 2))
-		.then(json => fs.promises.writeFile(path, json))
-		.catch(e => {
-			console.error("failed to write conf:", e)
-		})
-	return accessPromise
+export function getConfigFile(p: string, fs: $Exports<"fs">): ConfigFile {
+	if (!Object.keys(instances).includes(p)) {
+		instances[p] = new ConfigFile(p, fs)
+	}
+	return instances[p]
 }
 
+export type ConfigFileType = ConfigFile
 
+class ConfigFile {
+	_path: string;
+	_accessPromise: Promise<any>
+	+_fs: $Exports<"fs">
+
+	/**
+	 * @param p path to the file the json objects should be stored in
+	 * @param fs
+	 **/
+	constructor(p: string, fs: $Exports<"fs">) {
+		this._path = p
+		this._accessPromise = Promise.resolve()
+		this._fs = fs
+	}
+
+	ensurePresence(defaultObj: any): Promise<void> {
+		try {
+			this._fs.accessSync(this._path, this._fs.constants.F_OK)
+		} catch (e) {
+			return this.writeJSON(defaultObj || {})
+		}
+		return Promise.resolve()
+	}
+
+	readJSON(): Promise<any> {
+		this._accessPromise = this._accessPromise
+		                          .then(() => this._fs.promises.readFile(this._path, "utf8"))
+		                          .then(t => JSON.parse(t))
+		                          .catch(e => {
+			                          // catch needed to make future reads/writes work
+			                          console.error("failed to read config!", e)
+		                          })
+		return this._accessPromise
+	}
+
+	/**
+	 * asynchronously write an object to a file.
+	 * multiple writes are handled in a fifo manner to prevent race conditions that could
+	 * cause the file to contain invalid json
+	 * deliberately not using async to make sure the chain of writes doesn't branch.
+	 *
+	 * @param obj the object to serialize
+	 * @returns {Promise<void>} resolves when the object has been written
+	 */
+	writeJSON(obj: any): Promise<void> {
+		this._accessPromise = this._accessPromise
+		                          .then(() => JSON.stringify(obj, null, 2))
+		                          .then(json => this._fs.promises.writeFile(this._path, json))
+		                          .catch(e => {
+			                          console.error("failed to write conf:", e)
+		                          })
+		return this._accessPromise
+	}
+}

--- a/src/desktop/config/ConfigFile.js
+++ b/src/desktop/config/ConfigFile.js
@@ -1,0 +1,37 @@
+// @flow
+import fs from "fs"
+
+let accessPromise: Promise<any> = Promise.resolve()
+
+export function readJSON(path: string): Promise<any> {
+	accessPromise = accessPromise
+		.then(() => fs.promises.readFile(path, "utf8"))
+		.then(t => JSON.parse(t))
+		.catch(e => {
+			// catch needed to make future reads/writes work
+			console.error("failed to read config!", e)
+		})
+	return accessPromise
+}
+
+/**
+ * asynchronously write an object to a file.
+ * multiple writes are handled in a fifo manner to prevent race conditions that could
+ * cause the file to contain invalid json
+ * deliberately not using async to make sure the chain of writes doesn't branch.
+ *
+ * @param path path to the file the json object should be stored in
+ * @param obj the object to serialize
+ * @returns {Promise<void>} resolves when the object has been written
+ */
+export function writeJSON(path: string, obj: any): Promise<void> {
+	accessPromise = accessPromise
+		.then(() => JSON.stringify(obj, null, 2))
+		.then(json => fs.promises.writeFile(path, json))
+		.catch(e => {
+			console.error("failed to write conf:", e)
+		})
+	return accessPromise
+}
+
+

--- a/src/desktop/config/DesktopConfig.js
+++ b/src/desktop/config/DesktopConfig.js
@@ -1,7 +1,7 @@
 // @flow
 import path from 'path'
 import type {DeferredObject} from "../../api/common/utils/Utils"
-import {defer, downcast, getChangedProps} from "../../api/common/utils/Utils"
+import {defer, downcast} from "../../api/common/utils/Utils"
 import type {MigrationKind} from "./migrations/DesktopConfigMigrator"
 import {DesktopConfigMigrator} from "./migrations/DesktopConfigMigrator"
 import fs from "fs"
@@ -14,6 +14,7 @@ import {DesktopCryptoFacade} from "../DesktopCryptoFacade"
 import {CryptoError} from "../../api/common/error/CryptoError"
 import {log} from "../DesktopLog"
 import {ProgrammingError} from "../../api/common/error/ProgrammingError"
+import {readJSON, writeJSON} from "./ConfigFile"
 
 
 type AllConfigKeysEnum = DesktopConfigKeyEnum | DesktopConfigEncKeyEnum
@@ -63,7 +64,7 @@ export class DesktopConfig {
 			fs.writeFileSync(this._desktopConfigPath, JSON.stringify(defaultConf))
 		}
 
-		const userConf = await readJSON(this._desktopConfigPath).catch(() => defaultConf)
+		const userConf = (await readJSON(this._desktopConfigPath)) || defaultConf
 		const populatedConfig = Object.assign({}, defaultConf, userConf)
 		const desktopConfig = await this._migrator.applyMigrations(
 			downcast<MigrationKind>(buildConfig["configMigrationFunction"]),
@@ -189,14 +190,4 @@ export class DesktopConfig {
 			}
 		}
 	}
-}
-
-async function readJSON(path: string): Promise<any> {
-	const text: string = await fs.promises.readFile(path, "utf8")
-	return JSON.parse(text)
-}
-
-async function writeJSON(path: string, obj: any): Promise<void> {
-	const json = JSON.stringify(obj, null, 2)
-	return fs.promises.writeFile(path, json)
 }

--- a/src/desktop/config/DesktopConfig.js
+++ b/src/desktop/config/DesktopConfig.js
@@ -14,7 +14,8 @@ import {DesktopCryptoFacade} from "../DesktopCryptoFacade"
 import {CryptoError} from "../../api/common/error/CryptoError"
 import {log} from "../DesktopLog"
 import {ProgrammingError} from "../../api/common/error/ProgrammingError"
-import {readJSON, writeJSON} from "./ConfigFile"
+import type {ConfigFileType} from "./ConfigFile"
+import {getConfigFile} from "./ConfigFile"
 
 
 type AllConfigKeysEnum = DesktopConfigKeyEnum | DesktopConfigEncKeyEnum
@@ -27,7 +28,7 @@ type ConfigValue = string | number | {} | boolean | $ReadOnlyArray<ConfigValue>
 export class DesktopConfig {
 	_buildConfig: DeferredObject<Config>;
 	_desktopConfig: DeferredObject<Config>; // user preferences as set for this installation
-	_desktopConfigPath: string;
+	_desktopConfigFile: ConfigFileType;
 	_deviceKeyProvider: DesktopDeviceKeyProvider
 	_cryptoFacade: DesktopCryptoFacade
 	_app: App
@@ -39,7 +40,7 @@ export class DesktopConfig {
 		this._cryptoFacade = cryptFacade
 		this._app = app
 		this._migrator = migrator
-		this._desktopConfigPath = path.join(app.getPath('userData'), 'conf.json')
+		this._desktopConfigFile = getConfigFile(path.join(app.getPath('userData'), 'conf.json'), fs)
 		this._onValueSetListeners = {}
 		this._buildConfig = defer()
 		this._desktopConfig = defer()
@@ -47,8 +48,8 @@ export class DesktopConfig {
 
 	async init() {
 		try {
-			const packageJsonPath = path.join(this._app.getAppPath(), 'package.json')
-			const packageJson = downcast<{[string]: mixed}>(await readJSON(packageJsonPath))
+			const packageJsonFile = getConfigFile(path.join(this._app.getAppPath(), 'package.json'), fs)
+			const packageJson = downcast<{[string]: mixed}>(await packageJsonFile.readJSON())
 			this._buildConfig.resolve(downcast<Config>(packageJson['tutao-config']))
 		} catch (e) {
 			throw new Error("Could not load build config: " + e)
@@ -58,20 +59,16 @@ export class DesktopConfig {
 		const defaultConf: Config = downcast(buildConfig["defaultDesktopConfig"])
 
 		// create default config if none exists
-		try {
-			fs.accessSync(this._desktopConfigPath, fs.constants.F_OK)
-		} catch (e) {
-			fs.writeFileSync(this._desktopConfigPath, JSON.stringify(defaultConf))
-		}
+		await this._desktopConfigFile.ensurePresence(defaultConf)
 
-		const userConf = (await readJSON(this._desktopConfigPath)) || defaultConf
+		const userConf = (await this._desktopConfigFile.readJSON()) || defaultConf
 		const populatedConfig = Object.assign({}, defaultConf, userConf)
 		const desktopConfig = await this._migrator.applyMigrations(
 			downcast<MigrationKind>(buildConfig["configMigrationFunction"]),
 			populatedConfig,
 		)
 		await fs.promises.mkdir(path.join(this._app.getPath('userData')), {recursive: true})
-		await writeJSON(this._desktopConfigPath, desktopConfig)
+		await this._desktopConfigFile.writeJSON(desktopConfig)
 		this._desktopConfig.resolve(desktopConfig)
 	}
 
@@ -148,7 +145,7 @@ export class DesktopConfig {
 
 	async _saveAndNotify(key: AllConfigKeysEnum, value: ?ConfigValue): Promise<void> {
 		const desktopConfig = await this._desktopConfig.promise
-		await writeJSON(this._desktopConfigPath, desktopConfig)
+		await this._desktopConfigFile.writeJSON(desktopConfig)
 		this._notifyChangeListeners(key, value)
 	}
 

--- a/src/desktop/sse/DesktopSseClient.js
+++ b/src/desktop/sse/DesktopSseClient.js
@@ -2,6 +2,7 @@
 
 import type {App} from "electron"
 import {base64ToBase64Url, stringToUtf8Uint8Array, uint8ArrayToBase64} from "../../api/common/utils/Encoding"
+import type {TimeoutSetter} from "../../api/common/utils/Utils"
 import {filterInt, neverNull, randomIntFromInterval} from "../../api/common/utils/Utils"
 import type {DesktopNotifier} from '../DesktopNotifier.js'
 import type {WindowManager} from "../DesktopWindowManager.js"
@@ -9,7 +10,7 @@ import type {DesktopConfig} from "../config/DesktopConfig"
 import {NotificationResult} from "../DesktopConstants"
 import {FileNotFoundError} from "../../api/common/error/FileNotFoundError"
 import type {DesktopAlarmScheduler} from "./DesktopAlarmScheduler"
-import type {DesktopNetworkClient} from "../DesktopNetworkClient"
+import type {DesktopClientRequest, DesktopNetworkClient} from "../DesktopNetworkClient"
 import {DesktopCryptoFacade} from "../DesktopCryptoFacade"
 import {_TypeModel as MissedNotificationTypeModel} from "../../api/entities/sys/MissedNotification"
 import type {DesktopAlarmStorage} from "./DesktopAlarmStorage"
@@ -26,8 +27,6 @@ import {
 import {TutanotaError} from "../../api/common/error/TutanotaError"
 import {log} from "../DesktopLog"
 import {DesktopConfigEncKey, DesktopConfigKey} from "../config/ConfigKeys"
-import type {DesktopClientRequest} from "../DesktopNetworkClient"
-import type {TimeoutSetter} from "../../api/common/utils/Utils"
 
 export type SseInfo = {|
 	identifier: string,
@@ -145,6 +144,9 @@ export class DesktopSseClient {
 		}
 		const url = sseInfo.sseOrigin + "/sse?_body=" + this._requestJson(sseInfo.identifier, userId)
 		log.debug("starting sse connection")
+
+		// webstorm seems to think that ClientRequest.end() returns void.
+		// noinspection JSVoidFunctionReturnValueUsed
 		this._connection = this._net.request(url, {
 			headers: {
 				"Content-Type": "application/json",
@@ -369,6 +371,9 @@ export class DesktopSseClient {
 			if (lastProcessedId) {
 				headers["lastProcessedNotificationId"] = lastProcessedId
 			}
+
+			// webstorm seems to think that ClientRequest.end() returns void.
+			// noinspection JSVoidFunctionReturnValueUsed
 			const req = this._net
 			                .request(url, {
 					                method: "GET",

--- a/test/api/common/ArrayUtilsTest.js
+++ b/test/api/common/ArrayUtilsTest.js
@@ -1,12 +1,20 @@
 //@flow
 import o from "ospec"
 import {
-	arrayEquals, arrayEqualsWithPredicate,
+	arrayEquals,
+	arrayEqualsWithPredicate,
 	concat,
-	deduplicate, difference,
-	findLastIndex, flat, flatMap, groupBy, groupByAndMap, groupByAndMapUniquely,
+	deduplicate,
+	difference,
+	findLastIndex,
+	flat,
+	flatMap,
+	groupBy,
+	groupByAndMap,
+	groupByAndMapUniquely,
 	insertIntoSortedArray,
-	splitInChunks, symmetricDifference
+	splitInChunks,
+	symmetricDifference
 } from "../../../src/api/common/utils/ArrayUtils"
 
 type ObjectWithId = {
@@ -214,6 +222,26 @@ o.spec("array utils", function () {
 				[1, [1, 4, 4]],
 				[2, [2]]
 			])
+	})
+
+	o("splitInChunks", function() {
+		o(splitInChunks(-1, []))
+			.deepEquals([])
+
+		o(splitInChunks(-1, [1, 2, 3, 4]))
+			.deepEquals([])
+
+		o(splitInChunks(0, []))
+			.deepEquals([])
+
+		o(splitInChunks(0, [1, 2, 3]))
+			.deepEquals([])
+
+		o(splitInChunks(1, [1, 2, 3]))
+			.deepEquals([[1], [2], [3]])
+
+		o(splitInChunks(2, [1, 2, 3]))
+			.deepEquals([[1, 2], [3]])
 	})
 
 	o("groupByAndMap", function () {

--- a/test/client/Suite.js
+++ b/test/client/Suite.js
@@ -77,6 +77,7 @@ import {preTest, reportTest} from "../api/TestUtils"
 		await import("./desktop/DesktopCryptoFacadeTest.js")
 		await import("./desktop/DesktopContextMenuTest.js")
 		await import("./desktop/DeviceKeyProviderTest.js")
+		await import ("./desktop/config/ConfigFileTest.js")
 	}
 
 	preTest()

--- a/test/client/desktop/config/ConfigFileTest.js
+++ b/test/client/desktop/config/ConfigFileTest.js
@@ -1,0 +1,116 @@
+// @flow
+
+import o from "ospec"
+import n from "../../nodemocker"
+import {delay} from "../../../../src/api/common/utils/PromiseUtils"
+import {getConfigFile} from "../../../../src/desktop/config/ConfigFile"
+import {numberRange} from "../../../../src/api/common/utils/ArrayUtils"
+
+const MAX_LATENCY = 20
+const rndDelay = () => delay(Math.floor(Math.random() * MAX_LATENCY))
+
+const fsMock = {
+	accessSync: function (p) {
+		if (Object.keys(this.promises.fs).includes(p)) return
+		throw new Error("404")
+	},
+	constants: {},
+	promises: {
+		"fs": {
+			"present.json": JSON.stringify({a: "hello", b: ""})
+		},
+		writeFile: function (p: string, v: string) {
+			return rndDelay().then(() => this.fs[p] = v)
+		},
+		readFile: function (p: string) {
+			return rndDelay().then(() => this.fs[p])
+		},
+	}
+}
+
+
+o.spec("ConfigFileTest", function () {
+	o("ensurePresence works", async function () {
+		const newV = {a: "bye", b: "hello"}
+		const cf = getConfigFile(
+			"present.json",
+			n.mock("fs", fsMock).set()
+		)
+		return cf.ensurePresence(newV)
+		         .then(() => cf.readJSON())
+		         .then(v => {
+			         o(v).notDeepEquals(newV)
+		         })
+	})
+
+	o("ensurePresence works 2", async function () {
+		const cf = getConfigFile(
+			"not-present.json",
+			n.mock("fs", fsMock).set()
+		)
+		const newV = {a: "bye", b: "hello"}
+		return cf.ensurePresence(newV)
+		         .then(() => cf.readJSON())
+		         .then(v => {
+			         o(v).deepEquals(newV)
+		         })
+	})
+
+	o("interleaved reads/writes work", async function () {
+		o.timeout(500)
+		const cf = getConfigFile(
+			"conf.json",
+			n.mock("fs", fsMock).set()
+		)
+
+		const cycles = 19
+		const res = []
+
+
+		for (let i = 0; i < cycles + 1;) {
+			await Promise.resolve()
+			cf.writeJSON({a: i++})
+			await Promise.resolve()
+			cf.readJSON().then(v => {
+				i = v.a
+				res.push(i)
+			})
+		}
+
+		// flush writes/reads
+		await cf.readJSON()
+
+		o(res).deepEquals(numberRange(0, cycles))
+	})
+
+	o("instance pool works", async function () {
+		const fs = n.mock("fs", fsMock).set()
+		const first = getConfigFile(
+			"somepath.json",
+			fs
+		)
+
+		await first.ensurePresence({"mork": 123})
+
+		const second = getConfigFile(
+			"somepath.json",
+			fs
+		)
+
+		await second.ensurePresence({"mork": 321})
+
+		const unchanged_content = await first.readJSON()
+		o(unchanged_content).deepEquals({"mork": 123})
+
+		second.writeJSON({a: false})
+
+		const changed_content = await first.readJSON()
+		o(changed_content).deepEquals({a: false})
+
+		// $FlowIgnore[prop-missing]
+		first.t = true
+		// $FlowIgnore[prop-missing]
+		o(second.t).equals(true)
+	})
+})
+

--- a/test/client/desktop/sse/DesktopAlarmSchedulerTest.js
+++ b/test/client/desktop/sse/DesktopAlarmSchedulerTest.js
@@ -191,39 +191,6 @@ o.spec("DesktopAlarmSchedulerTest", function () {
 			onClick(NotificationResult.Click)
 			o(wmMock.openCalendar.callCount).equals(1)
 		})
-
-		o("notification is shown and calendar is opened when it's clicked", async function () {
-			const {wmMock, notifierMock, alarmStorageMock, cryptoMock} = standardMocks()
-
-			const alarmScheduler = makeAlarmScheduler()
-			const scheduler = new DesktopAlarmScheduler(wmMock, notifierMock, alarmStorageMock, cryptoMock, alarmScheduler)
-
-			const an1 = createAlarmNotification({
-				startTime: new Date(2019, 9, 20, 10),
-				endTime: new Date(2019, 9, 20, 12),
-				trigger: "5M",
-				endType: EndType.Never,
-				endValue: null,
-				frequency: RepeatPeriod.ANNUALLY,
-				interval: '1'
-			})
-
-			await scheduler.handleAlarmNotification(an1)
-			o(notifierMock.submitGroupedNotification.callCount).equals(0)
-
-			const cb = lastThrow(alarmScheduler.scheduleAlarm.calls[0].args)
-			const title = "title"
-			const body = "body"
-			cb(title, body)
-
-			o(notifierMock.submitGroupedNotification.calls.map(c => c.args.slice(0, -1))).deepEquals([
-				[title, body, an1.alarmInfo.alarmIdentifier]
-			])
-			o(wmMock.openCalendar.callCount).equals(0)
-			const onClick = lastThrow(notifierMock.submitGroupedNotification.calls[0].args)
-			onClick(NotificationResult.Click)
-			o(wmMock.openCalendar.callCount).equals(1)
-		})
 	})
 })
 

--- a/test/client/desktop/sse/DesktopSseClientTest.js
+++ b/test/client/desktop/sse/DesktopSseClientTest.js
@@ -667,7 +667,7 @@ o.spec("DesktopSseClient Test", function () {
 		downcast(electronMock.app).callbacks['will-quit']()
 	})
 
-	o("suspension on downloadMissedNotification", async function () {
+	o("suspension on downloadMissedNotification Service Unavailable", async function () {
 		const sse = new DesktopSseClient(electronMock.app, confMock, notifierMock, wmMock, alarmSchedulerMock, netMock, cryptoMock,
 			alarmStorageMock, langMock, timeoutMock)
 		const sseResponse = new net.Response(200)
@@ -702,7 +702,7 @@ o.spec("DesktopSseClient Test", function () {
 		downcast(electronMock.app).callbacks['will-quit']()
 	})
 
-	o("suspension on downloadMissedNotification", async function () {
+	o("suspension on downloadMissedNotification Too Many Requests", async function () {
 		const sse = new DesktopSseClient(electronMock.app, confMock, notifierMock, wmMock, alarmSchedulerMock, netMock, cryptoMock,
 			alarmStorageMock, langMock, timeoutMock)
 		const sseResponse = new net.Response(200)


### PR DESCRIPTION
main changes:

* DesktopDeviceKeyProvider should only get the key once, otherwise it might generate more than one key in a sequence and leave different parts of the app with different device keys. #3295 
* writes and reads to the config file are sequenced now to prevent race condition from corrupting it.
 this can be readily reproduced by creating several alarms, checking that they are written to conf.json and then deleting one of the events from the calendar. the file is likely to contain invalid json. #3295 #3316