### PR TITLE
Catch corrupt deviceidentifier 3295

### DIFF
--- a/src/desktop/DesktopMain.js
+++ b/src/desktop/DesktopMain.js
@@ -118,7 +118,10 @@ async function createComponents(): Promise<Components> {
 	const wm = new WindowManager(conf, tray, notifier, electron, shortcutManager, dl, themeManager)
 	const alarmScheduler = new AlarmSchedulerImpl(dateProvider, new SchedulerImpl(dateProvider, global))
 	const desktopAlarmScheduler = new DesktopAlarmScheduler(wm, notifier, alarmStorage, desktopCrypto, alarmScheduler)
-	desktopAlarmScheduler.rescheduleAll()
+	desktopAlarmScheduler.rescheduleAll().catch(e => {
+		log.error("Could not reschedule alarms", e)
+		return sse.resetStoredState()
+	})
 
 	tray.setWindowManager(wm)
 	const sse = new DesktopSseClient(app, conf, notifier, wm, desktopAlarmScheduler, desktopNet, desktopCrypto, alarmStorage, lang)

--- a/src/desktop/DeviceKeyProviderImpl.js
+++ b/src/desktop/DeviceKeyProviderImpl.js
@@ -45,7 +45,6 @@ export class DeviceKeyProviderImpl implements DesktopDeviceKeyProvider {
 			this._deviceKey.reject(new DeviceStorageUnavailableError("could not retrieve device key from device secret storage", e))
 			return
 		}
-
 		if (storedKey) {
 			this._deviceKey.resolve(base64ToKey(storedKey))
 			return

--- a/src/desktop/sse/DesktopAlarmStorage.js
+++ b/src/desktop/sse/DesktopAlarmStorage.js
@@ -44,6 +44,7 @@ export class DesktopAlarmStorage {
 	}
 
 	removePushIdentifierKeys(): Promise<void> {
+		this._sessionKeysB64 = {}
 		return this._conf.setVar(DesktopConfigKey.pushEncSessionKeys, null)
 	}
 

--- a/src/desktop/sse/DesktopAlarmStorage.js
+++ b/src/desktop/sse/DesktopAlarmStorage.js
@@ -62,11 +62,11 @@ export class DesktopAlarmStorage {
 	 */
 	async getPushIdentifierSessionKey(notificationSessionKey: NotificationSessionKey): Promise<?Base64> {
 		const pw = await this._deviceKeyProvider.getDeviceKey()
-		const keys = await this._conf.getVar(DesktopConfigKey.pushEncSessionKeys) || {}
 		const pushIdentifierId = elementIdPart(notificationSessionKey.pushIdentifier)
 		if (this._sessionKeysB64[pushIdentifierId]) {
 			return this._sessionKeysB64[pushIdentifierId]
 		} else {
+			const keys = await this._conf.getVar(DesktopConfigKey.pushEncSessionKeys) || {}
 			const sessionKeyFromConf = keys[pushIdentifierId]
 			if (sessionKeyFromConf == null) {
 				// key with this id is not saved in local conf, so we can't resolve it

--- a/test/client/desktop/sse/DesktopAlarmSchedulerTest.js
+++ b/test/client/desktop/sse/DesktopAlarmSchedulerTest.js
@@ -52,7 +52,7 @@ o.spec("DesktopAlarmSchedulerTest", function () {
 		const alarmStorage = {
 			storeAlarm: o.spy(() => Promise.resolve()),
 			deleteAlarm: o.spy(() => Promise.resolve()),
-			resolvePushIdentifierSessionKey: () => Promise.resolve({piSk: "piSk", piSkEncSk: "piSkEncSk"}),
+			getPushIdentifierSessionKey: () => Promise.resolve("piSk"),
 			getScheduledAlarms: () => []
 		}
 		const alarmStorageMock = n.mock("__alarmStorage", alarmStorage).set()

--- a/test/client/desktop/sse/DesktopAlarmStorageTest.js
+++ b/test/client/desktop/sse/DesktopAlarmStorageTest.js
@@ -82,10 +82,8 @@ o.spec("DesktopAlarmStorageTest", function () {
 		const {confMock, cryptoMock, secretStorageMock} = standardMocks()
 
 		const desktopStorage = new DesktopAlarmStorage(confMock, cryptoMock, deviceKeyProvider)
-		await desktopStorage.resolvePushIdentifierSessionKey([
-			{pushIdentifierSessionEncSessionKey: "abc", pushIdentifier: ["oneId", "twoId"]},
-			{pushIdentifierSessionEncSessionKey: "def", pushIdentifier: ["threeId", "fourId"]}
-		])
+		await desktopStorage.getPushIdentifierSessionKey({pushIdentifierSessionEncSessionKey: "abc", pushIdentifier: ["oneId", "twoId"]})
+		await desktopStorage.getPushIdentifierSessionKey({pushIdentifierSessionEncSessionKey: "def", pushIdentifier: ["threeId", "fourId"]})
 		o(cryptoMock.aes256DecryptKeyToB64.callCount).equals(2)
 	})
 
@@ -97,10 +95,8 @@ o.spec("DesktopAlarmStorageTest", function () {
 		)
 		const desktopStorage = new DesktopAlarmStorage(confMock, cryptoMock, deviceKeyProvider)
 		await desktopStorage.storePushIdentifierSessionKey("fourId", "user4pw=")
-		await desktopStorage.resolvePushIdentifierSessionKey([
-			{pushIdentifierSessionEncSessionKey: "abc", pushIdentifier: ["oneId", "twoId"]},
-			{pushIdentifierSessionEncSessionKey: "def", pushIdentifier: ["threeId", "fourId"]}
-		])
+		await desktopStorage.getPushIdentifierSessionKey({pushIdentifierSessionEncSessionKey: "abc", pushIdentifier: ["oneId", "twoId"]})
+		await desktopStorage.getPushIdentifierSessionKey({pushIdentifierSessionEncSessionKey: "def", pushIdentifier: ["threeId", "fourId"]})
 		o(cryptoMock.aes256DecryptKeyToB64.callCount).equals(0)
 		o(confMock.setVar.callCount).equals(1)
 		o(confMock.setVar.args.length).equals(2)

--- a/test/client/desktop/sse/DesktopSseClientTest.js
+++ b/test/client/desktop/sse/DesktopSseClientTest.js
@@ -104,8 +104,8 @@ o.spec("DesktopSseClient Test", function () {
 						userInfo: {userId: "myId", mailAddress: "a@b.c"}
 					}
 				]
-
-			}
+			},
+			invalidateAlarms: () => Promise.resolve()
 		}
 
 		const alarmScheduler = {
@@ -626,6 +626,7 @@ o.spec("DesktopSseClient Test", function () {
 
 		o(notifierMock.submitGroupedNotification.callCount).equals(0)
 		o(alarmSchedulerMock.handleAlarmNotification.callCount).equals(0)
+		await Promise.resolve()
 		o(confMock.setVar.calls.find(c => c.args[0] === DesktopConfigEncKey.sseInfo)?.args).deepEquals([
 			DesktopConfigEncKey.sseInfo, {
 				identifier,
@@ -762,7 +763,8 @@ o.spec("DesktopSseClient Test", function () {
 
 		o(alarmSchedulerMock.unscheduleAllAlarms.callCount).equals(1)
 		o(confMock.setVar.calls[0].args).deepEquals([DesktopConfigKey.lastMissedNotificationCheckTime, null])
-		o(confMock.setVar.calls[1].args)
+		o(confMock.setVar.calls[1].args).deepEquals(['lastProcessedNotificationId', null])
+		o(confMock.setVar.calls[2].args)
 			.deepEquals([DesktopConfigEncKey.sseInfo, {identifier, userIds: [], sseOrigin: sseInfo.sseOrigin}])
 		o(alarmStorageMock.removePushIdentifierKeys.callCount).equals(1)
 		o(timeoutSpy.callCount).equals(1)


### PR DESCRIPTION
The alarmscheduler of the desktop client should try to decrypt alarmnotifications until there are no keys left it could use before throwing an error.

if it does throw, there's something wrong with the locally stored sseinfo, alarmnotifications or pushIdentifierSessionKeys and we should clear them, essentially returning to the state of a new device and redownloading alarms.

It will never use alarmNotifications that are partially unable to be decrypted ("_errors" key gets set by the InstanceMapper).