### PR TITLE
Fix saving the custom theme to the storage

### DIFF
--- a/src/gui/ThemeController.js
+++ b/src/gui/ThemeController.js
@@ -141,10 +141,9 @@ export class ThemeController {
 	}
 
 	/**
-	 * Set the custom theme, if permanent === true, then the new theme will be saved
+	 * Apply the custom theme, if permanent === true, then the new theme will be saved
 	 */
 	async updateCustomTheme(customizations: ThemeCustomizations, permanent: boolean = true): Promise<void> {
-
 		const updatedTheme = this.assembleTheme(customizations)
 		// Set no logo until we sanitize it.
 		const filledWithoutLogo = Object.assign({}, updatedTheme, {logo: ""})
@@ -169,6 +168,9 @@ export class ThemeController {
 		}
 	}
 
+	/**
+	 * Save theme to the storage.
+	 */
 	async updateSavedThemeDefinition(updatedTheme: Theme): Promise<Theme> {
 		const nonNullTheme = Object.assign({}, this.getDefaultTheme(), updatedTheme)
 		await this._sanitizeTheme(nonNullTheme)

--- a/src/misc/WhitelabelCustomizations.js
+++ b/src/misc/WhitelabelCustomizations.js
@@ -2,6 +2,7 @@
 import type {BaseThemeId, Theme} from "../gui/theme"
 import type {BootstrapFeatureTypeEnum} from "../api/common/TutanotaConstants"
 import {assertMainOrNodeBoot} from "../api/common/Env"
+import type {WhitelabelConfig} from "../api/entities/sys/WhitelabelConfig"
 
 assertMainOrNodeBoot()
 
@@ -24,3 +25,6 @@ export function getWhitelabelCustomizations(window: typeof window): ?WhitelabelC
 	return window.whitelabelCustomizations
 }
 
+export function getThemeCustomizations(whitelabelConfig: WhitelabelConfig): ThemeCustomizations {
+	return JSON.parse(whitelabelConfig.jsonTheme, (k, v) => k === "__proto__" ? undefined : v)
+}

--- a/src/settings/whitelabel/WhitelabelSettingsViewer.js
+++ b/src/settings/whitelabel/WhitelabelSettingsViewer.js
@@ -47,6 +47,7 @@ import type {UpdatableSettingsViewer} from "../SettingsView"
 import {promiseMap} from "@tutao/tutanota-utils"
 import type {ThemeCustomizations} from "../../misc/WhitelabelCustomizations"
 import {EntityClient} from "../../api/common/EntityClient"
+import {getThemeCustomizations} from "../../misc/WhitelabelCustomizations"
 
 assertMainOrNode()
 
@@ -305,7 +306,7 @@ export class WhitelabelSettingsViewer implements UpdatableSettingsViewer {
 					return loadRange(BookingTypeRef, neverNull(customerInfo.bookings).items, GENERATED_MAX_ID, 1, true)
 						.then(bookings => {
 							this._lastBooking = bookings.length === 1 ? bookings[0] : null
-							this._customJsonTheme = (this._whitelabelConfig) ? JSON.parse(this._whitelabelConfig.jsonTheme) : null
+							this._customJsonTheme = (this._whitelabelConfig) ? getThemeCustomizations(this._whitelabelConfig) : null
 							m.redraw()
 							this._customerProperties.getAsync().then(m.redraw)
 						})


### PR DESCRIPTION
We incorrectly assumed that whitelabel config has the full custom theme.
It is not the case anymore.

fix #3638