### PR TITLE
[desktop] make sure currentBounds is updated on Ctrl+0

### DIFF
--- a/src/desktop/ApplicationWindow.js
+++ b/src/desktop/ApplicationWindow.js
@@ -87,7 +87,7 @@ export class ApplicationWindow {
 			{key: Keys.F, meta: isMac, ctrl: !isMac, exec: () => this._openFindInPage(), help: "searchPage_label"},
 			{key: Keys.P, meta: isMac, ctrl: !isMac, exec: () => this._printMail(), help: "print_action"},
 			{key: Keys.F12, exec: () => this._toggleDevTools(), help: "toggleDevTools_action"},
-			{key: Keys["0"], meta: isMac, ctrl: !isMac, exec: () => {this.setZoomFactor(1)}, help: "resetZoomFactor_action"}
+			{key: Keys["0"], meta: isMac, ctrl: !isMac, exec: () => {wm.changeZoom(1)}, help: "resetZoomFactor_action"}
 		].concat(isMac
 			? [{key: Keys.F, meta: true, ctrl: true, exec: () => this._toggleFullScreen(), help: "toggleFullScreen_action"},]
 			: [

--- a/src/desktop/DesktopWindowManager.js
+++ b/src/desktop/DesktopWindowManager.js
@@ -103,13 +103,7 @@ export class WindowManager {
 			this._tray.update(this._notifier)
 		}).on('zoom-changed', (ev: Event, direction: "in" | "out") => {
 			let scale = ((this._currentBounds.scale * 100) + (direction === "out" ? -5 : 5)) / 100
-			if (scale > 3) {
-				scale = 3
-			} else if (scale < 0.5) {
-				scale = 0.5
-			}
-			this._currentBounds.scale = scale
-			windows.forEach(w => w.setZoomFactor(scale))
+			this.changeZoom(scale)
 			const w = this.getEventSender(downcast(ev))
 			if (!w) return
 			this.saveBounds(w.getBounds())
@@ -171,6 +165,14 @@ export class WindowManager {
 
 	minimize() {
 		windows.forEach(w => w.minimize())
+	}
+
+	changeZoom(scale: number) {
+		if (scale > 3) {
+			scale = 3
+		} else if (scale < 0.5) scale = 0.5
+		this._currentBounds.scale = scale
+		windows.forEach(w => w.setZoomFactor(scale))
 	}
 
 	async getIcon(): Promise<NativeImage> {


### PR DESCRIPTION
normal zoom changes update the zoom factor maintained by the windowmanager
Ctrl+0 didn't, so the window manager would reset the zoom to the saved,
now outdated value on did-navigate events.

this commit globally changes the zoom on all windows and updates the saved
value when Ctrl+0 is pressed.

fix #3717