### PR TITLE
[desktop] try to find perfect match before fallback textId in Spellch…

### DIFF
--- a/src/gui/dialogs/SpellcheckLanguageDialog.js
+++ b/src/gui/dialogs/SpellcheckLanguageDialog.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type {SelectorItem} from "../base/DropDownSelectorN"
-import {mapNullable} from "@tutao/tutanota-utils"
 import type {TranslationKey} from "../../misc/LanguageViewModel"
 
 export async function showSpellcheckLanguageDialog(): Promise<string> {
@@ -49,7 +48,7 @@ async function getItems(): Promise<Array<SelectorItem<string>>> {
 
 			const [langCode, locale] = code.split("-")
 			// first, find the name for a language given a locale with a perfect match
-			const l = languages.find(language => (locale && language.code === `${langCode}_${locale.toLowerCase()}`))
+			const language = languages.find(language => (locale && language.code === `${langCode}_${locale.toLowerCase()}`))
 				// find the name for a language without a locale, with a perfect match
 				|| languages.find(language => language.code === langCode)
 				// try to get a missing one before splitting
@@ -57,9 +56,7 @@ async function getItems(): Promise<Array<SelectorItem<string>>> {
 				// the code given by electron doesn't always have a locale when we do,
 				// e.g. for Persian we have "fa_ir" in LanguageViewModel, but electron only gives us "fa"
 				|| languages.find(language => language.code.slice(0, 2) === langCode)
-			const textId = mapNullable(l, language => language.textId)
-
-			console.log(textId, langCode, locale)
+			const textId = language?.textId
 			const name = textId
 				? lang.get(textId) + ` (${code})`
 				: code

--- a/src/gui/dialogs/SpellcheckLanguageDialog.js
+++ b/src/gui/dialogs/SpellcheckLanguageDialog.js
@@ -48,18 +48,18 @@ async function getItems(): Promise<Array<SelectorItem<string>>> {
 		...options.map(code => {
 
 			const [langCode, locale] = code.split("-")
+			// first, find the name for a language given a locale with a perfect match
+			const l = languages.find(language => (locale && language.code === `${langCode}_${locale.toLowerCase()}`))
+				// find the name for a language without a locale, with a perfect match
+				|| languages.find(language => language.code === langCode)
+				// try to get a missing one before splitting
+				|| getMissingLanguage(langCode)
+				// the code given by electron doesn't always have a locale when we do,
+				// e.g. for Persian we have "fa_ir" in LanguageViewModel, but electron only gives us "fa"
+				|| languages.find(language => language.code.slice(0, 2) === langCode)
+			const textId = mapNullable(l, language => language.textId)
 
-			const textId = mapNullable(languages.find(
-				language =>
-					// find the name for a language given a locale with a perfect match
-					(locale && language.code === `${langCode}_${locale.toLowerCase()}`)
-					// fine the name for a language without a locale, with a perfect match
-					|| language.code === langCode
-					// the code given by electron doesn't always have a locale when we do,
-					// e.g. for Persian we have "fa_ir" in LanguageViewModel, but electron only gives us "fa"
-					|| language.code.slice(0, 2) === langCode), language => language.textId)
-				|| getMissingLanguageLabel(langCode)
-
+			console.log(textId, langCode, locale)
 			const name = textId
 				? lang.get(textId) + ` (${code})`
 				: code
@@ -73,8 +73,8 @@ async function getItems(): Promise<Array<SelectorItem<string>>> {
  * Electron has a different selection of spellchecker languages from what our client supports,
  * so we can't get all of the names from the LanguageViewModel
  */
-function getMissingLanguageLabel(code): TranslationKey {
-	return {
+function getMissingLanguage(code): {textId: TranslationKey, code: string} | null {
+	const id = {
 		"af": "languageAfrikaans_label",
 		"cy": "languageWelsh_label",
 		"fo": "languageFaroese_label",
@@ -84,5 +84,8 @@ function getMissingLanguageLabel(code): TranslationKey {
 		"sq": "languageAlbanian_label",
 		"ta": "languageTamil_label",
 		"tg": "languageTajik_label",
+		"pt": "languagePortugese_label"
 	}[code]
+
+	return id && {textId: id, code}
 }

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -711,6 +711,7 @@ export default {
 		"languagePolish_label": "Polish",
 		"languagePortugeseBrazil_label": "Portuguese, Brazil",
 		"languagePortugesePortugal_label": "Portuguese, Portugal",
+		"languagePortugese_label": "Portuguese",
 		"languageRomanian_label": "Romanian",
 		"languageRussian_label": "Russian",
 		"languageSerbian_label": "Serbian",


### PR DESCRIPTION
…eckLanguageDialog.js

SpellcheckLanguageDialog.js looked for the first language in the
LanguageViewModel that fullfills any of these:
* its langCode-locale has perfect match with dictionaries langCode-locale
* it only has a langCode that matches the dictionaries' langCode perfectly
* the language code with its locale removed matches the dictionaries' langCode

the language pt-br runs into the third case and gets returned for the pt-pt dict,
even though later in the languages list there would be a perfect match with pt-pt.

this commit adds another missing language text id (Portuguese) and changes
the textId selection so it tries to find perfect matches before considering
any fallbacks.

fix #3659