### PR TITLE
Remove buggy workaround for old Chrome versions

### DIFF
--- a/src/contacts/model/ContactUtils.ts
+++ b/src/contacts/model/ContactUtils.ts
@@ -28,30 +28,9 @@ export function getContactListName(contact: Contact): string {
 
 export function formatBirthdayNumeric(birthday: Birthday): string {
 	if (birthday.year) {
-		//in chromimum Intl.DateTimeFormat is buggy for some dates with years the format subtracts a day from the date
-		//example date is 15.8.1911 ->format returns 14.8.1911
-		//this issue does not happen with recent years so the formatting is done with the current year then this year is changed with the original of the birthday
-		let refYear = new Date()
-		let bdayString = formatDate(new Date(refYear.getFullYear(), Number(neverNull(birthday).month) - 1, Number(neverNull(birthday).day)))
-		bdayString = bdayString.replace(/\d{4}/g, String(neverNull(birthday).year))
-		return bdayString
+		return formatDate(new Date(Number(neverNull(birthday).year), Number(neverNull(birthday).month) - 1, Number(neverNull(birthday).day)))
 	} else {
 		return lang.formats.simpleDateWithoutYear.format(new Date(Number(2011), Number(neverNull(birthday).month) - 1, Number(neverNull(birthday).day)))
-	}
-}
-
-export function formatBirthdayWithMonthName(birthday: Birthday): string {
-	if (birthday.year) {
-		//todo github issue #414
-		//in chromimum Intl.DateTimeFormat is buggy for some dates with years the format subtracts a day from the date
-		//example date is 15.8.1911 ->format returns 14.8.1911
-		//this issue does not happen with recent years so the formatting is done with the current year then this year is changed with the original of the birthday
-		let refYear = new Date()
-		let bdayString = formatDateWithMonth(new Date(refYear.getFullYear(), Number(neverNull(birthday).month) - 1, Number(neverNull(birthday).day)))
-		bdayString = bdayString.replace(/\d{4}/g, String(neverNull(birthday).year))
-		return bdayString
-	} else {
-		return lang.formats.dateWithoutYear.format(new Date(Number(2011), Number(neverNull(birthday).month) - 1, Number(neverNull(birthday).day)))
 	}
 }
 

--- a/src/contacts/model/ContactUtils.ts
+++ b/src/contacts/model/ContactUtils.ts
@@ -1,8 +1,7 @@
 import {lang} from "../../misc/LanguageViewModel"
 import type {Contact} from "../../api/entities/tutanota/Contact"
-import {neverNull} from "@tutao/tutanota-utils"
 import type {Birthday} from "../../api/entities/tutanota/Birthday"
-import {formatDate, formatDateWithMonth} from "../../misc/Formatter"
+import {formatDate} from "../../misc/Formatter"
 import {isoDateToBirthday} from "../../api/common/utils/BirthdayUtils"
 import {assertMainOrNode} from "../../api/common/Env"
 
@@ -28,9 +27,9 @@ export function getContactListName(contact: Contact): string {
 
 export function formatBirthdayNumeric(birthday: Birthday): string {
 	if (birthday.year) {
-		return formatDate(new Date(Number(neverNull(birthday).year), Number(neverNull(birthday).month) - 1, Number(neverNull(birthday).day)))
+		return formatDate(new Date(Number(birthday.year), Number(birthday.month) - 1, Number(birthday.day)))
 	} else {
-		return lang.formats.simpleDateWithoutYear.format(new Date(Number(2011), Number(neverNull(birthday).month) - 1, Number(neverNull(birthday).day)))
+		return lang.formats.simpleDateWithoutYear.format(new Date(Number(2011), Number(birthday.month) - 1, Number(birthday.day)))
 	}
 }
 

--- a/test/client/contact/ContactUtilsTest.ts
+++ b/test/client/contact/ContactUtilsTest.ts
@@ -61,7 +61,7 @@ o.spec("ContactUtilsTest", function () {
 		o(result).equals(expectedResult)
 	}
 
-	o("compareContacts by first name", () => {
+	o("compareContacts by first name", function () {
 		// only first name
 		compare("Alf", "", null, "", "", null, true, -1)
 		compare("Alf", "", null, "Bob", "", null, true, -1)
@@ -94,7 +94,7 @@ o.spec("ContactUtilsTest", function () {
 
 		compare("ma", "p", "aa", "Gump", "Forrest", "aa", true, 1) // reverse id
 	})
-	o("compareContacts by last name", () => {
+	o("compareContacts by last name", function () {
 		// only first name
 		compare("Alf", "", null, "", "", null, false, -1)
 		compare("Alf", "", null, "Bob", "", null, false, -1)
@@ -152,8 +152,7 @@ o.spec("ContactUtilsTest", function () {
 		bday.year = "2009"
 	})
 
-	o("formatBirthdayNumeric", () => {
-
+	o("formatBirthdayNumeric", function () {
 		const leapYearBirthday = createBirthday()
 		leapYearBirthday.year = "2016"
 		leapYearBirthday.month = "2"

--- a/test/client/contact/ContactUtilsTest.ts
+++ b/test/client/contact/ContactUtilsTest.ts
@@ -5,149 +5,180 @@ import {createContactMailAddress} from "../../../src/api/entities/tutanota/Conta
 import {createBirthday} from "../../../src/api/entities/tutanota/Birthday"
 import {lang} from "../../../src/misc/LanguageViewModel"
 import {compareContacts} from "../../../src/contacts/view/ContactGuiUtils"
+
 o.spec("ContactUtilsTest", function () {
-    let compare = function (
-        c1Firstname,
-        c1Lastname,
-        c1MailAddress,
-        c2Firstname,
-        c2Lastname,
-        c2MailAddress,
-        byFirstName,
-        expectedResult,
-    ) {
-        let c1 = createContact()
-        let c2 = createContact()
-        c1._id = ["a", "1"]
-        c2._id = ["a", "2"]
-        c1.firstName = c1Firstname
-        c2.firstName = c2Firstname
-        c1.lastName = c1Lastname
-        c2.lastName = c2Lastname
+	let compare = function (
+		c1Firstname,
+		c1Lastname,
+		c1MailAddress,
+		c2Firstname,
+		c2Lastname,
+		c2MailAddress,
+		byFirstName,
+		expectedResult,
+	) {
+		let c1 = createContact()
+		let c2 = createContact()
+		c1._id = ["a", "1"]
+		c2._id = ["a", "2"]
+		c1.firstName = c1Firstname
+		c2.firstName = c2Firstname
+		c1.lastName = c1Lastname
+		c2.lastName = c2Lastname
 
-        if (c1MailAddress) {
-            let m = createContactMailAddress()
-            m.address = c1MailAddress
-            c1.mailAddresses.push(m)
-        }
+		if (c1MailAddress) {
+			let m = createContactMailAddress()
+			m.address = c1MailAddress
+			c1.mailAddresses.push(m)
+		}
 
-        if (c2MailAddress) {
-            let m = createContactMailAddress()
-            m.address = c2MailAddress
-            c2.mailAddresses.push(m)
-        }
+		if (c2MailAddress) {
+			let m = createContactMailAddress()
+			m.address = c2MailAddress
+			c2.mailAddresses.push(m)
+		}
 
-        let result = compareContacts(c1, c2, byFirstName)
+		let result = compareContacts(c1, c2, byFirstName)
 
-        // We should use Mithril's ability to print messages instead of this log when it will work again (and the moment of writing it's
-        // fixed but not released: https://github.com/MithrilJS/mithril.js/issues/2391
-        if (result != expectedResult) {
-            console.log(
-                "error >>>>>>>",
-                "'" + c1Firstname + "'",
-                "'" + c1Lastname + "'",
-                c1MailAddress,
-                "'" + c2Firstname + "'",
-                "'" + c2Lastname + "'",
-                c2MailAddress,
-                "expected:",
-                expectedResult,
-                "result",
-                result,
-            )
-        }
+		// We should use Mithril's ability to print messages instead of this log when it will work again (and the moment of writing it's
+		// fixed but not released: https://github.com/MithrilJS/mithril.js/issues/2391
+		if (result != expectedResult) {
+			console.log(
+				"error >>>>>>>",
+				"'" + c1Firstname + "'",
+				"'" + c1Lastname + "'",
+				c1MailAddress,
+				"'" + c2Firstname + "'",
+				"'" + c2Lastname + "'",
+				c2MailAddress,
+				"expected:",
+				expectedResult,
+				"result",
+				result,
+			)
+		}
 
-        o(result).equals(expectedResult)
-    }
+		o(result).equals(expectedResult)
+	}
 
-    o("compareContacts by first name", () => {
-        // only first name
-        compare("Alf", "", null, "", "", null, true, -1)
-        compare("Alf", "", null, "Bob", "", null, true, -1)
-        compare("", "", null, "Bob", "", null, true, 1)
-        compare("Bob", "", null, "Alf", "", null, true, 1)
-        // only last name
-        compare("", "Alf", null, "", "", null, true, -1)
-        compare("", "Alf", null, "", "Bob", null, true, -1)
-        compare("", "", null, "", "Bob", null, true, 1)
-        compare("", "Bob", null, "", "Alf", null, true, 1)
-        // only mail address
-        compare("", "", "Alf", "", "", null, true, -1)
-        compare("", "", "Alf", "", "", "Bob", true, -1)
-        compare("", "", null, "", "", "Bob", true, 1)
-        compare("", "", "Bob", "", "", "Alf", true, 1)
-        // first and last name
-        compare("", "Alf", null, "Alf", "Bob", null, true, 1)
-        compare("Alf", "Bob", null, "Bob", "Alf", null, true, -1)
-        compare("Alf", "Bob", null, "", "Bob", null, true, -1)
-        compare("Alf", "", null, "Alf", "Bob", null, true, 1)
-        // mixed
-        compare("", "Bob", null, "", "", "Alf", true, -1)
-        compare("Bob", "", null, "", "", "Alf", true, -1)
-        compare("Alf", "Bob", "Bob", "Alf", "Bob", "Alf", true, 1)
-        compare("Alf", "Bob", null, "", "", "Alf", true, -1)
-        // none or same
-        compare("", "", null, "", "", null, true, 1) // reverse id
+	o("compareContacts by first name", () => {
+		// only first name
+		compare("Alf", "", null, "", "", null, true, -1)
+		compare("Alf", "", null, "Bob", "", null, true, -1)
+		compare("", "", null, "Bob", "", null, true, 1)
+		compare("Bob", "", null, "Alf", "", null, true, 1)
+		// only last name
+		compare("", "Alf", null, "", "", null, true, -1)
+		compare("", "Alf", null, "", "Bob", null, true, -1)
+		compare("", "", null, "", "Bob", null, true, 1)
+		compare("", "Bob", null, "", "Alf", null, true, 1)
+		// only mail address
+		compare("", "", "Alf", "", "", null, true, -1)
+		compare("", "", "Alf", "", "", "Bob", true, -1)
+		compare("", "", null, "", "", "Bob", true, 1)
+		compare("", "", "Bob", "", "", "Alf", true, 1)
+		// first and last name
+		compare("", "Alf", null, "Alf", "Bob", null, true, 1)
+		compare("Alf", "Bob", null, "Bob", "Alf", null, true, -1)
+		compare("Alf", "Bob", null, "", "Bob", null, true, -1)
+		compare("Alf", "", null, "Alf", "Bob", null, true, 1)
+		// mixed
+		compare("", "Bob", null, "", "", "Alf", true, -1)
+		compare("Bob", "", null, "", "", "Alf", true, -1)
+		compare("Alf", "Bob", "Bob", "Alf", "Bob", "Alf", true, 1)
+		compare("Alf", "Bob", null, "", "", "Alf", true, -1)
+		// none or same
+		compare("", "", null, "", "", null, true, 1) // reverse id
 
-        compare("Alf", "Bob", "Bob", "Alf", "Bob", "Bob", true, 1) // reverse id
+		compare("Alf", "Bob", "Bob", "Alf", "Bob", "Bob", true, 1) // reverse id
 
-        compare("ma", "p", "aa", "Gump", "Forrest", "aa", true, 1) // reverse id
-    })
-    o("compareContacts by last name", () => {
-        // only first name
-        compare("Alf", "", null, "", "", null, false, -1)
-        compare("Alf", "", null, "Bob", "", null, false, -1)
-        compare("", "", null, "Bob", "", null, false, 1)
-        compare("Bob", "", null, "Alf", "", null, false, 1)
-        // only last name
-        compare("", "Alf", null, "", "", null, false, -1)
-        compare("", "Alf", null, "", "Bob", null, false, -1)
-        compare("", "", null, "", "Bob", null, false, 1)
-        compare("", "Bob", null, "", "Alf", null, false, 1)
-        // only mail address
-        compare("", "", "Alf", "", "", null, false, -1)
-        compare("", "", "Alf", "", "", "Bob", false, -1)
-        compare("", "", null, "", "", "Bob", false, 1)
-        compare("", "", "Bob", "", "", "Alf", false, 1)
-        // first and last name
-        compare("", "Alf", null, "Alf", "Bob", null, false, -1)
-        compare("Alf", "Bob", null, "Bob", "Alf", null, false, 1)
-        compare("Alf", "Bob", null, "", "Bob", null, false, -1)
-        compare("Alf", "", null, "Alf", "Bob", null, false, 1)
-        // mixed
-        compare("", "Bob", null, "", "", "Alf", false, -1)
-        compare("Bob", "", null, "", "", "Alf", false, -1)
-        compare("Alf", "Bob", "Bob", "Alf", "Bob", "Alf", false, 1)
-        compare("Alf", "Bob", null, "", "", "Alf", false, -1)
-        // none or same
-        compare("", "", null, "", "", null, false, 1) // reverse id
+		compare("ma", "p", "aa", "Gump", "Forrest", "aa", true, 1) // reverse id
+	})
+	o("compareContacts by last name", () => {
+		// only first name
+		compare("Alf", "", null, "", "", null, false, -1)
+		compare("Alf", "", null, "Bob", "", null, false, -1)
+		compare("", "", null, "Bob", "", null, false, 1)
+		compare("Bob", "", null, "Alf", "", null, false, 1)
+		// only last name
+		compare("", "Alf", null, "", "", null, false, -1)
+		compare("", "Alf", null, "", "Bob", null, false, -1)
+		compare("", "", null, "", "Bob", null, false, 1)
+		compare("", "Bob", null, "", "Alf", null, false, 1)
+		// only mail address
+		compare("", "", "Alf", "", "", null, false, -1)
+		compare("", "", "Alf", "", "", "Bob", false, -1)
+		compare("", "", null, "", "", "Bob", false, 1)
+		compare("", "", "Bob", "", "", "Alf", false, 1)
+		// first and last name
+		compare("", "Alf", null, "Alf", "Bob", null, false, -1)
+		compare("Alf", "Bob", null, "Bob", "Alf", null, false, 1)
+		compare("Alf", "Bob", null, "", "Bob", null, false, -1)
+		compare("Alf", "", null, "Alf", "Bob", null, false, 1)
+		// mixed
+		compare("", "Bob", null, "", "", "Alf", false, -1)
+		compare("Bob", "", null, "", "", "Alf", false, -1)
+		compare("Alf", "Bob", "Bob", "Alf", "Bob", "Alf", false, 1)
+		compare("Alf", "Bob", null, "", "", "Alf", false, -1)
+		// none or same
+		compare("", "", null, "", "", null, false, 1) // reverse id
 
-        compare("Alf", "Bob", "Bob", "Alf", "Bob", "Bob", false, 1) // reverse id
+		compare("Alf", "Bob", "Bob", "Alf", "Bob", "Bob", false, 1) // reverse id
 
-        compare("ma", "p", "aa", "Gump", "Forrest", "aa", false, 1) // reverse id
-    })
-    o("formatNewBirthdayTest", function () {
-        lang.setLanguage({
-            code: "en",
-            languageTag: "en",
-        })
-        lang.updateFormats({})
-        let bday = createBirthday()
-        bday.day = "12"
-        bday.month = "10"
-        bday.year = "2009"
-        o(formatBirthdayNumeric(bday)).equals("10/12/2009")
-        bday.day = "9"
-        bday.month = "07"
-        bday.year = null
-        o(formatBirthdayNumeric(bday)).equals("7/9")
-        bday.day = "09"
-        bday.month = "7"
-        bday.year = null
-        o(formatBirthdayNumeric(bday)).equals("7/9")
-        bday = createBirthday()
-        bday.day = "12"
-        bday.month = "10"
-        bday.year = "2009"
-    })
+		compare("ma", "p", "aa", "Gump", "Forrest", "aa", false, 1) // reverse id
+	})
+	o("formatNewBirthdayTest", function () {
+		lang.setLanguage({
+			code: "en",
+			languageTag: "en",
+		})
+		lang.updateFormats({})
+		let bday = createBirthday()
+		bday.day = "12"
+		bday.month = "10"
+		bday.year = "2009"
+		o(formatBirthdayNumeric(bday)).equals("10/12/2009")
+		bday.day = "9"
+		bday.month = "07"
+		bday.year = null
+		o(formatBirthdayNumeric(bday)).equals("7/9")
+		bday.day = "09"
+		bday.month = "7"
+		bday.year = null
+		o(formatBirthdayNumeric(bday)).equals("7/9")
+		bday = createBirthday()
+		bday.day = "12"
+		bday.month = "10"
+		bday.year = "2009"
+	})
+
+	o("formatBirthdayNumeric", () => {
+
+		const leapYearBirthday = createBirthday()
+		leapYearBirthday.year = "2016"
+		leapYearBirthday.month = "2"
+		leapYearBirthday.day = "29"
+
+		// Chrome date bug issue: https://github.com/tutao/tutanota/issues/414
+		const chromeBugBirthday = createBirthday()
+		chromeBugBirthday.year = "1911"
+		chromeBugBirthday.month = "8"
+		chromeBugBirthday.day = "15"
+
+		lang._setLanguageTag("en")
+		o(formatBirthdayNumeric(leapYearBirthday)).equals("2/29/2016")
+		o(formatBirthdayNumeric(chromeBugBirthday)).equals("8/15/1911")
+
+		lang._setLanguageTag("de")
+		o(formatBirthdayNumeric(leapYearBirthday)).equals("29.2.2016")
+		o(formatBirthdayNumeric(chromeBugBirthday)).equals("15.8.1911")
+
+		lang._setLanguageTag("ja")
+		o(formatBirthdayNumeric(leapYearBirthday)).equals("2016/2/29")
+		o(formatBirthdayNumeric(chromeBugBirthday)).equals("1911/8/15")
+
+		lang._setLanguageTag("pt")
+		o(formatBirthdayNumeric(leapYearBirthday)).equals("29/02/2016")
+		o(formatBirthdayNumeric(chromeBugBirthday)).equals("15/08/1911")
+	})
 })


### PR DESCRIPTION
The workaround was done to fix #414, but it failed to consider leap
years. As a result, birthdays of contacts on Feb. 29 were displayed
as Mar. 1.

The aforementioned bug does not appear to be present in recent
Chrome versions.

 fix #3684