### PR TITLE
Change date parsing to not remove empty date parts, fix #3782

### DIFF
--- a/src/misc/DateParser.ts
+++ b/src/misc/DateParser.ts
@@ -179,6 +179,6 @@ export function _cleanupAndSplit(dateString: string): number[] {
 	dateString = dateString.replace(/[^ 0-9.\/-]/g, "")
 	return dateString
 		.split(/[.\/-]/g)
-		.filter(part => part.trim().length > 0)
+		.filter((part, index) => index < 3)
 		.map(part => parseInt(part))
 }

--- a/src/misc/DateParser.ts
+++ b/src/misc/DateParser.ts
@@ -179,6 +179,6 @@ export function _cleanupAndSplit(dateString: string): number[] {
 	dateString = dateString.replace(/[^ 0-9.\/-]/g, "")
 	return dateString
 		.split(/[.\/-]/g)
-		.filter((part, index) => index < 3)
+		.slice(0, 3) // keep at most three date parts even if the string contains more than two separators (e.g., extra '.' at the end)
 		.map(part => parseInt(part))
 }


### PR DESCRIPTION
`DateParser._cleanUpAndSplit` removes any characters
that cannot be dealt with, such as the char 'a'.
This results in an empty date part if a date of the form
"a/4/12", for example, is entered by a user.
`_cleanUpAndSplit` would then remove the part containing only 'a'
(zero-length) and the date would be interpreted as
month/day or day/month, depending on locale, which
resulted in unexpected dates being saved.

Instead, we cut off dates that have more than three
parts and do not remove zero-length parts, which
fixes the test failure mentioned in the issue.