### PR TITLE
Fix opening search

### DIFF
--- a/src/search/view/MultiSearchViewer.ts
+++ b/src/search/view/MultiSearchViewer.ts
@@ -38,11 +38,11 @@ export class MultiSearchViewer {
 	_mobileContactActionBarButtons: () => ButtonAttrs[]
 
 	constructor(searchListView: SearchListView) {
+		this._searchListView = searchListView
 		const mailActionBarButtons = this.createMailActionBarButtons(true)
 		const contactActionBarButtons = this.createContactActionBarButtons(true)
 		this._mobileMailActionBarButtons = lazyMemoized(() => this.createMailActionBarButtons(false))
 		this._mobileContactActionBarButtons = lazyMemoized(() => this.createContactActionBarButtons(false))
-		this._searchListView = searchListView
 
 		this.view = () => {
 			if (this._searchListView._lastType) {


### PR DESCRIPTION
`this._searchListView` was used before being assigned

fix #3784