### PR TITLE
Fix: Android notification not working #3796

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.java
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.java
@@ -121,6 +121,7 @@ public class SseClient {
 		} catch (Exception exception) {
 			handleException(random, exception, connectionData.userId);
 		} finally {
+			Log.d(TAG, "It turns finally");
 			if (reader != null) {
 				try {
 					reader.close();
@@ -128,6 +129,8 @@ public class SseClient {
 				}
 			}
 			httpsURLConnectionRef.set(null);
+			Log.d(TAG, "ConnectionRef not available, schedule connect");
+			reschedule(0);
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
 				"electron-packager": "15.4.0",
 				"electron-updater": "4.3.9",
 				"fs-extra": "10.0.0",
-				"full-icu": "1.3.4",
 				"glob": "7.1.7",
 				"js-yaml": "3.13.1",
 				"jszip": "^3.7.0",
@@ -3753,16 +3752,6 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/full-icu": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.4.tgz",
-			"integrity": "sha512-BERy9j2ybYSfP8QmXyg496NjVrGXfM73TZckQ5s5hgDV2lpKshjGfPEYYWU3hhE2kU8atZXUZNLSeNz4OQ8hNA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"bin": {
-				"node-full-icu-path": "node-icu-data.js"
 			}
 		},
 		"node_modules/function-bind": {
@@ -10979,12 +10968,6 @@
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
 			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
 			"optional": true
-		},
-		"full-icu": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.4.tgz",
-			"integrity": "sha512-BERy9j2ybYSfP8QmXyg496NjVrGXfM73TZckQ5s5hgDV2lpKshjGfPEYYWU3hhE2kU8atZXUZNLSeNz4OQ8hNA==",
-			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
 		"electron-packager": "15.4.0",
 		"electron-updater": "4.3.9",
 		"fs-extra": "10.0.0",
-		"full-icu": "1.3.4",
 		"glob": "7.1.7",
 		"js-yaml": "3.13.1",
 		"jszip": "^3.7.0",


### PR DESCRIPTION
Fix: Android notification not working #3796
Fix: remove useless dependency full-icu, which caused problem executing `npm ci` (See [this issue](https://github.com/nodejs/full-icu-npm/issues/61))

Note: I don't really know if this fix of #3796 is the supposed way, but it works.