### PR TITLE
Update node-forge to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"linkifyjs": "^3.0.0-beta.3",
 				"luxon": "1.28.0",
 				"mithril": "2.0.4",
+				"node-forge": "1.2.1",
 				"qrcode-svg": "1.0.0",
 				"squire-rte": "1.11.1",
 				"systemjs": "6.10.2"
@@ -56,7 +57,6 @@
 				"js-yaml": "3.13.1",
 				"jszip": "^3.7.0",
 				"mithril-node-render": "3.0.1",
-				"node-forge": "0.10.0",
 				"node-gyp": "^8.1.0",
 				"nollup": "0.18.7",
 				"octokit": "^1.3.0",
@@ -5269,12 +5269,11 @@
 			}
 		},
 		"node_modules/node-forge": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-			"dev": true,
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+			"integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
 			"engines": {
-				"node": ">= 6.0.0"
+				"node": ">= 6.13.0"
 			}
 		},
 		"node_modules/node-gyp": {
@@ -12182,10 +12181,9 @@
 			"dev": true
 		},
 		"node-forge": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-			"integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-			"dev": true
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+			"integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w=="
 		},
 		"node-gyp": {
 			"version": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"mithril": "2.0.4",
 		"qrcode-svg": "1.0.0",
 		"squire-rte": "1.11.1",
-		"systemjs": "6.10.2"
+		"systemjs": "6.10.2",
+	  	"node-forge": "1.2.1"
 	},
 	"devDependencies": {
 		"@octokit/auth-token": "^2.4.5",
@@ -65,7 +66,6 @@
 		"js-yaml": "3.13.1",
 		"jszip": "^3.7.0",
 		"mithril-node-render": "3.0.1",
-		"node-forge": "0.10.0",
 		"node-gyp": "^8.1.0",
 		"nollup": "0.18.7",
 		"octokit": "^1.3.0",


### PR DESCRIPTION
I compared two versions, there are not so many changes:
https://github.com/digitalbazaar/forge/compare/0.10.0...v1.2.0

However, I noticed that it is pretty big and we need only a little part of it. I think we might be able to easily replace it with SubtleCrypto APIs built into Node: https://nodejs.org/api/webcrypto.html

All we need to do is decode PEM and verify signature (like in this example: https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8_import).
Or we can say that we provide raw key data when building the app and then we don't even need to parse it.

close #3771