### PR TITLE
Fix loading without BigInt

### DIFF
--- a/src/misc/2fa/webauthn/WebauthnClient.ts
+++ b/src/misc/2fa/webauthn/WebauthnClient.ts
@@ -50,7 +50,11 @@ export class WebauthnClient {
 	isSupported(): boolean {
 		// We explicitly disable apps and desktop because even if webauthn somehow works there it won't match our domain.
 		// For those platforms another implementation with separate webview should be used instead.
-		return !isDesktop() && !isApp() && this.api != null
+		return !isDesktop() && !isApp() &&
+			this.api != null &&
+			// @ts-ignore see polyfill.js
+			// We just stub BigInt in order to import cborg without issues but we can't actually use it
+			!BigInt.polyfilled
 	}
 
 	async register(userId: Id, name: string, mailAddress: string, signal: AbortSignal): Promise<U2fRegisteredDevice> {

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -27,12 +27,14 @@ if (typeof performance.measure !== "function") {
 	performance.measure = noOp
 }
 
-if (typeof Uint8Array.prototype.slice === "undefined") {
-	Uint8Array.prototype.slice = function (from, to) {
-		if (!to) {
-			to = this.byteLength
-		}
+// We need BigInt stub for cborg
+if (typeof BigInt === "undefined") {
+	console.log("No BigInt support in browser, stubbing...")
 
-		return new Uint8Array(this.subarray(from, to))
+	function BigInt(arg: any) {
+		return arg
 	}
+	BigInt.polyfilled = true
+	// @ts-ignore
+	globalContext.BigInt = BigInt
 }


### PR DESCRIPTION
cborg needs BigInt to work properly. We could load cborg dynamically
only if we know that it will work but we do not want to introduce
another chunk just for it. So instead we allow loading it but we will
not use it for webauthn.

 Also removes Uint8Array.prototype.slice polyfill as it exists pretty
 much everywhere

fix #3830