### PR TITLE
Fix logging out not working on the first try

### DIFF
--- a/packages/tutanota-utils/lib/PromiseUtils.ts
+++ b/packages/tutanota-utils/lib/PromiseUtils.ts
@@ -96,6 +96,9 @@ export class PromisableWrapper<T> {
 }
 
 export function delay(ms: number): Promise<void> {
+	if (Number.isNaN(ms) || ms < 0) {
+		throw new Error(`Invalid delay: ${ms}`)
+	}
 	return new Promise(resolve => {
 		setTimeout(resolve, ms)
 	})

--- a/src/misc/ErrorHandler.ts
+++ b/src/misc/ErrorHandler.ts
@@ -14,7 +14,7 @@ function produceThrottledFunction<R>(ms: number, fn: () => Promise<R>): () => Pr
 		let previousTry = lastTry
 		lastTry = Date.now()
 
-		if (previousTry - Date.now() < ms) {
+		if (previousTry !== 0 && previousTry - Date.now() < ms) {
 			await delay(previousTry - Date.now())
 		}
 


### PR DESCRIPTION
The first time throttled import would be called it would wait forever
because passing negative number to delay() would just never complete
(as setTimeout would never fire either).

fix #3834