### PR TITLE
fix alignment of current day indicator on mobile,

### DIFF
--- a/src/calendar/view/CalendarMonthView.ts
+++ b/src/calendar/view/CalendarMonthView.ts
@@ -268,7 +268,7 @@ export class CalendarMonthView implements Component<CalendarMonthAttrs>, ClassCo
 					 }: CalendarDay, today: Date, onDateSelected: (date: Date, calendarViewTypeToShow: CalendarViewType) => unknown): Children {
 		return m(".flex-center", [
 			m(
-				(client.isDesktopDevice() ? ".calendar-day-indicator.circle" : "") + getDateIndicator(date, today),
+				".calendar-day-indicator.circle" + getDateIndicator(date, today),
 				{
 					onclick: (e: MouseEvent) => {
 						onDateSelected(new Date(date), CalendarViewType.DAY)


### PR DESCRIPTION
fix #3624

Some CSS classes were only being applied on desktop. This seems to somehow have been a fix for some issue in the past, but upon removing it, i dont see anything wrong, so whatever it was is probably gone now anyway