### PR TITLE
[ci] don't use double quotes for environment variable interpolation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline {
 					   		]
 						)
 						{
-							sh "security unlock-keychain -p ${FASTLANE_KEYCHAIN_PASSWORD}"
+							sh 'security unlock-keychain -p $FASTLANE_KEYCHAIN_PASSWORD'
 							script {
 								def stage = params.RELEASE ? 'release' : 'prod'
 								sh '''


### PR DESCRIPTION
Jenkins warns about this line in the build info pages.

https://www.jenkins.io/doc/pipeline/steps/credentials-binding/