### PR TITLE
[build] Split webapp and desktop builds in Jenkins

### DIFF
--- a/Webapp.Jenkinsfile
+++ b/Webapp.Jenkinsfile
@@ -1,0 +1,100 @@
+pipeline {
+    environment {
+         NODE_PATH="/opt/node-v16.3.0-linux-x64/bin"
+         NODE_MAC_PATH="/usr/local/opt/node@16/bin/"
+    }
+	options {
+		preserveStashes()
+	}
+
+	parameters {
+        booleanParam(
+			name: 'RELEASE',
+			defaultValue: false,
+			description: "Prepare a release version (doesn't publish to production, this is done manually). Also publishes NPM modules"
+		)
+    }
+
+    agent {
+        label 'master'
+    }
+
+    stages {
+        stage('Build') {
+        	environment {
+        		PATH="${env.NODE_PATH}:${env.PATH}"
+        	}
+            agent {
+                label 'linux'
+            }
+            steps {
+            	sh 'npm ci'
+            	sh 'npm run build-packages'
+				sh 'node webapp.js release'
+				// excluding web-specific and mobile specific parts which we don't need in desktop
+				stash includes: 'build/dist/**', excludes: '**/app.html, **/desktop.html, **/index-app.js, **/index-desktop.js', name: 'webapp_built'
+
+				// Bundle size stats
+				publishHTML target: [
+					allowMissing: false,
+					alwaysLinkToLastBuild: false,
+					keepAll: true,
+					reportDir: 'build',
+					reportFiles: 'stats.html',
+					reportName: 'bundle stats'
+				]
+				// Bundle dependencies graph
+				sh 'dot -Tsvg build/bundles.dot > build/bundles.svg'
+				sh """echo '<!doctype html><html><body><img src="./bundles.svg" /></body></html>' > build/bundles.html"""
+				publishHTML target: [
+					allowMissing: false,
+					alwaysLinkToLastBuild: false,
+					keepAll: true,
+					reportDir: 'build',
+					reportFiles: 'bundles.html',
+					reportName: 'bundle dependencies'
+				]
+            }
+        }
+
+        stage('Publish') {
+            when {
+            	expression { params.RELEASE }
+            }
+            agent {
+                label 'linux'
+            }
+			environment {
+				PATH="${env.NODE_PATH}:${env.PATH}"
+			}
+            steps {
+            	sh 'npm ci'
+				sh 'rm -rf ./build/*'
+
+				unstash 'webapp_built'
+				sh 'node buildSrc/publish.js webapp'
+            }
+        }
+
+        stage('Publish npm modules') {
+			when {
+				expression { params.RELEASE }
+			}
+			agent {
+				label 'linux'
+			}
+			environment {
+				PATH="${env.NODE_PATH}:${env.PATH}"
+			}
+			steps {
+				catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+					sh "npm ci && npm run build-packages"
+					// .npmrc expects $NPM_TOKEN
+					withCredentials([string(credentialsId: 'npm-token',variable: 'NPM_TOKEN')]) {
+						sh "npm --workspaces publish"
+					}
+				}
+			}
+        }
+    }
+}

--- a/Webapp.Jenkinsfile
+++ b/Webapp.Jenkinsfile
@@ -1,12 +1,10 @@
 pipeline {
     environment {
-         NODE_PATH="/opt/node-v16.3.0-linux-x64/bin"
-         NODE_MAC_PATH="/usr/local/opt/node@16/bin/"
+         PATH="/opt/node-v16.3.0-linux-x64/bin:${env.PATH}"
     }
 	options {
 		preserveStashes()
 	}
-
 	parameters {
         booleanParam(
 			name: 'RELEASE',
@@ -14,16 +12,11 @@ pipeline {
 			description: "Prepare a release version (doesn't publish to production, this is done manually). Also publishes NPM modules"
 		)
     }
-
     agent {
         label 'master'
     }
-
     stages {
         stage('Build') {
-        	environment {
-        		PATH="${env.NODE_PATH}:${env.PATH}"
-        	}
             agent {
                 label 'linux'
             }
@@ -64,9 +57,6 @@ pipeline {
             agent {
                 label 'linux'
             }
-			environment {
-				PATH="${env.NODE_PATH}:${env.PATH}"
-			}
             steps {
             	sh 'npm ci'
 				sh 'rm -rf ./build/*'
@@ -82,9 +72,6 @@ pipeline {
 			}
 			agent {
 				label 'linux'
-			}
-			environment {
-				PATH="${env.NODE_PATH}:${env.PATH}"
 			}
 			steps {
 				catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {

--- a/buildSrc/publish.js
+++ b/buildSrc/publish.js
@@ -59,29 +59,30 @@ import 'zx/globals'
 
 async function packageAndPublishDeb({version, fpmRootMapping, name, fpmAfterInstallScript, destinationDir}) {
 
-	const flags = [
+	const fpmFlags = [
 		`--force`,
 		`--input-type`, `dir`,
 		`--output-type`, `deb`,
 		`--deb-user`, `tutadb`,
 		`--deb-group`, `tutadb`,
 		`--name`, name,
-		`--version`, `${version}`,
+		`--version`, version,
 	]
 
 	if (fpmAfterInstallScript != null) {
-		flags.push(`--after-install`, `${fpmAfterInstallScript}`)
+		fpmFlags.push(`--after-install`, `${fpmAfterInstallScript}`)
 	}
 
-	await $`/usr/local/bin/fpm ${flags} ${fpmRootMapping}`
+	await $`/usr/local/bin/fpm ${fpmFlags} ${fpmRootMapping}`
 
 	// The output filename from fpm
 	const debName = `${name}_${version}_amd64.deb`
+	const destination = path.join(destinationDir, debName)
 
-	await $`/bin/cp -f ./${debName} ${path.join(destinationDir, debName)}`
+	await $`/bin/cp -f ./${debName} ${destination}`
 
 	// user puppet needs to read the deb file from jetty
-	await $`/bin/chmod o+r ${path.join(destinationDir, debName)}`
+	await $`/bin/chmod o+r ${destination}`
 }
 
 async function tagRelease({tagName}) {

--- a/buildSrc/publish.js
+++ b/buildSrc/publish.js
@@ -65,7 +65,7 @@ async function packageAndPublishDeb({version, fpmRootMapping, name, fpmAfterInst
 		`--output-type`, `deb`,
 		`--deb-user`, `tutadb`,
 		`--deb-group`, `tutadb`,
-		`--name`, `${name}`,
+		`--name`, name,
 		`--version`, `${version}`,
 	]
 

--- a/buildSrc/publish.js
+++ b/buildSrc/publish.js
@@ -70,7 +70,7 @@ async function packageAndPublishDeb({version, fpmRootMapping, name, fpmAfterInst
 	]
 
 	if (fpmAfterInstallScript != null) {
-		fpmFlags.push(`--after-install`, `${fpmAfterInstallScript}`)
+		fpmFlags.push(`--after-install`, fpmAfterInstallScript)
 	}
 
 	await $`/usr/local/bin/fpm ${fpmFlags} ${fpmRootMapping}`

--- a/buildSrc/publish.js
+++ b/buildSrc/publish.js
@@ -2,114 +2,89 @@
  * This is a script that runs all steps necessary for publishing the finished build artifacts, i.e. signed binaries.
  * The steps performed in here should be moved to the Jenkinsfile. That would be much simpler plus we never want to run this outside of our CI environment.
  */
-import {spawnSync} from "child_process"
-import {exitOnFail, getTutanotaAppVersion} from "./buildUtils.js"
-import {dirname} from "path"
-import {fileURLToPath} from "url"
+import {getTutanotaAppVersion} from "./buildUtils.js"
+import 'zx/globals'
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+(async function () {
 
-packageAndPublish()
-	.then(v => {
-		console.log("Published successfully")
-		process.exit()
-	})
-	.catch(e => {
-		console.log("Publishing failed: ", e)
+
+	// Find and compress built code (js and html)
+	const compress = () => $`/usr/bin/find ./build '(' -name "*.js" -o -name "*.html" ')' -exec gzip --force --keep --verbose --best '{}' ';'`
+
+	if (process.argv[2] === "webapp") {
+		await compress()
+		const tutanotaVersion = await getTutanotaAppVersion()
+		await packageAndPublishDeb({
+			version: tutanotaVersion,
+			name: "tutanota",
+			fpmRootMapping: "./build/dist/=/opt/tutanota",
+			fpmAfterInstallScript: "./resources/scripts/after-install.sh",
+			destinationDir: `/opt/repository/tutanota`
+		})
+		await tagRelease({
+			tagName: `tutanota-release-${tutanotaVersion}`
+		})
+
+	} else if (process.argv[2] === "desktop") {
+		await compress()
+		const tutanotaVersion = await getTutanotaAppVersion()
+		await packageAndPublishDeb({
+			version: tutanotaVersion,
+			name: "tutanota-desktop",
+			fpmRootMapping: `./build/desktop/=/opt/tutanota-desktop`,
+			destinationDir: `/opt/repository/tutanota-desktop`,
+		})
+		await packageAndPublishDeb({
+			version: tutanotaVersion,
+			name: "tutanota-desktop-test",
+			fpmRootMapping: `./build/desktop-test/=/opt/tutanota-desktop`,
+			destinationDir: `/opt/repository/tutanota-desktop-test`,
+		})
+
+		await tagRelease({
+			tagName: `tutanota-desktop-release-${tutanotaVersion}`
+		})
+
+		// copy appimage for dev_clients
+		// in order to release this new version locally, execute:
+		// mv /opt/repository/dev_client/tutanota-desktop-linux-new.AppImage /opt/repository/dev_client/tutanota-desktop-linux.AppImage
+		await $`/bin/cp -f ./build/desktop/tutanota-desktop-linux.AppImage /opt/repository/dev_client/tutanota-desktop-linux-new.AppImage`
+		await $`/bin/chmod o+r /opt/repository/dev_client/tutanota-desktop-linux-new.AppImage`
+
+	} else {
+		console.error("Usage: node publish <webapp|desktop>")
 		process.exit(1)
-	})
+	}
+})()
 
-async function packageAndPublish() {
-	const version = await getTutanotaAppVersion()
-	const debs = {
-		webApp: `tutanota_${version}_amd64.deb`,
-		desktop: `tutanota-desktop_${version}_amd64.deb`,
-		desktopTest: `tutanota-desktop-test_${version}_amd64.deb`,
-		// the dicts are bound to an electron release, so we use that version number.
-		dict: `tutanota-desktop-dicts_${electronVersion}_amd64.deb`
+async function packageAndPublishDeb({version, fpmRootMapping, name, fpmAfterInstallScript, destinationDir}) {
+
+	const flags = [
+		`--force`,
+		`--input-type`, `dir`,
+		`--output-type`, `deb`,
+		`--deb-user`, `tutadb`,
+		`--deb-group`, `tutadb`,
+		`--name`, `${name}`,
+		`--version`, `${version}`,
+	]
+
+	if (fpmAfterInstallScript != null) {
+		flags.push(`--after-install`, `${fpmAfterInstallScript}`)
 	}
 
-	packageDeb(version, debs)
-	publish(version, debs)
-}
+	await $`/usr/local/bin/fpm ${flags} ${fpmRootMapping}`
 
-function publish(version, debs) {
-	console.log("Create git tag and copy .deb")
-	exitOnFail(spawnSync("/usr/bin/git", `tag -a tutanota-release-${version} -m ''`.split(" "), {
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
+	// The output filename from fpm
+	const debName = `${name}_${version}_amd64.deb`
 
-	exitOnFail(spawnSync("/usr/bin/git", `push origin tutanota-release-${version}`.split(" "), {
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-
-	exitOnFail(spawnSync("/bin/cp", `-f build/${debs.webApp} /opt/repository/tutanota/`.split(" "), {
-		cwd: __dirname,
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-
-	exitOnFail(spawnSync("/bin/cp", `-f build/${debs.desktop} /opt/repository/tutanota-desktop/`.split(" "), {
-		cwd: __dirname,
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-	exitOnFail(spawnSync("/bin/cp", `-f build/${debs.desktopTest} /opt/repository/tutanota-desktop-test/`.split(" "), {
-		cwd: __dirname,
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-
-	// copy appimage for dev_clients
-	exitOnFail(spawnSync("/bin/cp", `-f build/desktop/tutanota-desktop-linux.AppImage /opt/repository/dev_client/tutanota-desktop-linux-new.AppImage`.split(" "), {
-		cwd: __dirname,
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
+	await $`/bin/cp -f ./${debName} ${path.join(destinationDir, debName)}`
 
 	// user puppet needs to read the deb file from jetty
-	exitOnFail(spawnSync("/bin/chmod", `o+r /opt/repository/tutanota/${debs.webApp}`.split(" "), {
-		cwd: __dirname + '/build/',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-
-	exitOnFail(spawnSync("/bin/chmod", `o+r /opt/repository/tutanota-desktop/${debs.desktop}`.split(" "), {
-		cwd: __dirname + '/build/',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-	exitOnFail(spawnSync("/bin/chmod", `o+r /opt/repository/tutanota-desktop-test/${debs.desktopTest}`.split(" "), {
-		cwd: __dirname + '/build/',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-	// in order to release this new version locally, execute:
-	// mv /opt/repository/dev_client/tutanota-desktop-linux-new.AppImage /opt/repository/dev_client/tutanota-desktop-linux.AppImage
-	exitOnFail(spawnSync("/bin/chmod", `o+r /opt/repository/dev_client/tutanota-desktop-linux-new.AppImage`.split(" "), {
-		cwd: __dirname + '/build/',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
+	await $`/bin/chmod o+r ${path.join(destinationDir, debName)}`
 }
 
-function packageDeb(version, debs) {
-	// overwrite output, source=dir target=deb, set owner
-	const commonArgs = `-f -s dir -t deb --deb-user tutadb --deb-group tutadb`
-	const target = `/opt/tutanota`
-
-	exitOnFail(spawnSync("/usr/bin/find", `. ( -name *.js -o -name *.html ) -exec gzip -fkv --best {} \;`.split(" "), {
-		cwd: __dirname + '/build/dist',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-
-	console.log("create " + debs.webApp)
-	exitOnFail(spawnSync("/usr/local/bin/fpm", `${commonArgs} --after-install ../resources/scripts/after-install.sh -n tutanota -v ${version} dist/=${target}`.split(" "), {
-		cwd: __dirname + '/build',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-
-	console.log("create " + debs.desktop)
-	exitOnFail(spawnSync("/usr/local/bin/fpm", `${commonArgs} -n tutanota-desktop -v ${version} desktop/=${target}-desktop`.split(" "), {
-		cwd: __dirname + '/build',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
-
-	console.log("create " + debs.desktopTest)
-	exitOnFail(spawnSync("/usr/local/bin/fpm", `${commonArgs} -n tutanota-desktop-test -v ${version} desktop-test/=${target}-desktop`.split(" "), {
-		cwd: __dirname + '/build',
-		stdio: [process.stdin, process.stdout, process.stderr]
-	}))
+async function tagRelease({tagName}) {
+	await $`/usr/bin/git tag -a ${tagName} -m ''`
+	await $`/usr/bin/git push origin ${tagName}`
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,8 @@
 				"rollup-plugin-visualizer": "5.5.2",
 				"testdouble": "3.16.4",
 				"typescript": "4.5.4",
-				"xhr2": "0.2.1"
+				"xhr2": "0.2.1",
+				"zx": "5.1.0"
 			},
 			"engines": {
 				"npm": ">=7.0.0"
@@ -264,6 +265,41 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/@npmcli/fs": {
@@ -914,6 +950,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/@types/minimist": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+			"dev": true
+		},
 		"node_modules/@types/mithril": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@types/mithril/-/mithril-2.0.8.tgz",
@@ -926,9 +968,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.0.tgz",
-			"integrity": "sha512-nmP+VR4oT0pJUPFbKE4SXj3Yb4Q/kz3M9dSAO1GGMebRKWHQxLfDNmU/yh3xxCJha3N60nQ/JwXWwOE/ZSEVag=="
+			"version": "17.0.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
+			"integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA=="
 		},
 		"node_modules/@types/node-forge": {
 			"version": "1.0.0",
@@ -2612,6 +2654,15 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
 			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -2747,6 +2798,27 @@
 				"node": ">= 0.6.x"
 			}
 		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/dir-glob/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/dmg-builder": {
 			"version": "22.14.5",
 			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.5.tgz",
@@ -2838,6 +2910,12 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
 			"integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+			"dev": true
+		},
+		"node_modules/duplexer": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
 		"node_modules/duplexer3": {
@@ -3442,6 +3520,21 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/event-stream": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"dependencies": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
+		},
 		"node_modules/exit-on-epipe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
@@ -3597,11 +3690,36 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
+		"node_modules/fast-glob": {
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=8.6.0"
+			}
+		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
+		},
+		"node_modules/fastq": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"dev": true,
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"node_modules/fd-slicer": {
 			"version": "1.1.0",
@@ -3609,6 +3727,29 @@
 			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"dependencies": {
 				"pend": "~1.2.0"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+			"integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
 			}
 		},
 		"node_modules/file-uri-to-path": {
@@ -3763,6 +3904,18 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -3778,6 +3931,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
 		},
 		"node_modules/fromentries": {
 			"version": "1.3.2",
@@ -4123,6 +4282,25 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/globby": {
+			"version": "13.1.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.1.tgz",
+			"integrity": "sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==",
+			"dev": true,
+			"dependencies": {
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.11",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/got": {
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -4309,6 +4487,15 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/ignore": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
 		},
 		"node_modules/immediate": {
 			"version": "3.0.6",
@@ -5040,6 +5227,12 @@
 				"node": ">= 10"
 			}
 		},
+		"node_modules/map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"node_modules/matcher": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -5083,12 +5276,34 @@
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/micromatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"dev": true,
+			"dependencies": {
+				"braces": "^3.0.1",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": ">=8.6"
 			}
 		},
 		"node_modules/mime": {
@@ -5330,6 +5545,25 @@
 			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
 			"dev": true,
 			"optional": true
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"engines": {
+				"node": ">=10.5.0"
+			}
 		},
 		"node_modules/node-fetch": {
 			"version": "2.6.7",
@@ -5791,6 +6025,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"dependencies": {
+				"through": "~2.3"
+			}
+		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -5933,6 +6176,21 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/ps-tree": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+			"integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+			"dev": true,
+			"dependencies": {
+				"event-stream": "=3.3.4"
+			},
+			"bin": {
+				"ps-tree": "bin/ps-tree.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -5978,6 +6236,26 @@
 			"engines": {
 				"node": ">=0.6"
 			}
+		},
+		"node_modules/queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/quibble": {
 			"version": "0.6.8",
@@ -6211,6 +6489,16 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6369,6 +6657,29 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"queue-microtask": "^1.2.2"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -6623,6 +6934,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/slice-ansi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -6798,6 +7121,18 @@
 			"integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
 			"dev": true
 		},
+		"node_modules/split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"dependencies": {
+				"through": "2"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6836,6 +7171,15 @@
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"dependencies": {
+				"duplexer": "~0.1.1"
 			}
 		},
 		"node_modules/string_decoder": {
@@ -7092,6 +7436,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
 			"integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+			"dev": true
+		},
+		"node_modules/through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
 		"node_modules/tmp": {
@@ -7527,6 +7877,15 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+			"integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -7788,6 +8147,15 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
+		"node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "17.1.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
@@ -7866,6 +8234,61 @@
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/zx": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/zx/-/zx-5.1.0.tgz",
+			"integrity": "sha512-J62b/7sFwqt4zbmPbeKJGwZlvW2X3ynyfWHZPr+xLAGF80h4aY4SgXaadMjljpvIbWGOwRmK38vwEdi5XgUpcQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/fs-extra": "^9.0.13",
+				"@types/minimist": "^1.2.2",
+				"@types/node": "^17.0",
+				"chalk": "^5.0.0",
+				"fs-extra": "^10.0.0",
+				"globby": "^13.1.1",
+				"minimist": "^1.2.5",
+				"node-fetch": "^3.2.0",
+				"ps-tree": "^1.2.0",
+				"which": "^2.0.2",
+				"yaml": "^1.10.2"
+			},
+			"bin": {
+				"zx": "zx.mjs"
+			},
+			"engines": {
+				"node": ">= 16.0.0"
+			}
+		},
+		"node_modules/zx/node_modules/chalk": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+			"integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/zx/node_modules/node-fetch": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+			"integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
+			"dev": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"packages/tutanota-build-server": {
@@ -8162,6 +8585,32 @@
 						"universalify": "^2.0.0"
 					}
 				}
+			}
+		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
 			}
 		},
 		"@npmcli/fs": {
@@ -8859,6 +9308,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"@types/minimist": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+			"dev": true
+		},
 		"@types/mithril": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/@types/mithril/-/mithril-2.0.8.tgz",
@@ -8871,9 +9326,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "16.9.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.0.tgz",
-			"integrity": "sha512-nmP+VR4oT0pJUPFbKE4SXj3Yb4Q/kz3M9dSAO1GGMebRKWHQxLfDNmU/yh3xxCJha3N60nQ/JwXWwOE/ZSEVag=="
+			"version": "17.0.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
+			"integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA=="
 		},
 		"@types/node-forge": {
 			"version": "1.0.0",
@@ -10208,6 +10663,12 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
 			"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
 		},
+		"data-uri-to-buffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+			"integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+			"dev": true
+		},
 		"debug": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -10310,6 +10771,23 @@
 				}
 			}
 		},
+		"dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"requires": {
+				"path-type": "^4.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				}
+			}
+		},
 		"dmg-builder": {
 			"version": "22.14.5",
 			"resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.14.5.tgz",
@@ -10383,6 +10861,12 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
 			"integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+			"dev": true
+		},
+		"duplexer": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
 		},
 		"duplexer3": {
@@ -10854,6 +11338,21 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
+		"event-stream": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1",
+				"from": "~0",
+				"map-stream": "~0.1.0",
+				"pause-stream": "0.0.11",
+				"split": "0.3",
+				"stream-combiner": "~0.0.4",
+				"through": "~2.3.1"
+			}
+		},
 		"exit-on-epipe": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
@@ -10991,11 +11490,33 @@
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
 		},
+		"fast-glob": {
+			"version": "3.2.11",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+			"integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.4"
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+			"integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -11003,6 +11524,16 @@
 			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"requires": {
 				"pend": "~1.2.0"
+			}
+		},
+		"fetch-blob": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+			"integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+			"dev": true,
+			"requires": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
 			}
 		},
 		"file-uri-to-path": {
@@ -11131,6 +11662,15 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"requires": {
+				"fetch-blob": "^3.1.2"
+			}
+		},
 		"forwarded": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -11140,6 +11680,12 @@
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+		},
+		"from": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+			"dev": true
 		},
 		"fromentries": {
 			"version": "1.3.2",
@@ -11410,6 +11956,19 @@
 				"define-properties": "^1.1.3"
 			}
 		},
+		"globby": {
+			"version": "13.1.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-13.1.1.tgz",
+			"integrity": "sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==",
+			"dev": true,
+			"requires": {
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.2.11",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
+				"slash": "^4.0.0"
+			}
+		},
 		"got": {
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -11551,6 +12110,12 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+		},
+		"ignore": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"dev": true
 		},
 		"immediate": {
 			"version": "3.0.6",
@@ -12141,6 +12706,12 @@
 				"ssri": "^8.0.0"
 			}
 		},
+		"map-stream": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+			"dev": true
+		},
 		"matcher": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -12174,10 +12745,26 @@
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
+		"merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true
+		},
 		"methods": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+		},
+		"micromatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"dev": true,
+			"requires": {
+				"braces": "^3.0.1",
+				"picomatch": "^2.2.3"
+			}
 		},
 		"mime": {
 			"version": "2.6.0",
@@ -12353,6 +12940,12 @@
 			"integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
 			"dev": true,
 			"optional": true
+		},
+		"node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"dev": true
 		},
 		"node-fetch": {
 			"version": "2.6.7",
@@ -12693,6 +13286,15 @@
 				}
 			}
 		},
+		"pause-stream": {
+			"version": "0.0.11",
+			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+			"dev": true,
+			"requires": {
+				"through": "~2.3"
+			}
+		},
 		"pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -12798,6 +13400,15 @@
 				"ipaddr.js": "1.9.1"
 			}
 		},
+		"ps-tree": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+			"integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+			"dev": true,
+			"requires": {
+				"event-stream": "=3.3.4"
+			}
+		},
 		"pump": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -12831,6 +13442,12 @@
 			"version": "6.7.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
 			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+			"dev": true
 		},
 		"quibble": {
 			"version": "0.6.8",
@@ -13019,6 +13636,12 @@
 			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 			"dev": true
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
 		"rimraf": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -13136,6 +13759,15 @@
 						"yargs-parser": "^20.2.2"
 					}
 				}
+			}
+		},
+		"run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"dev": true,
+			"requires": {
+				"queue-microtask": "^1.2.2"
 			}
 		},
 		"safe-buffer": {
@@ -13323,6 +13955,12 @@
 				}
 			}
 		},
+		"slash": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+			"integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+			"dev": true
+		},
 		"slice-ansi": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
@@ -13466,6 +14104,15 @@
 			"integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
 			"dev": true
 		},
+		"split": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+			"dev": true,
+			"requires": {
+				"through": "2"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -13496,6 +14143,15 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
 			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+		},
+		"stream-combiner": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+			"dev": true,
+			"requires": {
+				"duplexer": "~0.1.1"
+			}
 		},
 		"string_decoder": {
 			"version": "1.1.1",
@@ -13704,6 +14360,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
 			"integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+			"dev": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
 		},
 		"tmp": {
@@ -14046,6 +14708,12 @@
 				}
 			}
 		},
+		"web-streams-polyfill": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+			"integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+			"dev": true
+		},
 		"webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -14251,6 +14919,12 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
+		"yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"dev": true
+		},
 		"yargs": {
 			"version": "17.1.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
@@ -14313,6 +14987,44 @@
 			"requires": {
 				"buffer-crc32": "~0.2.3",
 				"fd-slicer": "~1.1.0"
+			}
+		},
+		"zx": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/zx/-/zx-5.1.0.tgz",
+			"integrity": "sha512-J62b/7sFwqt4zbmPbeKJGwZlvW2X3ynyfWHZPr+xLAGF80h4aY4SgXaadMjljpvIbWGOwRmK38vwEdi5XgUpcQ==",
+			"dev": true,
+			"requires": {
+				"@types/fs-extra": "^9.0.13",
+				"@types/minimist": "^1.2.2",
+				"@types/node": "^17.0",
+				"chalk": "^5.0.0",
+				"fs-extra": "^10.0.0",
+				"globby": "^13.1.1",
+				"minimist": "^1.2.5",
+				"node-fetch": "^3.2.0",
+				"ps-tree": "^1.2.0",
+				"which": "^2.0.2",
+				"yaml": "^1.10.2"
+			},
+			"dependencies": {
+				"chalk": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+					"integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==",
+					"dev": true
+				},
+				"node-fetch": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+					"integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
+					"dev": true,
+					"requires": {
+						"data-uri-to-buffer": "^4.0.0",
+						"fetch-blob": "^3.1.4",
+						"formdata-polyfill": "^4.0.10"
+					}
+				}
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,15 @@
 		"@tutao/oxmsg": "0.0.9-beta.0",
 		"@tutao/tutanota-crypto": "3.91.12",
 		"@tutao/tutanota-utils": "3.91.12",
+		"@types/better-sqlite3": "7.4.2",
+		"@types/dompurify": "2.3.0",
+		"@types/linkifyjs": "2.1.4",
+		"@types/luxon": "1.27.1",
+		"@types/mithril": "2.0.8",
+		"@types/node-forge": "1.0.0",
+		"@types/qrcode-svg": "1.1.1",
+		"@types/systemjs": "6.1.1",
+		"@types/winreg": "1.2.31",
 		"better-sqlite3": "7.5.0",
 		"cborg": "1.5.4",
 		"dompurify": "2.3.0",
@@ -38,17 +47,7 @@
 		"qrcode-svg": "1.0.0",
 		"squire-rte": "1.11.1",
 		"systemjs": "6.10.2",
-		"jszip": "3.7.0",
-		"winreg": "1.2.4",
-		"@types/better-sqlite3": "7.4.2",
-		"@types/dompurify": "2.3.0",
-		"@types/linkifyjs": "2.1.4",
-		"@types/luxon": "1.27.1",
-		"@types/mithril": "2.0.8",
-		"@types/node-forge": "1.0.0",
-		"@types/qrcode-svg": "1.1.1",
-		"@types/systemjs": "6.1.1",
-		"@types/winreg": "1.2.31"
+		"winreg": "1.2.4"
 	},
 	"devDependencies": {
 		"@octokit/auth-token": "2.5.0",
@@ -79,7 +78,8 @@
 		"rollup-plugin-visualizer": "5.5.2",
 		"testdouble": "3.16.4",
 		"typescript": "4.5.4",
-		"xhr2": "0.2.1"
+		"xhr2": "0.2.1",
+		"zx": "5.1.0"
 	},
 	"workspaces": [
 		"./packages/*"


### PR DESCRIPTION
This commit enables building the webapp and the desktop clients separately
Now it is possible to get a test webapp client running even if the desktop builds are failing

We will have to make sure that flatpak is still building properly as this commit introduces
a new git tag, `tutanota-desktop-release-$version`

We should look into creating a meta-pipeline that can run all build pipelines together, to ease part of the release process a bit