### PR TITLE
[test-utils] Add utility to count testdouble's `verify` as ospec assertions

### DIFF
--- a/packages/tutanota-test-utils/lib/TestUtils.ts
+++ b/packages/tutanota-test-utils/lib/TestUtils.ts
@@ -1,4 +1,6 @@
 import o from "ospec"
+import * as td from "testdouble"
+
 
 /**
  * Mocks an attribute (function or object) on an object and makes sure that it can be restored to the original attribute by calling unmockAttribute() later.
@@ -156,4 +158,23 @@ function delay(ms: number): Promise<void> {
 	return new Promise(resolve => {
 		setTimeout(resolve, ms)
 	})
+}
+
+/** Verify using testdouble, but register as an ospec assertion */
+export function verify(demonstration: any, config?: td.VerificationConfig) {
+	function check(demonstration) {
+		try {
+			td.verify(demonstration, config)
+			return {
+				pass: true,
+				message: "Successful verification"
+			}
+		} catch (e) {
+			return {
+				pass: false,
+				message: e.toString()
+			}
+		}
+	}
+	o(demonstration).satisfies(check)
 }

--- a/packages/tutanota-test-utils/lib/index.ts
+++ b/packages/tutanota-test-utils/lib/index.ts
@@ -1,15 +1,16 @@
 export {
-    mockAttribute,
-    unmockAttribute,
-    spy,
-    mock,
-    mapToObject,
-    mapObject,
-    replaceAllMaps,
-    asResult,
-    assertThrows,
-    assertResolvedIn,
-    assertNotResolvedIn,
-    makeTimeoutMock,
+	mockAttribute,
+	unmockAttribute,
+	spy,
+	mock,
+	mapToObject,
+	mapObject,
+	replaceAllMaps,
+	asResult,
+	assertThrows,
+	assertResolvedIn,
+	assertNotResolvedIn,
+	makeTimeoutMock,
+	verify
 } from "./TestUtils.js"
 export type {Spy, TimeoutMock} from "./TestUtils.js"

--- a/packages/tutanota-test-utils/package.json
+++ b/packages/tutanota-test-utils/package.json
@@ -19,7 +19,8 @@
 		"LICENSE.txt"
 	],
 	"peerDependencies": {
-		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
+		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
+	  	"testdouble": "3.16.4"
 	},
 	"devDependencies": {
 		"typescript": "4.5.4"

--- a/test/client/desktop/DesktopCryptoFacadeTest.ts
+++ b/test/client/desktop/DesktopCryptoFacadeTest.ts
@@ -154,7 +154,7 @@ o.spec("DesktopCryptoFacadeTest", () => {
             keyToBase64(aes128Key),
             aes256EncryptedKeyb64,
         )
-        o(instance).deepEquals({
+        o(instance as any).deepEquals({
             a: "property_a",
             b: true,
             c: 42,

--- a/test/client/mail/SendMailModelTest.ts
+++ b/test/client/mail/SendMailModelTest.ts
@@ -3,10 +3,10 @@ import o from "ospec"
 import en from "../../../src/translations/en"
 import type {IUserController} from "../../../src/api/main/UserController"
 import type {LoginController} from "../../../src/api/main/LoginController"
-import {MailboxDetail, MailModel} from "../../../src/mail/model/MailModel"
+import {MailModel} from "../../../src/mail/model/MailModel"
 import {Contact, ContactTypeRef, createContact} from "../../../src/api/entities/tutanota/Contact"
 import {ContactModel} from "../../../src/contacts/model/ContactModel"
-import {assertThrows} from "@tutao/tutanota-test-utils"
+import {assertThrows, verify} from "@tutao/tutanota-test-utils"
 import {downcast, isSameTypeRef} from "@tutao/tutanota-utils"
 import {createTutanotaProperties} from "../../../src/api/entities/tutanota/TutanotaProperties"
 import {SendMailModel, TOO_MANY_VISIBLE_RECIPIENTS} from "../../../src/mail/editor/SendMailModel"
@@ -35,7 +35,7 @@ import {ConversationEntryTypeRef, createConversationEntry} from "../../../src/ap
 import {isSameId} from "../../../src/api/common/utils/EntityUtils"
 import {MailFacade} from "../../../src/api/worker/facades/MailFacade"
 import {RecipientField} from "../../../src/mail/model/MailUtils"
-import {func, instance, matchers, object, replace, verify, when} from "testdouble"
+import {func, instance, matchers, object, replace, when} from "testdouble"
 
 const {anything, argThat} = matchers
 

--- a/types/ospec.d.ts
+++ b/types/ospec.d.ts
@@ -39,6 +39,12 @@ declare module "ospec" {
 
 			/** Asserts that the function does **not** throw an error of given type */
 			notThrows(this: Assertion<() => any>, error: string | ErrorConstructor | ObjectConstructor<any>): AssertionDescriber; // See above
+
+			/** Asserts that a value satisfies a given check */
+			satisfies(this: Assertion<T>, check: (value: T) => { pass: boolean, message: string })
+
+			/** Asserts that a value does **not** satisfy a given check */
+			notSatisfies(this: Assertion<T>, check: (value: T) => { pass: boolean, message: string })
 		}
 
 		type Definer = (done: (error?: Error | null) => void, timeout: (delay: number) => void) => void | PromiseLike<any>;


### PR DESCRIPTION
Rather than doing anything fancy with extending `o` (I looked into it), I opted to just create a function that looks and behaves the same was as `verify`, but it _secretly_ makes an assertion with ospec