### PR TITLE
[android] Fix crash caused by IOUtils update on old systems

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -116,7 +116,8 @@ dependencies {
 	androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
 		exclude group: 'com.android.support', module: 'support-annotations'
 	})
-	implementation 'commons-io:commons-io:2.11.0'
+	// Important: cannot be updated without additional measures as Android 6 and 7 do not have Java 9
+	implementation 'commons-io:commons-io:2.5'
 	implementation 'org.jdeferred:jdeferred-core:1.2.4'
 	implementation 'androidx.core:core:1.7.0'
 	implementation "androidx.activity:activity:$activity_version"


### PR DESCRIPTION
Newer IOUtils requires Android 9 or at least some APIs from it and
Android 6 and 7 do not have it without some kind of polyfills.

It would manifest as constant crashes for background process and
crashes when downloading files.

We need to either move away from io-commons or introduce some sort of
de-sugaring/polyfill.

 fix #3962