### PR TITLE
[desktop] Fix macos webdialog

### DIFF
--- a/src/desktop/WebDialog.ts
+++ b/src/desktop/WebDialog.ts
@@ -114,6 +114,7 @@ export class WebDialogController implements IWebDialogController {
 			movable: false,
 			alwaysOnTop: true,
 			fullscreenable: false,
+			roundedCorners: false,
 			frame: false,
 			width: 400,
 			height: 200,

--- a/src/misc/2fa/SecondFactorAuthView.ts
+++ b/src/misc/2fa/SecondFactorAuthView.ts
@@ -1,7 +1,7 @@
 import m, {Children, Component, Vnode} from "mithril"
 import type {TranslationKey} from "../LanguageViewModel"
 import {lang} from "../LanguageViewModel"
-import {ButtonN, ButtonType} from "../../gui/base/ButtonN"
+import {ButtonAttrs, ButtonN, ButtonType} from "../../gui/base/ButtonN"
 import {Icon, progressIcon} from "../../gui/base/Icon"
 import {Icons, SecondFactorImage} from "../../gui/base/icons/Icons"
 import {theme} from "../../gui/theme"
@@ -83,16 +83,18 @@ export class SecondFactorAuthView implements Component<SecondFactorViewAttrs> {
 		let items
 		const {state} = webauthn
 
+		const doWebauthnButtonAttrs: ButtonAttrs = {
+			label: "useSecurityKey_action",
+			click: () => webauthn.doWebauthn(),
+			type: ButtonType.Login,
+		}
+
 		switch (state.state) {
 			case "init":
 				items = [
 					m(
 						".align-self-center",
-						m(ButtonN, {
-							label: "useSecurityKey_action",
-							click: () => webauthn.doWebauthn(),
-							type: ButtonType.Primary,
-						}),
+						m(ButtonN, doWebauthnButtonAttrs),
 					),
 				]
 				break
@@ -117,11 +119,7 @@ export class SecondFactorAuthView implements Component<SecondFactorViewAttrs> {
 							),
 							m("", lang.get(state.error)),
 						]),
-						m(ButtonN, {
-							label: "useSecurityKey_action",
-							click: () => webauthn.doWebauthn(),
-							type: ButtonType.Primary,
-						}),
+						m(ButtonN, doWebauthnButtonAttrs),
 					]),
 				]
 				break
@@ -153,7 +151,7 @@ export class SecondFactorAuthView implements Component<SecondFactorViewAttrs> {
 			return null
 		}
 
-		return m(".small.right", [
+		return m(".small.text-center.pt-m", [
 			m(
 				`a[href=#]`,
 				{


### PR DESCRIPTION
remove rounded corners from WebDialog window on MacOs

the rounded corners seem to take up some space from inside the window
this caused the alignment of the content to be different than expected

fix https://github.com/tutao/tutanota/issues/3950

Also included:
some people miss the primary button on the dialog,
making it stand out more could help. centered primary buttons on the
bottom of dialogs are atypical for us anyway.

also centers the "lost account access" link because it looks strange
next to the red button when right-aligned
