### PR TITLE
Fix move mails shortcut in mailviewer

### DIFF
--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -22,6 +22,7 @@ import {assertMainOrNode} from "../../api/common/Env"
 import {ButtonN, ButtonType} from "./ButtonN"
 import {LoadingState, LoadingStateTracker} from "../../offline/LoadingState"
 import {lang} from "../../misc/LanguageViewModel"
+import {PosRect} from "./Dropdown"
 
 assertMainOrNode()
 export const ScrollBuffer = 15 // virtual elements that are used as scroll buffer in both directions
@@ -788,6 +789,28 @@ export class List<T extends ListElement, R extends VirtualRow<T>> implements Com
 	getSelectedEntities(): T[] {
 		// return a copy to avoid outside modifications
 		return this.selectedEntities.slice()
+	}
+
+	getSelectionBounds(): PosRect {
+		const selected = this.getSelectedEntities()
+
+		const rowBounds = this.virtualList
+							  .filter(row => row.domElement != null && row.entity != null && selected.includes(row.entity))
+							  .map(row => row.domElement!.getBoundingClientRect())
+
+		const left = Math.min(...rowBounds.map(row => row.left))
+		const right = Math.max(...rowBounds.map(row => row.right))
+		const top = Math.min(...rowBounds.map(row => row.top))
+		const bottom = Math.max(...rowBounds.map(row => row.bottom))
+
+		return {
+			left,
+			right,
+			top,
+			bottom,
+			height: bottom - top,
+			width: right - left
+		}
 	}
 
 	/**

--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -48,7 +48,7 @@ import {styles} from "../../gui/styles"
 import {size} from "../../gui/size"
 import {FolderColumnView} from "../../gui/base/FolderColumnView"
 import {modal} from "../../gui/base/Modal"
-import {DomRectReadOnlyPolyfilled, PosRect} from "../../gui/base/Dropdown"
+import {DomRectReadOnlyPolyfilled} from "../../gui/base/Dropdown"
 import type {MailFolder} from "../../api/entities/tutanota/MailFolder"
 import {UserError} from "../../api/main/UserError"
 import {showUserError} from "../../misc/ErrorHandlerImpl"
@@ -93,7 +93,6 @@ export class MailView implements CurrentView {
 
 	private _multiMailViewer: MultiMailViewer
 	private _mailViewerViewModel: MailViewerViewModel | null = null
-	private mailViewer: MailViewer | null = null
 
 	get mailViewerViewModel(): MailViewerViewModel | null {
 		return this._mailViewerViewModel
@@ -175,17 +174,9 @@ export class MailView implements CurrentView {
 					".mail",
 					this.mailViewerViewModel != null
 						? m(MailViewer, {
-							oncreate: (vnode) => {
-								this.mailViewer = vnode.state as MailViewer
-							},
 							viewModel: this.mailViewerViewModel
 						})
-						: m("",
-							{
-								oncreate: () => this.mailViewer = null
-							},
-							m(this._multiMailViewer)
-						)
+						: m(this._multiMailViewer)
 				),
 			},
 			ColumnType.Background,
@@ -465,18 +456,11 @@ export class MailView implements CurrentView {
 				}))
 			}, 300)
 
-			let mailViewerBounds: PosRect | null
-			if (this.mailViewer) {
-				mailViewerBounds = this.mailViewer.dom.getBoundingClientRect()
-			} else {
-				mailViewerBounds = this._multiMailViewer?.getBounds()
-			}
-
-			if (mailViewerBounds) {
-				const origin = new DomRectReadOnlyPolyfilled(mailViewerBounds.left, mailViewerBounds.top, mailViewerBounds.width, 0)
-				dropdown.setOrigin(origin)
-				modal.displayUnique(dropdown)
-			}
+			// Render the dropdown at the position of the selected mails in the MailList
+			const bounds = this.mailList.list.getSelectionBounds()
+			const origin = new DomRectReadOnlyPolyfilled(bounds.left, bounds.top, bounds.width, 0)
+			dropdown.setOrigin(origin)
+			modal.displayUnique(dropdown)
 		})
 		return false
 	}

--- a/src/mail/view/MailViewer.ts
+++ b/src/mail/view/MailViewer.ts
@@ -1,5 +1,5 @@
 import {size} from "../../gui/size"
-import m, {Children, Component, Vnode} from "mithril"
+import m, {_NoLifecycle, Children, CommonAttributes, Component, Vnode, VnodeDOM} from "mithril"
 import stream from "mithril/stream"
 import {ExpanderButtonN, ExpanderPanelN} from "../../gui/base/Expander"
 import {Button} from "../../gui/base/Button"
@@ -82,14 +82,16 @@ type MailAddressAndName = {
 	address: string
 }
 
-export interface MailViewerAttrs {
+export type MailViewerAttrs = {
 	viewModel: MailViewerViewModel
-}
+} & CommonAttributes<MailViewerAttrs, MailViewer>
 
 /**
  * The MailViewer displays a mail. The mail body is loaded asynchronously.
  */
 export class MailViewer implements Component<MailViewerAttrs> {
+
+	dom!: HTMLElement
 
 	/** it is set after we measured mail body element */
 	private bodyLineHeight: number | null = null
@@ -166,7 +168,10 @@ export class MailViewer implements Component<MailViewerAttrs> {
 		this.shortcuts = this.setupShortcuts()
 	}
 
-	oncreate() {
+	oncreate(vnode: VnodeDOM<MailViewerAttrs>) {
+		if (vnode.attrs.oncreate) {
+			vnode.attrs.oncreate.call(this, vnode)
+		}
 		keyManager.registerShortcuts(this.shortcuts)
 		this.viewModel.replaceInlineImages()
 		windowFacade.addResizeListener(this.resizeListener)
@@ -199,7 +204,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 			m(
 				"#mail-viewer.fill-absolute" + (client.isMobileDevice() ? ".scroll-no-overlay.overflow-x-hidden" : ".flex.flex-column"),
 				{
-					oncreate: vnode => this.viewModel.setMailViewerDom(vnode.dom as HTMLElement),
+					oncreate: vnode => this.dom = vnode.dom as HTMLElement
 				},
 				[
 					m(".header.plr-l.margin-are-inset-lr", [

--- a/src/mail/view/MailViewer.ts
+++ b/src/mail/view/MailViewer.ts
@@ -1,5 +1,5 @@
 import {size} from "../../gui/size"
-import m, {_NoLifecycle, Children, CommonAttributes, Component, Vnode, VnodeDOM} from "mithril"
+import m, {Children, Component, Vnode, VnodeDOM} from "mithril"
 import stream from "mithril/stream"
 import {ExpanderButtonN, ExpanderPanelN} from "../../gui/base/Expander"
 import {Button} from "../../gui/base/Button"
@@ -84,14 +84,12 @@ type MailAddressAndName = {
 
 export type MailViewerAttrs = {
 	viewModel: MailViewerViewModel
-} & CommonAttributes<MailViewerAttrs, MailViewer>
+}
 
 /**
  * The MailViewer displays a mail. The mail body is loaded asynchronously.
  */
 export class MailViewer implements Component<MailViewerAttrs> {
-
-	dom!: HTMLElement
 
 	/** it is set after we measured mail body element */
 	private bodyLineHeight: number | null = null
@@ -168,10 +166,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 		this.shortcuts = this.setupShortcuts()
 	}
 
-	oncreate(vnode: VnodeDOM<MailViewerAttrs>) {
-		if (vnode.attrs.oncreate) {
-			vnode.attrs.oncreate.call(this, vnode)
-		}
+	oncreate() {
 		keyManager.registerShortcuts(this.shortcuts)
 		this.viewModel.replaceInlineImages()
 		windowFacade.addResizeListener(this.resizeListener)
@@ -203,9 +198,6 @@ export class MailViewer implements Component<MailViewerAttrs> {
 		return [
 			m(
 				"#mail-viewer.fill-absolute" + (client.isMobileDevice() ? ".scroll-no-overlay.overflow-x-hidden" : ".flex.flex-column"),
-				{
-					oncreate: vnode => this.dom = vnode.dom as HTMLElement
-				},
 				[
 					m(".header.plr-l.margin-are-inset-lr", [
 						m(".flex-space-between.button-min-height", [

--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -70,7 +70,6 @@ import {CustomerTypeRef} from "../../api/entities/sys/Customer"
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog"
 import {MailRestriction} from "../../api/entities/tutanota/MailRestriction"
 import {animations, DomMutation, scroll} from "../../gui/animation/Animations"
-import {PosRect} from "../../gui/base/Dropdown"
 import {ease} from "../../gui/animation/Easing"
 import {isNewMailActionAvailable} from "../../gui/nav/NavFunctions"
 import {CancelledError} from "../../api/common/error/CancelledError"
@@ -123,7 +122,6 @@ export class MailViewerViewModel {
 	private domBody: HTMLElement | null = null
 
 	// Initialize with NoExternalContent so that the banner doesn't flash, this will be set later in _loadMailBody
-	private domMailViewer: HTMLElement | null = null
 	private scrollAnimation: Promise<void> | null = null
 	private domForScrolling: HTMLElement | null = null
 
@@ -382,10 +380,6 @@ export class MailViewerViewModel {
 
 	getRestrictions(): MailRestriction | null {
 		return this.mail.restrictions
-	}
-
-	setMailViewerDom(dom: HTMLElement) {
-		this.domMailViewer = dom
 	}
 
 	setScrollDom(scrollDom: HTMLElement) {
@@ -963,10 +957,6 @@ export class MailViewerViewModel {
 			const end = dom.scrollHeight - dom.offsetHeight
 			return scroll(dom.scrollTop, end)
 		})
-	}
-
-	getBounds(): PosRect | null {
-		return this.domMailViewer && this.domMailViewer.getBoundingClientRect()
 	}
 
 	private scrollIfDomBody(cb: (dom: HTMLElement) => DomMutation) {

--- a/src/mail/view/MultiMailViewer.ts
+++ b/src/mail/view/MultiMailViewer.ts
@@ -14,7 +14,6 @@ import {BootIcons} from "../../gui/base/icons/BootIcons"
 import {theme} from "../../gui/theme"
 import type {Mail} from "../../api/entities/tutanota/Mail"
 import {locator} from "../../api/main/MainLocator"
-import type {PosRect} from "../../gui/base/Dropdown"
 import {moveMails, promptAndDeleteMails} from "./MailGuiUtils"
 import {attachDropdown} from "../../gui/base/DropdownN"
 import {exportMails} from "../export/Exporter"
@@ -28,7 +27,6 @@ assertMainOrNode()
 export class MultiMailViewer implements Component {
 	view: Component["view"]
 	private readonly _mailView: MailView
-	private _domMailViewer: HTMLElement | null = null
 
 	constructor(mailView: MailView) {
 		this._mailView = mailView
@@ -37,11 +35,6 @@ export class MultiMailViewer implements Component {
 			return [
 				m(
 					".fill-absolute.mt-xs.plr-l",
-					{
-						oncreate: vnode => {
-							this._domMailViewer = vnode.dom as HTMLElement
-						},
-					},
 					mailView.mailList && mailView.mailList.list.getSelectedEntities().length > 0
 						? [
 							m(".button-height"), // just for the margin
@@ -60,10 +53,6 @@ export class MultiMailViewer implements Component {
 				),
 			]
 		}
-	}
-
-	getBounds(): PosRect | null {
-		return this._domMailViewer && this._domMailViewer.getBoundingClientRect()
 	}
 
 	_getMailSelectionMessage(mailView: MailView): string {

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -1,4 +1,4 @@
-	/**
+/**
  * @file Common declarations across packages. Should be included in each package.
  */
 


### PR DESCRIPTION
There are two commits, the first is the basic bugfix, the second is an improvement in the UI, so that the dropdown doesn't open at the opposite side of the window to where the user would already be looking

We may choose to leave the second commit out for now, to avoid increasing the testing load

fix #4006