### PR TITLE
Fix "show more" section in mailviewer

### DIFF
--- a/src/mail/view/MailViewer.ts
+++ b/src/mail/view/MailViewer.ts
@@ -113,7 +113,6 @@ export class MailViewer implements Component<MailViewerAttrs> {
 
 	private viewModel: MailViewerViewModel
 
-	private details: Children
 	private detailsExpanded = stream<boolean>(false)
 
 	private delayIsOver = false
@@ -151,8 +150,6 @@ export class MailViewer implements Component<MailViewerAttrs> {
 
 		this.resizeListener = () => this.viewModel.getResolvedDomBody().then(dom => this.updateLineHeight(dom))
 
-		this.details = this.createDetailsExpanderChildren({bubbleMenuWidth: 300})
-
 		this.viewModel.delayBodyRenderingUntil.then(() => {
 			this.delayIsOver = true
 			m.redraw()
@@ -187,12 +184,6 @@ export class MailViewer implements Component<MailViewerAttrs> {
 	view(vnode: Vnode<MailViewerAttrs>): Children {
 
 		this.viewModel = vnode.attrs.viewModel
-
-		const detailsExpanderButtonAttrs = {
-			label: "showMore_action",
-			expanded: this.detailsExpanded,
-			style: {},
-		} as const
 
 		const dateTime = formatDateWithWeekday(this.viewModel.mail.receivedDate) + " • " + formatTime(this.viewModel.mail.receivedDate)
 		return [
@@ -229,8 +220,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 							]),
 							!this.viewModel.isAnnouncement() && styles.isUsingBottomNavigation()
 								? null
-								: m(".pt-0",
-									m(ExpanderButtonN, detailsExpanderButtonAttrs)),
+								: m(".pt-0", this.renderShowMoreButton()),
 						]),
 						m(
 							".mb-m",
@@ -239,7 +229,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 								{
 									expanded: this.detailsExpanded,
 								},
-								this.details,
+								this.renderDetails({bubbleMenuWidth: 300}),
 							),
 						),
 						m(".subject-actions.flex-space-between.flex-wrap.mt-xs", [
@@ -272,7 +262,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 										m(
 											".flex.flex-column-reverse",
 											!this.viewModel.isAnnouncement() && styles.isUsingBottomNavigation()
-												? m(".pt-m", m(ExpanderButtonN, detailsExpanderButtonAttrs))
+												? m(".pt-m", this.renderShowMoreButton())
 												: null,
 										),
 									],
@@ -443,7 +433,14 @@ export class MailViewer implements Component<MailViewerAttrs> {
 			: null
 	}
 
-	private createDetailsExpanderChildren({bubbleMenuWidth}: {bubbleMenuWidth: number}): Children {
+	private renderShowMoreButton() {
+		return m(ExpanderButtonN, {
+			label: "showMore_action",
+			expanded: this.detailsExpanded,
+		})
+	}
+
+	private renderDetails({bubbleMenuWidth}: {bubbleMenuWidth: number}): Children {
 		const envelopeSender = this.viewModel.getDifferentEnvelopeSender()
 		return [
 			m(RecipientButton, {

--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -267,10 +267,6 @@ export class MailViewerViewModel {
 		return this.mail._id
 	}
 
-	isMailBodyLoaded(): boolean {
-		return this.sanitizedMailBody != null
-	}
-
 	getSanitizedMailBody(): string | null {
 		return this.sanitizedMailBody
 	}


### PR DESCRIPTION
The from/to/cc/bcc/replyTo fields weren't being updated when switching between mails, because they were still being rendered in the constructor of the MailViewer, so now we just render them in `view`

This commit keeps the behaviour where the show more section will stay open when you switch mails, which deviates from the behaviour on production but seems less janky

 fix #4015