### PR TITLE
[desktop/linux] retry on next LazyLoaded.getAsync when load rejected

### DIFF
--- a/packages/tutanota-utils/lib/LazyLoaded.ts
+++ b/packages/tutanota-utils/lib/LazyLoaded.ts
@@ -40,7 +40,10 @@ export class LazyLoaded<T> {
 			return Promise.resolve(neverNull(this._loadedObject))
 		} else {
 			if (!this._loadingPromise) {
-				this._loadingPromise = this._loadFunction().then(result => {
+				this._loadingPromise = this._loadFunction().catch(e => {
+					this._loadingPromise = null
+					throw e
+				}).then(result => {
 					this._loadedObject = result
 					this._isLoaded = true
 					return result

--- a/packages/tutanota-utils/test/LazyLoadedTest.ts
+++ b/packages/tutanota-utils/test/LazyLoadedTest.ts
@@ -1,0 +1,53 @@
+import o from "ospec"
+import {LazyLoaded} from "../lib/LazyLoaded.js"
+import {assertThrows} from "@tutao/tutanota-test-utils"
+
+o.spec("LazyLoaded", function () {
+
+	o("default value", async function () {
+		const ll = new LazyLoaded<number>(() => Promise.resolve(1), 3)
+		o(ll.isLoaded()).equals(false)
+		o(ll.getSync()).equals(3)
+		const v = await ll.getAsync()
+		o(v).equals(1)
+		o(ll.getSync()).equals(1)
+	})
+
+	o("reset and reload", async function () {
+		let ret = 0
+		const ll = new LazyLoaded<number>(() => Promise.resolve(ret++), -1)
+		o(ll.getSync()).equals(-1)
+		const v = await ll.getAsync()
+		o(v).equals(0)
+		o(ll.isLoaded()).equals(true)
+		ll.reset()
+		o(ll.isLoaded()).equals(false)
+		o(ll.getSync()).equals(null)
+		const v2 = await ll.getAsync()
+		o(v2).equals(1)
+	})
+
+	o("multiple getAsync", async function () {
+		let ret = 0
+		const ll = new LazyLoaded<number>(() => Promise.resolve(ret++))
+		const arr = await Promise.all([
+			ll.getAsync(),
+			ll.getAsync(),
+			ll.getAsync()
+		])
+
+		o(arr).deepEquals([0, 0, 0])
+	})
+
+	o("don't cache errors", async function () {
+		let ret = 0
+		const ll = new LazyLoaded<number>(() => ret % 2 === 1
+			? Promise.resolve(ret++)
+			: Promise.reject((ret++, new Error("fail")))
+		)
+		await assertThrows(Error, async () => await ll.getAsync())
+		o(ret).equals(1)
+		const one = await ll.getAsync()
+		o(one).equals(1)
+	})
+})

--- a/packages/tutanota-utils/test/Suite.ts
+++ b/packages/tutanota-utils/test/Suite.ts
@@ -7,5 +7,6 @@ import "./EncodingTest.js"
 import "./PromiseUtilTest.js"
 import "./SortedArrayTest.js"
 import "./MathUtilsTest.js"
+import "./LazyLoadedTest.js"
 
 o.run()


### PR DESCRIPTION
previously, a LazyLoaded instance would reject forever once the loader
rejected because the rejected promise was cached. fixed by inserting a
catch that deletes the cached promise before rethrowing
the error.

also add LazyLoaded test suite.

fix #3995