### PR TITLE
Fix trying to load list while offline

### DIFF
--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -487,7 +487,7 @@ export class List<T extends ListElement, R extends VirtualRow<T>> implements Com
 				m(ButtonN, {
 					label: "retry_action",
 					type: ButtonType.Primary,
-					click: () => this.loadMoreIfNecessary()
+					click: () => this.retryLoading()
 				})
 			]
 		)
@@ -1026,10 +1026,22 @@ export class List<T extends ListElement, R extends VirtualRow<T>> implements Com
 	private loadMoreIfNecessary() {
 		let lastBunchVisible = this.currentPosition > this.loadedEntities.length * this.config.rowHeight - this.visibleElementsHeight * 2
 
-		if (lastBunchVisible && !this.loadingState.isLoading() && !this.loadedCompletely) {
+		if (lastBunchVisible &&
+			!this.loadingState.isLoading() &&
+			!this.loadedCompletely &&
+			!this.loadingState.isConnectionLost()
+		) {
 			this.loadMore().then(() => {
 				this.domList.style.height = this.calculateListHeight()
 			})
+		}
+	}
+
+	private async retryLoading() {
+		if (this.loadingState.isConnectionLost()) {
+			await this.loadMore()
+			// We might need to remove extra space for the "retry" list item.
+			this.domList.style.height = this.calculateListHeight()
 		}
 	}
 


### PR DESCRIPTION
With the new loading state for offline error we have been missing a
check in `loadMoreIfNecessary()` so the list loading would be triggering
continuously while scrolling near the retry button. It was especially
prominent on iOS where there is an overscroll effect and UI updates
seem to take longer.

Simply adding a check to `loadMoreIfNecessary()` is not enough as it
was also used for retry itself. Instead, we introduce another function
which doesn't check for position and only works in the correct state.

 fix #4032