### PR TITLE
Fix bugs with MailViewer

### DIFF
--- a/src/calendar/date/CalendarUpdateDistributor.ts
+++ b/src/calendar/date/CalendarUpdateDistributor.ts
@@ -149,7 +149,7 @@ export class CalendarMailDistributor implements CalendarUpdateDistributor {
 									  subject: message,
 									  replyTos: [],
 								  },
-								  Promise.resolve(new Map()),
+								  new Map(),
 							  )
 						  })
 						  .then(model => {

--- a/src/gui/base/ViewSlider.ts
+++ b/src/gui/base/ViewSlider.ts
@@ -1,5 +1,6 @@
 import m, {Children, Component} from "mithril"
 import {ColumnType, ViewColumn} from "./ViewColumn"
+import type {windowSizeListener} from "../../misc/WindowFacade"
 import {windowFacade} from "../../misc/WindowFacade"
 import {size} from "../size"
 import {alpha, AlphaEnum, animations, transform, TransformEnum} from "../animation/Animations"
@@ -11,7 +12,6 @@ import {header} from "./Header"
 import {styles} from "../styles"
 import {AriaLandmarks} from "../AriaUtils"
 import {LayerType} from "../../RootView"
-import type {windowSizeListener} from "../../misc/WindowFacade"
 import {assertMainOrNode} from "../../api/common/Env"
 
 assertMainOrNode()

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -762,7 +762,7 @@ export function newMailEditor(mailboxDetails: MailboxDetail): Promise<Dialog> {
 export function newMailEditorAsResponse(
     args: ResponseMailParameters,
     blockExternalContent: boolean,
-    inlineImages: Promise<InlineImages>,
+    inlineImages: InlineImages,
     mailboxDetails?: MailboxDetail,
 ): Promise<Dialog> {
     return _mailboxPromise(mailboxDetails)
@@ -776,7 +776,7 @@ export function newMailEditorFromDraft(
     attachments: Array<TutanotaFile>,
     bodyText: string,
     blockExternalContent: boolean,
-    inlineImages: Promise<InlineImages>,
+    inlineImages: InlineImages,
     mailboxDetails?: MailboxDetail,
 ): Promise<Dialog> {
     return _mailboxPromise(mailboxDetails)

--- a/src/mail/editor/SendMailModel.ts
+++ b/src/mail/editor/SendMailModel.ts
@@ -364,7 +364,7 @@ export class SendMailModel {
 		})
 	}
 
-	async initAsResponse(args: ResponseMailParameters, inlineImages: Promise<InlineImages>): Promise<SendMailModel> {
+	async initAsResponse(args: ResponseMailParameters, inlineImages: InlineImages): Promise<SendMailModel> {
 		const {
 			previousMail,
 			conversationType,
@@ -395,7 +395,7 @@ export class SendMailModel {
 				  )
 		// if we reuse the same image references, changing the displayed mail in mail view will cause the minimized draft to lose
 		// that reference, because it will be revoked
-		this.loadedInlineImages = cloneInlineImages(await inlineImages)
+		this.loadedInlineImages = cloneInlineImages(inlineImages)
 		return this._init({
 			conversationType,
 			subject,
@@ -410,7 +410,7 @@ export class SendMailModel {
 		})
 	}
 
-	async initWithDraft(draft: Mail, attachments: TutanotaFile[], bodyText: string, inlineImages: Promise<InlineImages>): Promise<SendMailModel> {
+	async initWithDraft(draft: Mail, attachments: TutanotaFile[], bodyText: string, inlineImages: InlineImages): Promise<SendMailModel> {
 		let previousMessageId: string | null = null
 		let previousMail: Mail | null = null
 
@@ -435,7 +435,7 @@ export class SendMailModel {
 
 		// if we reuse the same image references, changing the displayed mail in mail view will cause the minimized draft to lose
 		// that reference, because it will be revoked
-		this.loadedInlineImages = cloneInlineImages(await inlineImages)
+		this.loadedInlineImages = cloneInlineImages(inlineImages)
 		const {confidential, sender, toRecipients, ccRecipients, bccRecipients, subject, replyTos} = draft
 		const recipients: Recipients = {
 			to: toRecipients.map(mailAddressToRecipient),

--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -7,7 +7,7 @@ import type {ButtonAttrs} from "../../gui/base/ButtonN"
 import {ButtonColor, ButtonN, ButtonType} from "../../gui/base/ButtonN"
 import type {NavButtonAttrs} from "../../gui/base/NavButtonN"
 import {isNavButtonSelected, isSelectedPrefix, NavButtonColor} from "../../gui/base/NavButtonN"
-import {createMailViewerViewModell, MailViewer} from "./MailViewer"
+import {createMailViewerViewModel, MailViewer} from "./MailViewer"
 import {Dialog} from "../../gui/base/Dialog"
 import {FeatureType, Keys, MailFolderType, OperationType} from "../../api/common/TutanotaConstants"
 import {CurrentView} from "../../gui/base/Header"
@@ -746,11 +746,12 @@ export class MailView implements CurrentView {
 		selectionChanged,
 		multiSelectOperation,
 	) => {
+		// Make the animation of switching between list and single email smooth by delaying sanitizing/heavy rendering until the animation is done.
 		const animationOverDeferred = defer<void>()
 
 		if (mails.length === 1 && !multiSelectOperation && (selectionChanged || !this.mailViewerViewModel)) {
 			// set or update the visible mail
-			this.mailViewerViewModel = createMailViewerViewModell({
+			this.mailViewerViewModel = createMailViewerViewModel({
 				mail: mails[0],
 				showFolder: false,
 				delayBodyRenderingUntil: animationOverDeferred.promise,
@@ -836,7 +837,7 @@ export class MailView implements CurrentView {
 					return locator.entityClient
 								  .load(MailTypeRef, this.mailViewerViewModel.getMailId())
 								  .then(updatedMail => {
-									  this.mailViewerViewModel = createMailViewerViewModell({
+									  this.mailViewerViewModel = createMailViewerViewModel({
 										  mail: updatedMail,
 										  showFolder: false,
 									  })

--- a/src/search/view/SearchResultDetailsViewer.ts
+++ b/src/search/view/SearchResultDetailsViewer.ts
@@ -3,7 +3,7 @@ import {SearchListView, SearchResultListEntry} from "./SearchListView"
 import type {Mail} from "../../api/entities/tutanota/Mail"
 import {MailTypeRef} from "../../api/entities/tutanota/Mail"
 import {LockedError, NotFoundError} from "../../api/common/error/RestError"
-import {createMailViewerViewModell, MailViewer} from "../../mail/view/MailViewer"
+import {createMailViewerViewModel, MailViewer} from "../../mail/view/MailViewer"
 import {ContactViewer} from "../../contacts/view/ContactViewer"
 import ColumnEmptyMessageBox from "../../gui/base/ColumnEmptyMessageBox"
 import type {Contact} from "../../api/entities/tutanota/Contact"
@@ -64,7 +64,7 @@ export class SearchResultDetailsViewer {
 			const mail = entity as Mail
 			this._viewer = {
 				mode: "mail",
-				viewModel: createMailViewerViewModell({
+				viewModel: createMailViewerViewModel({
 					mail,
 					showFolder: true,
 				})

--- a/test/client/mail/SendMailModelTest.ts
+++ b/test/client/mail/SendMailModelTest.ts
@@ -257,7 +257,7 @@ o.spec("SendMailModel", function () {
 				conversationEntry: testIdGenerator.newIdTuple()
 			})
 			when(entity.load(ConversationEntryTypeRef, draftMail.conversationEntry)).thenResolve(createConversationEntry({conversationType: ConversationType.REPLY}))
-			const initializedModel = await model.initWithDraft(draftMail, [], BODY_TEXT_1, Promise.resolve(new Map()))
+			const initializedModel = await model.initWithDraft(draftMail, [], BODY_TEXT_1, new Map())
 			o(initializedModel.getConversationType()).equals(ConversationType.REPLY)
 			o(initializedModel.getSubject()).equals(draftMail.subject)
 			o(initializedModel.getBody()).equals(BODY_TEXT_1)
@@ -295,7 +295,7 @@ o.spec("SendMailModel", function () {
 			when(entity.load(ConversationEntryTypeRef, draftMail.conversationEntry))
 				.thenResolve(createConversationEntry({conversationType: ConversationType.FORWARD}))
 
-			const initializedModel = await model.initWithDraft(draftMail, [], BODY_TEXT_1, Promise.resolve(new Map()))
+			const initializedModel = await model.initWithDraft(draftMail, [], BODY_TEXT_1, new Map())
 			o(initializedModel.getConversationType()).equals(ConversationType.FORWARD)
 			o(initializedModel.getSubject()).equals(draftMail.subject)
 			o(initializedModel.getBody()).equals(BODY_TEXT_1)


### PR DESCRIPTION
Inline images are no longer stored or passed as a promise because it is
not necessary: we redraw before we finish loading.

Clarified animation delays for:
 1. Rendering mail body in single column layout
 2. Spinner when switching between mails

Moved mail body and inline image processing back into mail viewer
because of lifecycle differences:
 1. When switching between mails, mailViewer stays but viewModel is
 replaced
 2. When switching between app sections, mailViewer is recreated but
 viewModel stays

handleAnchorClick is moved back to viewer because it makes more sense
in GUI-related code

replaceInlineImages is back into MailViewer because it is coupled
tightly to mailBody and works on HTML.

closes #4031