### PR TITLE
chore: remove git.io

### DIFF
--- a/libs/s.js
+++ b/libs/s.js
@@ -5,7 +5,7 @@
 (function () {
 
   function errMsg(errCode, msg) {
-    return (msg || "") + " (SystemJS https://git.io/JvFET#" + errCode + ")";
+    return (msg || "") + " (SystemJS https://github.com/systemjs/systemjs/blob/master/docs/errors.md#" + errCode + ")";
   }
 
   var hasSymbol = typeof Symbol !== 'undefined';
@@ -526,7 +526,7 @@
         System.import(script.src.slice(0, 7) === 'import:' ? script.src.slice(7) : resolveUrl(script.src, baseUrl)).catch(function (e) {
           // if there is a script load error, dispatch an "error" event
           // on the script tag.
-          if (e.message.indexOf('https://git.io/JvFET#3') > -1) {
+          if (e.message.indexOf('https://github.com/systemjs/systemjs/blob/master/docs/errors.md#3') > -1) {
             var event = document.createEvent('Event');
             event.initEvent('error', false, false);
             script.dispatchEvent(event);

--- a/src/misc/ErrorHandlerImpl.ts
+++ b/src/misc/ErrorHandlerImpl.ts
@@ -59,7 +59,7 @@ export async function handleUncaughtError(e: Error) {
 	}
 
 	// This is from the s.js and it shouldn't change. Unfortunately it is a plain Error.
-	if (e.message.includes("(SystemJS https://git.io/JvFET#")) {
+	if (e.message.includes("(SystemJS https://github.com/systemjs/systemjs/blob/master/docs/errors.md#")) {
 		handleImportError()
 		return
 	}


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/