### PR TITLE
[build] fix launch html

### DIFF
--- a/buildSrc/LaunchHtml.js
+++ b/buildSrc/LaunchHtml.js
@@ -85,6 +85,6 @@ function csp(env) {
 }
 
 function renderScriptImport({src, type}) {
-	const typeString = type ? `type="${type}"` : ""
+	const typeString = type ? ` type="${type}"` : ""
 	return `<script src="${src}"${typeString} defer></script>`
 }


### PR DESCRIPTION
It was generating broken html files for the browser tests because the type attribute was not being generated correctly. It didn't show up in production because we don't specify type