### PR TITLE
(#3564) Make the Calendar Agenda View Title easier to understand, by displaying startDate in DateWithWeekday format

### DIFF
--- a/src/calendar/view/CalendarAgendaView.ts
+++ b/src/calendar/view/CalendarAgendaView.ts
@@ -42,13 +42,9 @@ export class CalendarAgendaView implements Component<Attrs> {
 		const tomorrow = incrementDate(new Date(today), 1)
 		const days = getNextFourteenDays(today)
 		const lastDay = lastThrow(days)
-		let title: string
-
-		if (days[0].getMonth() === lastDay.getMonth()) {
-			title = `${lang.formats.dateWithWeekdayWoMonth.format(days[0])} - ${lang.formats.dateWithWeekdayAndYear.format(lastDay)}`
-		} else {
-			title = `${lang.formats.dateWithWeekday.format(days[0])} - ${lang.formats.dateWithWeekdayAndYear.format(lastDay)}`
-		}
+		const title = days[0].getFullYear() === lastDay.getFullYear()
+			? `${lang.formats.dateWithWeekday.format(days[0])} - ${lang.formats.dateWithWeekdayAndYear.format(lastDay)}`
+			: `${lang.formats.dateWithWeekdayAndYear.format(days[0])} - ${lang.formats.dateWithWeekdayAndYear.format(lastDay)}`
 
 		const lastDayFormatted = formatDate(lastDay)
 		return m(".fill-absolute.flex.col.margin-are-inset-lr", [


### PR DESCRIPTION
Make the Calendar Agenda View Title easier to understand, by displaying startDate in DateWithWeekday format
Addresses: #3564 

* This makes the day easier to understand, providing some context
* Removed the month comparison and dispaly dateWithWeekday even when startDate month and endDate month are equal
* Previously the displayed Date format was: `4 Wed - Tue, May 17, 2022`, now it is `Wed, May 4 - Tue, May 17, 2022`