### PR TITLE
wait for other windows to finish logging out before deleting database

### DIFF
--- a/src/desktop/ipc/DesktopInterWindowEventSender.ts
+++ b/src/desktop/ipc/DesktopInterWindowEventSender.ts
@@ -2,6 +2,7 @@ import type {IInterWindowEventHandler, IInterWindowEventSender, InterWindowEvent
 import type {IPC} from "../IPC"
 import {WindowManager} from "../DesktopWindowManager"
 import {exposeRemote} from "../../api/common/WorkerProxy"
+import {ApplicationWindow} from "../ApplicationWindow"
 
 export class DesktopInterWindowEventSender implements IInterWindowEventSender {
 	constructor(
@@ -12,14 +13,16 @@ export class DesktopInterWindowEventSender implements IInterWindowEventSender {
 	}
 
 	async send(event: InterWindowEvent): Promise<void> {
-		for (const window of this.windowManager.getAll()) {
-			if (window.id !== this.windowId) {
-				// Do not send to the same window it was sent from or funny things will happen
-				const {interWindowEventHandler} = exposeRemote<{interWindowEventHandler: IInterWindowEventHandler}>(
-					(r) => this.ipc.sendRequest(window.id, r.requestType, r.args)
-				)
-				interWindowEventHandler.onEvent(event)
-			}
+		await Promise.all(this.windowManager.getAll().map(window => this.sendToWindow(window, event)))
+	}
+
+	private async sendToWindow(window: ApplicationWindow, event: InterWindowEvent): Promise<void> {
+		if (window.id !== this.windowId) {
+			// Do not send to the same window it was sent from or funny things will happen
+			const {interWindowEventHandler} = exposeRemote<{interWindowEventHandler: IInterWindowEventHandler}>(
+				(r) => this.ipc.sendRequest(window.id, r.requestType, r.args)
+			)
+			return interWindowEventHandler.onEvent(event)
 		}
 	}
 }

--- a/src/desktop/ipc/IInterWindowEventBus.ts
+++ b/src/desktop/ipc/IInterWindowEventBus.ts
@@ -11,4 +11,4 @@ export interface IInterWindowEventSender {
 /** Receives events from interwindow event bus*/
 export interface IInterWindowEventHandler {
 	onEvent(event: InterWindowEvent): Promise<void>
-}
+	}

--- a/src/login/LoginListener.ts
+++ b/src/login/LoginListener.ts
@@ -133,12 +133,12 @@ class LoginListener implements LoginEventHandler {
 		this.enforcePasswordChange()
 
 		if (isDesktop()) {
-			locator.interWindowEventBus.events.map(async (event) => {
+			locator.interWindowEventBus.addListener(async (event) => {
 				if (event.name === CREDENTIALS_DELETED_EVENT) {
 					if ((event as CredentialsDeletedEvent).userId === logins.getUserController().user._id) {
-						await logins.logout(false)
-						await windowFacade.reload({noAutoLogin: true})
-					}
+					await logins.logout(false)
+					await windowFacade.reload({noAutoLogin: true})
+				}
 				}
 			})
 		}

--- a/src/misc/credentials/CredentialsProvider.ts
+++ b/src/misc/credentials/CredentialsProvider.ts
@@ -231,7 +231,7 @@ export class CredentialsProvider implements ICredentialsProvider {
 			name: CREDENTIALS_DELETED_EVENT,
 			userId,
 		}
-		this.interWindowEventBus?.send(event)
+		await this.interWindowEventBus?.send(event)
 		await this.offlineDbFacade?.deleteDatabaseForUser(userId)
 		this.storage.deleteByUserId(userId)
 	}


### PR DESCRIPTION
The interwindow event bus would send it's messages off and forget about them. When deleting credentials though it's only safe to delete the offline database once the other windows have finished closing their database connections, which means we need to know when they have completed. now the interwindoweventbus will not resolve until all of it's listeners have also resolved

fix #4108