### PR TITLE
Do not save a draft if message is unchanged

### DIFF
--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -710,6 +710,13 @@ async function createMailEditorDialog(model: SendMailModel, blockExternalContent
 	}
 
 	const minimize = () => {
+		// If the mail is unchanged, close instead of saving
+		if (!model.hasMailChanged()) {
+			dispose()
+			dialog.close()
+			return
+		}
+
 		const saveStatus = stream<SaveStatus>({status: SaveStatusEnum.Saving})
 		save(false)
 			.then(() => saveStatus({status: SaveStatusEnum.Saved}))

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -136,7 +136,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 
 		const onEditorChanged = () => {
 			cleanupInlineAttachments(this.editor.getDOM(), this.inlineImageElements, model.getAttachments())
-			model.setMailChanged(true)
+			model.markAsChangedIfNecessary(true)
 			m.redraw()
 		}
 

--- a/src/mail/editor/SendMailModel.ts
+++ b/src/mail/editor/SendMailModel.ts
@@ -182,7 +182,7 @@ export class SendMailModel {
 	setPassword(mailAddress: string, password: string) {
 		this.passwords.set(mailAddress, password)
 
-		this.setMailChanged(true)
+		this.markAsChangedIfNecessary(true)
 	}
 
 	getPassword(mailAddress: string): string {
@@ -204,12 +204,12 @@ export class SendMailModel {
 
 	setBody(body: string) {
 		this.body = body
-		this.setMailChanged(true)
+		this.markAsChangedIfNecessary(true)
 	}
 
 	setSender(senderAddress: string) {
 		this.senderAddress = senderAddress
-		this.setMailChanged(true)
+		this.markAsChangedIfNecessary(true)
 	}
 
 	getSender(): string {
@@ -232,9 +232,11 @@ export class SendMailModel {
 		return this.mailChanged
 	}
 
-	setMailChanged(hasChanged: boolean) {
-		this.mailChanged = hasChanged
-		this.onMailChanged(hasChanged) // if this method is called wherever state gets changed, onMailChanged should function properly
+	markAsChangedIfNecessary(hasChanged: boolean) {
+		if (!hasChanged) return
+		this.mailChanged = true
+		// if this method is called wherever state gets changed, onMailChanged should function properly
+		this.onMailChanged(true)
 	}
 
 	/**
@@ -479,10 +481,10 @@ export class SendMailModel {
 				if (!this.passwords.has(address) && contact != null) {
 					this.setPassword(address, contact.presharedPassword ?? "")
 				}
-				this.setMailChanged(true)
+				this.markAsChangedIfNecessary(true)
 			})
 
-			this.setMailChanged(true)
+			this.markAsChangedIfNecessary(true)
 
 		}
 
@@ -503,7 +505,7 @@ export class SendMailModel {
 	removeRecipient(recipient: Recipient, type: RecipientField, notify: boolean = true): boolean {
 		const recipients = this.recipients.get(type) ?? []
 		const didRemove = findAndRemove(recipients, r => r.address === recipient.address)
-		this.setMailChanged(didRemove)
+		this.markAsChangedIfNecessary(didRemove)
 
 		if (didRemove && notify) {
 			this.onRecipientDeleted({
@@ -536,7 +538,7 @@ export class SendMailModel {
 
 		this.attachments.push(...sizeCheckResult.attachableFiles)
 
-		this.setMailChanged(true)
+		this.markAsChangedIfNecessary(true)
 
 		if (sizeCheckResult.tooBigFiles.length > 0) {
 			throw new UserError(() => lang.get("tooBigAttachment_msg") + "\n" + sizeCheckResult.tooBigFiles.join("\n"))
@@ -545,7 +547,7 @@ export class SendMailModel {
 
 	removeAttachment(file: Attachment): void {
 		if (remove(this.attachments, file)) {
-			this.setMailChanged(true)
+			this.markAsChangedIfNecessary(true)
 		}
 	}
 
@@ -858,7 +860,7 @@ export class SendMailModel {
 
 	setSelectedNotificationLanguageCode(code: string) {
 		this.selectedNotificationLanguage = code
-		this.setMailChanged(true)
+		this.markAsChangedIfNecessary(true)
 	}
 
 	private updateExternalLanguage() {
@@ -964,7 +966,7 @@ export class SendMailModel {
 				}
 			}
 
-			this.setMailChanged(true)
+			this.markAsChangedIfNecessary(true)
 		} else if (isUpdateForTypeRef(CustomerPropertiesTypeRef, update)) {
 			this.updateAvailableNotificationTemplateLanguages()
 		}


### PR DESCRIPTION
This adds a check for hasMailChanged() when the mail dialog is minimized, such as when closed.

The change to SendMailModel.ts is because drafts opened that have senders (such as a reply) are set as changed after the code below would have set it to unchanged. I'm not sure if there is a better way to handle this.

Also would it make sense to check if the mail was created as a reply and save anyway?

If merged, this closes #3580 