### PR TITLE
Fix AddSpamRuleDialog being stuck in invalid state

### DIFF
--- a/src/settings/AddInboxRuleDialog.ts
+++ b/src/settings/AddInboxRuleDialog.ts
@@ -1,6 +1,6 @@
 import m from "mithril"
 import {Dialog} from "../gui/base/Dialog"
-import {lang} from "../misc/LanguageViewModel"
+import {lang, TranslationKey} from "../misc/LanguageViewModel"
 import {InboxRuleType} from "../api/common/TutanotaConstants"
 import {isDomainName, isMailAddress, isRegularExpression} from "../misc/FormatValidator"
 import {getInboxRuleTypeNameMapping} from "../mail/model/InboxRuleHandler"
@@ -65,7 +65,7 @@ export function show(mailBoxDetails: MailboxDetail, ruleOrTemplate: InboxRule) {
 		const addInboxRuleOkAction = (dialog: Dialog) => {
 			let rule = createInboxRule()
 			rule.type = inboxRuleType()
-			rule.value = _getCleanedValue(inboxRuleType(), inboxRuleValue())
+			rule.value = getCleanedValue(inboxRuleType(), inboxRuleValue())
 			rule.targetFolder = inboxRuleTarget()._id
 			const props = logins.getUserController().props
 			const inboxRules = props.inboxRules
@@ -91,7 +91,7 @@ export function show(mailBoxDetails: MailboxDetail, ruleOrTemplate: InboxRule) {
 		Dialog.showActionDialog({
 			title: lang.get("addInboxRule_action"),
 			child: form,
-			validator: () => _validateInboxRuleInput(inboxRuleType(), inboxRuleValue(), ruleOrTemplate._id),
+			validator: () => validateInboxRuleInput(inboxRuleType(), inboxRuleValue(), ruleOrTemplate._id),
 			allowOkWithReturn: true,
 			okAction: addInboxRuleOkAction,
 		})
@@ -101,16 +101,16 @@ export function show(mailBoxDetails: MailboxDetail, ruleOrTemplate: InboxRule) {
 export function createInboxRuleTemplate(ruleType: string | null, value: string | null): InboxRule {
 	const template = createInboxRule()
 	template.type = ruleType || InboxRuleType.FROM_EQUALS
-	template.value = _getCleanedValue(neverNull(ruleType), value || "")
+	template.value = getCleanedValue(neverNull(ruleType), value || "")
 	return template
 }
 
-function _validateInboxRuleInput(type: string, value: string, ruleId: Id) {
-	let currentCleanedValue = _getCleanedValue(type, value)
+function validateInboxRuleInput(type: string, value: string, ruleId: Id): TranslationKey | null {
+	let currentCleanedValue = getCleanedValue(type, value)
 
 	if (currentCleanedValue === "") {
 		return "inboxRuleEnterValue_msg"
-	} else if (_isInvalidRegex(currentCleanedValue)) {
+	} else if (isInvalidRegex(currentCleanedValue)) {
 		return "invalidRegexSyntax_msg"
 	} else if (
 		type !== InboxRuleType.SUBJECT_CONTAINS &&
@@ -131,7 +131,7 @@ function _validateInboxRuleInput(type: string, value: string, ruleId: Id) {
 	return null
 }
 
-function _getCleanedValue(type: string, value: string) {
+function getCleanedValue(type: string, value: string) {
 	if (type === InboxRuleType.SUBJECT_CONTAINS || type === InboxRuleType.MAIL_HEADER_CONTAINS) {
 		return value
 	} else {
@@ -144,7 +144,7 @@ function _getCleanedValue(type: string, value: string) {
  * @returns true if provided string is a regex and it's unparseable by RegExp, else false
  * @private
  */
-function _isInvalidRegex(value: string) {
+function isInvalidRegex(value: string) {
 	if (!isRegularExpression(value)) return false // not a regular expression is not an invalid regular expression
 
 	try {


### PR DESCRIPTION
AddSpamRuleDialog would try to load some data for validation but would
never expect an error if it can't load it. In that case it would return
an "emptyString_msg" (which denotes "failed" validation) so the user
would see an empty dialog.

Now we catch the errors while loading the data and close the dialog if
it fails as it's the easiest way to trigger retry. Also failed
validation dialog would display loading message instead of an empty
dialog.

fix #4152