### PR TITLE
always show default offline time range for free users

### DIFF
--- a/src/settings/OfflineStorageSettings.ts
+++ b/src/settings/OfflineStorageSettings.ts
@@ -37,10 +37,17 @@ export class OfflineStorageSettingsModel {
 	}
 
 	/**
-	 * get stored time range, will error out if offlineStorage isn't available
+	 * get stored time range, will error out if offlineStorage isn't available.
+	 * if the user account is free, always returns the default time range and
+	 * resets the stored value if it's different from the default.
 	 */
 	getTimeRange(): number {
 		this.assertAvailable()
+		if (this.userController.isFreeAccount() && this.timeRange !== OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS) {
+			this.setTimeRange(OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS).catch(e => console.log("error while resetting storage time range:", e))
+			this.timeRange = OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS
+			return OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS
+		}
 		return this.timeRange
 	}
 

--- a/src/subscription/SwitchSubscriptionDialog.ts
+++ b/src/subscription/SwitchSubscriptionDialog.ts
@@ -2,10 +2,9 @@ import m, {Component} from "mithril"
 import {Dialog} from "../gui/base/Dialog"
 import {lang} from "../misc/LanguageViewModel"
 import {ButtonN, ButtonType} from "../gui/base/ButtonN"
-import type {AccountingInfo, Booking, Customer, CustomerInfo} from "../api/entities/sys/TypeRefs.js"
+import type {AccountingInfo, Booking, Customer, CustomerInfo, SwitchAccountTypeData} from "../api/entities/sys/TypeRefs.js"
 import {createSwitchAccountTypeData} from "../api/entities/sys/TypeRefs.js"
 import {AccountType, BookingItemFeatureByCode, BookingItemFeatureType, Const, Keys, UnsubscribeFailureReason} from "../api/common/TutanotaConstants"
-import {BadRequestError, InvalidDataError, PreconditionFailedError} from "../api/common/error/RestError"
 import {SubscriptionSelector} from "./SubscriptionSelector"
 import stream from "mithril/stream"
 import {showProgressDialog} from "../gui/dialogs/ProgressDialog"
@@ -36,80 +35,75 @@ import {
 	isUpgradeWhitelabelNeeded,
 	SwitchSubscriptionDialogModel,
 } from "./SwitchSubscriptionDialogModel"
-import {ofClass} from "@tutao/tutanota-utils"
 import {locator} from "../api/main/MainLocator"
-import {SwitchAccountTypeService} from "../api/entities/sys/Services"
+import {SwitchAccountTypeService} from "../api/entities/sys/Services.js"
+import {BadRequestError, InvalidDataError, PreconditionFailedError} from "../api/common/error/RestError.js"
 
 /**
  * Only shown if the user is already a Premium user. Allows cancelling the subscription (only private use) and switching the subscription to a different paid subscription.
  */
-export function showSwitchDialog(customer: Customer, customerInfo: CustomerInfo, accountingInfo: AccountingInfo, lastBooking: Booking): Promise<void> {
+export async function showSwitchDialog(customer: Customer, customerInfo: CustomerInfo, accountingInfo: AccountingInfo, lastBooking: Booking): Promise<void> {
 	const model = new SwitchSubscriptionDialogModel(locator.bookingFacade, customer, customerInfo, accountingInfo, lastBooking)
-	return showProgressDialog("pleaseWait_msg", model.loadSwitchSubscriptionPrices()).then(prices => {
-		const cancelAction = () => {
-			dialog.close()
-		}
+	const prices = await showProgressDialog("pleaseWait_msg", model.loadSwitchSubscriptionPrices())
+	const cancelAction = () => dialog.close()
 
-		const headerBarAttrs: DialogHeaderBarAttrs = {
-			left: [
-				{
-					label: "cancel_action",
-					click: cancelAction,
-					type: ButtonType.Secondary,
-				},
-			],
-			right: [],
-			middle: () => lang.get("subscription_label"),
-		}
-		const currentSubscriptionInfo = model.currentSubscriptionInfo
-		const dialog = Dialog.largeDialog(headerBarAttrs, {
-			view: () =>
-				m(
-					"#upgrade-account-dialog.pt",
-					m(SubscriptionSelector, {
-						// paymentInterval will not be updated as isInitialUpgrade is false
-						options: {
-							businessUse: stream(currentSubscriptionInfo.businessUse),
-							paymentInterval: stream(currentSubscriptionInfo.paymentInterval),
-						},
-						campaignInfoTextId: null,
-						boxWidth: 230,
-						boxHeight: 230,
-						currentSubscriptionType: currentSubscriptionInfo.subscriptionType,
-						currentlySharingOrdered: currentSubscriptionInfo.currentlySharingOrdered,
-						currentlyBusinessOrdered: currentSubscriptionInfo.currentlyBusinessOrdered,
-						currentlyWhitelabelOrdered: currentSubscriptionInfo.currentlyWhitelabelOrdered,
-						orderedContactForms: currentSubscriptionInfo.orderedContactForms,
-						isInitialUpgrade: false,
-						planPrices: prices,
-						actionButtons: subscriptionActionButtons,
-					}),
-				),
-		})
-							 .addShortcut({
-								 key: Keys.ESC,
-								 exec: cancelAction,
-								 help: "close_alt",
-							 })
-							 .setCloseHandler(cancelAction)
-		const subscriptionActionButtons: SubscriptionActionButtons = {
-			Free: {
-				view: () => {
-					return m(ButtonN, {
-						label: "pricing.select_action",
-						click: () => cancelSubscription(dialog, currentSubscriptionInfo),
-						type: ButtonType.Login,
-					})
-				},
+	const headerBarAttrs: DialogHeaderBarAttrs = {
+		left: [
+			{
+				label: "cancel_action",
+				click: cancelAction,
+				type: ButtonType.Secondary,
 			},
-			Premium: createSubscriptionPlanButton(dialog, SubscriptionType.Premium, currentSubscriptionInfo),
-			PremiumBusiness: createSubscriptionPlanButton(dialog, SubscriptionType.PremiumBusiness, currentSubscriptionInfo),
-			Teams: createSubscriptionPlanButton(dialog, SubscriptionType.Teams, currentSubscriptionInfo),
-			TeamsBusiness: createSubscriptionPlanButton(dialog, SubscriptionType.TeamsBusiness, currentSubscriptionInfo),
-			Pro: createSubscriptionPlanButton(dialog, SubscriptionType.Pro, currentSubscriptionInfo),
-		}
-		dialog.show()
-	})
+		],
+		right: [],
+		middle: () => lang.get("subscription_label"),
+	}
+	const currentSubscriptionInfo = model.currentSubscriptionInfo
+	const dialog: Dialog = Dialog.largeDialog(headerBarAttrs, {
+		view: () =>
+			m(
+				"#upgrade-account-dialog.pt",
+				m(SubscriptionSelector, {
+					// paymentInterval will not be updated as isInitialUpgrade is false
+					options: {
+						businessUse: stream(currentSubscriptionInfo.businessUse),
+						paymentInterval: stream(currentSubscriptionInfo.paymentInterval),
+					},
+					campaignInfoTextId: null,
+					boxWidth: 230,
+					boxHeight: 230,
+					currentSubscriptionType: currentSubscriptionInfo.subscriptionType,
+					currentlySharingOrdered: currentSubscriptionInfo.currentlySharingOrdered,
+					currentlyBusinessOrdered: currentSubscriptionInfo.currentlyBusinessOrdered,
+					currentlyWhitelabelOrdered: currentSubscriptionInfo.currentlyWhitelabelOrdered,
+					orderedContactForms: currentSubscriptionInfo.orderedContactForms,
+					isInitialUpgrade: false,
+					planPrices: prices,
+					actionButtons: subscriptionActionButtons,
+				}),
+			),
+	}).addShortcut({
+		key: Keys.ESC,
+		exec: cancelAction,
+		help: "close_alt",
+	}).setCloseHandler(cancelAction)
+	const subscriptionActionButtons: SubscriptionActionButtons = {
+		Free: {
+			view: () => {
+				return m(ButtonN, {
+					label: "pricing.select_action",
+					click: () => cancelSubscription(dialog, currentSubscriptionInfo),
+					type: ButtonType.Login,
+				})
+			},
+		},
+		Premium: createSubscriptionPlanButton(dialog, SubscriptionType.Premium, currentSubscriptionInfo),
+		PremiumBusiness: createSubscriptionPlanButton(dialog, SubscriptionType.PremiumBusiness, currentSubscriptionInfo),
+		Teams: createSubscriptionPlanButton(dialog, SubscriptionType.Teams, currentSubscriptionInfo),
+		TeamsBusiness: createSubscriptionPlanButton(dialog, SubscriptionType.TeamsBusiness, currentSubscriptionInfo),
+		Pro: createSubscriptionPlanButton(dialog, SubscriptionType.Pro, currentSubscriptionInfo),
+	}
+	dialog.show()
 }
 
 function createSubscriptionPlanButton(
@@ -130,83 +124,91 @@ function createSubscriptionPlanButton(
 	}
 }
 
-function cancelSubscription(dialog: Dialog, currentSubscriptionInfo: CurrentSubscriptionInfo) {
-	Dialog.confirm("unsubscribeConfirm_msg").then(ok => {
-		if (!ok) {
-			return
-		}
+function handleSwitchAccountPreconditionFailed(e: PreconditionFailedError): Promise<void> {
+	const reason = e.data
 
-		let d = createSwitchAccountTypeData()
-		d.accountType = AccountType.FREE
-		d.date = Const.CURRENT_DATE
-		showProgressDialog(
-			"pleaseWait_msg",
-			cancelAllAdditionalFeatures(SubscriptionType.Free, currentSubscriptionInfo).then(failed => {
-				if (failed) {
-					return
+	if (reason == null) {
+		return Dialog.message("unknownError_msg")
+	} else {
+		let detailMsg: string
+
+		switch (reason) {
+			case UnsubscribeFailureReason.TOO_MANY_ENABLED_USERS:
+				detailMsg = lang.get("accountSwitchTooManyActiveUsers_msg")
+				break
+
+			case UnsubscribeFailureReason.CUSTOM_MAIL_ADDRESS:
+				detailMsg = lang.get("accountSwitchCustomMailAddress_msg")
+				break
+
+			case UnsubscribeFailureReason.TOO_MANY_CALENDARS:
+				detailMsg = lang.get("accountSwitchMultipleCalendars_msg")
+				break
+
+			case UnsubscribeFailureReason.CALENDAR_TYPE:
+				detailMsg = lang.get("accountSwitchSharedCalendar_msg")
+				break
+
+			case UnsubscribeFailureReason.TOO_MANY_ALIASES:
+				detailMsg = lang.get("accountSwitchAliases_msg")
+				break
+
+			default:
+				if (reason.startsWith(UnsubscribeFailureReason.FEATURE)) {
+					const feature = reason.slice(UnsubscribeFailureReason.FEATURE.length + 1)
+					const featureName = BookingItemFeatureByCode[feature as BookingItemFeatureType]
+					detailMsg = lang.get("accountSwitchFeature_msg", {
+						"{featureName}": featureName,
+					})
+				} else {
+					detailMsg = lang.get("unknownError_msg")
 				}
 
-				return locator
-					.serviceExecutor
-					.post(SwitchAccountTypeService, d)
-					.then(() => locator.customerFacade.switchPremiumToFreeGroup())
-					.catch(
-						ofClass(PreconditionFailedError, e => {
-							const reason = e.data
+				break
+		}
 
-							if (reason == null) {
-								return Dialog.message("unknownError_msg")
-							} else {
-								let detailMsg: string
-
-								switch (reason) {
-									case UnsubscribeFailureReason.TOO_MANY_ENABLED_USERS:
-										detailMsg = lang.get("accountSwitchTooManyActiveUsers_msg")
-										break
-
-									case UnsubscribeFailureReason.CUSTOM_MAIL_ADDRESS:
-										detailMsg = lang.get("accountSwitchCustomMailAddress_msg")
-										break
-
-									case UnsubscribeFailureReason.TOO_MANY_CALENDARS:
-										detailMsg = lang.get("accountSwitchMultipleCalendars_msg")
-										break
-
-									case UnsubscribeFailureReason.CALENDAR_TYPE:
-										detailMsg = lang.get("accountSwitchSharedCalendar_msg")
-										break
-
-									case UnsubscribeFailureReason.TOO_MANY_ALIASES:
-										detailMsg = lang.get("accountSwitchAliases_msg")
-										break
-
-									default:
-										if (reason.startsWith(UnsubscribeFailureReason.FEATURE)) {
-											const feature = reason.slice(UnsubscribeFailureReason.FEATURE.length + 1)
-											const featureName = BookingItemFeatureByCode[feature as BookingItemFeatureType]
-											detailMsg = lang.get("accountSwitchFeature_msg", {
-												"{featureName}": featureName,
-											})
-										} else {
-											detailMsg = lang.get("unknownError_msg")
-										}
-
-										break
-								}
-
-								return Dialog.message(() =>
-									lang.get("accountSwitchNotPossible_msg", {
-										"{detailMsg}": detailMsg,
-									}),
-								)
-							}
-						}),
-					)
-					.catch(ofClass(InvalidDataError, () => Dialog.message("accountSwitchTooManyActiveUsers_msg")))
-					.catch(ofClass(BadRequestError, () => Dialog.message("deactivatePremiumWithCustomDomainError_msg")))
+		return Dialog.message(() =>
+			lang.get("accountSwitchNotPossible_msg", {
+				"{detailMsg}": detailMsg,
 			}),
-		).finally(() => dialog.close())
-	})
+		)
+	}
+}
+
+
+async function tryDowngradePremiumToFree(switchAccountTypeData: SwitchAccountTypeData, currentSubscriptionInfo: CurrentSubscriptionInfo): Promise<void> {
+	const failed = await cancelAllAdditionalFeatures(SubscriptionType.Free, currentSubscriptionInfo)
+	if (failed) {
+		return
+	}
+
+	try {
+		await locator.serviceExecutor.post(SwitchAccountTypeService, switchAccountTypeData)
+		await locator.customerFacade.switchPremiumToFreeGroup()
+	} catch (e) {
+		if (e instanceof PreconditionFailedError) {
+			return handleSwitchAccountPreconditionFailed(e)
+		} else if (e instanceof InvalidDataError) {
+			return Dialog.message("accountSwitchTooManyActiveUsers_msg")
+		} else if (e instanceof BadRequestError) {
+			return Dialog.message("deactivatePremiumWithCustomDomainError_msg")
+		}
+	}
+}
+
+async function cancelSubscription(dialog: Dialog, currentSubscriptionInfo: CurrentSubscriptionInfo): Promise<void> {
+	const ok = Dialog.confirm("unsubscribeConfirm_msg")
+	if (!ok) {
+		return
+	}
+	const switchAccountTypeData = createSwitchAccountTypeData()
+	switchAccountTypeData.accountType = AccountType.FREE
+	switchAccountTypeData.date = Const.CURRENT_DATE
+	try {
+		await showProgressDialog("pleaseWait_msg", tryDowngradePremiumToFree(switchAccountTypeData, currentSubscriptionInfo))
+	} finally {
+		dialog.close()
+	}
 }
 
 function getUpOrDowngradeMessage(targetSubscription: SubscriptionType, currentSubscriptionInfo: CurrentSubscriptionInfo): string {
@@ -250,91 +252,62 @@ function getUpOrDowngradeMessage(targetSubscription: SubscriptionType, currentSu
 	return msg
 }
 
-function switchSubscription(targetSubscription: SubscriptionType, dialog: Dialog, currentSubscriptionInfo: CurrentSubscriptionInfo) {
+async function checkNeededUpgrades(targetSubscription: SubscriptionType, currentSubscriptionInfo: CurrentSubscriptionInfo): Promise<void> {
+	if (isUpgradeAliasesNeeded(targetSubscription, currentSubscriptionInfo.currentTotalAliases)) {
+		await buyAliases(subscriptions[targetSubscription].orderNbrOfAliases)
+	}
+	if (isUpgradeStorageNeeded(targetSubscription, currentSubscriptionInfo.currentTotalStorage)) {
+		await buyStorage(subscriptions[targetSubscription].orderStorageGb)
+	}
+	if (isUpgradeSharingNeeded(targetSubscription, currentSubscriptionInfo.currentlySharingOrdered)) {
+		await buySharing(true)
+	}
+	if (isUpgradeBusinessNeeded(targetSubscription, currentSubscriptionInfo.currentlyBusinessOrdered)) {
+		await buyBusiness(true)
+	}
+	if (isUpgradeWhitelabelNeeded(targetSubscription, currentSubscriptionInfo.currentlyWhitelabelOrdered)) {
+		await buyWhitelabel(true)
+	}
+	if (isDowngrade(targetSubscription, currentSubscriptionInfo.subscriptionType)) {
+		await cancelAllAdditionalFeatures(targetSubscription, currentSubscriptionInfo)
+	}
+}
+
+async function switchSubscription(targetSubscription: SubscriptionType, dialog: Dialog, currentSubscriptionInfo: CurrentSubscriptionInfo) {
 	if (targetSubscription === currentSubscriptionInfo.subscriptionType) {
 		return
 	}
 
-	Dialog.confirm(() => getUpOrDowngradeMessage(targetSubscription, currentSubscriptionInfo)).then(ok => {
-		if (!ok) {
-			return
-		}
-
-		return showProgressDialog(
-			"pleaseWait_msg",
-			Promise.resolve()
-				   .then(() => {
-					   if (isUpgradeAliasesNeeded(targetSubscription, currentSubscriptionInfo.currentTotalAliases)) {
-						   return buyAliases(subscriptions[targetSubscription].orderNbrOfAliases)
-					   }
-				   })
-				   .then(() => {
-					   if (isUpgradeStorageNeeded(targetSubscription, currentSubscriptionInfo.currentTotalStorage)) {
-						   return buyStorage(subscriptions[targetSubscription].orderStorageGb)
-					   }
-				   })
-				   .then(() => {
-					   if (isUpgradeSharingNeeded(targetSubscription, currentSubscriptionInfo.currentlySharingOrdered)) {
-						   return buySharing(true)
-					   }
-				   })
-				   .then(() => {
-					   if (isUpgradeBusinessNeeded(targetSubscription, currentSubscriptionInfo.currentlyBusinessOrdered)) {
-						   return buyBusiness(true)
-					   }
-				   })
-				   .then(() => {
-					   if (isUpgradeWhitelabelNeeded(targetSubscription, currentSubscriptionInfo.currentlyWhitelabelOrdered)) {
-						   return buyWhitelabel(true)
-					   }
-				   })
-				   .then(() => {
-					   if (isDowngrade(targetSubscription, currentSubscriptionInfo.subscriptionType)) {
-						   return cancelAllAdditionalFeatures(targetSubscription, currentSubscriptionInfo)
-					   }
-				   }),
-		).then(() => dialog.close())
-	})
+	const ok = await Dialog.confirm(() => getUpOrDowngradeMessage(targetSubscription, currentSubscriptionInfo))
+	if (!ok) {
+		return
+	}
+	try {
+		await showProgressDialog("pleaseWait_msg", checkNeededUpgrades(targetSubscription, currentSubscriptionInfo))
+	} finally {
+		dialog.close()
+	}
 }
 
 /**
  * @returns True if any of the additional features could not be canceled, false otherwise
  */
-function cancelAllAdditionalFeatures(targetSubscription: SubscriptionType, currentSubscriptionInfo: CurrentSubscriptionInfo): Promise<boolean> {
-	return Promise.resolve()
-				  .then(() => {
-					  if (isDowngradeAliasesNeeded(targetSubscription, currentSubscriptionInfo.currentTotalAliases, currentSubscriptionInfo.includedAliases)) {
-						  return buyAliases(subscriptions[targetSubscription].orderNbrOfAliases)
-					  } else {
-						  return false
-					  }
-				  })
-				  .then(previousFailed => {
-					  if (isDowngradeStorageNeeded(targetSubscription, currentSubscriptionInfo.currentTotalStorage, currentSubscriptionInfo.includedStorage)) {
-						  return buyStorage(subscriptions[targetSubscription].orderStorageGb).then(thisFailed => thisFailed || previousFailed)
-					  } else {
-						  return previousFailed
-					  }
-				  })
-				  .then(previousFailed => {
-					  if (isDowngradeSharingNeeded(targetSubscription, currentSubscriptionInfo.currentlySharingOrdered)) {
-						  return buySharing(false).then(thisFailed => thisFailed || previousFailed)
-					  } else {
-						  return previousFailed
-					  }
-				  })
-				  .then(previousFailed => {
-					  if (isDowngradeBusinessNeeded(targetSubscription, currentSubscriptionInfo.currentlyBusinessOrdered)) {
-						  return buyBusiness(false).then(thisFailed => thisFailed || previousFailed)
-					  } else {
-						  return previousFailed
-					  }
-				  })
-				  .then(previousFailed => {
-					  if (isDowngradeWhitelabelNeeded(targetSubscription, currentSubscriptionInfo.currentlyWhitelabelOrdered)) {
-						  return buyWhitelabel(false).then(thisFailed => thisFailed || previousFailed)
-					  } else {
-						  return previousFailed
-					  }
-				  })
+async function cancelAllAdditionalFeatures(targetSubscription: SubscriptionType, currentSubscriptionInfo: CurrentSubscriptionInfo): Promise<boolean> {
+	let failed = false
+	if (isDowngradeAliasesNeeded(targetSubscription, currentSubscriptionInfo.currentTotalAliases, currentSubscriptionInfo.includedAliases)) {
+		failed = await buyAliases(subscriptions[targetSubscription].orderNbrOfAliases)
+	}
+	if (isDowngradeStorageNeeded(targetSubscription, currentSubscriptionInfo.currentTotalStorage, currentSubscriptionInfo.includedStorage)) {
+		failed = failed || await buyStorage(subscriptions[targetSubscription].orderStorageGb)
+	}
+	if (isDowngradeSharingNeeded(targetSubscription, currentSubscriptionInfo.currentlySharingOrdered)) {
+		failed = failed || await buySharing(false)
+	}
+	if (isDowngradeBusinessNeeded(targetSubscription, currentSubscriptionInfo.currentlyBusinessOrdered)) {
+		failed = failed || await buyBusiness(false)
+	}
+	if (isDowngradeWhitelabelNeeded(targetSubscription, currentSubscriptionInfo.currentlyWhitelabelOrdered)) {
+		failed = failed || await buyWhitelabel(false)
+	}
+	return failed
 }


### PR DESCRIPTION
if a previously premium user downgrades, they will still keep their time
range as they had configured it. This is being handled in
`clearExcludedData` but in the settings
it was still showing what was stored in localStorage.

fix https://github.com/tutao/tutanota/issues/4159

also improve readability of SwitchSubscriptionDialog