### PR TITLE
Fix logging in after upgrading from 3.96.3, fix websocket

### DIFF
--- a/src/api/worker/facades/LoginFacade.ts
+++ b/src/api/worker/facades/LoginFacade.ts
@@ -560,8 +560,7 @@ export class LoginFacadeImpl implements LoginFacade {
 	): Promise<{user: User, accessToken: string, userGroupInfo: GroupInfo}> {
 		// We might have userId already if:
 		// - session has expired and a new one was created
-		// - if it's an async login
-		// - if we failed an async login
+		// - if it's a partial login
 		const userIdFromFormerLogin = this.userFacade.getUser()?._id ?? null
 
 		if (userIdFromFormerLogin && userId !== userIdFromFormerLogin) {

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -425,11 +425,6 @@ o.spec("LoginFacadeTest", function () {
 
 				fullLoginDeferred = defer()
 				when(loginListener.onFullLoginSuccess()).thenDo(() => fullLoginDeferred.resolve())
-				let fullyLoggedIn = false
-				when(userFacade.unlockUserGroupKey(anything())).thenDo(() => {
-					fullyLoggedIn = true
-				})
-				when(userFacade.isFullyLoggedIn()).thenDo(() => fullyLoggedIn)
 			})
 
 			o("When successfully logged in, userFacade is initialised", async function () {
@@ -451,6 +446,7 @@ o.spec("LoginFacadeTest", function () {
 				const groupInfo = createGroupInfo()
 				when(entityClientMock.load(GroupInfoTypeRef, user.userGroup.groupInfo)).thenResolve(groupInfo)
 				const connectionError = new ConnectionError("test")
+				when(userFacade.isFullyLoggedIn()).thenReturn(false)
 
 				when(restClientMock.request(matchers.contains("sys/session"), HttpMethod.GET, anything()))
 					// @ts-ignore


### PR DESCRIPTION
The problem occurred because before offline login we didn't use the
cache for the login process so user's GroupInfo was likely not cached as
it is not downloaded that often after login.

Now there's a temporary workaround that just falls back to the sync
login.

Also, after e3fc4135be9e8b855fb876ccb88476f39b2f04f6 websocket would not
connect in async login because it would think that there's already
previous login (because of the partial login), so it would try to
reconnect instead which didn't work because we started in the
terminated state.

Now it checks for full login and always uses connect().

fix #4150