### PR TITLE
only show first part of offline indicator for mobile layouts

### DIFF
--- a/src/gui/base/OfflineIndicator.ts
+++ b/src/gui/base/OfflineIndicator.ts
@@ -103,10 +103,6 @@ export class OfflineIndicatorMobile implements Component<OfflineIndicatorAttrs> 
 			tabindex: "0",
 			role: "button",
 			onclick: a.state === OfflineIndicatorState.Offline ? a.reconnectAction : noOp
-		}, [
-			attrToFirstLine(a),
-			secondLine && m("span.mlr-s", "—"),
-			secondLine
-		])
+		}, attrToFirstLine(a))
 	}
 }


### PR DESCRIPTION
with the second part, it was too wide for some languages.

the states are still distinguishable:
online - just "online"
offline - "offline" with reconnect button
syncing - "online" with loading bar
reconnecting - "offline" without reconnect button

fix #4148