### PR TITLE
[build] add VERSION env var to Webapp.Jenkinsfile

### DIFF
--- a/Webapp.Jenkinsfile
+++ b/Webapp.Jenkinsfile
@@ -1,6 +1,7 @@
 pipeline {
     environment {
          PATH="/opt/node-v16.3.0-linux-x64/bin:${env.PATH}"
+         VERSION = sh(returnStdout: true, script: "${NODE_PATH}/node -p -e \"require('./package.json').version\" | tr -d \"\n\"")
     }
 	options {
 		preserveStashes()


### PR DESCRIPTION
the missing line caused the step of pushing release notes in the Publish stage to fail
with `No such property: VERSION for class: groovy.lang.Binding`