### PR TITLE
hide offline indicator on mobile if there is an injected view

### DIFF
--- a/src/gui/Header.ts
+++ b/src/gui/Header.ts
@@ -79,7 +79,7 @@ export class Header implements Component {
 						this.renderCenterContent(),
 						this.renderRightContent()
 					],
-				styles.isUsingBottomNavigation() && logins.isAtLeastPartiallyLoggedIn() && !this.mobileSearchBarVisible()
+				styles.isUsingBottomNavigation() && logins.isAtLeastPartiallyLoggedIn() && !this.mobileSearchBarVisible() && !injectedView
 					? m(OfflineIndicatorMobile, this.offlineIndicatorModel.getCurrentAttrs())
 					: null
 			],


### PR DESCRIPTION
these are arbitrary and can't be relied upon to leave enough space.

fix #4178