### PR TITLE
Fix making service requests w/o auth but w/ sessionKey

### DIFF
--- a/src/api/worker/rest/EntityRestClient.ts
+++ b/src/api/worker/rest/EntityRestClient.ts
@@ -345,7 +345,7 @@ export class EntityRestClient implements EntityRestInterface {
 
 		if (!this.authDataProvider.isFullyLoggedIn() && typeModel.encrypted) {
 			// Short-circuit before we do an actual request which we can't decrypt
-			throw new LoginIncompleteError("Trying to do a network request with encrypted entity but is not fully logged in yet")
+			throw new LoginIncompleteError(`Trying to do a network request with encrypted entity but is not fully logged in yet, type: ${typeModel.name}`)
 		}
 
 		let path = typeRefToPath(typeRef)

--- a/src/api/worker/rest/ServiceExecutor.ts
+++ b/src/api/worker/rest/ServiceExecutor.ts
@@ -72,9 +72,15 @@ export class ServiceExecutor implements IServiceExecutor {
 		params: ExtraServiceParams | undefined,
 	): Promise<any> {
 		const methodDefinition = this.getMethodDefinition(service, method)
-		if (methodDefinition.return && (await resolveTypeReference(methodDefinition.return)).encrypted && !this.authDataProvider.isFullyLoggedIn()) {
+		if (methodDefinition.return &&
+			params?.sessionKey == null &&
+			(await resolveTypeReference(methodDefinition.return)).encrypted &&
+			!this.authDataProvider.isFullyLoggedIn()
+		) {
 			// Short-circuit before we do an actual request which we can't decrypt
-			throw new LoginIncompleteError("Tried to make service request with encrypted return type but is not fully logged in yet")
+			// If we have a session key passed it doesn't mean that it is for the return type but it is likely
+			// so we allow the request.
+			throw new LoginIncompleteError(`Tried to make service request with encrypted return type but is not fully logged in yet, service: ${service.name}`)
 		}
 
 		const modelVersion = await this.getModelVersion(methodDefinition)

--- a/test/tests/api/worker/rest/ServiceExecutorTest.ts
+++ b/test/tests/api/worker/rest/ServiceExecutorTest.ts
@@ -153,6 +153,32 @@ o.spec("ServiceExecutor", function () {
 			assertThatNoRequestsWereMade()
 		})
 
+		o("when get returns encrypted data and we are not logged in but we have a session key it returns decrypted data", async function () {
+			const getService: GetService = {
+				...service,
+				get: {
+					data: null,
+					return: AlarmServicePostTypeRef,
+				},
+			}
+			const sessionKey = [1, 2, 3]
+			fullyLoggedIn = false
+			const returnData = createSaltData({mailAddress: "test"})
+			const literal = {literal: true}
+			const saltTypeModel = await resolveTypeReference(AlarmServicePostTypeRef)
+			when(instanceMapper.decryptAndMapToInstance(saltTypeModel, literal, sessionKey))
+				.thenResolve(returnData)
+
+			respondWith(`{"literal":true}`)
+
+			const response = await executor.get(getService, null, {sessionKey})
+
+			o(response).equals(returnData)
+			verify(
+				restClient.request("/rest/testapp/testservice", HttpMethod.GET, matchers.argThat((p) => p.responseType === MediaType.Json))
+			)
+		})
+
 		o("when get returns unencrypted data and we are not logged in it does not throw an error", async function () {
 			const getService: GetService = {
 				...service,
@@ -242,6 +268,32 @@ o.spec("ServiceExecutor", function () {
 			fullyLoggedIn = false
 			await assertThrows(LoginIncompleteError, () => executor.post(postService, null))
 			assertThatNoRequestsWereMade()
+		})
+
+		o("when post returns encrypted data and we are not logged in but we have a session key it returns decrypted data", async function () {
+			const getService: PostService = {
+				...service,
+				post: {
+					data: null,
+					return: AlarmServicePostTypeRef,
+				},
+			}
+			const sessionKey = [1, 2, 3]
+			fullyLoggedIn = false
+			const returnData = createSaltData({mailAddress: "test"})
+			const literal = {literal: true}
+			const saltTypeModel = await resolveTypeReference(AlarmServicePostTypeRef)
+			when(instanceMapper.decryptAndMapToInstance(saltTypeModel, literal, sessionKey))
+				.thenResolve(returnData)
+
+			respondWith(`{"literal":true}`)
+
+			const response = await executor.post(getService, null, {sessionKey})
+
+			o(response).equals(returnData)
+			verify(
+				restClient.request("/rest/testapp/testservice", HttpMethod.POST, matchers.argThat((p) => p.responseType === MediaType.Json))
+			)
 		})
 	})
 


### PR DESCRIPTION
With offline login handling we've added a check that to get a encrypted
instance or a service response we must be logged in. It normally makes
sense but we missed the case where we pass session key manually. One
of such cases is getting giftCard information where key is encoded in
the hash part of the URL.

Now we've made an exception where we will allow making the request when
sessionKey is passed manually. This might still fail if we are not
logged in (where we want to use sessionKey to encrypt the request and
not to decrypt the response) but these cases are very rare. Better
solution would probably be to refactor the code to explicitly pass the
key for request or response (two separate fields in params) and do not
event attempt to resolve the key if that doesn't work. This would also
make CryptoFacade simpler as it would always expect to have a full
login.

 fix #4194