### PR TITLE
Fix handling for expired sessions

### DIFF
--- a/src/misc/ErrorHandlerImpl.ts
+++ b/src/misc/ErrorHandlerImpl.ts
@@ -192,7 +192,9 @@ export async function reloginForExpiredSession() {
 				// Fetch old credentials to preserve database key if it's there
 				const oldCredentials = await locator.credentialsProvider.getCredentialsByUserId(userId)
 				await locator.credentialsProvider.deleteByUserId(userId, {deleteOfflineDb: false})
-				await locator.credentialsProvider.store({credentials: credentials, databaseKey: oldCredentials?.databaseKey})
+				if (sessionType === SessionType.Persistent) {
+					await locator.credentialsProvider.store({credentials: credentials, databaseKey: oldCredentials?.databaseKey})
+				}
 				loginDialogActive = false
 				dialog.close()
 				return ""


### PR DESCRIPTION
With offline login we've added handling for closed session after going
online. The code path is the same as for expired sessions. For offline
we've added code which re-saves the credentials after new session is
created. This shouldn't happen for ephemeral sessions (when they expire)
because we don't store them but this check was missing.

fix #4193