### PR TITLE
make all calendars available offline

### DIFF
--- a/packages/tutanota-utils/lib/TypeRef.ts
+++ b/packages/tutanota-utils/lib/TypeRef.ts
@@ -1,4 +1,6 @@
-// T should be restricted to Entity
+/**
+ * T should be restricted to Entity.
+ */
 export class TypeRef<T> {
 	readonly app: string
 	readonly type: string
@@ -15,19 +17,24 @@ export class TypeRef<T> {
 		Object.freeze(this)
 	}
 
+	/**
+	 * breaks when the object passes worker barrier
+	 */
 	toString(): string {
 		return `[TypeRef ${this.app} ${this.type}]`
 	}
 
-	getId(): string {
-		return this.app + "/" + this.type
-	}
+
 }
 
-export function isSameTypeRefByAttr(typeRef: TypeRef<any>, app: string, type: string): boolean {
+export function getTypeId(typeRef: TypeRef<unknown>) {
+	return typeRef.app + "/" + typeRef.type
+}
+
+export function isSameTypeRefByAttr(typeRef: TypeRef<unknown>, app: string, type: string): boolean {
 	return typeRef.app === app && typeRef.type === type
 }
 
-export function isSameTypeRef(typeRef1: TypeRef<any>, typeRef2: TypeRef<any>): boolean {
+export function isSameTypeRef(typeRef1: TypeRef<unknown>, typeRef2: TypeRef<unknown>): boolean {
 	return isSameTypeRefByAttr(typeRef1, typeRef2.app, typeRef2.type)
 }

--- a/packages/tutanota-utils/lib/index.ts
+++ b/packages/tutanota-utils/lib/index.ts
@@ -115,7 +115,7 @@ export {
 	byteLength,
 	replaceAll,
 } from "./StringUtils.js"
-export {TypeRef, isSameTypeRefByAttr, isSameTypeRef} from "./TypeRef.js"
+export {TypeRef, isSameTypeRefByAttr, isSameTypeRef, getTypeId} from "./TypeRef.js"
 export {
 	defer,
 	deferWithHandler,

--- a/src/api/common/EntityClient.ts
+++ b/src/api/common/EntityClient.ts
@@ -1,10 +1,10 @@
 import type {EntityRestInterface} from "../worker/rest/EntityRestClient"
 import type {RootInstance} from "../entities/sys/TypeRefs.js"
 import {RootInstanceTypeRef} from "../entities/sys/TypeRefs.js"
-import {CUSTOM_MIN_ID, GENERATED_MIN_ID, getElementId, getLetId, RANGE_ITEM_LIMIT} from "./utils/EntityUtils"
+import {CUSTOM_MIN_ID, firstBiggerThanSecond, GENERATED_MIN_ID, getElementId, getLetId, RANGE_ITEM_LIMIT} from "./utils/EntityUtils"
 import {Type, ValueType} from "./EntityConstants"
 import {last, TypeRef} from "@tutao/tutanota-utils"
-import {getFirstIdIsBiggerFnForType, resolveTypeReference} from "./EntityFunctions"
+import { resolveTypeReference} from "./EntityFunctions"
 import type {ElementEntity, ListElementEntity, SomeEntity} from "./EntityTypes"
 import {downcast} from "@tutao/tutanota-utils";
 
@@ -50,8 +50,7 @@ export class EntityClient {
 		const typeModel = await resolveTypeReference(typeRef)
 		if (typeModel.type !== Type.ListElement) throw new Error("only ListElement types are permitted")
 		const loadedEntities = await this._target.loadRange<T>(typeRef, listId, start, rangeItemLimit, true)
-		const comparator = getFirstIdIsBiggerFnForType(typeModel)
-		const filteredEntities = loadedEntities.filter(entity => comparator(getElementId(entity), end))
+		const filteredEntities = loadedEntities.filter(entity => firstBiggerThanSecond(getElementId(entity), end, typeModel))
 
 		if (filteredEntities.length === rangeItemLimit) {
 			const lastElementId = getElementId(filteredEntities[loadedEntities.length - 1])

--- a/src/api/common/EntityFunctions.ts
+++ b/src/api/common/EntityFunctions.ts
@@ -1,6 +1,5 @@
-import {Type, ValueType} from "./EntityConstants"
+import {Type} from "./EntityConstants"
 import {TypeRef} from "@tutao/tutanota-utils"
-import {customIdToString, firstBiggerThanSecond} from "./utils/EntityUtils"
 import type {TypeModel} from "./EntityTypes"
 import {typeModels as baseTypeModels} from "../entities/base/TypeModels.js"
 import {typeModels as sysTypeModels} from "../entities/sys/TypeModels.js"
@@ -65,24 +64,6 @@ export async function resolveTypeReference(typeRef: TypeRef<any>): Promise<TypeM
 		throw new Error("Cannot find TypeRef: " + JSON.stringify(typeRef))
 	} else {
 		return typeModel
-	}
-}
-
-/**
- * Return appropriate id sorting function for typeModel.
- *
- * For generated IDs we use base64ext which is sortable. For custom IDs we use base64url which is not sortable.
- *
- * Important: works only with custom IDs which are derived from strings.
- *
- * @param typeModel
- * @return {(function(string, string): boolean)}
- */
-export function getFirstIdIsBiggerFnForType(typeModel: TypeModel): (arg0: Id, arg1: Id) => boolean {
-	if (typeModel.values["_id"].type === ValueType.CustomId) {
-		return (left, right) => firstBiggerThanSecond(customIdToString(left), customIdToString(right))
-	} else {
-		return firstBiggerThanSecond
 	}
 }
 

--- a/src/api/common/utils/CommonCalendarUtils.ts
+++ b/src/api/common/utils/CommonCalendarUtils.ts
@@ -65,10 +65,11 @@ export function generateEventElementId(timestamp: number): string {
  * * The actual range of times supported by ECMAScript Date objects is slightly smaller: a range of +-8,640,000,000,000,000 milliseconds
  * -> this makes the element Id a string of between 1 and 17 number characters (the shiftDays are negligible)
  *
+ * exported for testing
  * @param timestamp
  * @param shiftDays
  */
-function createEventElementId(timestamp: number, shiftDays: number): string {
+export function createEventElementId(timestamp: number, shiftDays: number): string {
 	return stringToCustomId(String(timestamp + shiftDays))
 }
 

--- a/src/api/common/utils/CommonCalendarUtils.ts
+++ b/src/api/common/utils/CommonCalendarUtils.ts
@@ -2,12 +2,21 @@ import {DAY_IN_MILLIS} from "@tutao/tutanota-utils"
 import type {CalendarEvent} from "../../entities/tutanota/TypeRefs.js"
 import {stringToCustomId} from "./EntityUtils"
 
+/**
+ * the time in ms that element ids for calendar events and alarms  get randomized by
+ */
 export const DAYS_SHIFTED_MS = 15 * DAY_IN_MILLIS
 
+/*
+ * convenience wrapper for isAllDayEventByTimes
+ */
 export function isAllDayEvent({startTime, endTime}: CalendarEvent): boolean {
 	return isAllDayEventByTimes(startTime, endTime)
 }
 
+/**
+ * determine if an event with the given start and end times would be an all-day event
+ */
 export function isAllDayEventByTimes(startTime: Date, endTime: Date): boolean {
 	return (
 		startTime.getUTCHours() === 0 &&
@@ -35,19 +44,48 @@ export function getAllDayDateLocal(utcDate: Date): Date {
 	return new Date(utcDate.getUTCFullYear(), utcDate.getUTCMonth(), utcDate.getUTCDate())
 }
 
+
+/**
+ * generate a semi-randomized element id for a calendar event or an alarm
+ * @param timestamp the start time of the event or the creation time of the alarm
+ */
 export function generateEventElementId(timestamp: number): string {
+	// the id is based on either the event start time or the alarm creation time
+	// we add a random shift between -DAYS_SHIFTED_MS and +DAYS_SHIFTED_MS to the event
+	// id to prevent the server from knowing the exact time but still being able to
+	// approximately sort them.
 	const randomDay = Math.floor(Math.random() * DAYS_SHIFTED_MS) * 2
 	return createEventElementId(timestamp, randomDay - DAYS_SHIFTED_MS)
 }
 
+
+/**
+ * https://262.ecma-international.org/5.1/#sec-15.9.1.1
+ * * ECMAScript Number values can represent all integers from –9,007,199,254,740,992 to 9,007,199,254,740,992
+ * * The actual range of times supported by ECMAScript Date objects is slightly smaller: a range of +-8,640,000,000,000,000 milliseconds
+ * -> this makes the element Id a string of between 1 and 17 number characters (the shiftDays are negligible)
+ *
+ * @param timestamp
+ * @param shiftDays
+ */
 function createEventElementId(timestamp: number, shiftDays: number): string {
 	return stringToCustomId(String(timestamp + shiftDays))
 }
 
+/**
+ * the maximum id an event with a given start time could have based on its
+ * randomization.
+ * @param timestamp
+ */
 export function geEventElementMaxId(timestamp: number): string {
 	return createEventElementId(timestamp, DAYS_SHIFTED_MS)
 }
 
+/**
+ * the minimum an event with a given start time could have based on its
+ * randomization.
+ * @param timestamp
+ */
 export function getEventElementMinId(timestamp: number): string {
 	return createEventElementId(timestamp, -DAYS_SHIFTED_MS)
 }

--- a/src/api/common/utils/CommonCalendarUtils.ts
+++ b/src/api/common/utils/CommonCalendarUtils.ts
@@ -51,26 +51,3 @@ export function geEventElementMaxId(timestamp: number): string {
 export function getEventElementMinId(timestamp: number): string {
 	return createEventElementId(timestamp, -DAYS_SHIFTED_MS)
 }
-
-export function eventsAtTheSameTime(firstEvent: CalendarEvent, secondEvent: CalendarEvent): boolean {
-	if (firstEvent.startTime !== secondEvent.startTime) {
-		return false
-	}
-
-	const firstRule = firstEvent.repeatRule
-	const secondRule = secondEvent.repeatRule
-
-	if (firstRule && secondRule) {
-		return (
-			firstRule.frequency === secondRule.frequency &&
-			firstRule.interval === secondRule.interval &&
-			firstRule.endType === secondRule.endType &&
-			firstRule.endValue === secondRule.endValue &&
-			firstRule.timeZone === secondRule.timeZone
-		)
-	} else if (!firstRule && !secondRule) {
-		return true
-	} else {
-		return false
-	}
-}

--- a/src/api/common/utils/EntityUtils.ts
+++ b/src/api/common/utils/EntityUtils.ts
@@ -39,6 +39,15 @@ export const GENERATED_ID_BYTES_LENGTH = 9
  * The minimum ID for elements with custom id stored on the server
  */
 export const CUSTOM_MIN_ID = ""
+/**
+ * the maximum custom element id is enforced to be less than 256 bytes on the server. decoding this as b64url gives 255 bytes.
+ *
+ * NOTE: this is currently only used as a marker value when caching calendar events.
+ */
+export const CUSTOM_MAX_ID =
+	"_______________________________________________________________________________________________________________________________________________________" +
+	"_______________________________________________________________________________________________________________________________________________________" +
+	"______________________________________"
 export const RANGE_ITEM_LIMIT = 1000
 export const LOAD_MULTIPLE_LIMIT = 100
 export const POST_MULTIPLE_LIMIT = 100

--- a/src/api/common/utils/EntityUtils.ts
+++ b/src/api/common/utils/EntityUtils.ts
@@ -45,18 +45,28 @@ export const POST_MULTIPLE_LIMIT = 100
 
 /**
  * Tests if one id is bigger than another.
+ * For generated IDs we use base64ext which is sortable.
+ * For custom IDs we use base64url which is not sortable, so we convert them to string before comparing.
+ * Important: using this for custom IDs works only with custom IDs which are derived from strings.
+ *
  * @param firstId The element id that is tested if it is bigger.
  * @param secondId The element id that is tested against.
+ * @param typeModel optional - the type the Ids belong to. this can be used to compare custom IDs.
  * @return True if firstId is bigger than secondId, false otherwise.
  */
-export function firstBiggerThanSecond(firstId: Id, secondId: Id): boolean {
-	// if the number of digits is bigger, then the id is bigger, otherwise we can use the lexicographical comparison
-	if (firstId.length > secondId.length) {
-		return true
-	} else if (secondId.length > firstId.length) {
-		return false
+export function firstBiggerThanSecond(firstId: Id, secondId: Id, typeModel?: TypeModel): boolean {
+
+	if (typeModel?.values._id.type === ValueType.CustomId) {
+		return firstBiggerThanSecond(customIdToString(firstId), customIdToString(secondId))
 	} else {
-		return firstId > secondId
+		// if the number of digits is bigger, then the id is bigger, otherwise we can use the lexicographical comparison
+		if (firstId.length > secondId.length) {
+			return true
+		} else if (secondId.length > firstId.length) {
+			return false
+		} else {
+			return firstId > secondId
+		}
 	}
 }
 

--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -300,7 +300,7 @@ export class OfflineStorage implements CacheStorage, ExposedCacheStorage {
 		return this.deserializeList(typeRef, await this.offlineDbFacade.getListElementsOfType(this.userId, getTypeId(typeRef)))
 	}
 
-	private async getWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<T>> {
+	async getWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<T>> {
 		return this.deserializeList(typeRef, await this.offlineDbFacade.getWholeList(this.userId, getTypeId(typeRef), listId))
 	}
 

--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -199,7 +199,7 @@ export class OfflineStorage implements CacheStorage, ExposedCacheStorage {
 		// Free users always have default time range regardless of what is stored
 		const isFreeUser = user?.accountType === AccountType.FREE
 		const timeRange = isFreeUser || timeRangeDays == null ? OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS : timeRangeDays
-		const cutoffTimestamp =  this.dateProvider.now() - timeRange * DAY_IN_MILLIS
+		const cutoffTimestamp = this.dateProvider.now() - timeRange * DAY_IN_MILLIS
 		const cutoffId = timestampToGeneratedId(cutoffTimestamp)
 
 		const folders = await this.getListElementsOfType(MailFolderTypeRef)

--- a/src/api/worker/rest/CacheStorageProxy.ts
+++ b/src/api/worker/rest/CacheStorageProxy.ts
@@ -121,6 +121,10 @@ export class LateInitializedCacheStorageImpl implements LateInitializedCacheStor
 		return this.inner.provideFromRange(typeRef, listId, start, count, reverse)
 	}
 
+	getWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<T>> {
+		return this.inner.getWholeList(typeRef, listId)
+	}
+
 	purgeStorage(): Promise<void> {
 		return this.inner.purgeStorage()
 	}

--- a/src/api/worker/rest/EntityRestCache.ts
+++ b/src/api/worker/rest/EntityRestCache.ts
@@ -99,6 +99,13 @@ export interface ExposedCacheStorage {
 	 */
 	provideFromRange<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, start: Id, count: number, reverse: boolean): Promise<T[]>;
 
+	/**
+	 * retrieve all list elements that are in the cache
+	 * @param typeRef
+	 * @param listId
+	 */
+	getWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<T>>
+
 	getLastUpdateTime(): Promise<number | null>
 }
 

--- a/src/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/api/worker/rest/EphemeralCacheStorage.ts
@@ -209,4 +209,14 @@ export class EphemeralCacheStorage implements CacheStorage {
 	async putLastUpdateTime(value: number): Promise<void> {
 		this.lastUpdateTime = value
 	}
+
+	async getWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<T>> {
+		const listCache = this.lists.get(typeRefToPath(typeRef))?.get(listId)
+
+		if (listCache == null) {
+			return []
+		}
+
+		return listCache.allRange.map(id => clone((listCache.elements.get(id) as T)))
+	}
 }

--- a/src/api/worker/search/MailIndexer.ts
+++ b/src/api/worker/search/MailIndexer.ts
@@ -34,6 +34,7 @@ import type {SomeEntity} from "../../common/EntityTypes"
 import {EntityUpdateData} from "../../main/EventController";
 import {EphemeralCacheStorage} from "../rest/EphemeralCacheStorage";
 import {IndexingErrorReason} from "./SearchTypes"
+import {CustomCacheHandlerMap} from "../rest/CustomCacheHandler.js"
 
 export const INITIAL_MAIL_INDEX_INTERVAL_DAYS = 28
 const ENTITY_INDEXER_CHUNK = 20
@@ -688,7 +689,7 @@ class IndexLoader {
 			this.entityCache = cachingEntityClient
 			this._entity = new EntityClient(cachingEntityClient)
 		} else {
-			cachingEntityClient = new EntityRestCache(restClient, new EphemeralCacheStorage())
+			cachingEntityClient = new EntityRestCache(restClient, new EphemeralCacheStorage(), new CustomCacheHandlerMap())
 			this._entity = new EntityClient(restClient)
 		}
 		this.entityCache = cachingEntityClient

--- a/src/app.ts
+++ b/src/app.ts
@@ -202,7 +202,11 @@ import("./translations/en")
 		}
 
 		const {PostLoginActions} = await import("./login/PostLoginActions")
+		const {CachePostLoginAction} = await import("./offline/CachePostLoginAction")
 		logins.addPostLoginAction(new PostLoginActions(locator.credentialsProvider, locator.secondFactorHandler))
+		logins.addPostLoginAction(new CachePostLoginAction(
+			locator.calendarModel, locator.entityClient, locator.progressTracker, logins, isDesktop() ? locator.systemApp : null
+		))
 
 		styles.init()
 		const {usingKeychainAuthentication} = await import("./misc/credentials/CredentialsProviderFactory")

--- a/src/calendar/date/CalendarUtils.ts
+++ b/src/calendar/date/CalendarUtils.ts
@@ -24,22 +24,18 @@ import {
 	WeekStart,
 } from "../../api/common/TutanotaConstants"
 import {DateTime, FixedOffsetZone, IANAZone} from "luxon"
-import type {CalendarRepeatRule} from "../../api/entities/tutanota/TypeRefs.js"
+import type {CalendarEvent, CalendarGroupRoot, CalendarRepeatRule, UserSettingsGroupRoot} from "../../api/entities/tutanota/TypeRefs.js"
 import {createCalendarRepeatRule} from "../../api/entities/tutanota/TypeRefs.js"
 import {DAYS_SHIFTED_MS, generateEventElementId, isAllDayEvent, isAllDayEventByTimes} from "../../api/common/utils/CommonCalendarUtils"
 import {lang} from "../../misc/LanguageViewModel"
 import {formatDateTime, formatDateWithMonth, formatTime, timeStringFromParts} from "../../misc/Formatter"
 import {size} from "../../gui/size"
-import type {CalendarEvent} from "../../api/entities/tutanota/TypeRefs.js"
-import type {CalendarGroupRoot} from "../../api/entities/tutanota/TypeRefs.js"
-import type {User} from "../../api/entities/sys/TypeRefs.js"
+import type {RepeatRule, User} from "../../api/entities/sys/TypeRefs.js"
 import {isColorLight} from "../../gui/base/Color"
 import type {GroupColors} from "../view/CalendarView"
 import {isSameId} from "../../api/common/utils/EntityUtils"
-import type {UserSettingsGroupRoot} from "../../api/entities/tutanota/TypeRefs.js"
 import type {Time} from "../../api/common/utils/Time"
 import type {SelectorItemList} from "../../gui/base/DropDownSelectorN"
-import type {RepeatRule} from "../../api/entities/sys/TypeRefs.js"
 import type {CalendarInfo} from "../model/CalendarModel"
 import {assertMainOrNode} from "../../api/common/Env"
 import {ChildArray, Children} from "mithril";
@@ -289,6 +285,7 @@ export function getValidTimeZone(zone: string, fallback?: string): string {
 export function getTimeZone(): string {
 	return DateTime.local().zoneName
 }
+
 export class DateProviderImpl implements DateProvider {
 	now(): number {
 		return Date.now()
@@ -529,6 +526,9 @@ export function getAllDayDateUTCFromZone(date: Date, timeZone: string): Date {
 }
 
 export function isLongEvent(event: CalendarEvent, zone: string): boolean {
+	// long events are longer than the event ID randomization range. we need to distinguish them
+	// to be able to still load and display the ones overlapping the query range even though their
+	// id might not be contained in the query timerange +- randomization range
 	return getEventEnd(event, zone).getTime() - getEventStart(event, zone).getTime() > DAYS_SHIFTED_MS
 }
 

--- a/src/offline/CachePostLoginAction.ts
+++ b/src/offline/CachePostLoginAction.ts
@@ -1,0 +1,44 @@
+import {IPostLoginAction, LoggedInEvent, LoginController} from "../api/main/LoginController.js"
+import {CalendarModel} from "../calendar/model/CalendarModel.js"
+import {CalendarEventTypeRef} from "../api/entities/tutanota/TypeRefs.js"
+import {CUSTOM_MIN_ID} from "../api/common/utils/EntityUtils.js"
+import {EntityClient} from "../api/common/EntityClient.js"
+import {DesktopConfigKey} from "../desktop/config/ConfigKeys.js"
+import {NativeSystemApp} from "../native/common/NativeSystemApp.js"
+import {ProgressTracker} from "../api/main/ProgressTracker.js"
+
+
+export class CachePostLoginAction implements IPostLoginAction {
+
+	constructor(
+		private readonly calendarModel: CalendarModel,
+		private readonly entityClient: EntityClient,
+		private readonly progressTracker: ProgressTracker,
+		private readonly logins: LoginController,
+		private readonly systemApp: NativeSystemApp | null
+	) {
+
+	}
+
+	async onFullLoginSuccess(loggedInEvent: LoggedInEvent): Promise<void> {
+		if (await this.systemApp?.getConfigValue(DesktopConfigKey.offlineStorageEnabled)) {
+			// 3 work to load calendar info, 2 work to load short and long events
+			const workPerCalendar = 3 + 2
+			const totalWork = this.logins.getUserController().getCalendarMemberships().length * workPerCalendar
+			const monitorHandle = this.progressTracker.registerMonitor(totalWork)
+			const progressMonitor = this.progressTracker.getMonitor(monitorHandle)
+			const calendarInfos = await this.calendarModel.loadCalendarInfos(progressMonitor!)
+			const loadingPromises = []
+			for (const {groupRoot} of calendarInfos.values()) {
+				loadingPromises.push(this.entityClient.loadAll(CalendarEventTypeRef, groupRoot.longEvents, CUSTOM_MIN_ID).then(() => progressMonitor?.workDone(1)))
+				loadingPromises.push(this.entityClient.loadAll(CalendarEventTypeRef, groupRoot.shortEvents, CUSTOM_MIN_ID).then(() => progressMonitor?.workDone(1)))
+			}
+			await Promise.all(loadingPromises)
+			progressMonitor?.completed()
+		}
+	}
+
+	async onPartialLoginSuccess(loggedInEvent: LoggedInEvent): Promise<void> {
+		return Promise.resolve()
+	}
+}

--- a/test/tests/Suite.ts
+++ b/test/tests/Suite.ts
@@ -95,6 +95,7 @@ import "./translations/TranslationKeysTest.js"
 import "./misc/UsageTestModelTest.js"
 import "./file/FileControllerTest.js"
 import "./api/worker/offline/OfflineStorageMigratorTest.js"
+import "./api/worker/rest/CustomCacheHandlerTest.js"
 
 import * as td from "testdouble"
 import {random} from "@tutao/tutanota-crypto"

--- a/test/tests/api/worker/offline/OfflineStorageTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageTest.ts
@@ -5,7 +5,7 @@ import {OfflineDbFacade, OfflineDbFactory} from "../../../../../src/desktop/db/O
 import {instance, matchers, object, when} from "testdouble"
 import * as cborg from "cborg"
 import {GENERATED_MIN_ID, generatedIdToTimestamp, getElementId, getListId, timestampToGeneratedId} from "../../../../../src/api/common/utils/EntityUtils.js"
-import {firstThrow, getDayShifted, lastThrow, promiseMap} from "@tutao/tutanota-utils"
+import {firstThrow, getDayShifted, lastThrow, promiseMap, getTypeId} from "@tutao/tutanota-utils"
 import {DateProvider} from "../../../../../src/api/common/DateProvider.js"
 import {
 	createFile,
@@ -88,9 +88,9 @@ o.spec("OfflineStorage", function () {
 
 		o.spec("Clearing excluded data", function () {
 			const listId = "listId"
-			const mailType = MailTypeRef.getId()
-			const mailFolderType = MailFolderTypeRef.getId()
-			const mailBodyType = MailBodyTypeRef.getId()
+			const mailType = getTypeId(MailTypeRef)
+			const mailFolderType = getTypeId(MailFolderTypeRef)
+			const mailBodyType = getTypeId(MailBodyTypeRef)
 
 			o("old ranges will be deleted", async function () {
 				const upper = offsetId(-1)
@@ -257,7 +257,7 @@ o.spec("OfflineStorage", function () {
 
 				await storage.init(userId, databaseKey, timeRangeDays)
 				verify(dbFacadeMock.deleteIn(userId, mailType, inboxMailList, [getElementId(mailBefore)]))
-				verify(dbFacadeMock.deleteIn(userId, FileTypeRef.getId(), fileListId, [getElementId(fileBefore)]))
+				verify(dbFacadeMock.deleteIn(userId, getTypeId(FileTypeRef), fileListId, [getElementId(fileBefore)]))
 			})
 
 		})

--- a/test/tests/api/worker/rest/CustomCacheHandlerTest.ts
+++ b/test/tests/api/worker/rest/CustomCacheHandlerTest.ts
@@ -1,0 +1,87 @@
+import o from "ospec"
+import {instance, matchers, verify, when} from "testdouble"
+import {CalendarEventTypeRef, createCalendarEvent} from "../../../../../src/api/entities/tutanota/TypeRefs.js"
+import {CustomCalendarEventCacheHandler} from "../../../../../src/api/worker/rest/CustomCacheHandler.js"
+import {createEventElementId} from "../../../../../src/api/common/utils/CommonCalendarUtils.js"
+import {EntityRestClient} from "../../../../../src/api/worker/rest/EntityRestClient.js"
+import {LateInitializedCacheStorageImpl} from "../../../../../src/api/worker/rest/CacheStorageProxy.js"
+import {CUSTOM_MAX_ID, CUSTOM_MIN_ID, LOAD_MULTIPLE_LIMIT} from "../../../../../src/api/common/utils/EntityUtils.js"
+import {numberRange} from "@tutao/tutanota-utils"
+
+
+o.spec("Custom calendar events handler", function () {
+	const entityRestClientMock = instance(EntityRestClient)
+	const cacheHandler = new CustomCalendarEventCacheHandler(entityRestClientMock)
+	const offlineStorageMock = instance(LateInitializedCacheStorageImpl)
+	const listId = "listId"
+	let timestamp = Date.now()
+	const ids = [0, 1, 2, 3, 4, 5, 6].map(n => createEventElementId(timestamp, n))
+	const allList = [0, 1, 2, 3, 4, 5, 6].map(n => createCalendarEvent({_id: [listId, ids[n]]}))
+
+	const bigListId = "bigListId"
+	const bigListIds = numberRange(0, 299).map(n => createEventElementId(timestamp, n))
+	const bigList = numberRange(0, 299).map(n => createCalendarEvent({_id: [bigListId, bigListIds[n]]}))
+	const toElementId = e => e._id[1]
+
+	o.spec("Load elements from cache", function () {
+		o.beforeEach(function () {
+			when(offlineStorageMock.getWholeList(CalendarEventTypeRef, listId)).thenResolve(allList)
+			when(offlineStorageMock.getRangeForList(CalendarEventTypeRef, listId)).thenResolve({lower: CUSTOM_MIN_ID, upper: CUSTOM_MAX_ID})
+		})
+
+		o("load range returns n elements following but excluding start id", async function () {
+			const res = await cacheHandler.loadRange(offlineStorageMock, listId, ids[0], 3, false)
+			o(res.map(toElementId)).deepEquals(allList.map(toElementId).slice(1, 4))
+
+
+		})
+
+		o("load range reverse returns n elements before but excluding start id in reverse order", async function () {
+			const res = await cacheHandler.loadRange(offlineStorageMock, listId, ids[6], 3, true)
+			o(res.map(toElementId)).deepEquals(allList.map(toElementId).slice(3, 6).reverse())
+		})
+	})
+	o.spec("Load elements from server when they are not in cache", function () {
+		o.beforeEach(function () {
+			when(offlineStorageMock.getRangeForList(CalendarEventTypeRef, listId)).thenResolve(null)
+
+		})
+
+		o("result of server request is inserted into cache and the range is set.", async function () {
+			when(entityRestClientMock.loadRange(CalendarEventTypeRef, listId, CUSTOM_MIN_ID, LOAD_MULTIPLE_LIMIT, false)).thenResolve(allList)
+			const res = await cacheHandler.loadRange(offlineStorageMock, listId, ids[0], 3, false)
+			o(res.map(toElementId)).deepEquals(allList.map(toElementId).slice(1, 4))("count elements are returned")
+			verify(offlineStorageMock.put(matchers.anything()), {times: allList.length})
+			verify(offlineStorageMock.setNewRangeForList(CalendarEventTypeRef, listId, CUSTOM_MIN_ID, CUSTOM_MAX_ID))
+
+		})
+
+		o("result of server request is inserted into cache and the range is set. Loads more than 100, but only count elements are returned.", async function () {
+			when(entityRestClientMock.loadRange(CalendarEventTypeRef, bigListId, CUSTOM_MIN_ID, LOAD_MULTIPLE_LIMIT, false)).thenResolve(bigList.slice(0, 100))
+			when(entityRestClientMock.loadRange(CalendarEventTypeRef, bigListId, bigListIds[99], LOAD_MULTIPLE_LIMIT, false)).thenResolve(bigList.slice(100, 200))
+			when(entityRestClientMock.loadRange(CalendarEventTypeRef, bigListId, bigListIds[199], LOAD_MULTIPLE_LIMIT, false)).thenResolve(bigList.slice(200, 300))
+			when(entityRestClientMock.loadRange(CalendarEventTypeRef, bigListId, bigListIds[299], LOAD_MULTIPLE_LIMIT, false)).thenResolve([])
+			const res = await cacheHandler.loadRange(offlineStorageMock, bigListId, bigListIds[0], 3, false)
+			o(res.map(toElementId)).deepEquals(allList.map(toElementId).slice(1, 4))("count elements are returned")
+			verify(offlineStorageMock.put(matchers.anything()), {times: bigList.length})
+			verify(offlineStorageMock.setNewRangeForList(CalendarEventTypeRef, bigListId, CUSTOM_MIN_ID, CUSTOM_MAX_ID))
+			verify(entityRestClientMock.loadRange(CalendarEventTypeRef, bigListId, matchers.anything(), LOAD_MULTIPLE_LIMIT, false), {times: 4})
+		})
+
+		o("result of server request is inserted into cache and the range is set. No elements on the server. No elements are returned.", async function () {
+			when(entityRestClientMock.loadRange(CalendarEventTypeRef, bigListId, CUSTOM_MIN_ID, LOAD_MULTIPLE_LIMIT, false)).thenResolve([])
+			const res = await cacheHandler.loadRange(offlineStorageMock, bigListId, bigListIds[0], 3, false)
+			o(res.map(toElementId)).deepEquals([])("no elements are returned")
+			verify(offlineStorageMock.put(matchers.anything()), {times: 0})
+			verify(offlineStorageMock.setNewRangeForList(CalendarEventTypeRef, bigListId, CUSTOM_MIN_ID, CUSTOM_MAX_ID))
+		})
+
+		o("result of server request is inserted into cache and the range is set. Less elements on the server than requested. Only elements that are on the server are returned.", async function () {
+			when(entityRestClientMock.loadRange(CalendarEventTypeRef, listId, CUSTOM_MIN_ID, LOAD_MULTIPLE_LIMIT, false)).thenResolve(allList)
+			const res = await cacheHandler.loadRange(offlineStorageMock, listId, CUSTOM_MIN_ID, 30, false)
+			o(res.map(toElementId)).deepEquals(allList.map(toElementId))("allList is returned")
+			verify(offlineStorageMock.put(matchers.anything()), {times: allList.length})
+			verify(offlineStorageMock.setNewRangeForList(CalendarEventTypeRef, listId, CUSTOM_MIN_ID, CUSTOM_MAX_ID))
+		})
+	})
+})


### PR DESCRIPTION
enables caching of calendar events and retrieves all calendars and
events on successful full login when offline storage is enabled

for the initial loading:
* the offline cache is available after partial login, but we can only
  fill it after full login.
* most of the work is available on the main thread already:
  * calendarModel.loadCalendarInfos
  * progress tracking
* we don't care about the return values of the loading.

this makes a post login action a good place for the initial loading of
calendars.

for the caching of CalendarEvents:
* CalendarEvents have CustomIds that depend on the start time,
  but are not sortable and therefore were incompatible with the
  EntityRestCache range caching logic.
* converting their Ids clientside to sortable b64ext of the GeneratedIds
  is problematic because there may be references to CustomIdTypes that
  are not marked as such that could be missed.
* doing it server side has similar problems in addition to requiring a
  plan for the transition period (old clients)
* instead, this is now handled by giving the EntityRestCache a map from
  types to CustomCacheHandlers that can replace the range caching logic
  for types where this makes sense. it is only passed when offline
  storage is enabled.
* in the case of Calendar Events, this logic is to load the entire
  calendar on the first cache request and always load entity events.

close https://github.com/tutao/tutanota/issues/3699

Note to reviewers:

https://github.com/tutao/tutanota/blob/fb7f1b89d572f1033428c727d014532afd4b6904/src/api/worker/rest/CustomCacheHandler.ts#L122-L124

the way this needed to be implemented to work seems to contradict the way the cache is supposed to work: when everything is loaded the range is MIN_ID to MAX_ID
and all entity updates are in range and therefore loaded & cached. is there a misunderstanding?
