### PR TITLE
don't triplicate the recipient search dropdown in mail editor.

### DIFF
--- a/src/gui/MailRecipientsTextField.ts
+++ b/src/gui/MailRecipientsTextField.ts
@@ -33,11 +33,12 @@ export interface MailRecipientsTextFieldAttrs {
  */
 export class MailRecipientsTextField implements ClassComponent<MailRecipientsTextFieldAttrs> {
 	private selectedSuggestionIdx = 0
+	private focused = false
 
 	view({attrs}: Vnode<MailRecipientsTextFieldAttrs>): Children {
 		return [
 			this.renderTextField(attrs),
-			this.renderSuggestions(attrs)
+			this.focused ? this.renderSuggestions(attrs) : null
 		]
 	}
 
@@ -88,7 +89,11 @@ export class MailRecipientsTextField implements ClassComponent<MailRecipientsTex
 				this.setSelectedSuggestionIdx(attrs, this.selectedSuggestionIdx - 1)
 				return false
 			},
+			onFocus: () => {
+				this.focused = true
+			},
 			onBlur: () => {
+				this.focused = false
 				this.resolveInput(attrs)
 				return true
 			},

--- a/src/gui/base/BubbleTextField.ts
+++ b/src/gui/base/BubbleTextField.ts
@@ -18,6 +18,7 @@ export interface BubbleTextFieldAttrs {
 	onDownKey: () => boolean
 	disabled: boolean
 	injectionsRight?: Children | null
+	onFocus: () => void
 	onBlur: () => void
 }
 
@@ -71,6 +72,7 @@ export class BubbleTextField implements ClassComponent<BubbleTextFieldAttrs> {
 				onDomInputCreated: dom => this.domInput = dom,
 				onfocus: () => {
 					this.active = true
+					attrs.onFocus()
 				},
 				onblur: () => {
 					this.active = false


### PR DESCRIPTION
We are passing in the same search model to all three recipient fields. perhaps better would have been to create a different model for each field but i think that is overkill.

instead we just only show the dropdown iff the field is focussed

I also fixed a bug in which the selected search entry wouldn't be updated when the dropdown shrinks, and tabbing away would cause a failed non-null assertion

fix #4232