### PR TITLE
improve handling of invalid pasted recipients

### DIFF
--- a/src/misc/TranslationKey.ts
+++ b/src/misc/TranslationKey.ts
@@ -1446,3 +1446,4 @@ export type TranslationKeyType =
 	| "yourMessage_label"
 	| "you_label"
 	| "emptyString_msg"
+	| "invalidPastedRecipients_msg"

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1463,6 +1463,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "DEINE ORDNER",
 		"yourMessage_label": "Deine Nachricht",
-		"you_label": "Du"
+		"you_label": "Du",
+		"invalidPastedRecipients_msg": "Die folgende E-Mail-Adressen sind ungültig:"
 	}
 }

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -1463,6 +1463,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "Ihre ORDNER",
 		"yourMessage_label": "Ihre Nachricht",
-		"you_label": "Sie"
+		"you_label": "Sie",
+		"invalidPastedRecipients_msg": "Die folgende E-Mail-Adressen sind ungültig:"
 	}
 }

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1459,6 +1459,7 @@ export default {
 		"yourCalendars_label": "Your calendars",
 		"yourFolders_action": "YOUR FOLDERS",
 		"yourMessage_label": "Your message",
-		"you_label": "You"
+		"you_label": "You",
+		"invalidPastedRecipients_msg": "The input contained the following invalid email addresses:"
 	}
 }


### PR DESCRIPTION
i botched the handling when I split up the input handler. now when a list of recipients is given, invalid ones are filtered out and displayed in an error message

a new translation key was added so we should pull translations from phrase

#4101

#4240