### PR TITLE
improve the reporting of chunking problems

### DIFF
--- a/buildSrc/buildWebapp.js
+++ b/buildSrc/buildWebapp.js
@@ -59,7 +59,6 @@ export async function buildWebapp({version, stage, host, measure, minify, projec
 	await fs.copy(path.join(projectDir, '/resources/favicon'), path.join(projectDir, 'build/dist/images'))
 	await fs.copy(path.join(projectDir, '/src/braintree.html'), path.join(projectDir, '/build/dist/braintree.html'))
 
-
 	console.log("started bundling", measure())
 	const bundle = await rollup({
 		input: ["src/app.ts", "src/api/worker/worker.ts"],
@@ -78,6 +77,7 @@ export async function buildWebapp({version, stage, host, measure, minify, projec
 			nodeResolve(),
 		],
 	})
+
 	console.log("bundling timings: ")
 	for (let [k, v] of Object.entries(bundle.getTimings())) {
 		console.log(k, v[0])


### PR DESCRIPTION
The chunking check aborted the build on the first problem that is found.
This is fine for small changes, but for bigger ones the
check-fix-check-fix cycle can get annoying.

The check is also only mandatory in CI now, which is slow anyway. This means
the tradeoff between fast and complete feedback falls squarely on the
side of completeness, giving the developer the chance to fix all
problems before even re-running the check locally.

With this commit, the check plugin aggregates the errors and outputs
them all at the same time after the check is finished before throwing.

## Test notes:

* [ ] import one/multiple language files and get all reports when running `node webapp`
* [ ] import one/multiple files in the wrong chunk (refer to `buildSrc/RollupConfig.js`) and get all reports
* [ ] combinations of the above