### PR TITLE
fix missing connection list indicator

### DIFF
--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -961,17 +961,21 @@ export class List<T extends ListElement, R extends VirtualRow<T>> implements Com
 		}
 	}
 
-	private loadMoreIfNecessary() {
-		let lastBunchVisible = this.currentPosition > this.loadedEntities.length * this.config.rowHeight - this.visibleElementsHeight * 2
+	private async loadMoreIfNecessary() {
+		// WARNING this is hacky:
+		// lastBunchVisible depends on visibleElementsHeight which is set inside _createVirtualRows which might not have completed by the time we
+		// reach here, so waiting for domDeferred guarantees that oncreate has finished running, and in turn that _createVirtualRows has completed
+		await this.domDeferred.promise
+
+		const lastBunchVisible = this.currentPosition > this.loadedEntities.length * this.config.rowHeight - this.visibleElementsHeight * 2
 
 		if (lastBunchVisible &&
 			!this.loadingState.isLoading() &&
 			!this.loadedCompletely &&
 			!this.loadingState.isConnectionLost()
 		) {
-			this.loadMore().then(() => {
-				this.updateListHeight()
-			})
+			await this.loadMore()
+			this.updateListHeight()
 		}
 	}
 


### PR DESCRIPTION
when offline with only a partial mail list cached, sometimes the connection lost indicator does not get rendered, even though it should. there was a race between `loadMoreIfNecessary` reading the value of `visibleElementsHeight` and `_createVirtualRows` writing to it. if it was read before it was written, then `loadMoreIfNecessary` would not try to load more from the server and would therefore not receive a connection lost error:

what should happen
- `loadMore` calls `loadAndAppendAnotherChunk`, which only returns a partial list
- `loadMore` then calls `loadMoreIfNecessary`, which tries to load the rest of the list, but gets an offline error
- because of the offline error, we show the connection lost indicator

what happens instead:

- `loadMore` is called
- `loadMore` calls `loadAndAppendAnotherChunk`, which only returns a partial list
- `loadMore` then calls `loadMoreIfNecessary`, which in turn doesn't do anything because this: `let lastBunchVisible = this.currentPosition > this.loadedEntities.length * this.config.rowHeight - this.visibleElementsHeight * 2` evaluates to false
- list gets confused and shows an empty list item

the fix is to force `loadMoreIfNecessary` to wait until `visibleElementsHeight` has definitely been written to

pretty hacky, I'm not sure of a better way that wouldn't require larger changes

fix #4117