### PR TITLE
[admin] create a searchTextFacade for the admin client web process

### DIFF
--- a/src/api/common/Env.ts
+++ b/src/api/common/Env.ts
@@ -87,6 +87,10 @@ export function isAdminClient(): boolean {
 	return env.mode === Mode.Admin
 }
 
+export function isElectronClient(): boolean {
+	return isDesktop() || isAdminClient()
+}
+
 export function isMainOrNode(): boolean {
 	return !worker || node || env.mode === Mode.Test
 }

--- a/src/api/common/TutanotaConstants.ts
+++ b/src/api/common/TutanotaConstants.ts
@@ -5,7 +5,7 @@ import type {CertificateInfo, CreditCard, EmailSenderListElement, GroupMembershi
 import {AccountingInfo, Customer} from "../entities/sys/TypeRefs.js";
 import type {CalendarEventAttendee, UserSettingsGroupRoot} from "../entities/tutanota/TypeRefs.js"
 import {ContactSocialId, MailFolder} from "../entities/tutanota/TypeRefs.js";
-import {isAdminClient, isApp, isDesktop} from "./Env"
+import {isAdminClient, isApp, isDesktop, isElectronClient} from "./Env"
 import type {Country} from "./CountryList"
 import {ProgrammingError} from "./error/ProgrammingError";
 
@@ -910,7 +910,7 @@ export const enum ClientType {
 }
 
 export function getClientType(): ClientType {
-	return isApp() ? ClientType.App : isDesktop() || isAdminClient() ? ClientType.Desktop : ClientType.Browser
+	return isApp() ? ClientType.App : isElectronClient() ? ClientType.Desktop : ClientType.Browser
 }
 
 export const enum ExternalImageRule {

--- a/src/api/main/MainLocator.ts
+++ b/src/api/main/MainLocator.ts
@@ -4,7 +4,7 @@ import {EventController} from "./EventController"
 import {EntropyCollector} from "./EntropyCollector"
 import {SearchModel} from "../../search/model/SearchModel"
 import {MailModel} from "../../mail/model/MailModel"
-import {assertMainOrNode, assertOfflineStorageAvailable, getWebRoot, isAdminClient, isBrowser, isDesktop} from "../common/Env"
+import {assertMainOrNode, assertOfflineStorageAvailable, getWebRoot, isBrowser, isDesktop, isElectronClient} from "../common/Env"
 import {notifications} from "../../gui/Notifications"
 import {logins} from "./LoginController"
 import type {ContactModel} from "../../contacts/model/ContactModel"
@@ -200,15 +200,15 @@ class MainLocator implements IMainLocator {
 	}
 
 	get interWindowEventBus(): InterWindowEventBus<InterWindowEventTypes> {
-		if (!isDesktop() && !isAdminClient()) {
-			throw new ProgrammingError("Trying to use InterWindowEventBus not on desktop")
+		if (!isElectronClient()) {
+			throw new ProgrammingError("Trying to use InterWindowEventBus not in electron")
 		}
 		return this._interWindowEventBus
 	}
 
 	get webauthnController(): IWebauthn {
 		const creds = navigator.credentials
-		return isDesktop() || isAdminClient()
+		return isElectronClient()
 			? this.getExposedNativeInterface().webauthn
 			: new BrowserWebauthn(creds, window.location.hostname)
 	}
@@ -315,7 +315,7 @@ class MainLocator implements IMainLocator {
 		this.cacheStorage = cacheStorage
 
 		if (!isBrowser()) {
-			if (isDesktop() || isAdminClient()) {
+			if (isElectronClient()) {
 				const {InterWindowEventBus} = await import("../../native/common/InterWindowEventBus.js")
 				this._interWindowEventBus = new InterWindowEventBus()
 			}
@@ -337,7 +337,7 @@ class MainLocator implements IMainLocator {
 				this.entityClient,
 			)
 
-			if (isDesktop() || isAdminClient()) {
+			if (isElectronClient()) {
 				const desktopInterfaces = createDesktopInterfaces(this.native)
 				this.searchTextFacade = desktopInterfaces.searchTextFacade
 				this.interWindowEventBus.init(this.getExposedNativeInterface().interWindowEventSender)

--- a/src/api/main/MainLocator.ts
+++ b/src/api/main/MainLocator.ts
@@ -200,7 +200,7 @@ class MainLocator implements IMainLocator {
 	}
 
 	get interWindowEventBus(): InterWindowEventBus<InterWindowEventTypes> {
-		if (!isDesktop()) {
+		if (!isDesktop() && !isAdminClient()) {
 			throw new ProgrammingError("Trying to use InterWindowEventBus not on desktop")
 		}
 		return this._interWindowEventBus
@@ -315,7 +315,7 @@ class MainLocator implements IMainLocator {
 		this.cacheStorage = cacheStorage
 
 		if (!isBrowser()) {
-			if (isDesktop()) {
+			if (isDesktop() || isAdminClient()) {
 				const {InterWindowEventBus} = await import("../../native/common/InterWindowEventBus.js")
 				this._interWindowEventBus = new InterWindowEventBus()
 			}
@@ -337,12 +337,14 @@ class MainLocator implements IMainLocator {
 				this.entityClient,
 			)
 
-			if (isDesktop()) {
-				this.interWindowEventBus.init(this.getExposedNativeInterface().interWindowEventSender)
+			if (isDesktop() || isAdminClient()) {
 				const desktopInterfaces = createDesktopInterfaces(this.native)
 				this.searchTextFacade = desktopInterfaces.searchTextFacade
-				this.desktopSettingsFacade = desktopInterfaces.desktopSettingsFacade
-				this.desktopSystemFacade = desktopInterfaces.desktopSystemFacade
+				this.interWindowEventBus.init(this.getExposedNativeInterface().interWindowEventSender)
+				if (isDesktop()) {
+					this.desktopSettingsFacade = desktopInterfaces.desktopSettingsFacade
+					this.desktopSystemFacade = desktopInterfaces.desktopSystemFacade
+				}
 			}
 		}
 

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -3,7 +3,7 @@ import {px, size} from "./size"
 import {client} from "../misc/ClientDetector"
 import {lang} from "../misc/LanguageViewModel"
 import {noselect, position_absolute, positionValue} from "./mixins"
-import {assertMainOrNodeBoot, isAdminClient, isApp, isDesktop} from "../api/common/Env"
+import {assertMainOrNodeBoot, isAdminClient, isApp, isElectronClient} from "../api/common/Env"
 import {getContentButtonIconBackground, getElevatedBackground, getNavigationMenuBg, theme} from "./theme"
 import {BrowserType} from "../misc/ClientConstants"
 
@@ -36,7 +36,7 @@ const boxShadow = `0 2px 12px rgba(0, 0, 0, 0.4), 0 10px 40px rgba(0, 0, 0, 0.3)
 styles.registerStyle("main", () => {
 	return {
 		"#link-tt":
-			isDesktop() || isAdminClient()
+			isElectronClient()
 				? {
 					"pointer-events": "none",
 					"font-size": px(size.font_size_small),
@@ -57,7 +57,7 @@ styles.registerStyle("main", () => {
 				}
 				: {},
 		"#link-tt.reveal":
-			isDesktop() || isAdminClient()
+			isElectronClient()
 				? {
 					opacity: 1,
 					transition: "opacity .1s linear",

--- a/src/misc/WindowFacade.ts
+++ b/src/misc/WindowFacade.ts
@@ -1,5 +1,5 @@
 import m, {Params} from "mithril"
-import {assertMainOrNodeBoot, isAdminClient, isApp, isDesktop, isIOSApp, Mode} from "../api/common/Env"
+import {assertMainOrNodeBoot, isApp, isElectronClient, isIOSApp, Mode} from "../api/common/Env"
 import {lang} from "./LanguageViewModel"
 import type {WorkerClient} from "../api/main/WorkerClient"
 import {client} from "./ClientDetector"
@@ -223,7 +223,7 @@ class WindowFacade {
 	}
 
 	async reload(args: Params) {
-		if (isApp() || isDesktop() || isAdminClient()) {
+		if (isApp() || isElectronClient()) {
 			if (!args.hasOwnProperty("noAutoLogin")) {
 				args.noAutoLogin = true
 			}

--- a/src/native/main/NativeInterfaceFactory.ts
+++ b/src/native/main/NativeInterfaceFactory.ts
@@ -1,7 +1,7 @@
 import {NativeInterfaceMain} from "./NativeInterfaceMain.js"
 import {NativePushServiceApp} from "./NativePushServiceApp.js"
 import {NativeFileApp} from "../common/FileApp.js"
-import {isAdminClient, isBrowser, isDesktop} from "../../api/common/Env.js"
+import {isBrowser, isElectronClient} from "../../api/common/Env.js"
 import {ProgrammingError} from "../../api/common/error/ProgrammingError.js"
 import {ExposedWebInterface} from "../common/NativeInterface.js"
 import {DesktopFacade} from "../common/generatedipc/DesktopFacade.js"
@@ -83,8 +83,8 @@ export function createNativeInterfaces(
 }
 
 export function createDesktopInterfaces(native: NativeInterfaceMain): DesktopInterfaces {
-	if (!isDesktop() && !isAdminClient()) {
-		throw new ProgrammingError("tried to create desktop interfaces in non-desktop")
+	if (!isElectronClient()) {
+		throw new ProgrammingError("tried to create desktop interfaces in non-electron client")
 	}
 	return {
 		searchTextFacade: new SearchTextInAppFacadeSendDispatcher(native),

--- a/src/native/main/NativeInterfaceFactory.ts
+++ b/src/native/main/NativeInterfaceFactory.ts
@@ -1,7 +1,7 @@
 import {NativeInterfaceMain} from "./NativeInterfaceMain.js"
 import {NativePushServiceApp} from "./NativePushServiceApp.js"
 import {NativeFileApp} from "../common/FileApp.js"
-import {isBrowser, isDesktop} from "../../api/common/Env.js"
+import {isAdminClient, isBrowser, isDesktop} from "../../api/common/Env.js"
 import {ProgrammingError} from "../../api/common/error/ProgrammingError.js"
 import {ExposedWebInterface} from "../common/NativeInterface.js"
 import {DesktopFacade} from "../common/generatedipc/DesktopFacade.js"
@@ -83,7 +83,7 @@ export function createNativeInterfaces(
 }
 
 export function createDesktopInterfaces(native: NativeInterfaceMain): DesktopInterfaces {
-	if(!isDesktop()) {
+	if (!isDesktop() && !isAdminClient()) {
 		throw new ProgrammingError("tried to create desktop interfaces in non-desktop")
 	}
 	return {

--- a/src/native/main/NativeInterfaceMain.ts
+++ b/src/native/main/NativeInterfaceMain.ts
@@ -1,4 +1,4 @@
-import {assertMainOrNode, isAdminClient, isAndroidApp, isDesktop, isIOSApp} from "../../api/common/Env"
+import {assertMainOrNode, isAndroidApp, isElectronClient, isIOSApp} from "../../api/common/Env"
 import type {Transport} from "../../api/common/MessageDispatcher"
 import {MessageDispatcher, Request} from "../../api/common/MessageDispatcher"
 import type {DeferredObject} from "@tutao/tutanota-utils"
@@ -33,7 +33,7 @@ export class NativeInterfaceMain implements NativeInterface {
 			transport = androidTransport
 		} else if (isIOSApp()) {
 			transport = new IosNativeTransport(window)
-		} else if (isDesktop() || isAdminClient()) {
+		} else if (isElectronClient()) {
 			transport = new DesktopNativeTransport(window.nativeApp)
 		} else {
 			throw new ProgrammingError("Tried to create a native interface in the browser")


### PR DESCRIPTION
isDesktop() excludes the admin client, which leads to the ctrl+f search
overlay not being able to use the locator.searchTextFacade operations.