### PR TITLE
fix invisible calendar events in desktop client non-persistent sessions

### DIFF
--- a/src/api/worker/rest/CacheStorageProxy.ts
+++ b/src/api/worker/rest/CacheStorageProxy.ts
@@ -6,6 +6,8 @@ import {OfflineStorage} from "../offline/OfflineStorage.js"
 import {WorkerImpl} from "../WorkerImpl"
 import {uint8ArrayToKey} from "@tutao/tutanota-crypto"
 import {EphemeralCacheStorage} from "./EphemeralCacheStorage"
+import {EntityRestClient} from "./EntityRestClient.js"
+import {CustomCacheHandlerMap} from "./CustomCacheHandler.js"
 
 interface OfflineStorageInitArgs {
 	userId: Id
@@ -152,5 +154,9 @@ export class LateInitializedCacheStorageImpl implements LateInitializedCacheStor
 
 	setUpperRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, id: Id): Promise<void> {
 		return this.inner.setUpperRangeForList(typeRef, listId, id)
+	}
+
+	getCustomCacheHandlerMap(entityRestClient: EntityRestClient): CustomCacheHandlerMap {
+		return this.inner.getCustomCacheHandlerMap(entityRestClient)
 	}
 }

--- a/src/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/api/worker/rest/EphemeralCacheStorage.ts
@@ -1,8 +1,9 @@
 import {ElementEntity, ListElementEntity, SomeEntity} from "../../common/EntityTypes.js"
-import {typeRefToPath} from "./EntityRestClient.js"
+import {EntityRestClient, typeRefToPath} from "./EntityRestClient.js"
 import {firstBiggerThanSecond, getElementId, getListId, isElementEntity} from "../../common/utils/EntityUtils.js"
 import {CacheStorage} from "./EntityRestCache.js"
 import {clone, getFromMap, remove, TypeRef} from "@tutao/tutanota-utils"
+import {CustomCacheHandlerMap} from "./CustomCacheHandler.js"
 
 type ListTypeCache = Map<Id, {
 	/** All entities loaded inside the range. */
@@ -16,6 +17,7 @@ type ListTypeCache = Map<Id, {
 export class EphemeralCacheStorage implements CacheStorage {
 	private readonly entities: Map<string, Map<Id, ElementEntity>> = new Map()
 	private readonly lists: Map<string, ListTypeCache> = new Map()
+	private readonly customCacheHandlerMap: CustomCacheHandlerMap = new CustomCacheHandlerMap()
 	private lastUpdateTime: number | null = null
 
 	/**
@@ -218,5 +220,9 @@ export class EphemeralCacheStorage implements CacheStorage {
 		}
 
 		return listCache.allRange.map(id => clone((listCache.elements.get(id) as T)))
+	}
+
+	getCustomCacheHandlerMap(entityRestClient: EntityRestClient): CustomCacheHandlerMap {
+		return this.customCacheHandlerMap
 	}
 }

--- a/src/api/worker/search/MailIndexer.ts
+++ b/src/api/worker/search/MailIndexer.ts
@@ -1,22 +1,14 @@
 import {FULL_INDEXED_TIMESTAMP, MailFolderType, MailState, NOTHING_INDEXED_TIMESTAMP, OperationType} from "../../common/TutanotaConstants"
-import type {MailBody} from "../../entities/tutanota/TypeRefs.js"
-import {MailBodyTypeRef} from "../../entities/tutanota/TypeRefs.js"
+import type {File as TutanotaFile, Mail, MailBody, MailBox, MailFolder} from "../../entities/tutanota/TypeRefs.js"
+import {FileTypeRef, MailBodyTypeRef, MailboxGroupRootTypeRef, MailBoxTypeRef, MailFolderTypeRef, MailTypeRef} from "../../entities/tutanota/TypeRefs.js"
 import {ConnectionError, NotAuthorizedError, NotFoundError} from "../../common/error/RestError"
-import {MailboxGroupRootTypeRef} from "../../entities/tutanota/TypeRefs.js"
-import type {MailBox} from "../../entities/tutanota/TypeRefs.js"
-import {MailBoxTypeRef} from "../../entities/tutanota/TypeRefs.js"
-import type {MailFolder} from "../../entities/tutanota/TypeRefs.js"
-import {MailFolderTypeRef} from "../../entities/tutanota/TypeRefs.js"
-import type {Mail} from "../../entities/tutanota/TypeRefs.js"
-import {MailTypeRef} from "../../entities/tutanota/TypeRefs.js"
 import {typeModels} from "../../entities/tutanota/TypeModels"
 import {containsEventOfType, getMailBodyText} from "../../common/utils/Utils"
 import {flat, groupBy, isNotNull, neverNull, noOp, ofClass, promiseMap, splitInChunks, TypeRef} from "@tutao/tutanota-utils"
 import {elementIdPart, isSameId, listIdPart, timestampToGeneratedId} from "../../common/utils/EntityUtils"
 import {_createNewIndexUpdate, encryptIndexKeyBase64, filterMailMemberships, getPerformanceTimestamp, htmlToText, typeRefToTypeInfo} from "./IndexUtils"
 import type {Db, GroupData, IndexUpdate, SearchIndexEntry} from "./SearchTypes"
-import type {File as TutanotaFile} from "../../entities/tutanota/TypeRefs.js"
-import {FileTypeRef} from "../../entities/tutanota/TypeRefs.js"
+import {IndexingErrorReason} from "./SearchTypes"
 import {CancelledError} from "../../common/error/CancelledError"
 import {IndexerCore} from "./IndexerCore"
 import {ElementDataOS, GroupDataOS, Metadata, MetaDataOS} from "./Indexer"
@@ -24,17 +16,13 @@ import type {WorkerImpl} from "../WorkerImpl"
 import {DbError} from "../../common/error/DbError"
 import {EntityRestCache} from "../rest/EntityRestCache"
 import type {DateProvider} from "../DateProvider"
-import type {EntityUpdate} from "../../entities/sys/TypeRefs.js"
-import type {User} from "../../entities/sys/TypeRefs.js"
-import type {GroupMembership} from "../../entities/sys/TypeRefs.js"
+import type {EntityUpdate, GroupMembership, User} from "../../entities/sys/TypeRefs.js"
 import {EntityRestClient} from "../rest/EntityRestClient"
 import {EntityClient} from "../../common/EntityClient"
 import {ProgressMonitor} from "../../common/utils/ProgressMonitor"
 import type {SomeEntity} from "../../common/EntityTypes"
 import {EntityUpdateData} from "../../main/EventController";
 import {EphemeralCacheStorage} from "../rest/EphemeralCacheStorage";
-import {IndexingErrorReason} from "./SearchTypes"
-import {CustomCacheHandlerMap} from "../rest/CustomCacheHandler.js"
 
 export const INITIAL_MAIL_INDEX_INTERVAL_DAYS = 28
 const ENTITY_INDEXER_CHUNK = 20
@@ -334,14 +322,14 @@ export class MailIndexer {
 
 			const success = this._core.isStoppedProcessing() || e instanceof CancelledError
 
-			const failedIndexingUpTo =  success
+			const failedIndexingUpTo = success
 				? null
 				: oldestTimestamp
 
 			const error = success
 				? null
 				: e instanceof ConnectionError
-				? IndexingErrorReason.ConnectionLost
+					? IndexingErrorReason.ConnectionLost
 					: IndexingErrorReason.Unknown
 
 			await this._worker.sendIndexState({
@@ -689,7 +677,7 @@ class IndexLoader {
 			this.entityCache = cachingEntityClient
 			this._entity = new EntityClient(cachingEntityClient)
 		} else {
-			cachingEntityClient = new EntityRestCache(restClient, new EphemeralCacheStorage(), new CustomCacheHandlerMap())
+			cachingEntityClient = new EntityRestCache(restClient, new EphemeralCacheStorage())
 			this._entity = new EntityClient(restClient)
 		}
 		this.entityCache = cachingEntityClient

--- a/src/offline/CachePostLoginAction.ts
+++ b/src/offline/CachePostLoginAction.ts
@@ -6,6 +6,7 @@ import {EntityClient} from "../api/common/EntityClient.js"
 import {ProgressTracker} from "../api/main/ProgressTracker.js"
 import {promiseMap} from "@tutao/tutanota-utils"
 import {NoopProgressMonitor} from "../api/common/utils/ProgressMonitor.js"
+import {SessionType} from "../api/common/SessionType.js"
 
 
 export class CachePostLoginAction implements IPostLoginAction {
@@ -20,7 +21,10 @@ export class CachePostLoginAction implements IPostLoginAction {
 	}
 
 	async onFullLoginSuccess(loggedInEvent: LoggedInEvent): Promise<void> {
-			// 3 work to load calendar info, 2 work to load short and long events
+		// we use an ephemeral cache for non-persistent sessions which doesn't
+		// support or save calendar events, so it's pointless to preload them.
+		if (loggedInEvent.sessionType !== SessionType.Persistent) return
+		// 3 work to load calendar info, 2 work to load short and long events
 		const workPerCalendar = 3 + 2
 		const totalWork = this.logins.getUserController().getCalendarMemberships().length * workPerCalendar
 		const monitorHandle = this.progressTracker.registerMonitor(totalWork)

--- a/test/tests/api/worker/rest/EntityRestCacheTest.ts
+++ b/test/tests/api/worker/rest/EntityRestCacheTest.ts
@@ -154,13 +154,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 			userId = "userId"
 			storage = await getStorage(userId)
 			entityRestClient = mockRestClient()
-			const customCacheHandlerMap = name === "offline"
-				? new CustomCacheHandlerMap({
-					ref: CalendarEventTypeRef,
-					handler: new CustomCalendarEventCacheHandler(entityRestClient)
-				})
-				: new CustomCacheHandlerMap()
-			cache = new EntityRestCache(entityRestClient, storage, customCacheHandlerMap)
+			cache = new EntityRestCache(entityRestClient, storage)
 		})
 
 		o.spec("entityEventsReceived", function () {
@@ -1101,7 +1095,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 				async function () {
 
 					const clientMock = object<EntityRestClient>()
-					const cache = new EntityRestCache(clientMock, storage, new CustomCacheHandlerMap())
+					const cache = new EntityRestCache(clientMock, storage)
 
 					const listId = "listId"
 
@@ -1144,7 +1138,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 			o("When there is a non-reverse range request that loads in the direction of the existing range, the range will grow to include the startId", async function () {
 
 				const clientMock = object<EntityRestClient>()
-				const cache = new EntityRestCache(clientMock, storage, new CustomCacheHandlerMap())
+				const cache = new EntityRestCache(clientMock, storage)
 
 				const listId = "listId1"
 
@@ -1179,7 +1173,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 			o("When there is a reverse range request that loads in the direction of the existing range, the range will grow to include the startId", async function () {
 
 				const clientMock = object<EntityRestClient>()
-				const cache = new EntityRestCache(clientMock, storage, new CustomCacheHandlerMap())
+				const cache = new EntityRestCache(clientMock, storage)
 
 				const listId = "listId1"
 				const mails = arrayOf(100, idx => createMailInstance(listId, createId(`${idx}`), `hola ${idx}`))
@@ -1212,7 +1206,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 
 			o("The range request starts on one end of the existing range, and would finish on the other end, so it loads from either direction of the range", async function () {
 				const clientMock = object<EntityRestClient>()
-				const cache = new EntityRestCache(clientMock, storage, new CustomCacheHandlerMap())
+				const cache = new EntityRestCache(clientMock, storage)
 
 				const id1 = createId("1")
 				const id2 = createId("2")
@@ -1304,7 +1298,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 				const client = downcast<EntityRestClient>({
 					load: o.spy(() => contact),
 				})
-				const cache = new EntityRestCache(client, storage, new CustomCacheHandlerMap())
+				const cache = new EntityRestCache(client, storage)
 				await cache.load(
 					ContactTypeRef,
 					contactId,
@@ -1339,7 +1333,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 						return contactOnTheServer
 					}),
 				})
-				const cache = new EntityRestCache(client, storage, new CustomCacheHandlerMap())
+				const cache = new EntityRestCache(client, storage)
 				const firstLoaded = await cache.load(ContactTypeRef, contactId)
 				o(firstLoaded).deepEquals(contactOnTheServer)
 				// @ts-ignore
@@ -1383,7 +1377,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id) => Pr
 						return permissionOnTheServer
 					}),
 				})
-				const cache = new EntityRestCache(client, storage, new CustomCacheHandlerMap())
+				const cache = new EntityRestCache(client, storage)
 				await cache.load(PermissionTypeRef, permissionId)
 				await cache.load(PermissionTypeRef, permissionId)
 				// @ts-ignore


### PR DESCRIPTION
* the worker thread needs to create an entity rest cache
* the cache needs a storage impl (ephemeral or offlineDB)
* the ephemeral cache doesn't support customId types, but the oDB does
  via custom handlers.
* because the custom handlers were initialized separately from the
  storage, we had an inconsistency where an ephemeral cache was created
  with the custom handlers for the oDB, which led to loadRange requests
  always returning empty event lists unless events were added after
  login. This affected all non-persistent sessions in desktop clients.

moving the custom handler selection into the storage impl makes this
this mixup impossible.

fix #4339