### PR TITLE
[desktop] make MailEditorViewModel download DataFiles and TutanotaFiles

### DIFF
--- a/src/api/common/DataFile.ts
+++ b/src/api/common/DataFile.ts
@@ -1,6 +1,8 @@
 import type {File as TutanotaFile} from "../entities/tutanota/TypeRefs.js"
 
-
+/**
+ * a structure containing file content and metadata
+ */
 export interface DataFile {
 	readonly _type: "DataFile",
 	name: string,

--- a/src/api/common/utils/FileUtils.ts
+++ b/src/api/common/utils/FileUtils.ts
@@ -1,11 +1,14 @@
-import {downcast, isSameTypeRef, toLowerCase} from "@tutao/tutanota-utils"
+import {downcast, intersection, isSameTypeRef, toLowerCase} from "@tutao/tutanota-utils"
 import type {File as TutanotaFile} from "../../entities/tutanota/TypeRefs.js"
 import {FileTypeRef as TutanotaFileTypeRef} from "../../entities/tutanota/TypeRefs.js"
-import {intersection} from "@tutao/tutanota-utils"
 import {DataFile} from "../DataFile";
+import {Attachment} from "../../../mail/editor/SendMailModel.js"
 
 type StringPredicate = (arg0: string) => boolean
 
+/**
+ * a reference by path to a file on disk
+ */
 export interface FileReference {
 	readonly _type: 'FileReference',
 	name: string,
@@ -127,14 +130,17 @@ export function isReservedFilename(filename: string): boolean {
 	return (env.platformId === "win32" && winReservedRe.test(filename)) || reservedRe.test(filename)
 }
 
-export function isTutanotaFile(file: TutanotaFile | DataFile | FileReference): file is TutanotaFile {
-	return file._type && file._type.hasOwnProperty("app") && file._type.hasOwnProperty("name") && isSameTypeRef(downcast(file._type), TutanotaFileTypeRef)
+export function isTutanotaFile(file: Attachment): file is TutanotaFile {
+	return file._type
+		&& file._type.hasOwnProperty("app")
+		&& file._type.hasOwnProperty("type")
+		&& isSameTypeRef(downcast(file._type), TutanotaFileTypeRef)
 }
 
-export function isDataFile(file: TutanotaFile | DataFile | FileReference): boolean {
+export function isDataFile(file: Attachment): file is DataFile {
 	return file._type === "DataFile"
 }
 
-export function isFileReference(file: TutanotaFile | DataFile | FileReference): boolean {
+export function isFileReference(file: Attachment): file is FileReference {
 	return file._type === "FileReference"
 }


### PR DESCRIPTION
pre-saving, a draft on the desktop client contains DataFile Attachments,
after saving they are TutanotaFiles.

The _downloadAttachment function of the MailEditorViewModel treated
these differently.

fix #4359