### PR TITLE
properly query shadow root for inline images

### DIFF
--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -198,7 +198,8 @@ export class MailEditor implements Component<MailEditorAttrs> {
 		})
 
 		this.editor.initialized.promise.then(() => {
-			this.inlineImageElements = replaceCidsWithInlineImages(this.editor.getDOM(), model.loadedInlineImages, (cid, event, dom) => {
+			const dom = this.editor.getDOM()
+			this.inlineImageElements = replaceCidsWithInlineImages(dom, model.loadedInlineImages, (cid, event, dom) => {
 				const downloadClickHandler = createDropdown({
 					lazyButtons: () => [
 						{

--- a/src/mail/view/MailGuiUtils.ts
+++ b/src/mail/view/MailGuiUtils.ts
@@ -149,6 +149,10 @@ export function replaceCidsWithInlineImages(
 ): Array<HTMLElement> {
 	// all image tags which have cid attribute. The cid attribute has been set by the sanitizer for adding a default image.
 	const imageElements: Array<HTMLElement> = Array.from(dom.querySelectorAll("img[cid]"))
+	if (dom.shadowRoot) {
+		const shadowImageElements: Array<HTMLElement> = Array.from(dom.shadowRoot.querySelectorAll("img[cid]"))
+		imageElements.push(...shadowImageElements)
+	}
 	const elementsWithCid: HTMLElement[] = []
 	imageElements.forEach(imageElement => {
 		const cid = imageElement.getAttribute("cid")

--- a/src/mail/view/MailViewer.ts
+++ b/src/mail/view/MailViewer.ts
@@ -633,7 +633,6 @@ export class MailViewer implements Component<MailViewerAttrs> {
 	async replaceInlineImages() {
 		const loadedInlineImages = await this.viewModel.getLoadedInlineImages()
 		const domBody = await this.domBodyDeferred.promise
-
 		replaceCidsWithInlineImages(domBody, loadedInlineImages, (cid, event) => {
 			const inlineAttachment = this.viewModel.getAttachments().find(attachment => attachment.cid === cid)
 


### PR DESCRIPTION
with our move to display mail bodies in shadow dom, we lost the
ability to directly query for inline images in order to replace them

we have to extract the shadowRoot before querying directly on it.

fix #4358