### PR TITLE
[desktop] Fix tray

### DIFF
--- a/src/desktop/tray/DesktopTray.ts
+++ b/src/desktop/tray/DesktopTray.ts
@@ -8,6 +8,7 @@ import {MacTray} from "./MacTray"
 import {NonMacTray} from "./NonMacTray"
 import {getResourcePath} from "../resources"
 import {BuildConfigKey, DesktopConfigKey} from "../config/ConfigKeys";
+import {log} from "../DesktopLog.js"
 
 export interface PlatformTray {
 	setBadge(): void
@@ -42,8 +43,8 @@ export class DesktopTray {
 
 				this._tray = null
 			}
-		}).on("ready", async () => {
-			if (!this._wm) console.warn("Tray: No WM set before 'ready'!")
+		}).whenReady().then(async () => {
+			if (!this._wm) log.warn("Tray: No WM set before 'ready'!")
 			this._tray = platformTray.getTray(this._wm, await this.getAppIcon())
 		})
 	}


### PR DESCRIPTION
Was observable on Windows. We set electron.app.on("ready") too late,
after the app was ready. The handler would not fire and we wouldn't
create the tray.

Co-authored-by: nig <nig@tutao.de>

fix #4337