### PR TITLE
Added a way to use different sender names through contacts

### DIFF
--- a/src/gui/base/DropDownSelector.ts
+++ b/src/gui/base/DropDownSelector.ts
@@ -31,6 +31,7 @@ export interface DropDownSelectorAttrs<T> {
 	selectionChangedHandler?: ((newValue: T) => unknown) | null
 	helpLabel?: lazy<Children>
 	dropdownWidth?: number
+	dropdownShowOnlyValuesAsString?: boolean
 	icon?: AllIcons
 	disabled?: boolean
 	class?: string
@@ -67,7 +68,7 @@ export class DropDownSelector<T> implements ClassComponent<DropDownSelectorAttrs
 						.filter(item => item.selectable !== false)
 						.map(item => {
 							return {
-								label: () => item.name,
+								label: () => a.dropdownShowOnlyValuesAsString ? String(item.value) : item.name,
 								click: () => {
 									a.selectionChangedHandler?.(item.value)
 									m.redraw()

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -385,12 +385,13 @@ export class MailEditor implements Component<MailEditorAttrs> {
 							items: getEnabledMailAddressesWithUser(model.mailboxDetails, model.user().userGroupInfo)
 								.sort()
 								.map(mailAddress => ({
-									name: mailAddress,
+									name: a.model.getSenderWithName(mailAddress),
 									value: mailAddress,
 								})),
 							selectedValue: a.model.getSender(),
 							selectionChangedHandler: (selection: string) => model.setSender(selection),
 							dropdownWidth: 250,
+							dropdownShowOnlyValuesAsString: true
 						}),
 					),
 					isConfidential

--- a/src/mail/model/MinimizedMailEditorViewModel.ts
+++ b/src/mail/model/MinimizedMailEditorViewModel.ts
@@ -70,6 +70,7 @@ export class MinimizedMailEditorViewModel {
 
 	// fully removes and reopens clicked mail
 	reopenMinimizedEditor(editor: MinimizedEditor): void {
+		editor.sendMailModel.updateSenderContacts()
 		editor.closeOverlayFunction()
 		editor.dialog.show()
 		remove(this._minimizedEditors, editor)


### PR DESCRIPTION
Added a way to use different sender names by creating contacts with owned aliases, by this way the first and last name of the contact will be used as sender name.
This feature is claimed by many users since 4 years in the issue #516 and as it's said in the issue, deep changes is required to implement this efficiently but I thought that using contacts for waiting the changes would be a nice workaround and bring very few changes in the code.

How looks like the mail editor with that changes:

![Screenshot 2022-07-22 110051](https://user-images.githubusercontent.com/55292583/180413543-47ebf19c-d839-487a-a55c-ab975c8021d7.png)

As you can see in the picture, the sender mail case will now show the sender name if there's existing one, meaning either the contact sender name or the global sender name.
But if both are missing only the mail will be shown, by this way users can verify before sending that the right sender name is used (if used) according the alias selected.

Code logic:

1. Search a contact having the alias as email address and use his first and last name if found, or use the global user sender name.
2. If the global sender name is empty, only the email will be shown and no sender mail will be used.
3. In the case a global sender name is existing, and a contact too, the contact will be used first, and the global sender name will be used on aliases that doesn't match a contact.

I also wanted to create a setting to make this as a feature togglable but I preferred let the team decide what do since it doesn't affect users if they don't create contacts with their email aliases.




