### PR TITLE
[desktop] ignore closed db error when in expired session recovery mode

### DIFF
--- a/src/api/common/error/OfflineDbClosedError.ts
+++ b/src/api/common/error/OfflineDbClosedError.ts
@@ -1,0 +1,9 @@
+import {TutanotaError} from "./TutanotaError.js"
+
+
+export class OfflineDbClosedError extends TutanotaError {
+
+	constructor(msg: string) {
+		super("OfflineDbClosedError", msg)
+	}
+}

--- a/src/api/common/error/OfflineDbClosedError.ts
+++ b/src/api/common/error/OfflineDbClosedError.ts
@@ -1,5 +1,6 @@
-import {TutanotaError} from "./TutanotaError.js"
+//@bundleInto:common-min
 
+import {TutanotaError} from "./TutanotaError.js"
 
 export class OfflineDbClosedError extends TutanotaError {
 

--- a/src/api/common/utils/Utils.ts
+++ b/src/api/common/utils/Utils.ts
@@ -50,6 +50,7 @@ import {ImportError} from "../error/ImportError"
 import {WebauthnError} from "../error/WebauthnError"
 import {SuspensionError} from "../error/SuspensionError.js"
 import {LoginIncompleteError} from "../error/LoginIncompleteError.js"
+import {OfflineDbClosedError} from "../error/OfflineDbClosedError.js"
 
 export function getWhitelabelDomain(customerInfo: CustomerInfo, domainName?: string): DomainInfo | null {
 	return customerInfo.domainInfos.find(info => info.whitelabelConfig != null && (domainName == null || info.domain === domainName)) ?? null
@@ -103,6 +104,7 @@ const ErrorNameToType = {
 	ProgrammingError,
 	RecipientsNotFoundError,
 	RecipientNotResolvedError,
+	OfflineDbClosedError,
 	OutOfSyncError,
 	ServiceUnavailableError,
 	DbError,

--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -14,7 +14,6 @@ import {EncodeOptions, Token, Type} from "cborg"
 import {assert, DAY_IN_MILLIS, getTypeId, groupByAndMap, mapNullable, TypeRef} from "@tutao/tutanota-utils"
 import type {OfflineDbFacade} from "../../../desktop/db/OfflineDbFacade.js"
 import {isOfflineStorageAvailable, isTest} from "../../common/Env.js"
-import {ProgrammingError} from "../../common/error/ProgrammingError.js"
 import {modelInfos} from "../../common/EntityFunctions.js"
 import {AccountType, MailFolderType, OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS} from "../../common/TutanotaConstants.js"
 import {DateProvider} from "../../common/DateProvider.js"
@@ -27,6 +26,7 @@ import {EntityRestClient} from "../rest/EntityRestClient.js"
 import {OfflineStorageInitArgs} from "../rest/CacheStorageProxy.js"
 import {uint8ArrayToKey} from "@tutao/tutanota-crypto"
 import {InterWindowEventFacadeSendDispatcher} from "../../../native/common/generatedipc/InterWindowEventFacadeSendDispatcher.js"
+import {OfflineDbClosedError} from "../../common/error/OfflineDbClosedError.js"
 
 function dateEncoder(data: Date, typ: string, options: EncodeOptions): TokenOrNestedTokens | null {
 	return [
@@ -103,7 +103,7 @@ export class OfflineStorage implements CacheStorage, ExposedCacheStorage {
 
 	private get userId(): Id {
 		if (this._userId == null) {
-			throw new ProgrammingError("Offline storage not initialized")
+			throw new OfflineDbClosedError("Offline storage not initialized")
 		}
 
 		return this._userId

--- a/src/desktop/db/OfflineDbFacade.ts
+++ b/src/desktop/db/OfflineDbFacade.ts
@@ -1,8 +1,8 @@
 import {OfflineDb, PersistedEntity} from "./OfflineDb"
 import {OfflineDbMeta} from "../../api/worker/offline/OfflineStorage.js"
-import {ProgrammingError} from "../../api/common/error/ProgrammingError"
 import {delay} from "@tutao/tutanota-utils"
 import {log} from "../DesktopLog.js"
+import {OfflineDbClosedError} from "../../api/common/error/OfflineDbClosedError.js"
 
 export interface OfflineDbFactory {
 	create(userid: string, key: Aes256Key, retry?: boolean): Promise<OfflineDb>
@@ -154,7 +154,7 @@ export class OfflineDbFacade {
 		const entry = this.cache.get(userId)
 
 		if (!entry) {
-			throw new ProgrammingError(`Db for user ${userId} is not open. must call openDataBaseForUser first :)`)
+			throw new OfflineDbClosedError(`Db for user ${userId} is not open :(`)
 		}
 
 		return entry.db

--- a/src/misc/ErrorHandlerImpl.ts
+++ b/src/misc/ErrorHandlerImpl.ts
@@ -29,6 +29,7 @@ import {CancelledError} from "../api/common/error/CancelledError"
 import {getLoginErrorMessage} from "./LoginUtils"
 import {isOfflineError} from "../api/common/utils/ErrorCheckUtils.js"
 import {SessionType} from "../api/common/SessionType.js"
+import {OfflineDbClosedError} from "../api/common/error/OfflineDbClosedError.js"
 
 assertMainOrNode()
 
@@ -110,6 +111,10 @@ export async function handleUncaughtErrorImpl(e: Error) {
 		if (!shownQuotaError) {
 			shownQuotaError = true
 			Dialog.message("storageQuotaExceeded_msg")
+		}
+	} else if (e instanceof OfflineDbClosedError) {
+		if (!loginDialogActive) {
+			throw e
 		}
 	} else if (ignoredError(e)) {
 		// ignore, this is not our code


### PR DESCRIPTION
when the saved credentials have a session that expired (ie deleted from
other device) we detect this and reset the session. this includes
closing the websocket asynchronously and closing the offline DB.

the app may try to write to the db after closing it and before closing
the websocket, which normally would not be allowed, but is fine to
ignore in this state since we're going to recreate the session anyway.

close #4401