### PR TITLE
[android/ios] explicitly disable u2f for mobile apps

### DIFF
--- a/src/misc/2fa/webauthn/BrowserWebauthn.ts
+++ b/src/misc/2fa/webauthn/BrowserWebauthn.ts
@@ -1,6 +1,6 @@
 import {COSEAlgorithmIdentifier} from "./WebauthnTypes.js"
 import {ProgrammingError} from "../../../api/common/error/ProgrammingError.js"
-import {getHttpOrigin} from "../../../api/common/Env.js"
+import {getHttpOrigin, isApp} from "../../../api/common/Env.js"
 import {
 	U2F_APPID,
 	U2f_APPID_SUFFIX,
@@ -44,8 +44,11 @@ export class BrowserWebauthn implements WebAuthnFacade {
 		return this.appId === appId
 	}
 
+	/**
+	 * test whether hardware key second factors are supported for this client
+	 */
 	async isSupported(): Promise<boolean> {
-		return this.api != null &&
+		return !isApp() && this.api != null &&
 			// @ts-ignore see polyfill.js
 			// We just stub BigInt in order to import cborg without issues but we can't actually use it
 			!BigInt.polyfilled


### PR DESCRIPTION
after the changes to the asset loading, the android client started
attempting u2f challenges because the domain matches the registered
keys.

this commit disables u2f in BrowserWebAuthn when used in apps until u2f
is properly supported.

this also fixes the misleading message
"security key is not registered for this domain" that would be shown to
mobile users, it's just "accept login from another client" now.

close #4426