### PR TITLE
Make BuyDialog.periodEndDate return a copy of the date

### DIFF
--- a/src/subscription/BuyDialog.ts
+++ b/src/subscription/BuyDialog.ts
@@ -399,7 +399,8 @@ class PriceChangeModel {
 	}
 
 	periodEndDate(): Date {
-		return this.price.periodEndDate
+		// return a copy to prevent the date from being changed by the caller
+		return new Date(this.price.periodEndDate)
 	}
 
 	addedPriceForCurrentPeriod(): number {


### PR DESCRIPTION
Prevent that the original date object can be accidentally edited directly when using this function.

For example, ConfirmSubscriptionView's view() function should not update the period end date directly when incrementing by 1.

Fixes #4196