### PR TITLE
Make switch subscription options' height match upgrade options

### DIFF
--- a/src/subscription/SwitchSubscriptionDialog.ts
+++ b/src/subscription/SwitchSubscriptionDialog.ts
@@ -71,7 +71,7 @@ export async function showSwitchDialog(customer: Customer, customerInfo: Custome
 					},
 					campaignInfoTextId: null,
 					boxWidth: 230,
-					boxHeight: 230,
+					boxHeight: 270,
 					currentSubscriptionType: currentSubscriptionInfo.subscriptionType,
 					currentlySharingOrdered: currentSubscriptionInfo.currentlySharingOrdered,
 					currentlyBusinessOrdered: currentSubscriptionInfo.currentlyBusinessOrdered,


### PR DESCRIPTION
Creating a new subscription has each option with a height of 270px, thus changing subscriptions should have the same height.

While this does mean there is some extra whitespace due to not having the monthly/yearly selection, having it be consistent is preferable, and it allows the Free plan to have enough room without being cut off.

Fixes #4163