### PR TITLE
[android] add some values to the MimeTypeMap

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -180,8 +180,7 @@ class MainActivity : FragmentActivity() {
 					}
 					try {
 						if (!assetPath.startsWith(BuildConfig.RES_ADDRESS)) throw IOException("can't find this")
-						val ext = MimeTypeMap.getFileExtensionFromUrl(url.toString())
-						val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+						val mimeType = getMimeTypeForUrl(url.toString())
 						WebResourceResponse(
 								mimeType,
 								null,
@@ -246,6 +245,20 @@ class MainActivity : FragmentActivity() {
 			handleIntent(intent)
 		}
 		firstLoaded = true
+	}
+
+	private fun getMimeTypeForUrl(url: String): String {
+		val ext = MimeTypeMap.getFileExtensionFromUrl(url)
+		// on old android mimetypemap doesn't contain js and returns null
+		// we add a few more for safety.
+		val mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext)
+		return mimeType ?: when (ext) {
+			"js" -> "text/javascript"
+			"json" -> "application/json"
+			"html" -> "text/html"
+			"ttf" -> "font/ttf"
+			else -> error("Unknown extension $ext")
+		}
 	}
 
 	@Suppress("DEPRECATION")


### PR DESCRIPTION
On old androids, webkit's MimeTypeMap would return null for
some extensions used in our assets (ie .js).

since we proxy the requests for assets, we set the mimetype
manually with mimetypemap, which doesn't sit well with the
WebView if the mimetype is null (refuses to load it as executable).

Because of that worker would never be initialized (it loads polyfill.js
dynamically). For users it would look like the request is stuck.

close #4453

Co-authored-by: ivk <ivk@tutao.de>