### PR TITLE
Fix technical sender in info banner overflowing

### DIFF
--- a/src/gui/base/InfoBanner.ts
+++ b/src/gui/base/InfoBanner.ts
@@ -6,10 +6,11 @@ import {lang} from "../../misc/LanguageViewModel"
 import type {ButtonAttrs} from "./Button.js"
 import {Button, ButtonType} from "./Button.js"
 import {NavButton} from "./NavButton.js"
+import type {lazy} from "@tutao/tutanota-utils"
 import {isNotNull, mapNullable} from "@tutao/tutanota-utils"
 import {Icons} from "./icons/Icons"
 import {ifAllowedTutanotaLinks} from "./GuiUtils"
-import type {lazy} from "@tutao/tutanota-utils"
+import {px, size} from "../size.js"
 
 const WARNING_RED = "#ca0606"
 
@@ -41,10 +42,11 @@ export class InfoBanner implements Component<InfoBannerAttrs> {
 				},
 			},
 			[
-				m(".flex", [
-					m(".mt-s.mr-s", this.renderIcon(icon, type ?? null)),
-					m(".flex-grow", [
-						m(".mr.pt-s", [m(".small", lang.getMaybeLazy(message))]),
+				m(".mt-s.mr-s.abs", this.renderIcon(icon, type ?? null)), // absolute position makes the icon fixed to the top left corner of the banner
+				m("",
+					{style: {"margin-left": px(size.icon_size_large + 1)}}, // allow room for the icon
+					[
+						m(".mr.pt-s", [m(".small.text-break", lang.getMaybeLazy(message))]),
 						m(
 							".flex.ml-negative-s",
 							{
@@ -63,7 +65,6 @@ export class InfoBanner implements Component<InfoBannerAttrs> {
 							],
 						),
 					]),
-				]),
 			],
 		)
 	}


### PR DESCRIPTION
InfoBanner's styling should be able to handle long words. For example, you may receive an email with a long technical sender containing words or sequences of characters that cannot be broken up nicely, and we do not want to have this overflow.

![image](https://user-images.githubusercontent.com/104824185/182848670-383691d2-a098-41b6-888e-fd28e05262e6.png)

Fixes #3910