### PR TITLE
Fix deactivating a whitelabel date not sending a date

### DIFF
--- a/src/settings/WhitelabelChildViewer.ts
+++ b/src/settings/WhitelabelChildViewer.ts
@@ -53,8 +53,8 @@ export class WhitelabelChildViewer implements UpdatableSettingsDetailsViewer {
 					},
 				],
 				selectedValue: this.isChildActive(),
-				selectionChangedHandler: (deactivate: boolean) => {
-					this.whitelabelChild.deletedDate = deactivate ? new Date() : null
+				selectionChangedHandler: (activate: boolean) => {
+					this.whitelabelChild.deletedDate = activate ? null : new Date()
 					return showProgressDialog("pleaseWait_msg", locator.entityClient.update(this.whitelabelChild))
 				},
 			})),


### PR DESCRIPTION
On commit 9d5e2f6fb4bc14a5cc0f7b1a74a606b32cd56e16, the visual status of whitelabel children was corrected, but the actual effects of the button were broken, as it was written with the inverted functionality (thus deactivating activates and vice versa).

This commit fixes this issue by now having it send a deactivation date on deactivation as expected.

Fixes #4462