### PR TITLE
[desktop/mac] make destroying ipc more robust with destroyed webcontents

### DIFF
--- a/src/desktop/ApplicationWindow.ts
+++ b/src/desktop/ApplicationWindow.ts
@@ -309,7 +309,6 @@ export class ApplicationWindow {
 		this._browserWindow
 			.on("close", async () => {
 				await this.closeDb()
-				this.remoteBridge.destroyBridge(this)
 			})
 			.on("focus", () => this.localShortcut.enableAll(this._browserWindow))
 			.on("blur", (_: FocusEvent) => this.localShortcut.disableAll(this._browserWindow))
@@ -387,8 +386,9 @@ export class ApplicationWindow {
 	}
 
 	async reload(queryParams: Record<string, string | boolean>) {
-		await this.closeDb()
+		// do this immediately as to not get the window destroyed on us
 		this.remoteBridge.destroyBridge(this)
+		await this.closeDb()
 		this.userId = null
 		this.initFacades()
 		const url = await this.getInitialUrl(queryParams)

--- a/src/desktop/WebDialog.ts
+++ b/src/desktop/WebDialog.ts
@@ -172,6 +172,6 @@ export class WebDialogController {
 	}
 
 	private async uninitRemoteFacade(webContents: WebContents) {
-		this.ipcHandler.removeHandler(webContents.id)
+		this.ipcHandler.removeHandler(webContents)
 	}
 }

--- a/src/desktop/ipc/ElectronWebContentsTransport.ts
+++ b/src/desktop/ipc/ElectronWebContentsTransport.ts
@@ -6,8 +6,7 @@ import type {WebContents} from "electron"
  * Implementation of Transport which delegates to CenterIpcHandler/WebContents.
  * Should be instantiated per WebContents.
  */
-export class ElectronWebContentsTransport<
-	IpcConfigType extends IpcConfig<string, string>,
+export class ElectronWebContentsTransport<IpcConfigType extends IpcConfig<string, string>,
 	OutgoingRequestType extends string,
 	IncomingRequestType extends string> implements Transport<OutgoingRequestType, IncomingRequestType> {
 
@@ -18,10 +17,10 @@ export class ElectronWebContentsTransport<
 	}
 
 	postMessage(message: Message<OutgoingRequestType>): void {
-		this.ipcHandler.sendTo(this.webContents.id, message)
+		this.ipcHandler.sendTo(this.webContents, message)
 	}
 
 	setMessageHandler(handler: (message: Message<IncomingRequestType>) => unknown): void {
-		this.ipcHandler.addHandler(this.webContents.id, handler)
+		this.ipcHandler.addHandler(this.webContents, handler)
 	}
 }

--- a/src/desktop/ipc/RemoteBridge.ts
+++ b/src/desktop/ipc/RemoteBridge.ts
@@ -39,6 +39,7 @@ export class RemoteBridge {
 
 	createBridge(window: ApplicationWindow): SendingFacades {
 		const webContents = window._browserWindow.webContents
+		webContents.on("destroyed", () => primaryIpcHandler.removeHandler(webContents))
 		const {desktopCommonSystemFacade, dispatcher} = this.dispatcherFactory(window)
 		const facadeHandler = this.facadeHandlerFactory(window)
 
@@ -64,6 +65,8 @@ export class RemoteBridge {
 	}
 
 	destroyBridge(window: ApplicationWindow) {
-		primaryIpcHandler.removeHandler(window._browserWindow.webContents.id)
+		// in this case, we can't get a ref to the wc anymore
+		if (!window._browserWindow || window._browserWindow.isDestroyed()) return
+		primaryIpcHandler.removeHandler(window._browserWindow.webContents)
 	}
 }


### PR DESCRIPTION
sometimes, the window is gone before we get to destroy the bridge.
This gives a TypeError: object has been destroyed.
In other cases, we try to send messages to already destroyed
webContents, giving TypeErrors because webContents.fromId returns
undefined.

To prevent this
  * we add a listener to the destroy event of the webContents
  * don't use ids for referencing the webContents, instead pass the
    content itself around to be able to check isDestroyed()

fix https://github.com/tutao/tutanota/issues/4467