### PR TITLE
[desktop] pass "secure: true" to registerSchemeAsPrivileged

### DIFF
--- a/src/desktop/DesktopWindowManager.ts
+++ b/src/desktop/DesktopWindowManager.ts
@@ -28,7 +28,7 @@ const TAG = "[DesktopWindowManager]"
 export function setupAssetProtocol(electron: ElectronExports) {
 	electron.protocol.registerSchemesAsPrivileged([{
 		scheme: ASSET_PROTOCOL,
-		privileges: {standard: true, supportFetchAPI: true}
+		privileges: {standard: true, supportFetchAPI: true, secure: true}
 	}])
 }
 


### PR DESCRIPTION
this is required to be able to use the crypto.subtle module in the web
app.