### PR TITLE
Make HtmlEditor not show a border if disabled

### DIFF
--- a/src/gui/editor/HtmlEditor.ts
+++ b/src/gui/editor/HtmlEditor.ts
@@ -42,7 +42,7 @@ export class HtmlEditor implements Component {
 
 		const modeSwitcherLabel = this.modeSwitcherLabel
 		let borderClasses = this._showBorders
-			? this.active
+			? (this.active && this.editor.isEnabled())
 				? ".editor-border-active"
 				: ".editor-border" + (modeSwitcherLabel != null ? ".editor-no-top-border" : "")
 			: ""


### PR DESCRIPTION
We do not want the editor to have an 'active' border when focused if it is disabled, as it may signal to the user that the editor can be edited in this state. The view call should check if the editor is now disabled before drawing a border.

Fixes #3935