### PR TITLE
Fix signature preview being writable

### DIFF
--- a/src/gui/editor/Editor.ts
+++ b/src/gui/editor/Editor.ts
@@ -123,6 +123,13 @@ export class Editor implements ImageHandler, Component {
 		})
 		this.squire = squire
 
+		// Suppress paste events if pasting while disabled
+		this.squire.addEventListener("willPaste", (e: Event) => {
+			if (!this.isEnabled()) {
+				e.preventDefault()
+			}
+		})
+
 		this.squire.addEventListener("pathChange", () => {
 			this.getStylesAtPath()
 			m.redraw() // allow richtexttoolbar to redraw elements
@@ -162,21 +169,8 @@ export class Editor implements ImageHandler, Component {
 
 	setEnabled(enabled: boolean) {
 		this.enabled = enabled
-
-		// not working currently
-		// text is pasted before the event is triggered
-		const pasteSuppressor = (e: Event) => {
-			e.preventDefault()
-		}
-
 		if (this.domElement) {
 			this.domElement.setAttribute("contenteditable", String(enabled))
-
-			if (this.enabled) {
-				this.domElement.removeEventListener("paste", pasteSuppressor)
-			} else {
-				this.domElement.addEventListener("paste", pasteSuppressor)
-			}
 		}
 	}
 

--- a/src/settings/EditSignatureDialog.ts
+++ b/src/settings/EditSignatureDialog.ts
@@ -35,6 +35,8 @@ export function show(props: TutanotaProperties) {
 			.setToolbarOptions({
 				imageButtonClickHandler: insertInlineImageB64ClickHandler,
 			})
+			.setEnabled(selectedType === EmailSignatureType.EMAIL_SIGNATURE_TYPE_CUSTOM)
+
 		const signatureTypes = getSignatureTypes(props)
 
 		const form = {


### PR DESCRIPTION
There was an issue where the signature preview could be edited unless it is disabled later by changing the preview, so this change disables it when it is initialized if needed.

Squire also handled pasting before our code could handle it. Luckily, Squire has a willPaste event which can be used to suppress paste events, so this change utilizes this and removes the "not working currently" comment.

Fixes #2690