### PR TITLE
fix mailbody issues

### DIFF
--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -773,11 +773,18 @@ export class MailView implements CurrentView {
 
 		if (mails.length === 1 && !multiSelectOperation && (selectionChanged || !this.mailViewerViewModel)) {
 			// set or update the visible mail
-			this.mailViewerViewModel = createMailViewerViewModel({
+
+				const viewModelParams = {
 				mail: mails[0],
 				showFolder: false,
 				delayBodyRenderingUntil: animationOverDeferred.promise,
-			})
+				}
+
+				if (this.mailViewerViewModel == null) {
+					this.mailViewerViewModel = createMailViewerViewModel(viewModelParams)
+				} else {
+					this.mailViewerViewModel.updateMail(viewModelParams)
+				}
 
 			const url = `/mail/${mails[0]._id.join("/")}`
 
@@ -858,12 +865,8 @@ export class MailView implements CurrentView {
 				isSameId(this.mailViewerViewModel.getMailId(), [instanceListId, instanceId])
 			) {
 				try {
-					const updatedMail = await locator.entityClient
-													 .load(MailTypeRef, this.mailViewerViewModel.getMailId())
-					this.mailViewerViewModel = createMailViewerViewModel({
-						mail: updatedMail,
-						showFolder: false,
-					})
+					const updatedMail = await locator.entityClient.load(MailTypeRef, this.mailViewerViewModel.getMailId())
+					this.mailViewerViewModel.updateMail({mail: updatedMail})
 				} catch (e) {
 					if (e instanceof NotFoundError) {
 						console.log(`Could not find updated mail ${JSON.stringify([instanceListId, instanceId])}`)

--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -231,7 +231,6 @@ export class MailViewerViewModel {
 	}
 
 	isContrastFixNeeded(): boolean {
-		console.log("contrastFix", this.contrastFixNeeded)
 		return this.contrastFixNeeded
 	}
 
@@ -497,12 +496,14 @@ export class MailViewerViewModel {
 
 	/** @return list of inline referenced cid */
 	private async loadMailBody(mail: Mail): Promise<string[]> {
+
+		// If the mail is a non-draft and we have loaded it before, we don't need to reload it because it cannot have been edited, so we return early
+		// drafts however can be edited, and we want to receive the changes, so for drafts we will always reload
 		if (
 			this.renderedMail != null && haveSameId(mail, this.renderedMail)
 			&& mail.state !== MailState.DRAFT
 			&& this.sanitizeResult != null
 		) {
-			// Short-circuit to avoid resetting contentBlockingStatus or mail body.
 			return this.sanitizeResult.inlineImageCids
 		}
 
@@ -793,7 +794,6 @@ export class MailViewerViewModel {
 			allowRelativeLinks: isTutanotaTeamMail(mail),
 		})
 		const {fragment, inlineImageCids, links, externalContent} = sanitizeResult
-		console.log("sanitize the mailbod")
 
 		/**
 		 * Check if we need to improve contrast for dark theme. We apply the contrast fix if any of the following is contained in

--- a/src/search/view/SearchResultDetailsViewer.ts
+++ b/src/search/view/SearchResultDetailsViewer.ts
@@ -1,13 +1,11 @@
 import m, {Children} from "mithril"
 import {SearchListView, SearchResultListEntry} from "./SearchListView"
-import type {Mail} from "../../api/entities/tutanota/TypeRefs.js"
-import {MailTypeRef} from "../../api/entities/tutanota/TypeRefs.js"
+import type {Contact, Mail} from "../../api/entities/tutanota/TypeRefs.js"
+import {ContactTypeRef, MailTypeRef} from "../../api/entities/tutanota/TypeRefs.js"
 import {LockedError, NotFoundError} from "../../api/common/error/RestError"
 import {createMailViewerViewModel, MailViewer} from "../../mail/view/MailViewer"
 import {ContactViewer} from "../../contacts/view/ContactViewer"
 import ColumnEmptyMessageBox from "../../gui/base/ColumnEmptyMessageBox"
-import type {Contact} from "../../api/entities/tutanota/TypeRefs.js"
-import {ContactTypeRef} from "../../api/entities/tutanota/TypeRefs.js"
 import {assertMainOrNode} from "../../api/common/Env"
 import {MultiSearchViewer} from "./MultiSearchViewer"
 import {theme} from "../../gui/theme"
@@ -62,12 +60,17 @@ export class SearchResultDetailsViewer {
 	showEntity(entity: Record<string, any>, entitySelected: boolean): void {
 		if (isSameTypeRef(MailTypeRef, entity._type)) {
 			const mail = entity as Mail
-			this._viewer = {
-				mode: "mail",
-				viewModel: createMailViewerViewModel({
-					mail,
-					showFolder: true,
-				})
+			const viewModelParams = {
+				mail,
+				showFolder: true,
+			}
+			if (this._viewer == null || this._viewer.mode !== "mail") {
+				this._viewer = {
+					mode: "mail",
+					viewModel: createMailViewerViewModel(viewModelParams)
+				}
+			} else {
+				this._viewer.viewModel.updateMail(viewModelParams)
 			}
 
 			this._viewerEntityId = mail._id
@@ -101,7 +104,7 @@ export class SearchResultDetailsViewer {
 				this._viewer = null
 				this._viewerEntityId = null
 			} else {
-				this._viewer = { mode: "multiSearch", viewer: this._multiSearchViewer }
+				this._viewer = {mode: "multiSearch", viewer: this._multiSearchViewer}
 			}
 
 			//let url = `/mail/${this.mailList.listId}`


### PR DESCRIPTION
fix the flicker when the unread state is changed:
Instead of recreating the view model we just update the mail in the existing one. This introduced the issue that the existing mail body would not be updated so we have to manually call `loadAll`, and also re-call `replaceInlineImages` hence the funky business with streams

fix the flickering when `contrastFixNeeded` is true: this is also fixed by not recreating the viewModel

fix the rendering of a new mailbody:
Mithril was reusing the dom element when switching from rendering a mail body to rendering the progress spinner. Because of the shadow dom, the old content was remaining. I opted to add keys to the different elements to force mithril to re-render it completely.

fix #4309