### PR TITLE
Have spam rules field options use inbox rules text

### DIFF
--- a/src/settings/AddSpamRuleDialog.ts
+++ b/src/settings/AddSpamRuleDialog.ts
@@ -156,10 +156,10 @@ function isInvalidRule(type: NumberString, value: string, customDomains: string[
 
 export function getSpamRuleFieldToName(): Record<SpamRuleFieldType, string> {
 	return {
-		[SpamRuleFieldType.FROM]: lang.get("from_label"),
-		[SpamRuleFieldType.TO]: lang.get("to_label"),
-		[SpamRuleFieldType.CC]: "CC",
-		[SpamRuleFieldType.BCC]: "BCC",
+		[SpamRuleFieldType.FROM]: lang.get("inboxRuleSenderEquals_action"),
+		[SpamRuleFieldType.TO]: lang.get("inboxRuleToRecipientEquals_action"),
+		[SpamRuleFieldType.CC]: lang.get("inboxRuleCCRecipientEquals_action"),
+		[SpamRuleFieldType.BCC]: lang.get("inboxRuleBCCRecipientEquals_action"),
 	}
 }
 


### PR DESCRIPTION
Make the field options in spam rules in line with the text used for inbox rules (e.g. From -> From/Sender). Also do not use hardcoded "CC"/"BCC" labels here.

Fixes #3350