### PR TITLE
Have invoice page number not display on first page of signup

### DIFF
--- a/src/subscription/InvoiceAndPaymentDataPage.ts
+++ b/src/subscription/InvoiceAndPaymentDataPage.ts
@@ -19,7 +19,7 @@ import {Button, ButtonType} from "../gui/base/Button.js"
 import type {SegmentControlItem} from "../gui/base/SegmentControl"
 import {SegmentControl} from "../gui/base/SegmentControl"
 import type {WizardPageAttrs, WizardPageN} from "../gui/base/WizardDialog.js"
-import {emitWizardEvent, WizardEventType} from "../gui/base/WizardDialog.js"
+import {emitWizardEvent, WizardDialogAttrsBuilder, WizardEventType} from "../gui/base/WizardDialog.js"
 import type {Country} from "../api/common/CountryList"
 import {DefaultAnimationTime} from "../gui/animation/Animations"
 import {EntityEventsListener, EntityUpdateData, isUpdateForTypeRef} from "../api/main/EventController"
@@ -207,6 +207,7 @@ export class InvoiceAndPaymentDataPage implements WizardPageN<UpgradeSubscriptio
 
 export class InvoiceAndPaymentDataPageAttrs implements WizardPageAttrs<UpgradeSubscriptionData> {
 	data: UpgradeSubscriptionData
+	_enabled: () => boolean = () => true
 
 	constructor(upgradeData: UpgradeSubscriptionData) {
 		this.data = upgradeData
@@ -225,7 +226,15 @@ export class InvoiceAndPaymentDataPageAttrs implements WizardPageAttrs<UpgradeSu
 	}
 
 	isEnabled(): boolean {
-		return this.data.type !== SubscriptionType.Free
+		return this._enabled()
+	}
+
+	/**
+	 * Set the enabled function for isEnabled
+	 * @param enabled
+	 */
+	setEnabledFunction<T>(enabled: () => boolean) {
+		this._enabled = enabled
 	}
 }
 

--- a/src/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/subscription/UpgradeSubscriptionWizard.ts
@@ -177,10 +177,12 @@ export async function loadSignupWizard(subscriptionParameters: SubscriptionParam
 		currentSubscription: null,
 		subscriptionParameters: subscriptionParameters,
 	}
+
+	const invoiceAttrs = new InvoiceAndPaymentDataPageAttrs(signupData)
 	const wizardPages = [
 		wizardPageWrapper(UpgradeSubscriptionPage, new UpgradeSubscriptionPageAttrs(signupData)),
 		wizardPageWrapper(SignupPage, new SignupPageAttrs(signupData)),
-		wizardPageWrapper(InvoiceAndPaymentDataPage, new InvoiceAndPaymentDataPageAttrs(signupData)),
+		wizardPageWrapper(InvoiceAndPaymentDataPage, invoiceAttrs),
 		wizardPageWrapper(UpgradeConfirmPage, new UpgradeConfirmPageAttrs(signupData)),
 	]
 	const wizardBuilder = createWizardDialog(signupData, wizardPages, async () => {
@@ -198,5 +200,9 @@ export async function loadSignupWizard(subscriptionParameters: SubscriptionParam
 			})
 		}
 	})
+
+	// for signup specifically, we only want the invoice and payment page to show up if signing up for a paid account (and the user did not go back to the first page!)
+	invoiceAttrs.setEnabledFunction(() => signupData.type !== SubscriptionType.Free && wizardBuilder.attrs.currentPage !== wizardPages[0])
+
 	return wizardBuilder.dialog
 }


### PR DESCRIPTION
Specify an enabled function for InvoiceAndPaymentDataPage's attrs so that its page button is displayed when appropriate.

When signing up for a new account, do not display it if the the user either did not select Free or they are on the first page (and thus we may not be certain if they want to select a paid plan).

We want to check this in particular for signup, as upgrading from free to paid will, of course, always have an invoice page. And changing from paid to another plan does not have an invoice page to begin with.

Fixes #3100