### PR TITLE
[ios] don't crash on unknown asset requests

### DIFF
--- a/app-ios/tutanota/Sources/CustomSchemeHandlers.swift
+++ b/app-ios/tutanota/Sources/CustomSchemeHandlers.swift
@@ -82,7 +82,15 @@ class AssetSchemeHandler : NSObject, WKURLSchemeHandler {
       let err = NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist)
       urlSchemeTask.didFailWithError(err)
     } else {
-      let fileContent = try! Data(contentsOf: URL(fileURLWithPath: requestedFilePath))
+      let fileContent: Data
+      do {
+        fileContent = try Data(contentsOf: URL(fileURLWithPath: requestedFilePath))
+      } catch {
+        TUTSLog("failed to load asset URL \(requestedFilePath), got error \(error)")
+        let err = NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist)
+        urlSchemeTask.didFailWithError(err)
+        return
+      }
       let mimeType = getFileMIMETypeWithDefault(path: requestedFilePath)
       urlSchemeTask.didReceive(URLResponse(
         url: urlSchemeTask.request.url!,


### PR DESCRIPTION
some mails contain relative URLs in image tags or CSS, which is not nice
that's why, from now on, we check requests, twice.

#4487

Co-authored-by: ivk <ivk@tutao.de>

## Test notes
 - [ ] App can load
 - [ ] App can load inline and external images
 - [ ] Craft an email with `<img src="">`, see that it doesn't crash the app when loaded