### PR TITLE
MailEditor should show CC/BCC if initialized with either

### DIFF
--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -115,7 +115,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 	templateModel: TemplatePopupModel | null
 	openKnowledgeBaseButtonAttrs: ButtonAttrs | null = null
 	sendMailModel: SendMailModel
-	private areDetailsExpanded = false
+	private areDetailsExpanded: boolean
 	private recipientShowConfidential: Map<string, boolean> = new Map()
 
 	constructor(vnode: Vnode<MailEditorAttrs>) {
@@ -126,6 +126,10 @@ export class MailEditor implements Component<MailEditorAttrs> {
 		const model = a.model
 		this.sendMailModel = model
 		this.templateModel = a.templateModel
+
+		// if we have any CC/BCC recipients, we should show these so, should the user send the mail, they know where it will be going to
+		this.areDetailsExpanded = (model.bccRecipients().length + model.ccRecipients().length) > 0
+
 		this.editor = new Editor(200, (html, isPaste) => {
 			const sanitized = htmlSanitizer.sanitizeFragment(html, {
 				blockExternalContent: !isPaste && a.doBlockExternalContent(),


### PR DESCRIPTION
We want to prevent that, when sending emails, emails are unexpectedly sent to recipients that the sender is unaware of.

Therefore, when opening a mail editor with pre-set CC/BCC recipients such as when clicking on a mailto link or opening a draft, we want the CC/BCC fields to be expanded automatically to indicate to the user that there are more recipients.

Fixes #3844