### PR TITLE
LoginForm should have email automatically focused if not on mobile

### DIFF
--- a/src/gui/base/TextField.ts
+++ b/src/gui/base/TextField.ts
@@ -195,9 +195,8 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 						"aria-label": lang.getMaybeLazy(a.label),
 						oncreate: vnode => {
 							this.domInput = vnode.dom as HTMLInputElement
-							vnode.attrs.onDomInputCreated?.(this.domInput)
+							a.onDomInputCreated?.(this.domInput)
 							this.domInput.value = a.value
-
 							if (a.type !== TextFieldType.Area) {
 								(vnode.dom as HTMLElement).addEventListener("animationstart", (e: AnimationEvent) => {
 									if (e.animationName === "onAutoFillStart") {

--- a/src/login/LoginForm.ts
+++ b/src/login/LoginForm.ts
@@ -5,7 +5,7 @@ import {BootstrapFeatureType} from "../api/common/TutanotaConstants"
 import {Button, ButtonType} from "../gui/base/Button.js"
 import {liveDataAttrs} from "../gui/AriaUtils"
 import {lang, TranslationKey} from "../misc/LanguageViewModel"
-import {TextFieldAttrs, TextField, TextFieldType} from "../gui/base/TextField.js"
+import {TextField, TextFieldType} from "../gui/base/TextField.js"
 import {Checkbox} from "../gui/base/Checkbox.js"
 import {client} from "../misc/ClientDetector"
 import {getWhitelabelCustomizations} from "../misc/WhitelabelCustomizations"
@@ -83,6 +83,11 @@ export class LoginForm implements Component<LoginFormAttrs> {
 						value: a.mailAddress(),
 						oninput: a.mailAddress,
 						type: TextFieldType.Email,
+						onDomInputCreated: (dom) => {
+							if (!client.isMobileDevice()) {
+								dom.focus() // have email address auto-focus so the user can immediately type their username (unless on mobile)
+							}
+						}
 					}),
 				),
 				m(


### PR DESCRIPTION
On a non-mobile device, we should automatically focus on email address so that the email can immediately be typed once on the login page.

Fixes #2810