### PR TITLE
Fix unwanted autologin when cancelling dialogs on login screen

### DIFF
--- a/src/login/recover/TakeOverDeletedAddressDialog.ts
+++ b/src/login/recover/TakeOverDeletedAddressDialog.ts
@@ -1,12 +1,6 @@
 import m from "mithril"
 import stream from "mithril/stream"
-import {
-	AccessBlockedError,
-	AccessDeactivatedError,
-	InvalidDataError,
-	NotAuthenticatedError,
-	TooManyRequestsError
-} from "../../api/common/error/RestError"
+import {AccessBlockedError, AccessDeactivatedError, InvalidDataError, NotAuthenticatedError, TooManyRequestsError} from "../../api/common/error/RestError"
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog"
 import {isMailAddress} from "../../misc/FormatValidator"
 import {lang} from "../../misc/LanguageViewModel"
@@ -77,7 +71,9 @@ export function showTakeOverDialog(mailAddress: string, password: string): Dialo
 					.catch(e => handleError(e))
 			}
 		},
-		cancelAction: () => m.route.set("/login"),
+		cancelAction: () => m.route.set("/login", {
+			noAutoLogin: true,
+		}),
 	})
 	return takeoverDialog
 }

--- a/src/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/subscription/UpgradeSubscriptionWizard.ts
@@ -190,6 +190,7 @@ export async function loadSignupWizard(subscriptionParameters: SubscriptionParam
 
 		if (signupData.newAccountData) {
 			m.route.set("/login", {
+				noAutoLogin: true,
 				loginWith: signupData.newAccountData.mailAddress,
 			})
 		} else {


### PR DESCRIPTION
When credentials are stored and the user cancels:

- the dialog for signing up a new account
- the dialog for taking over an account due to inactivity
- the dialog for having lost access to an account

the desired behavior should be that the user is not logged back into the
previously saved account.

To ensure this the parameters for redirecting to the login page have been
changed to not log the user in automatically after cancelling the mentioned
dialogs.

fixes #2549
Co-authored-by: @nif-tutao 

