### PR TITLE
Wrong label on confidential button in the mail editor

### DIFF
--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -250,7 +250,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 		const showConfidentialButton = model.containsExternalRecipients()
 		const isConfidential = model.isConfidential() && showConfidentialButton
 		const confidentialButtonAttrs: ButtonAttrs = {
-			label: "confidential_action",
+			label: model.isConfidential() ? "confidential_action" : "nonConfidential_action",
 			click: () => model.setConfidential(!model.isConfidential()),
 			icon: () => (model.isConfidential() ? Icons.Lock : Icons.Unlock),
 			isSelected: () => model.isConfidential(),


### PR DESCRIPTION
Added condition to check what label should be used.

fixes #3254