### PR TITLE
Fix automatically closing ephemeral sessions with a beacon

### DIFF
--- a/src/api/main/UserController.ts
+++ b/src/api/main/UserController.ts
@@ -190,7 +190,7 @@ export class UserController {
 
 			if (sendBeacon) {
 				try {
-					const path = `${getHttpOrigin()}/rest/sys/${CloseSessionService}`
+					const path = `${getHttpOrigin()}/rest/sys/${CloseSessionService.name.toLowerCase()}`
 					const requestObject = createCloseSessionServicePost({
 						accessToken: this.accessToken,
 						sessionId: this.sessionId,


### PR DESCRIPTION
When the browser tab is closed we try to delete ephemeral session
using Beacon but while assembling the URL for CloseSessionService we
interpolated the whole object instead of a service name so the
URL had `[object Object]` in it.

fix #4523