### PR TITLE
[desktop] Upload blobs via native

### DIFF
--- a/src/api/worker/facades/BlobFacade.ts
+++ b/src/api/worker/facades/BlobFacade.ts
@@ -1,23 +1,13 @@
 import {addParamsToUrl, isSuspensionResponse, RestClient} from "../rest/RestClient"
 import {CryptoFacade, encryptBytes} from "../crypto/CryptoFacade"
-import {
-	concat,
-	decodeBase64,
-	downcast,
-	Mapper,
-	neverNull,
-	promiseMap,
-	splitUint8ArrayInChunks,
-	uint8ArrayToBase64,
-	uint8ArrayToString,
-} from "@tutao/tutanota-utils"
+import {concat, downcast, Mapper, neverNull, promiseMap, splitUint8ArrayInChunks, uint8ArrayToBase64, uint8ArrayToString,} from "@tutao/tutanota-utils"
 import {ArchiveDataType, MAX_BLOB_SIZE_BYTES} from "../../common/TutanotaConstants"
 
 import {HttpMethod, MediaType, resolveTypeReference} from "../../common/EntityFunctions"
 import {assertWorkerOrNode, isApp, isDesktop} from "../../common/Env"
 import type {SuspensionHandler} from "../SuspensionHandler"
 import {BlobAccessTokenService, BlobService} from "../../entities/storage/Services"
-import {aes128Decrypt, random, sha256Hash} from "@tutao/tutanota-crypto"
+import {aes128Decrypt, sha256Hash} from "@tutao/tutanota-crypto"
 import type {FileUri, NativeFileApp} from "../../../native/common/FileApp"
 import type {AesApp} from "../../../native/worker/AesApp"
 import {InstanceMapper} from "../crypto/InstanceMapper"

--- a/src/desktop/CryptoFns.ts
+++ b/src/desktop/CryptoFns.ts
@@ -6,7 +6,17 @@ import crypto from "crypto"
 import {InstanceMapper} from "../api/worker/crypto/InstanceMapper"
 import type {TypeModel} from "../api/common/EntityTypes"
 import type {Base64} from "@tutao/tutanota-utils"
-import {aes128Decrypt, aes256Decrypt, aes256Encrypt, aes256RandomKey, base64ToKey, decrypt256Key, random, uint8ArrayToKey} from "@tutao/tutanota-crypto"
+import {
+	aes128Decrypt,
+	aes128Encrypt,
+	aes256Decrypt,
+	aes256Encrypt,
+	aes256RandomKey,
+	base64ToKey,
+	decrypt256Key,
+	random,
+	uint8ArrayToKey
+} from "@tutao/tutanota-crypto"
 
 // the prng throws if it doesn't have enough entropy
 // it may be called very early, so we need to seed it
@@ -28,6 +38,8 @@ const seed = () => {
 seed()
 
 export interface CryptoFunctions {
+	aes128Encrypt(key: Aes128Key, bytes: Uint8Array, iv: Uint8Array, usePadding: boolean, useMac: boolean): Uint8Array
+
 	aes128Decrypt(key: Aes128Key, encryptedBytes: Uint8Array, usePadding: boolean): Uint8Array
 
 	aes256Encrypt(key: Aes256Key, bytes: Uint8Array, iv: Uint8Array, usePadding: boolean, useMac: boolean): Uint8Array
@@ -55,6 +67,9 @@ export interface CryptoFunctions {
 
 const mapper = new InstanceMapper()
 export const cryptoFns: CryptoFunctions = {
+	aes128Encrypt(key: Aes128Key, bytes: Uint8Array, iv: Uint8Array, usePadding: boolean, useMac: boolean): Uint8Array {
+		return aes128Encrypt(key, bytes, iv, usePadding, useMac)
+	},
 	aes128Decrypt(key: Aes128Key, encryptedBytes: Uint8Array, usePadding: boolean): Uint8Array {
 		return aes128Decrypt(key, encryptedBytes, usePadding)
 	},

--- a/src/desktop/DesktopFileFacade.ts
+++ b/src/desktop/DesktopFileFacade.ts
@@ -2,7 +2,7 @@ import {FileFacade} from "../native/common/generatedipc/FileFacade.js"
 import {DownloadTaskResponse} from "../native/common/generatedipc/DownloadTaskResponse.js"
 import {IpcClientRect} from "../native/common/generatedipc/IpcClientRect.js"
 import {DesktopDownloadManager} from "./net/DesktopDownloadManager.js"
-import {ElectronExports, FsExports} from "./ElectronExportTypes.js"
+import {ElectronExports} from "./ElectronExportTypes.js"
 import {UploadTaskResponse} from "../native/common/generatedipc/UploadTaskResponse.js"
 import {DataFile} from "../api/common/DataFile.js"
 import {FileUri} from "../native/common/FileApp.js"
@@ -45,7 +45,7 @@ export class DesktopFileFacade implements FileFacade {
 	}
 
 	hashFile(fileUri: string): Promise<string> {
-		return this.dl.hashFile(fileUri)
+		return this.dl.blobHashFile(fileUri)
 	}
 
 	joinFiles(filename: string, files: Array<string>): Promise<string> {
@@ -74,11 +74,11 @@ export class DesktopFileFacade implements FileFacade {
 	}
 
 	splitFile(fileUri: string, maxChunkSizeBytes: number): Promise<Array<string>> {
-		throw Unimplemented()
+		return this.dl.splitFile(fileUri, maxChunkSizeBytes)
 	}
 
 	upload(fileUrl: string, targetUrl: string, method: string, headers: Record<string, string>): Promise<UploadTaskResponse> {
-		throw Unimplemented()
+		return this.dl.upload(fileUrl, targetUrl, method, headers)
 	}
 
 	writeDataFile(file: DataFile): Promise<string> {

--- a/src/desktop/DesktopNativeCryptoFacade.ts
+++ b/src/desktop/DesktopNativeCryptoFacade.ts
@@ -109,7 +109,17 @@ export class DesktopNativeCryptoFacade implements NativeCryptoFacade {
 	}
 
 	async aesEncryptFile(key: Uint8Array, fileUri: string): Promise<EncryptedFileInfo> {
-		throw new Error("not implemented for this platform")
+		const bytes = await this.fs.promises.readFile(fileUri)
+		const encrypted = this.cryptoFns.aes128Encrypt(this.cryptoFns.bytesToKey(key), bytes, this.cryptoFns.randomBytes(16), true, true)
+
+		const targetDir = path.join(this.utils.getTutanotaTempPath(), "encrypted")
+		await this.fs.promises.mkdir(targetDir, {recursive: true})
+		const filePath = path.join(targetDir, path.basename(fileUri))
+		await this.fs.promises.writeFile(filePath, encrypted)
+		return {
+			uri: filePath,
+			unencryptedSize: bytes.length,
+		}
 	}
 
 	async generateRsaKey(seed: Uint8Array): Promise<RsaKeyPair> {

--- a/src/file/FileControllerNative.ts
+++ b/src/file/FileControllerNative.ts
@@ -126,7 +126,7 @@ export class FileControllerNative implements FileController {
 		// For apps "opening" DataFile currently means saving and opening it.
 		try {
 			const fileReference = await this.fileApp.writeDataFile(file)
-			if (isAndroidApp()) {
+			if (isAndroidApp() || isDesktop()) {
 				await this.fileApp.putFileIntoDownloadsFolder(fileReference.location)
 				return
 			} else if (isIOSApp()) {

--- a/test/tests/desktop/DesktopCryptoFacadeTest.ts
+++ b/test/tests/desktop/DesktopCryptoFacadeTest.ts
@@ -15,9 +15,18 @@ o.spec("DesktopCryptoFacadeTest", () => {
 	const aes256Key = [2, 5, 6]
 	const aes256DecryptedKey = new Uint8Array([2, 5, 6, 2])
 	const aes256EncryptedKey = new Uint8Array([2, 5, 6, 1])
+	const encryptedUint8 = stringToUtf8Uint8Array("encrypted")
 	const decryptedUint8 = stringToUtf8Uint8Array("decrypted")
 	const someKey = new Uint8Array([1, 2])
 	const cryptoFns: CryptoFunctions = {
+		aes128Encrypt(key: Aes128Key, bytes: Uint8Array, iv: Uint8Array, usePadding: boolean, useMac: boolean): Uint8Array {
+			if (key === aes128Key) {
+				return decryptedUint8
+			} else {
+				throw new Error("stub!")
+			}
+		},
+
 		aes128Decrypt(key: Aes128Key, encryptedBytes: Uint8Array, usePadding: boolean): Uint8Array {
 			if (key === aes128Key) {
 				return decryptedUint8
@@ -131,7 +140,12 @@ o.spec("DesktopCryptoFacadeTest", () => {
 			desktopCrypto,
 		})
 	}
-
+	o("aesEncryptFile", async function () {
+		const {desktopCrypto, fsMock} = setupSubject()
+		const {uri} = await desktopCrypto.aesEncryptFile(someKey, "/some/path/to/encrypted/file.pdf")
+		o(uri).equals("/some/other/path/to/encrypted/file.pdf")
+		o(fsMock.promises.writeFile.callCount).equals(1)
+	})
 	o("aesDecryptFile", async function () {
 		const {desktopCrypto, fsMock} = setupSubject()
 		const file = await desktopCrypto.aesDecryptFile(someKey, "/some/path/to/file.pdf")


### PR DESCRIPTION
For reasons described in 6f4600f we started uploading
DataFile's via native. It was also changed in desktop but
we never actually implemented the desktop part.

With this change we fix multiple issues to make uploading blobs
work again on desktop:
- change writeDataFile() to not ask for path but instead write to a
temp directory for unencrypted files, like on other platforms,
and adjust the code accordingly
- implement aesEncryptFile(), splitFile() and upload(), needed for
blobs

fix #4529