### PR TITLE
Enable audit log for free accounts

### DIFF
--- a/src/settings/GlobalSettingsViewer.ts
+++ b/src/settings/GlobalSettingsViewer.ts
@@ -189,7 +189,7 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 						],
 						dropdownWidth: 250
 					}),
-					logins.getUserController().isGlobalAdmin() && logins.getUserController().isPremiumAccount()
+					logins.getUserController().isGlobalAdmin()
 						? m("", [
 							m(DropDownSelector, {
 								label: "enforcePasswordUpdate_title",

--- a/src/settings/GlobalSettingsViewer.ts
+++ b/src/settings/GlobalSettingsViewer.ts
@@ -191,32 +191,34 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 					}),
 					logins.getUserController().isGlobalAdmin()
 						? m("", [
-							m(DropDownSelector, {
-								label: "enforcePasswordUpdate_title",
-								helpLabel: () => lang.get("enforcePasswordUpdate_msg"),
-								selectedValue: this.requirePasswordUpdateAfterReset,
-								selectionChangedHandler: value => {
-									const newProps: CustomerServerProperties = Object.assign(
-										{},
-										this.props(),
+							logins.getUserController().isPremiumAccount()
+								? m(DropDownSelector, {
+									label: "enforcePasswordUpdate_title",
+									helpLabel: () => lang.get("enforcePasswordUpdate_msg"),
+									selectedValue: this.requirePasswordUpdateAfterReset,
+									selectionChangedHandler: value => {
+										const newProps: CustomerServerProperties = Object.assign(
+											{},
+											this.props(),
+											{
+												requirePasswordUpdateAfterReset: value,
+											}
+										)
+										locator.entityClient.update(newProps)
+									},
+									items: [
 										{
-											requirePasswordUpdateAfterReset: value,
-										}
-									)
-									locator.entityClient.update(newProps)
-								},
-								items: [
-									{
-										name: lang.get("yes_label"),
-										value: true,
-									},
-									{
-										name: lang.get("no_label"),
-										value: false,
-									},
-								],
-								dropdownWidth: 250
-							}),
+											name: lang.get("yes_label"),
+											value: true,
+										},
+										{
+											name: lang.get("no_label"),
+											value: false,
+										},
+									],
+									dropdownWidth: 250
+								})
+								: null,
 							this.customer
 								? m(
 									".mt-l",


### PR DESCRIPTION
There isn't really any reason the client can't show this for free users as it appears to be fully functional on free accounts and may be useful to note when a password was changed for example.

Fixes #4539