### PR TITLE
Fix issues with temporary login

### DIFF
--- a/src/api/main/LoginController.ts
+++ b/src/api/main/LoginController.ts
@@ -83,7 +83,7 @@ export class LoginControllerImpl implements LoginController {
 	private fullyLoggedIn: boolean = false
 	private atLeastPartiallyLoggedIn: boolean = false
 
-	async init() {
+	init() {
 		this.waitForFullLogin().then(async () => {
 			this.fullyLoggedIn = true
 			await this.waitForPartialLogin()
@@ -256,6 +256,10 @@ export class LoginControllerImpl implements LoginController {
 			await this.userController.deleteSession(sync)
 			this.userController = null
 			this.partialLogin = defer()
+			this.fullyLoggedIn = false
+			const locator = await this.getMainLocator()
+			locator.loginListener.reset()
+			this.init()
 		} else {
 			console.log("No session to delete")
 		}

--- a/src/api/main/LoginListener.ts
+++ b/src/api/main/LoginListener.ts
@@ -18,6 +18,12 @@ export class LoginListener {
 	) {
 	}
 
+	/** e.g. after temp logout */
+	reset() {
+		this.loginPromise = defer()
+		this.fullLoginFailed = false
+	}
+
 	waitForFullLogin(): Promise<void> {
 		return this.loginPromise.promise
 	}

--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -8,7 +8,7 @@ import {
 	listIdPart,
 	timestampToGeneratedId
 } from "../../common/utils/EntityUtils.js"
-import {CacheStorage, expandId, ExposedCacheStorage} from "../rest/DefaultEntityRestCache.js"
+import {CacheStorage, expandId, ExposedCacheStorage, LastUpdateTime} from "../rest/DefaultEntityRestCache.js"
 import * as cborg from "cborg"
 import {EncodeOptions, Token, Type} from "cborg"
 import {assert, DAY_IN_MILLIS, getTypeId, groupByAndMap, mapNullable, TypeRef} from "@tutao/tutanota-utils"
@@ -217,8 +217,9 @@ AND NOT(${firstIdBigger("elementId", upper)})`
 		await this.sqlCipherFacade.run(query, params)
 	}
 
-	async getLastUpdateTime(): Promise<number | null> {
-		return this.getMetadata("lastUpdateTime")
+	async getLastUpdateTime(): Promise<LastUpdateTime> {
+		const time = await this.getMetadata("lastUpdateTime")
+		return time ? {type: "recorded", time} : {type: "never"}
 	}
 
 	async putLastUpdateTime(ms: number): Promise<void> {

--- a/src/api/worker/rest/CacheStorageProxy.ts
+++ b/src/api/worker/rest/CacheStorageProxy.ts
@@ -1,4 +1,4 @@
-import {CacheStorage, Range} from "./DefaultEntityRestCache.js"
+import {CacheStorage, LastUpdateTime, Range} from "./DefaultEntityRestCache.js"
 import {ProgrammingError} from "../../common/error/ProgrammingError"
 import {ListElementEntity, SomeEntity} from "../../common/EntityTypes"
 import {TypeRef} from "@tutao/tutanota-utils"
@@ -22,6 +22,7 @@ interface CacheStorageInitReturn {
 
 export interface CacheStorageLateInitializer {
 	initialize(args: OfflineStorageInitArgs | null): Promise<CacheStorageInitReturn>;
+
 	deInitialize(): Promise<void>;
 }
 
@@ -112,8 +113,10 @@ export class LateInitializedCacheStorageImpl implements CacheStorageLateInitiali
 		return this.inner.getLastBatchIdForGroup(groupId)
 	}
 
-	getLastUpdateTime(): Promise<number | null> {
-		return this.inner.getLastUpdateTime()
+	async getLastUpdateTime(): Promise<LastUpdateTime> {
+		return this._inner
+			? this.inner.getLastUpdateTime()
+			: {type: "uninitialized"}
 	}
 
 	getRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Range | null> {

--- a/src/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/api/worker/rest/EphemeralCacheStorage.ts
@@ -1,7 +1,7 @@
 import {ElementEntity, ListElementEntity, SomeEntity} from "../../common/EntityTypes.js"
 import {EntityRestClient, typeRefToPath} from "./EntityRestClient.js"
 import {firstBiggerThanSecond, getElementId, getListId, isElementEntity} from "../../common/utils/EntityUtils.js"
-import {CacheStorage} from "./DefaultEntityRestCache.js"
+import {CacheStorage, LastUpdateTime} from "./DefaultEntityRestCache.js"
 import {clone, getFromMap, remove, TypeRef} from "@tutao/tutanota-utils"
 import {CustomCacheHandlerMap} from "./CustomCacheHandler.js"
 
@@ -210,8 +210,8 @@ export class EphemeralCacheStorage implements CacheStorage {
 	}
 
 
-	async getLastUpdateTime(): Promise<number | null> {
-		return this.lastUpdateTime
+	async getLastUpdateTime(): Promise<LastUpdateTime> {
+		return this.lastUpdateTime ? {type: "recorded", time: this.lastUpdateTime} : {type: "never"}
 	}
 
 	async putLastUpdateTime(value: number): Promise<void> {

--- a/src/gui/base/OfflineIndicatorViewModel.ts
+++ b/src/gui/base/OfflineIndicatorViewModel.ts
@@ -80,11 +80,18 @@ export class OfflineIndicatorViewModel {
 	private async onWsStateChange(newState: WsConnectionState): Promise<void> {
 		this.lastWsState = newState
 		if (newState !== WsConnectionState.connected) {
-			await this.logins!.waitForPartialLogin()
 			const lastUpdate = await this.cacheStorage!.getLastUpdateTime()
-			this.lastUpdate = lastUpdate != null
-				? new Date(lastUpdate)
-				: null
+			switch (lastUpdate.type) {
+				case "recorded":
+					this.lastUpdate = new Date(lastUpdate.time)
+					break
+				case "never":
+				// We can get into uninitialized state after temporary login e.g. during signup
+				case "uninitialized":
+					this.lastUpdate = null
+					this.wsWasConnectedBefore = false
+					break
+			}
 
 		} else {
 			this.wsWasConnectedBefore = true

--- a/src/login/PostLoginActions.ts
+++ b/src/login/PostLoginActions.ts
@@ -59,6 +59,7 @@ export class PostLoginActions implements IPostLoginAction {
 
 		// only show "Tutanota" after login if there is no custom title set
 		if (!logins.getUserController().isInternalUser()) {
+
 			if (document.title === LOGIN_TITLE) {
 				document.title = "Tutanota"
 			}
@@ -84,7 +85,7 @@ export class PostLoginActions implements IPostLoginAction {
 			hourCycle: getHourCycle(logins.getUserController().userSettingsGroupRoot),
 		})
 
-		if (!isAdminClient()) {
+		if (!isAdminClient() && loggedInEvent.sessionType !== SessionType.Temporary) {
 			await locator.mailModel.init()
 		}
 		if (isApp() || isDesktop()) {


### PR DESCRIPTION
The first issue is attempting to get last update time in OfflineIndicatorViewModel. It was trying to wait for partial login but unfortunately temporary login is also partial login.

We didn't want to just return null in this case as it might get interpreted incorrectly and instead we returned a sum type with the exact case and ignore uninitialized storage in this case.

The other issue was with LoginController and LoginListener not properly resetting themselves on logout (e.g. after temporary login) and giving incorrect results.

The third issue was with PostLoginActions initializing MailModel for temporary login. If a real login into another account is attempted afterwards it would lead to more errors.

To fully solve the problem we should rethink how temporary login affects the rest of the app and perhaps skip most of the things that happen during normal login.

fix #4559