### PR TITLE
Fix double login in specific cases

### DIFF
--- a/src/RootView.ts
+++ b/src/RootView.ts
@@ -22,11 +22,8 @@ export const enum LayerType {
 
 export class RootView {
 	view: (...args: Array<any>) => any
-	viewCache: Record<string, (...args: Array<any>) => any>
 
 	constructor() {
-		this.viewCache = {}
-
 		// On first mouse event disable outline. This is a compromise between keyboard navigation users and mouse users.
 		let onmousedown: ((e: EventRedraw<MouseEvent>) => unknown) | null = (e) => {
 			if (onmousedown) {

--- a/src/gui/BaseTopLevelView.ts
+++ b/src/gui/BaseTopLevelView.ts
@@ -1,0 +1,24 @@
+import {TopLevelAttrs} from "./Header.js"
+import {Vnode} from "mithril"
+
+/**
+ * Base (utility) class for top-level components. Will handle URL updates for you automatically and will only call {@link onNewUrl} when necessary.
+ */
+export abstract class BaseTopLevelView {
+	private lastPath: string = ""
+
+	oncreate({attrs}: Vnode<TopLevelAttrs>) {
+		this.lastPath = attrs.requestedPath
+		this.onNewUrl(attrs.args, attrs.requestedPath)
+	}
+
+	onupdate({attrs}: Vnode<TopLevelAttrs>) {
+		// onupdate() is called on every re-render but we don't want to call onNewUrl all the time
+		if (this.lastPath !== attrs.requestedPath) {
+			this.lastPath = attrs.requestedPath
+			this.onNewUrl(attrs.args, attrs.requestedPath)
+		}
+	}
+
+	protected abstract onNewUrl(args: Record<string, any>, requestedPath: string): void
+}

--- a/src/gui/Header.ts
+++ b/src/gui/Header.ts
@@ -1,6 +1,6 @@
 import m, {Children, Component} from "mithril"
 import {NavBar} from "./base/NavBar.js"
-import {NavButtonColor, NavButton} from "./base/NavButton.js"
+import {NavButton, NavButtonColor} from "./base/NavButton.js"
 import {styles} from "./styles.js"
 import {neverNull} from "@tutao/tutanota-utils"
 import type {Shortcut} from "../misc/KeyManager.js"
@@ -13,7 +13,6 @@ import {px, size as sizes} from "./size.js"
 import {BootIcons} from "./base/icons/BootIcons.js"
 import type {SearchBar} from "../search/SearchBar.js"
 import type {IMainLocator} from "../api/main/MainLocator.js"
-import {client} from "../misc/ClientDetector.js"
 import {CALENDAR_PREFIX, CONTACTS_PREFIX, MAIL_PREFIX, navButtonRoutes, SEARCH_PREFIX} from "../misc/RouteChange.js"
 import {AriaLandmarks, landmarkAttrs} from "./AriaUtils.js"
 import type {ViewSlider} from "./nav/ViewSlider.js"
@@ -26,8 +25,14 @@ const LogoutPath = "/login?noAutoLogin=true"
 export const LogoutUrl: string = window.location.hash.startsWith("#mail") ? "/ext?noAutoLogin=true" + location.hash : LogoutPath
 assertMainOrNode()
 
-export interface CurrentView extends Component {
-	updateUrl(args: Record<string, any>, requestedPath: string): void
+export interface TopLevelAttrs {
+	requestedPath: string,
+	args: Record<string, any>
+}
+
+export interface CurrentView<Attrs extends TopLevelAttrs = TopLevelAttrs> extends Component<Attrs> {
+	/** Called when URL is updated. Optional as is only needed for old-style components (the ones we instantiate manually) */
+	updateUrl?(args: Record<string, any>, requestedPath: string): void
 
 	readonly headerView?: () => Children
 	readonly headerRightView?: () => Children

--- a/src/mail/view/MailViewer.ts
+++ b/src/mail/view/MailViewer.ts
@@ -181,6 +181,10 @@ export class MailViewer implements Component<MailViewerAttrs> {
 		if (this.viewModel !== oldViewModel) {
 			this.loadAllListener.end(true)
 			this.loadAllListener = this.viewModel.loadCompleteNotification.map(async () => {
+				// streams are pretty much synchronous, so we could be in the middle of a redraw here and mithril does not just schedule another redraw, it
+				// will error out so before calling m.redraw.sync() we want to make sure that we are not inside a redraw by just scheduling a microtask with
+				// this simple await.
+				await Promise.resolve()
 				// Wait for mail body to be redrawn before replacing images
 				m.redraw.sync()
 				await this.replaceInlineImages()
@@ -451,14 +455,14 @@ export class MailViewer implements Component<MailViewerAttrs> {
 
 	private renderLoadingIcon(): Children {
 		return m(".progress-panel.flex-v-center.items-center",
-				{
-					key: "loadingIcon",
-					style: {
-						height: "200px",
-					},
+			{
+				key: "loadingIcon",
+				style: {
+					height: "200px",
 				},
-				[progressIcon(), m("small", lang.get("loading_msg"))],
-			)
+			},
+			[progressIcon(), m("small", lang.get("loading_msg"))],
+		)
 	}
 
 	private renderBanners(mail: Mail): Children {
@@ -1002,7 +1006,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 							),
 							m(".flex",
 								m(ExpanderButton, {
-									style: { paddingTop: "0px" },
+									style: {paddingTop: "0px"},
 									label: "showAll_action",
 									expanded: this.filesExpanded(),
 									onExpandedChange: this.filesExpanded,

--- a/src/misc/RouteChange.ts
+++ b/src/misc/RouteChange.ts
@@ -1,15 +1,7 @@
-import stream from "mithril/stream"
 import m from "mithril"
 import {assertMainOrNodeBoot} from "../api/common/Env"
-import Stream from "mithril/stream";
 
 assertMainOrNodeBoot()
-export type RouteChangeEvent = {
-	args: Record<string, any>
-	requestedPath: string
-	currentPath: string
-}
-export const routeChange: Stream<RouteChangeEvent> = stream()
 
 export function throttleRoute(): (url: string) => void {
 	const limit = 200


### PR DESCRIPTION
Double login could occur if LoginView would start the normal login process and then the URL would change (e.g. when native part would change trigger login with specific account). In this case a second LoginView would be constructed and would start the login on its own. Normally this shouldn't happen but for LoginView we specifically opted into not caching it to not accidentally hold to credentials any longer than necessary.

To prevent this issue we should not create LoginView manually but let mithril do it. This is a bit tricky as LoginView needs some info passed into it. We ended up rewriting LoginView as a proper component and creating a new RouteResolver implementation that can work with this type of views.

fix #4554
fix https://github.com/tutao/tutanota/issues/4570

also see the same branch for admin client