### PR TITLE
Fix updating mail details in search view

### DIFF
--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -50,7 +50,7 @@ import {
 import {LoginController} from "../../api/main/LoginController"
 import m from "mithril"
 import {LockedError, NotAuthorizedError, NotFoundError} from "../../api/common/error/RestError"
-import {elementIdPart, haveSameId, listIdPart} from "../../api/common/utils/EntityUtils"
+import {elementIdPart, haveSameId, isSameId, listIdPart} from "../../api/common/utils/EntityUtils"
 import {getReferencedAttachments, loadInlineImages, moveMails, revokeInlineImages} from "./MailGuiUtils"
 import {locator} from "../../api/main/MainLocator"
 import {SanitizedFragment} from "../../misc/HtmlSanitizer"
@@ -946,6 +946,9 @@ export class MailViewerViewModel {
 			showFolder?: boolean
 		}
 	) {
+		if (!isSameId(mail._id, this.mail._id)) {
+			throw new ProgrammingError(`Trying to update MailViewerViewModel with unrelated email ${JSON.stringify(this.mail._id)} ${JSON.stringify(mail._id)} ${m.route.get()}`)
+		}
 		this._mail = mail
 
 		if (delayBodyRenderingUntil) {

--- a/src/search/view/SearchResultDetailsViewer.ts
+++ b/src/search/view/SearchResultDetailsViewer.ts
@@ -64,15 +64,14 @@ export class SearchResultDetailsViewer {
 				mail,
 				showFolder: true,
 			}
-			if (this._viewer == null || this._viewer.mode !== "mail") {
+			if (this._viewer != null && this._viewer.mode === "mail" && isSameId(this._viewer.viewModel.mail._id, mail._id)) {
+				this._viewer.viewModel.updateMail(viewModelParams)
+			} else {
 				this._viewer = {
 					mode: "mail",
 					viewModel: createMailViewerViewModel(viewModelParams)
 				}
-			} else {
-				this._viewer.viewModel.updateMail(viewModelParams)
 			}
-
 			this._viewerEntityId = mail._id
 
 			if (entitySelected && mail.unread && !mail._errors) {


### PR DESCRIPTION
The bug was caused by not taking into account email id and trying to reuse the same ViewModel as before.

We added the condition to the SearchViewDetailsViewer and also added an assertion to the MailViewerViewModel itself.

Fix #4561