### PR TITLE
Fix errors when denying contact permission on iOS

### DIFF
--- a/src/misc/RecipientsSearchModel.ts
+++ b/src/misc/RecipientsSearchModel.ts
@@ -52,15 +52,15 @@ export class RecipientsSearchModel {
 
 		if (this.loading != null) {
 		} else if (query.length > 0 && !(this.previousQuery.length > 0 && query.indexOf(this.previousQuery) === 0 && this.searchResults.length === 0)) {
-			this.loading = this.findContacts(query.toLowerCase()).then(async newSuggestions => {
-				this.loading = null
-
-				// Only update search result if search query has not been changed during search and update in all other cases
-				if (query === this.currentQuery) {
-					this.searchResults = newSuggestions
-					this.previousQuery = query
-				}
-			})
+			this.loading = this.findContacts(query.toLowerCase())
+							   .then(newSuggestions => {
+								   // Only update search result if search query has not been changed during search and update in all other cases
+								   if (query === this.currentQuery) {
+									   this.searchResults = newSuggestions
+									   this.previousQuery = query
+								   }
+							   })
+							   .finally(() => this.loading = null)
 		} else if (query.length === 0 && query !== this.previousQuery) {
 			this.searchResults = []
 			this.previousQuery = query


### PR DESCRIPTION
Two issues:
  - RecipientsSearchModel.ts was not clearing "loading" promise on error so if an error occurred at least once all the subsequent searches would just reject with the same error.
 - ContactsSource.swift was not doing the right thing after conversion to async/await. The requestAccess() function has really odd interface where originally it's callback would return both boolean and error and in the old callback-based code we only checked the boolean. Now that we use an async() version it just throws. We fix it by catching it.

fix #4555