### PR TITLE
Support arbitrary URLs in EntityRestClient

### DIFF
--- a/src/api/worker/rest/EntityRestClient.ts
+++ b/src/api/worker/rest/EntityRestClient.ts
@@ -24,6 +24,10 @@ export function typeRefToPath(typeRef: TypeRef<any>): string {
 	return `/rest/${typeRef.app}/${typeRef.type.toLowerCase()}`
 }
 
+export interface EntityRestClientSetupOptions {
+	baseUrl?: string,
+}
+
 /**
  * The EntityRestInterface provides a convenient interface for invoking server side REST services.
  */
@@ -46,7 +50,7 @@ export interface EntityRestInterface {
 	/**
 	 * Creates a single element on the server. Entities are encrypted before they are sent.
 	 */
-	setup<T extends SomeEntity>(listId: Id | null, instance: T, extraHeaders?: Dict): Promise<Id>
+	setup<T extends SomeEntity>(listId: Id | null, instance: T, extraHeaders?: Dict, options?: EntityRestClientSetupOptions): Promise<Id>
 
 	/**
 	 * Creates multiple elements on the server. Entities are encrypted before they are sent.
@@ -197,7 +201,7 @@ export class EntityRestClient implements EntityRestInterface {
 		return this._crypto.applyMigrationsForInstance<T>(decryptedInstance)
 	}
 
-	async setup<T extends SomeEntity>(listId: Id | null, instance: T, extraHeaders?: Dict): Promise<Id> {
+	async setup<T extends SomeEntity>(listId: Id | null, instance: T, extraHeaders?: Dict, options?: EntityRestClientSetupOptions): Promise<Id> {
 		const typeRef = instance._type
 		const {
 			typeModel,
@@ -219,6 +223,7 @@ export class EntityRestClient implements EntityRestInterface {
 			path,
 			HttpMethod.POST,
 			{
+				baseUrl: options?.baseUrl,
 				queryParams,
 				headers,
 				body: JSON.stringify(encryptedEntity),

--- a/test/tests/api/worker/rest/EntityRestClientTest.ts
+++ b/test/tests/api/worker/rest/EntityRestClientTest.ts
@@ -21,7 +21,7 @@ import sysModelInfo from "../../../../../src/api/entities/sys/ModelInfo.js"
 import {AuthDataProvider} from "../../../../../src/api/worker/facades/UserFacade.js"
 import {LoginIncompleteError} from "../../../../../src/api/common/error/LoginIncompleteError.js"
 
-const {anything} = matchers
+const {anything, argThat} = matchers
 
 const accessToken = "My cool access token"
 const authHeader = {
@@ -323,6 +323,7 @@ o.spec("EntityRestClient", async function () {
 				`/rest/tutanota/contact/listId`,
 				HttpMethod.POST,
 				{
+					baseUrl: undefined,
 					headers: {...authHeader, v},
 					queryParams: undefined,
 					responseType: MediaType.Json,
@@ -348,6 +349,7 @@ o.spec("EntityRestClient", async function () {
 				`/rest/sys/customer`,
 				HttpMethod.POST,
 				{
+					baseUrl: undefined,
 					headers: {...authHeader, v},
 					queryParams: undefined,
 					responseType: MediaType.Json,
@@ -363,6 +365,16 @@ o.spec("EntityRestClient", async function () {
 			const newCustomer = createCustomer()
 			const result = await assertThrows(Error, async () => await entityRestClient.setup("listId", newCustomer))
 			o(result.message).equals("List id must not be defined for ETs")
+		})
+
+		o("Base URL option is passed to the rest client", async function () {
+			when(restClient.request(
+				anything(),
+				anything(),
+				anything()
+			), {times: 1}).thenResolve(JSON.stringify({generatedId: null}))
+			await entityRestClient.setup("listId", createContact(), undefined, {baseUrl: "some url"})
+			verify(restClient.request(anything(), HttpMethod.POST, argThat(arg => arg.baseUrl === "some url")))
 		})
 	})
 


### PR DESCRIPTION
Part of tutadb issue 1125.

### Regression Tests
Browser, iOS and one desktop platform

* [ ] sending mails
* [ ] receiving mails
* [ ] creating events
* [ ] deleting events
* [ ] editing events 
* [ ] changing settings
* [ ] singup 
* [ ] login