### PR TITLE
Remove usage test TTL behavior

### DIFF
--- a/src/misc/UsageTestModel.ts
+++ b/src/misc/UsageTestModel.ts
@@ -230,12 +230,6 @@ export class EphemeralUsageTestStorage implements UsageTestStorage {
 
 export const ASSIGNMENT_UPDATE_INTERVAL_MS = 1000 * 60 * 60 // 1h
 
-export const enum TtlBehavior {
-	/* Prefer loading usage test assignments from cache even if they are slightly stale (according to ASSIGNMENT_UPDATE_INTERVAL_MS). */
-	PossiblyOutdated,
-	/* Always fetch the latest assignments from the server. */
-	UpToDateOnly,
-}
 
 export const enum StorageBehavior {
 	/* Store usage test assignments in the "persistent" storage. Currently, this is the client's instance of DeviceConfig, which uses the browser's local storage.
@@ -330,7 +324,7 @@ export class UsageTestModel implements PingAdapter {
 	/**
 	 * If the storageBehavior is set to StorageBehavior.Persist, then init() must have been called before calling this method.
 	 */
-	async loadActiveUsageTests(ttlBehavior: TtlBehavior): Promise<UsageTest[]> {
+	async loadActiveUsageTests(): Promise<UsageTest[]> {
 		if (this.storageBehavior === StorageBehavior.Persist && !this.getOptInDecision()) {
 			return []
 		}
@@ -340,7 +334,7 @@ export class UsageTestModel implements PingAdapter {
 
 		if (persistedData == null ||
 			persistedData.usageModelVersion !== modelVersion ||
-			(ttlBehavior === TtlBehavior.UpToDateOnly && Date.now() - persistedData.updatedAt > ASSIGNMENT_UPDATE_INTERVAL_MS)
+			Date.now() - persistedData.updatedAt > ASSIGNMENT_UPDATE_INTERVAL_MS
 		) {
 			return this.assignmentsToTests(await this.loadAssignments())
 		} else {

--- a/src/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/subscription/UpgradeSubscriptionWizard.ts
@@ -21,7 +21,7 @@ import {UpgradeConfirmPage, UpgradeConfirmPageAttrs} from "./UpgradeConfirmPage"
 import {SignupPage, SignupPageAttrs} from "./SignupPage"
 import {assertMainOrNode} from "../api/common/Env"
 import {locator} from "../api/main/MainLocator"
-import {StorageBehavior, TtlBehavior} from "../misc/UsageTestModel"
+import {StorageBehavior} from "../misc/UsageTestModel"
 import {UpgradePriceService} from "../api/entities/sys/Services.js"
 
 assertMainOrNode()
@@ -141,7 +141,7 @@ export async function loadSignupWizard(subscriptionParameters: SubscriptionParam
 	const usageTestModel = locator.usageTestModel
 
 	usageTestModel.setStorageBehavior(StorageBehavior.Ephemeral)
-	locator.usageTestController.setTests(await usageTestModel.loadActiveUsageTests(TtlBehavior.UpToDateOnly))
+	locator.usageTestController.setTests(await usageTestModel.loadActiveUsageTests())
 
 	const prices = await loadUpgradePrices(registrationDataId)
 	const planPrices: SubscriptionPlanPrices = {

--- a/test/tests/misc/UsageTestModelTest.ts
+++ b/test/tests/misc/UsageTestModelTest.ts
@@ -4,7 +4,6 @@ import {
 	EphemeralUsageTestStorage,
 	PersistedAssignmentData,
 	StorageBehavior,
-	TtlBehavior,
 	UsageTestModel,
 	UsageTestStorage
 } from "../../../src/misc/UsageTestModel.js"
@@ -122,11 +121,11 @@ o.spec("UsageTestModel", function () {
 					})
 				)
 
-				const result = await usageTestModel.loadActiveUsageTests(TtlBehavior.PossiblyOutdated)
+				const result = await usageTestModel.loadActiveUsageTests()
 				await assertStored(ephemeralStorage, result, newAssignment)
 			})
 
-			o("possibly outdated, loads from server because model version has changed", async function () {
+			o("loads from server because model version has changed", async function () {
 
 				await ephemeralStorage.storeTestDeviceId(testDeviceId)
 				await ephemeralStorage.storeAssignments({
@@ -144,11 +143,11 @@ o.spec("UsageTestModel", function () {
 					})
 				)
 
-				const result = await usageTestModel.loadActiveUsageTests(TtlBehavior.PossiblyOutdated)
+				const result = await usageTestModel.loadActiveUsageTests()
 				await assertStored(ephemeralStorage, result, newAssignment)
 			})
 
-			o("possibly outdated, loads from server and stores if nothing is stored", async function () {
+			o("loads from server and stores if nothing is stored", async function () {
 				when(serviceExecutor.put(UsageTestAssignmentService, createUsageTestAssignmentIn({testDeviceId}), {
 					suspensionBehavior: SuspensionBehavior.Throw,
 				})).thenResolve(
@@ -160,21 +159,22 @@ o.spec("UsageTestModel", function () {
 
 				await ephemeralStorage.storeTestDeviceId(testDeviceId)
 
-				const result = await usageTestModel.loadActiveUsageTests(TtlBehavior.PossiblyOutdated)
+				const result = await usageTestModel.loadActiveUsageTests()
 
 				await assertStored(ephemeralStorage, result, newAssignment)
 			})
 
-			o("possibly outdated, returns result from storage if it's there", async function () {
+			o("returns result from storage if it's there", async function () {
 				await ephemeralStorage.storeTestDeviceId(testDeviceId)
+				assignmentData.updatedAt = dateProvider.now()
 				await ephemeralStorage.storeAssignments(assignmentData)
 
-				const result = await usageTestModel.loadActiveUsageTests(TtlBehavior.PossiblyOutdated)
+				const result = await usageTestModel.loadActiveUsageTests()
 
 				await assertStored(ephemeralStorage, result, oldAssignment)
 			})
 
-			o("up to date only, data outdated, loads from the server and stores", async function () {
+			o("data outdated, loads from the server and stores", async function () {
 				await ephemeralStorage.storeTestDeviceId(testDeviceId)
 				await ephemeralStorage.storeAssignments(assignmentData)
 
@@ -186,17 +186,17 @@ o.spec("UsageTestModel", function () {
 						testDeviceId: testDeviceId,
 					})
 				)
-				const result = await usageTestModel.loadActiveUsageTests(TtlBehavior.UpToDateOnly)
+				const result = await usageTestModel.loadActiveUsageTests()
 				await assertStored(ephemeralStorage, result, newAssignment)
 			})
 
-			o("up to date only, data not outdated, returns result from storage", async function () {
+			o("data not outdated, returns result from storage", async function () {
 				await ephemeralStorage.storeTestDeviceId(testDeviceId)
 				const nonOutdatedAssignmentData = clone(assignmentData)
 				nonOutdatedAssignmentData.updatedAt = dateProvider.now() - ASSIGNMENT_UPDATE_INTERVAL_MS / 2
 				await ephemeralStorage.storeAssignments(nonOutdatedAssignmentData)
 
-				const result = await usageTestModel.loadActiveUsageTests(TtlBehavior.UpToDateOnly)
+				const result = await usageTestModel.loadActiveUsageTests()
 				await assertStored(ephemeralStorage, result, oldAssignment)
 			})
 		})
@@ -245,7 +245,7 @@ o.spec("UsageTestModel", function () {
 					})
 				)
 
-				const result = await usageTestModel.loadActiveUsageTests(TtlBehavior.UpToDateOnly)
+				const result = await usageTestModel.loadActiveUsageTests()
 
 				await assertStored(persistentStorage, result, newAssignment)
 				verify(ephemeralStorage.getTestDeviceId(), {times: 0})
@@ -265,7 +265,7 @@ o.spec("UsageTestModel", function () {
 					})
 				)
 
-				await usageTestModel.loadActiveUsageTests(TtlBehavior.UpToDateOnly)
+				await usageTestModel.loadActiveUsageTests()
 
 				o(await persistentStorage.getAssignments()).equals(null)
 				verify(ephemeralStorage.getTestDeviceId(), {times: 0})
@@ -285,7 +285,7 @@ o.spec("UsageTestModel", function () {
 					})
 				)
 
-				await usageTestModel.loadActiveUsageTests(TtlBehavior.UpToDateOnly)
+				await usageTestModel.loadActiveUsageTests()
 
 				o(await persistentStorage.getAssignments()).equals(null)
 				verify(ephemeralStorage.getTestDeviceId(), {times: 0})


### PR DESCRIPTION
This is because the current impl. was
causing bugs in PostLoginActions.onPartialLoginSuccess(). 
This method is also called on registering an account so 
that the storage behavior was set to persist (although the 
user is not quite logged in) and thus the ephemeral tests 
were no longer accessible for the signup dropouts or 
payment usage tests.