### PR TITLE
Do not measure signups for upgrades in the client, #4632

### DIFF
--- a/src/gui/base/WizardDialog.ts
+++ b/src/gui/base/WizardDialog.ts
@@ -1,4 +1,4 @@
-import m, {Child, Children, Component, Vnode, VnodeDOM} from "mithril"
+import m, {Children, Component, Vnode, VnodeDOM} from "mithril"
 import {Dialog} from "./Dialog"
 import type {ButtonAttrs} from "./Button.js"
 import {ButtonType} from "./Button.js"
@@ -9,7 +9,7 @@ import {lang} from "../../misc/LanguageViewModel"
 import type {DialogHeaderBarAttrs} from "./DialogHeaderBar"
 import {Keys} from "../../api/common/TutanotaConstants"
 import {assertMainOrNode} from "../../api/common/Env"
-import {$Promisable, typedEntries, typedKeys} from "@tutao/tutanota-utils"
+import {$Promisable} from "@tutao/tutanota-utils"
 
 assertMainOrNode()
 
@@ -36,6 +36,10 @@ export interface WizardPageAttrs<T> {
 	 * The actual data, which is the same for the entire wizard needs to be also accessible to each page
 	 */
 	readonly data: T
+	/**
+	 * Holds an enum that indicates in what context the wizard page is being shown.
+	 */
+	readonly location?: any
 }
 
 export interface WizardPageN<T> extends Component<WizardPageAttrs<T>> {

--- a/src/gui/base/WizardDialog.ts
+++ b/src/gui/base/WizardDialog.ts
@@ -36,10 +36,6 @@ export interface WizardPageAttrs<T> {
 	 * The actual data, which is the same for the entire wizard needs to be also accessible to each page
 	 */
 	readonly data: T
-	/**
-	 * Holds an enum that indicates in what context the wizard page is being shown.
-	 */
-	readonly location?: any
 }
 
 export interface WizardPageN<T> extends Component<WizardPageAttrs<T>> {

--- a/src/subscription/UpgradeSubscriptionPage.ts
+++ b/src/subscription/UpgradeSubscriptionPage.ts
@@ -2,7 +2,7 @@ import m, {Children, Component, Vnode, VnodeDOM} from "mithril"
 import stream from "mithril/stream"
 import {lang} from "../misc/LanguageViewModel"
 import type {SubscriptionParameters, UpgradeSubscriptionData} from "./UpgradeSubscriptionWizard"
-import {SubscriptionTypeParameter} from "./UpgradeSubscriptionWizard"
+import {SubscriptionTypeParameter, UpgradeWizardLocation} from "./UpgradeSubscriptionWizard"
 import {SubscriptionSelector} from "./SubscriptionSelector"
 import {isApp, isTutanotaDomain} from "../api/common/Env"
 import {client} from "../misc/ClientDetector"
@@ -23,10 +23,12 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 	private _dom: HTMLElement | null = null
 	private __signupFreeTest?: UsageTest
 	private __signupPaidTest?: UsageTest
+	private location = UpgradeWizardLocation.Other
 
 	oncreate(vnode: VnodeDOM<WizardPageAttrs<UpgradeSubscriptionData>>): void {
 		this._dom = vnode.dom as HTMLElement
 		const subscriptionParameters = vnode.attrs.data.subscriptionParameters
+		this.location = vnode.attrs.location
 
 		this.__signupFreeTest = locator.usageTestController.getTest("signup.free")
 		this.__signupFreeTest.strictStageOrder = true
@@ -86,7 +88,7 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 			this.__signupPaidTest.active = false
 		}
 
-		if (this.__signupFreeTest) {
+		if (this.__signupFreeTest && this.location == UpgradeWizardLocation.AtSignup) {
 			this.__signupFreeTest.active = true
 			this.__signupFreeTest.getStage(0).complete()
 		}
@@ -161,7 +163,7 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 			this.__signupFreeTest.active = false
 		}
 
-		if (this.__signupPaidTest) {
+		if (this.__signupPaidTest && this.location == UpgradeWizardLocation.AtSignup) {
 			this.__signupPaidTest.active = true
 			this.__signupPaidTest.getStage(0).complete()
 		}
@@ -254,7 +256,10 @@ export class UpgradeSubscriptionPageAttrs implements WizardPageAttrs<UpgradeSubs
 	data: UpgradeSubscriptionData
 	subscriptionType: string | null = null
 
-	constructor(upgradeData: UpgradeSubscriptionData) {
+	constructor(
+		upgradeData: UpgradeSubscriptionData,
+		readonly location = UpgradeWizardLocation.Other,
+	) {
 		this.data = upgradeData
 	}
 

--- a/src/subscription/UpgradeSubscriptionPage.ts
+++ b/src/subscription/UpgradeSubscriptionPage.ts
@@ -2,7 +2,7 @@ import m, {Children, Component, Vnode, VnodeDOM} from "mithril"
 import stream from "mithril/stream"
 import {lang} from "../misc/LanguageViewModel"
 import type {SubscriptionParameters, UpgradeSubscriptionData} from "./UpgradeSubscriptionWizard"
-import {SubscriptionTypeParameter, UpgradeWizardLocation} from "./UpgradeSubscriptionWizard"
+import {SubscriptionTypeParameter} from "./UpgradeSubscriptionWizard"
 import {SubscriptionSelector} from "./SubscriptionSelector"
 import {isApp, isTutanotaDomain} from "../api/common/Env"
 import {client} from "../misc/ClientDetector"
@@ -23,12 +23,12 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 	private _dom: HTMLElement | null = null
 	private __signupFreeTest?: UsageTest
 	private __signupPaidTest?: UsageTest
-	private location = UpgradeWizardLocation.Other
+	private upgradeType: UpgradeType | null = null
 
 	oncreate(vnode: VnodeDOM<WizardPageAttrs<UpgradeSubscriptionData>>): void {
 		this._dom = vnode.dom as HTMLElement
 		const subscriptionParameters = vnode.attrs.data.subscriptionParameters
-		this.location = vnode.attrs.location
+		this.upgradeType = vnode.attrs.data.upgradeType
 
 		this.__signupFreeTest = locator.usageTestController.getTest("signup.free")
 		this.__signupFreeTest.strictStageOrder = true
@@ -88,7 +88,7 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 			this.__signupPaidTest.active = false
 		}
 
-		if (this.__signupFreeTest && this.location == UpgradeWizardLocation.AtSignup) {
+		if (this.__signupFreeTest && this.upgradeType == UpgradeType.Signup) {
 			this.__signupFreeTest.active = true
 			this.__signupFreeTest.getStage(0).complete()
 		}
@@ -163,7 +163,7 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 			this.__signupFreeTest.active = false
 		}
 
-		if (this.__signupPaidTest && this.location == UpgradeWizardLocation.AtSignup) {
+		if (this.__signupPaidTest && this.upgradeType == UpgradeType.Signup) {
 			this.__signupPaidTest.active = true
 			this.__signupPaidTest.getStage(0).complete()
 		}
@@ -256,10 +256,7 @@ export class UpgradeSubscriptionPageAttrs implements WizardPageAttrs<UpgradeSubs
 	data: UpgradeSubscriptionData
 	subscriptionType: string | null = null
 
-	constructor(
-		upgradeData: UpgradeSubscriptionData,
-		readonly location = UpgradeWizardLocation.Other,
-	) {
+	constructor(upgradeData: UpgradeSubscriptionData) {
 		this.data = upgradeData
 	}
 

--- a/src/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/subscription/UpgradeSubscriptionWizard.ts
@@ -89,6 +89,11 @@ function loadCustomerAndInfo(): Promise<{
 	)
 }
 
+export enum UpgradeWizardLocation {
+	AtSignup = 0,
+	Other = 1,
+}
+
 export function showUpgradeWizard(): void {
 	loadCustomerAndInfo().then(({customer, accountingInfo}) => {
 		return loadUpgradePrices(null).then(prices => {
@@ -181,7 +186,7 @@ export async function loadSignupWizard(subscriptionParameters: SubscriptionParam
 
 	const invoiceAttrs = new InvoiceAndPaymentDataPageAttrs(signupData)
 	const wizardPages = [
-		wizardPageWrapper(UpgradeSubscriptionPage, new UpgradeSubscriptionPageAttrs(signupData)),
+		wizardPageWrapper(UpgradeSubscriptionPage, new UpgradeSubscriptionPageAttrs(signupData, UpgradeWizardLocation.AtSignup)),
 		wizardPageWrapper(SignupPage, new SignupPageAttrs(signupData)),
 		wizardPageWrapper(InvoiceAndPaymentDataPage, invoiceAttrs),
 		wizardPageWrapper(UpgradeConfirmPage, new UpgradeConfirmPageAttrs(signupData)),

--- a/src/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/subscription/UpgradeSubscriptionWizard.ts
@@ -89,11 +89,6 @@ function loadCustomerAndInfo(): Promise<{
 	)
 }
 
-export enum UpgradeWizardLocation {
-	AtSignup = 0,
-	Other = 1,
-}
-
 export function showUpgradeWizard(): void {
 	loadCustomerAndInfo().then(({customer, accountingInfo}) => {
 		return loadUpgradePrices(null).then(prices => {
@@ -186,7 +181,7 @@ export async function loadSignupWizard(subscriptionParameters: SubscriptionParam
 
 	const invoiceAttrs = new InvoiceAndPaymentDataPageAttrs(signupData)
 	const wizardPages = [
-		wizardPageWrapper(UpgradeSubscriptionPage, new UpgradeSubscriptionPageAttrs(signupData, UpgradeWizardLocation.AtSignup)),
+		wizardPageWrapper(UpgradeSubscriptionPage, new UpgradeSubscriptionPageAttrs(signupData)),
 		wizardPageWrapper(SignupPage, new SignupPageAttrs(signupData)),
 		wizardPageWrapper(InvoiceAndPaymentDataPage, invoiceAttrs),
 		wizardPageWrapper(UpgradeConfirmPage, new UpgradeConfirmPageAttrs(signupData)),


### PR DESCRIPTION
Requires differentiating between subscriptions
during signup and upgrades when logged in to the client.

closes #4632
