### PR TITLE
fix bottom navigation sometimes not having a shadow

### DIFF
--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -1120,6 +1120,7 @@ styles.registerStyle("main", () => {
 			height: positionValue(size.bottom_nav_bar),
 			background: theme.header_bg,
 			"margin-bottom": "env(safe-area-inset-bottom)",
+			"z-index": 2,
 		},
 		".notification-overlay-content": {
 			"margin-left": px(size.vpad),


### PR DESCRIPTION
some HTML mails are displayed in front of the box shadow of the action bar / bottom navigation in the single-column layout

setting the z-index to the same as the header (2) prevents that

close #4635