### PR TITLE
Only show global usage test section to premium accounts, #4634

### DIFF
--- a/src/settings/GlobalSettingsViewer.ts
+++ b/src/settings/GlobalSettingsViewer.ts
@@ -250,34 +250,36 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 						])
 						: null,
 				]),
-				m(SettingsExpander, {
-						title: "usageData_label",
-						expanded: this.usageDataExpanded,
-					}, this.customerProperties.isLoaded()
-						? m(DropDownSelector, {
-							label: "customerUsageDataOptOut_label",
-							items: [
-								{
-									name: lang.get("customerUsageDataGloballyDeactivated_label"),
-									value: true,
+				logins.getUserController().isPremiumAccount()
+					? m(SettingsExpander, {
+							title: "usageData_label",
+							expanded: this.usageDataExpanded,
+						}, this.customerProperties.isLoaded()
+							? m(DropDownSelector, {
+								label: "customerUsageDataOptOut_label",
+								items: [
+									{
+										name: lang.get("customerUsageDataGloballyDeactivated_label"),
+										value: true,
+									},
+									{
+										name: lang.get("customerUsageDataGloballyPossible_label"),
+										value: false,
+									},
+								],
+								selectedValue: this.customerProperties.getSync()!.usageDataOptedOut,
+								selectionChangedHandler: v => {
+									if (this.customerProperties.isLoaded()) {
+										const customerProps = this.customerProperties.getSync()!
+										customerProps.usageDataOptedOut = v as boolean
+										locator.entityClient.update(customerProps)
+									}
 								},
-								{
-									name: lang.get("customerUsageDataGloballyPossible_label"),
-									value: false,
-								},
-							],
-							selectedValue: this.customerProperties.getSync()!.usageDataOptedOut,
-							selectionChangedHandler: v => {
-								if (this.customerProperties.isLoaded()) {
-									const customerProps = this.customerProperties.getSync()!
-									customerProps.usageDataOptedOut = v as boolean
-									locator.entityClient.update(customerProps)
-								}
-							},
-							dropdownWidth: 250,
-						})
-						: null
-				)
+								dropdownWidth: 250,
+							})
+							: null
+					)
+					: null
 			]),
 		]
 	}


### PR DESCRIPTION
Free users cannot have sub-accounts, thus showing
the section with the global opt-out makes no sense.

closes #4634