### PR TITLE
fix search on Android stops working after system back button press

### DIFF
--- a/src/search/view/SearchView.ts
+++ b/src/search/view/SearchView.ts
@@ -253,6 +253,18 @@ export class SearchView implements CurrentView {
 		return this.viewSlider
 	}
 
+	handleBackButton(): boolean {
+		// only handle back button if in single column layout and viewing details
+		if (this.viewSlider && styles.isSingleColumnLayout() &&
+			this.viewSlider.focusedColumn === this.resultDetailsColumn && this.viewSlider.isFocusPreviousPossible()) {
+			// current view can navigate back
+			this.viewSlider.focusPreviousColumn()
+			return true
+		}
+
+		return false
+	}
+
 	headerRightView(): Children {
 		const restriction = getRestriction(m.route.get())
 		return styles.isUsingBottomNavigation()


### PR DESCRIPTION
The system back button on Android leads from the detail search view back to MailView, when it should go back to the search overview

SearchView now overrides handleBackButton() like ContactView and CalendarView do.
This method handles the back button only in single-column layout, as this behavior is not needed for multiple columns.

fix #4621