### PR TITLE
Fix the misbehavior of the Android system back button in the settings

### DIFF
--- a/src/native/main/WebMobileFacade.ts
+++ b/src/native/main/WebMobileFacade.ts
@@ -8,6 +8,7 @@ import {getInboxFolder} from "../../mail/model/MailUtils"
 import {last} from "@tutao/tutanota-utils"
 import {CloseEventBusOption, SECOND_MS} from "../../api/common/TutanotaConstants.js"
 import {MobileFacade} from "../common/generatedipc/MobileFacade.js"
+import {styles} from "../../gui/styles"
 
 assertMainOrNode()
 
@@ -39,6 +40,15 @@ export class WebMobileFacade implements MobileFacade {
 					viewSlider.focusNextColumn()
 					return true
 				} else if (window.tutao.currentView && window.tutao.currentView.handleBackButton && window.tutao.currentView.handleBackButton()) {
+					return true
+				} else if (
+					viewSlider &&
+					viewSlider.focusedColumn !== viewSlider.getMainColumn() &&
+					styles.isSingleColumnLayout() &&
+					viewSlider.isFocusPreviousPossible()
+				) {
+					// current view can navigate back, a region column is focused (not main) and is in singleColumnLayout
+					viewSlider.focusPreviousColumn()
 					return true
 				} else if (
 					currentRoute.startsWith(CONTACTS_PREFIX) ||
@@ -74,10 +84,6 @@ export class WebMobileFacade implements MobileFacade {
 					}
 
 					return false
-				} else if (viewSlider && viewSlider.isFocusPreviousPossible()) {
-					// current view can navigate back
-					viewSlider.focusPreviousColumn()
-					return true
 				} else {
 					return false
 				}


### PR DESCRIPTION
The system back button on Android leads from the detail search view
in one of the settings back to MailView, when it should take you back
to the settings overview. For example for user management.

Therefore the order of the if statements in WebMobileFacade.ts has been
changed to check at an earlier stage whether it is possible to
focus the previous column. This only applies if the main column is not
the focused one. So we can eventually return to the main column.
Furthermore singleColumnLayout is a prerequisite because in the
multi-column layout it is not necessary to return to the previous column
since all columns are already visible.
also fix #4621 and fix #4649

fix #4656