### PR TITLE
Fix resetting the login state after some errors during login

### DIFF
--- a/src/api/worker/facades/LoginFacade.ts
+++ b/src/api/worker/facades/LoginFacade.ts
@@ -453,11 +453,11 @@ export class LoginFacade {
 				return await this.finishResumeSession(credentials, externalUserSalt, cacheInfo)
 			}
 		} catch (e) {
-			if (e instanceof NotAuthenticatedError) {
-				// If we initialized the cache but then we couldn't authenticate we should de-initialize
-				// the cache again because we will initialize it for the next attempt.
-				await this.deInitCache()
-			}
+			// If we initialized the cache, but then we couldn't authenticate we should de-initialize
+			// the cache again because we will initialize it for the next attempt.
+			// It might be also called in initSession but the error can be thrown even before that (e.g. if the db is empty for some reason) so we reset
+			// the session here as well, otherwise we might try to open the DB twice.
+			await this.resetSession()
 			throw e
 		}
 	}


### PR DESCRIPTION
e.g. when we try to log in offline without a populated db. Before we only reset the cache on auth errors but since we reset the offline db users will be missing the offline cache and would run into the offline error without appropriate handling.

fix #4706