### PR TITLE
fix better-sqlite on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"@types/qrcode-svg": "1.1.1",
 				"@types/systemjs": "6.1.1",
 				"@types/winreg": "1.2.31",
-				"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#7de2a4cc45681293087adb9558ae0b35116b43ae",
+				"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#e2c61e6122bc56c6cfc29e61d21001faf43e2b8e",
 				"cborg": "1.5.4",
 				"dompurify": "2.3.8",
 				"electron": "19.1.3",
@@ -2161,8 +2161,8 @@
 		"node_modules/better-sqlite3": {
 			"name": "@tutao/better-sqlite3-sqlcipher",
 			"version": "7.5.0",
-			"resolved": "git+ssh://git@github.com/tutao/better-sqlite3-sqlcipher.git#7de2a4cc45681293087adb9558ae0b35116b43ae",
-			"integrity": "sha512-Az5iH25JlaTC49tRVE+TTneqEbqC6E+EDH/GUuAcuB+8Wpuv9HzGNW527mx/gbaxKdO8JdgFdLBDEpJ+NcCulA==",
+			"resolved": "git+ssh://git@github.com/tutao/better-sqlite3-sqlcipher.git#e2c61e6122bc56c6cfc29e61d21001faf43e2b8e",
+			"integrity": "sha512-5Glt/vVhCWmRgiK92M6ci3SDtANi9cx72UpLalzak71ScUDTX5SzEaxeDYhQZv+io9UsY0C6RJjbdc+5gsnWbw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11828,9 +11828,9 @@
 			"dev": true
 		},
 		"better-sqlite3": {
-			"version": "git+ssh://git@github.com/tutao/better-sqlite3-sqlcipher.git#7de2a4cc45681293087adb9558ae0b35116b43ae",
-			"integrity": "sha512-Az5iH25JlaTC49tRVE+TTneqEbqC6E+EDH/GUuAcuB+8Wpuv9HzGNW527mx/gbaxKdO8JdgFdLBDEpJ+NcCulA==",
-			"from": "better-sqlite3@git+https://github.com/tutao/better-sqlite3-sqlcipher#7de2a4cc45681293087adb9558ae0b35116b43ae",
+			"version": "git+ssh://git@github.com/tutao/better-sqlite3-sqlcipher.git#e2c61e6122bc56c6cfc29e61d21001faf43e2b8e",
+			"integrity": "sha512-5Glt/vVhCWmRgiK92M6ci3SDtANi9cx72UpLalzak71ScUDTX5SzEaxeDYhQZv+io9UsY0C6RJjbdc+5gsnWbw==",
+			"from": "better-sqlite3@git+https://github.com/tutao/better-sqlite3-sqlcipher#e2c61e6122bc56c6cfc29e61d21001faf43e2b8e",
 			"requires": {
 				"bindings": "^1.5.0",
 				"prebuild-install": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"@types/qrcode-svg": "1.1.1",
 		"@types/systemjs": "6.1.1",
 		"@types/winreg": "1.2.31",
-		"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#7de2a4cc45681293087adb9558ae0b35116b43ae",
+		"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#e2c61e6122bc56c6cfc29e61d21001faf43e2b8e",
 		"cborg": "1.5.4",
 		"dompurify": "2.3.8",
 		"electron": "19.1.3",


### PR DESCRIPTION
better-sqlite would crash when opening a database, sometimes with apparent segfault, sometimes with dlopen failure
"could not find procedure"

when this breaks after an electron or compiler update check these places:
* binding.gyp of better-sqlite
* rebuild openssl