### PR TITLE
Fix same entry in settings is selectable again after navigating back

### DIFF
--- a/src/settings/GroupListView.ts
+++ b/src/settings/GroupListView.ts
@@ -151,6 +151,8 @@ export class GroupListView implements UpdatableSettingsViewer {
 			}
 
 			m.redraw()
+		} else {
+			this._settingsView.focusSettingsDetailsColumn()
 		}
 	}
 

--- a/src/settings/WhitelabelChildrenListView.ts
+++ b/src/settings/WhitelabelChildrenListView.ts
@@ -117,6 +117,8 @@ export class WhitelabelChildrenListView {
 			}
 
 			m.redraw()
+		} else {
+			this._settingsView.focusSettingsDetailsColumn()
 		}
 	}
 

--- a/src/settings/contactform/ContactFormListView.ts
+++ b/src/settings/contactform/ContactFormListView.ts
@@ -139,6 +139,8 @@ export class ContactFormListView implements UpdatableSettingsViewer {
 
 				m.redraw()
 			})
+		} else {
+			this.settingsView.focusSettingsDetailsColumn()
 		}
 	}
 


### PR DESCRIPTION
In the Groups, Whitelabel accounts or Contact forms settings it is not possible to select the same entry again after selecting it first but navigating back to the list. This applies only to single-column layout.

For example, for the user management in the settings this is not a problem, because the elementSelected method contains a case where the selection has not changed and the detail column is focused. This case is missing in the above settings. So by adding this case to the other settings, this issue is fixed.

fix #4657