### PR TITLE
Fix news indicator sometimes not being rendered, #4732

### DIFF
--- a/src/login/PostLoginActions.ts
+++ b/src/login/PostLoginActions.ts
@@ -138,7 +138,11 @@ export class PostLoginActions implements IPostLoginAction {
 		// There should not be a lot of re-rendering at this point since assignments for new tests are usually fetched right after a client version update.
 		locator.usageTestController.setTests(await usageTestModel.loadActiveUsageTests())
 
-		locator.newsModel.loadNewsIds()
+		// Needs to be called after UsageTestModel.init() if the UsageOptInNews is live! (its isShown() requires an initialized UsageTestModel)
+		await locator.newsModel.loadNewsIds()
+
+		// Redraw to render usage tests and news, among other things that may have changed.
+		m.redraw()
 	}
 
 	private deactivateOutOfOfficeNotification(notification: OutOfOfficeNotification): Promise<void> {


### PR DESCRIPTION
On slow connections, the news indicator was not being rendered until user interaction. This is because at the end of PostLoginActions.fullLoginAsyncActions(), the view was not being redrawn, and NewsModel.loadNewsIds() was not being awaited.

fixes #4732