### PR TITLE
Catch misconfigured usage test errors, #4736

### DIFF
--- a/packages/tutanota-usagetests/lib/model/UsageTest.ts
+++ b/packages/tutanota-usagetests/lib/model/UsageTest.ts
@@ -28,12 +28,15 @@ export class UsageTest {
 		return this.lastCompletedStage > ASSIGNMENT_STAGE
 	}
 
-	getStage(stageNum: number): Stage {
-		if (!this.stages.has(stageNum)) {
-			throw new Error(`Stage ${stageNum} is not registered`)
+	getStage(stageNum: number) {
+		const stage = this.stages.get(stageNum)
+
+		if (!stage) {
+			console.log(`Stage ${stageNum} is not registered, meaning that test '${this.testName}' is likely misconfigured`)
+			return new ObsoleteStage(0, this)
 		}
 
-		return this.stages.get(stageNum)!
+		return stage
 	}
 
 	addStage(stage: Stage): Stage {
@@ -62,7 +65,7 @@ export class UsageTest {
 			return false
 		}
 
-		console.log(`Completing stage: ${stage.number}, variant: ${this.variant}`)
+		console.log(`Test '${this.testName}': Completing stage ${stage.number}, variant ${this.variant}`)
 		this.lastCompletedStage = stage.number === (this.stages.size - 1) ? ASSIGNMENT_STAGE : stage.number
 		await this.pingAdapter.sendPing(this, stage)
 


### PR DESCRIPTION
We now catch BadRequestErrors and handle
usage test stages not being registered
in case a usage test is misconfigured.

This is so misconfigured tests never affect
user experience, but it also means that we need to test usage test implementations extra diligently
and make sure they are configured correctly.
Otherwise, we might silently run a misconfigured test for a while and miss pings.

fixes #4736