### PR TITLE
move startForeground call to onStartCommand method

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -73,19 +73,19 @@ class MainActivity : FragmentActivity() {
 		val fileFacade = AndroidFileFacade(this, LocalNotificationsFacade(this), SecureRandom())
 		val cryptoFacade = AndroidNativeCryptoFacade(this, fileFacade.tempDir)
 		sseStorage = SseStorage(
-			AppDatabase.getDatabase(this, false),
-			createAndroidKeyStoreFacade(cryptoFacade)
+				AppDatabase.getDatabase(this, false),
+				createAndroidKeyStoreFacade(cryptoFacade)
 		)
 		val alarmNotificationsManager = AlarmNotificationsManager(
-			sseStorage,
-			cryptoFacade,
-			SystemAlarmFacade(this),
-			LocalNotificationsFacade(this)
+				sseStorage,
+				cryptoFacade,
+				SystemAlarmFacade(this),
+				LocalNotificationsFacade(this)
 		)
 		val nativePushFacade = AndroidNativePushFacade(
-			this,
-			sseStorage,
-			alarmNotificationsManager
+				this,
+				sseStorage,
+				alarmNotificationsManager
 		)
 
 		val ipcJson = Json { ignoreUnknownKeys = true }
@@ -97,21 +97,21 @@ class MainActivity : FragmentActivity() {
 		commonSystemFacade = AndroidCommonSystemFacade(this, sqlCipherFacade, fileFacade.tempDir)
 
 		val globalDispatcher = AndroidGlobalDispatcher(
-			ipcJson,
-			commonSystemFacade,
-			fileFacade,
-			AndroidMobileSystemFacade(contact, fileFacade, this),
-			CredentialsEncryptionFactory.create(this, cryptoFacade),
-			cryptoFacade,
-			nativePushFacade,
-			sqlCipherFacade,
-			themeFacade,
+				ipcJson,
+				commonSystemFacade,
+				fileFacade,
+				AndroidMobileSystemFacade(contact, fileFacade, this),
+				CredentialsEncryptionFactory.create(this, cryptoFacade),
+				cryptoFacade,
+				nativePushFacade,
+				sqlCipherFacade,
+				themeFacade,
 		)
 		remoteBridge = RemoteBridge(
-			ipcJson,
-			this,
-			globalDispatcher,
-			commonSystemFacade,
+				ipcJson,
+				this,
+				globalDispatcher,
+				commonSystemFacade,
 		)
 
 		themeFacade.applyCurrentTheme()
@@ -164,7 +164,7 @@ class MainActivity : FragmentActivity() {
 					startActivity(intent)
 				} catch (e: ActivityNotFoundException) {
 					Toast.makeText(this@MainActivity, "Could not open link: $url", Toast.LENGTH_SHORT)
-						.show()
+							.show()
 				}
 				return true
 			}
@@ -174,16 +174,16 @@ class MainActivity : FragmentActivity() {
 				return if (request.method == "OPTIONS") {
 					Log.v(TAG, "replacing OPTIONS response to $url")
 					WebResourceResponse(
-						"text/html",
-						"UTF-8",
-						200,
-						"OK",
-						mutableMapOf(
-							"Access-Control-Allow-Origin" to "*",
-							"Access-Control-Allow-Methods" to "POST, GET, PUT, DELETE",
-							"Access-Control-Allow-Headers" to "*"
-						),
-						null
+							"text/html",
+							"UTF-8",
+							200,
+							"OK",
+							mutableMapOf(
+									"Access-Control-Allow-Origin" to "*",
+									"Access-Control-Allow-Methods" to "POST, GET, PUT, DELETE",
+									"Access-Control-Allow-Headers" to "*"
+							),
+							null
 					)
 				} else if (request.method == "GET" && url.toString().startsWith(BASE_WEB_VIEW_URL)) {
 					Log.v(TAG, "replacing asset GET response to ${url.path}")
@@ -194,22 +194,22 @@ class MainActivity : FragmentActivity() {
 						if (!assetPath.startsWith(BuildConfig.RES_ADDRESS)) throw IOException("can't find this")
 						val mimeType = getMimeTypeForUrl(url.toString())
 						WebResourceResponse(
-							mimeType,
-							null,
-							200,
-							"OK",
-							null,
-							assets.open(assetPath)
+								mimeType,
+								null,
+								200,
+								"OK",
+								null,
+								assets.open(assetPath)
 						)
 					} catch (e: IOException) {
 						Log.w(TAG, "Resource not found ${url.path}")
 						WebResourceResponse(
-							null,
-							null,
-							404,
-							"Not Found",
-							null,
-							null
+								null,
+								null,
+								404,
+								"Not Found",
+								null,
+								null
 						)
 					}
 				} else {
@@ -289,16 +289,16 @@ class MainActivity : FragmentActivity() {
 			try {
 				Log.d(TAG, "migrating credentials")
 				val oldTutanotaConfig = evalJavaScriptForResult(
-					"let s = localStorage.getItem('tutanotaConfig'); s ? btoa(s) : null",
-					"file:///dummy.html"
+						"let s = localStorage.getItem('tutanotaConfig'); s ? btoa(s) : null",
+						"file:///dummy.html"
 				)
 				WebStorage.getInstance().deleteAllData()
 				if (oldTutanotaConfig == "null") {
 					Log.d(TAG, "no credentials to migrate")
 				} else {
 					evalJavaScriptForResult(
-						"localStorage.setItem('tutanotaConfig', atob($oldTutanotaConfig))",
-						"https://assets.tutanota.com/dummy.html"
+							"localStorage.setItem('tutanotaConfig', atob($oldTutanotaConfig))",
+							"https://assets.tutanota.com/dummy.html"
 					)
 				}
 			} finally {
@@ -352,7 +352,7 @@ class MainActivity : FragmentActivity() {
 		if (intent.action != null) {
 			when (intent.action) {
 				Intent.ACTION_SEND, Intent.ACTION_SEND_MULTIPLE, Intent.ACTION_SENDTO, Intent.ACTION_VIEW -> share(
-					intent
+						intent
 				)
 				OPEN_USER_MAILBOX_ACTION -> openMailbox(intent)
 				OPEN_CALENDAR_ACTION -> openCalendar(intent)
@@ -372,8 +372,8 @@ class MainActivity : FragmentActivity() {
 		val preferences = android.preference.PreferenceManager.getDefaultSharedPreferences(this)
 
 		if (
-			!preferences.getBoolean(ASKED_BATTERY_OPTIMIZATIONS_PREF, false)
-			&& !powerManager.isIgnoringBatteryOptimizations(packageName)
+				!preferences.getBoolean(ASKED_BATTERY_OPTIMIZATIONS_PREF, false)
+				&& !powerManager.isIgnoringBatteryOptimizations(packageName)
 		) {
 
 			commonNativeFacade.showAlertDialog("allowPushNotification_msg")
@@ -382,8 +382,8 @@ class MainActivity : FragmentActivity() {
 				saveAskedBatteryOptimizations(preferences)
 				@SuppressLint("BatteryLife")
 				val intent = Intent(
-					Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-					Uri.parse("package:$packageName")
+						Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+						Uri.parse("package:$packageName")
 				)
 				startActivity(intent)
 			}
@@ -453,13 +453,13 @@ class MainActivity : FragmentActivity() {
 	}
 
 	suspend fun startActivityForResult(@RequiresPermission intent: Intent?): ActivityResult =
-		suspendCoroutine { continuation ->
-			val requestCode = getNextRequestCode()
-			activityRequests[requestCode] = continuation
-			// we need requestCode to identify the request which is not possible with new API
-			@Suppress("DEPRECATION")
-			super.startActivityForResult(intent, requestCode)
-		}
+			suspendCoroutine { continuation ->
+				val requestCode = getNextRequestCode()
+				activityRequests[requestCode] = continuation
+				// we need requestCode to identify the request which is not possible with new API
+				@Suppress("DEPRECATION")
+				super.startActivityForResult(intent, requestCode)
+			}
 
 	@Deprecated("Deprecated in Java")
 	override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -482,10 +482,10 @@ class MainActivity : FragmentActivity() {
 		}
 		val jobScheduler = getSystemService(JOB_SCHEDULER_SERVICE) as JobScheduler
 		jobScheduler.schedule(
-			JobInfo.Builder(1, ComponentName(this, PushNotificationService::class.java))
-				.setPeriodic(TimeUnit.MINUTES.toMillis(15))
-				.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
-				.setPersisted(true).build()
+				JobInfo.Builder(1, ComponentName(this, PushNotificationService::class.java))
+						.setPeriodic(TimeUnit.MINUTES.toMillis(15))
+						.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+						.setPersisted(true).build()
 		)
 	}
 
@@ -526,11 +526,11 @@ class MainActivity : FragmentActivity() {
 		}
 
 		commonNativeFacade.createMailEditor(
-			files,
-			text ?: "",
-			addresses,
-			subject ?: "",
-			mailToUrlString
+				files,
+				text ?: "",
+				addresses,
+				subject ?: "",
+				mailToUrlString
 		)
 	}
 
@@ -579,10 +579,10 @@ class MainActivity : FragmentActivity() {
 		val addresses = ArrayList<String>(1)
 		addresses.add(address)
 		startService(
-			notificationDismissedIntent(
-				this, addresses,
-				"MainActivity#openMailbox", isSummary
-			)
+				notificationDismissedIntent(
+						this, addresses,
+						"MainActivity#openMailbox", isSummary
+				)
 		)
 
 		commonNativeFacade.openMailBox(userId, address, null)
@@ -629,7 +629,7 @@ class MainActivity : FragmentActivity() {
 			menu.setHeaderTitle(link)
 			menu.add(0, 0, 0, "Copy link").setOnMenuItemClickListener {
 				(getSystemService(CLIPBOARD_SERVICE) as ClipboardManager)
-					.setPrimaryClip(ClipData.newPlainText(link, link))
+						.setPrimaryClip(ClipData.newPlainText(link, link))
 				true
 			}
 			menu.add(0, 2, 0, "Share").setOnMenuItemClickListener {
@@ -667,43 +667,43 @@ class MainActivity : FragmentActivity() {
 
 	@SuppressLint("SetJavascriptEnabled")
 	private suspend fun evalJavaScriptForResult(javaScript: String, origin: String): String =
-		withContext(Dispatchers.Main) {
-			val webView = WebView(this@MainActivity)
-			Log.d(TAG, "Created webview for evaluation!")
+			withContext(Dispatchers.Main) {
+				val webView = WebView(this@MainActivity)
+				Log.d(TAG, "Created webview for evaluation!")
 
-			webView.settings.apply {
-				javaScriptEnabled = true
-				domStorageEnabled = true
-				javaScriptCanOpenWindowsAutomatically = false
-				allowFileAccess = true
-				allowContentAccess = false
-				cacheMode = WebSettings.LOAD_NO_CACHE
-				mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
-			}
+				webView.settings.apply {
+					javaScriptEnabled = true
+					domStorageEnabled = true
+					javaScriptCanOpenWindowsAutomatically = false
+					allowFileAccess = true
+					allowContentAccess = false
+					cacheMode = WebSettings.LOAD_NO_CACHE
+					mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+				}
 
-			suspendCoroutine { cb ->
-				webView.webViewClient = object : WebViewClient() {
-					override fun onPageFinished(view: WebView?, url: String?) {
-						super.onPageFinished(view, url)
-						Log.d(TAG, "finished page: $url")
-						webView.evaluateJavascript(javaScript) { res ->
-							Log.d(TAG, "got a response for $origin")
-							webView.destroy()
-							cb.resume(res)
+				suspendCoroutine { cb ->
+					webView.webViewClient = object : WebViewClient() {
+						override fun onPageFinished(view: WebView?, url: String?) {
+							super.onPageFinished(view, url)
+							Log.d(TAG, "finished page: $url")
+							webView.evaluateJavascript(javaScript) { res ->
+								Log.d(TAG, "got a response for $origin")
+								webView.destroy()
+								cb.resume(res)
+							}
+						}
+
+						override fun onReceivedError(
+								view: WebView?,
+								request: WebResourceRequest?,
+								error: WebResourceError?
+						) {
+							Log.d(TAG, "received error: ${error?.description}")
+							super.onReceivedError(view, request, error)
 						}
 					}
 
-					override fun onReceivedError(
-						view: WebView?,
-						request: WebResourceRequest?,
-						error: WebResourceError?
-					) {
-						Log.d(TAG, "received error: ${error?.description}")
-						super.onReceivedError(view, request, error)
-					}
+					webView.loadDataWithBaseURL(origin, " ", "text/plain", null, null)
 				}
-
-				webView.loadDataWithBaseURL(origin, " ", "text/plain", null, null)
 			}
-		}
 }

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
@@ -27,17 +27,17 @@ class PushNotificationService : LifecycleJobService() {
 		val keyStoreFacade = createAndroidKeyStoreFacade(crypto)
 		val sseStorage = SseStorage(appDatabase, keyStoreFacade)
 		val alarmNotificationsManager = AlarmNotificationsManager(
-				sseStorage,
-				crypto,
-				SystemAlarmFacade(this),
-				localNotificationsFacade
+			sseStorage,
+			crypto,
+			SystemAlarmFacade(this),
+			localNotificationsFacade
 		)
 		alarmNotificationsManager.reScheduleAlarms()
 		sseClient = SseClient(
-				crypto,
-				sseStorage,
-				NetworkObserver(this, this),
-				NotificationSseListener(localNotificationsFacade, sseStorage, alarmNotificationsManager)
+			crypto,
+			sseStorage,
+			NetworkObserver(this, this),
+			NotificationSseListener(localNotificationsFacade, sseStorage, alarmNotificationsManager)
 		)
 		sseStorage.observeUsers().observeForever { userInfos ->
 			Log.d(TAG, "sse storage updated " + userInfos.size)
@@ -51,18 +51,13 @@ class PushNotificationService : LifecycleJobService() {
 				finishJobIfNeeded()
 			} else {
 				sseClient.restartConnectionIfNeeded(
-						SseInfo(
-								sseStorage.getPushIdentifier()!!,
-								userIds,
-								sseStorage.getSseOrigin()!!
-						)
+					SseInfo(
+						sseStorage.getPushIdentifier()!!,
+						userIds,
+						sseStorage.getSseOrigin()!!
+					)
 				)
 			}
-		}
-		if (atLeastOreo()) {
-			localNotificationsFacade.createNotificationChannels()
-			Log.d(TAG, "Starting foreground")
-			startForeground(1, localNotificationsFacade.makeConnectionNotification())
 		}
 	}
 
@@ -74,12 +69,17 @@ class PushNotificationService : LifecycleJobService() {
 	override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
 		super.onStartCommand(intent, flags, startId)
 		Log.d(TAG, "Received onStartCommand, sender: " + intent?.getStringExtra("sender"))
+
+		if (atLeastOreo()) {
+			localNotificationsFacade.createNotificationChannels()
+			Log.d(TAG, "Starting foreground")
+			startForeground(1, localNotificationsFacade.makeConnectionNotification())
+		}
+
 		if (intent != null && intent.hasExtra(NOTIFICATION_DISMISSED_ADDR_EXTRA)) {
-			val dismissAddresses =
-					intent.getStringArrayListExtra(NOTIFICATION_DISMISSED_ADDR_EXTRA)
+			val dismissAddresses = intent.getStringArrayListExtra(NOTIFICATION_DISMISSED_ADDR_EXTRA)
 			localNotificationsFacade.notificationDismissed(
-					dismissAddresses,
-					intent.getBooleanExtra(MainActivity.IS_SUMMARY_EXTRA, false)
+				dismissAddresses, intent.getBooleanExtra(MainActivity.IS_SUMMARY_EXTRA, false)
 			)
 		}
 
@@ -133,12 +133,13 @@ class PushNotificationService : LifecycleJobService() {
 	}
 
 	private inner class NotificationSseListener(
-			notificationsFacade: LocalNotificationsFacade,
-			sseStorage: SseStorage,
-			alarmNotificationsManager: AlarmNotificationsManager
+		notificationsFacade: LocalNotificationsFacade,
+		sseStorage: SseStorage,
+		alarmNotificationsManager: AlarmNotificationsManager
 	) : SseListener {
 
-		private val tutanotaNotificationsHandler = TutanotaNotificationsHandler(notificationsFacade, sseStorage, alarmNotificationsManager)
+		private val tutanotaNotificationsHandler =
+			TutanotaNotificationsHandler(notificationsFacade, sseStorage, alarmNotificationsManager)
 
 		override fun onStartingConnection(): Boolean {
 			return tutanotaNotificationsHandler.onConnect()

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
@@ -71,7 +71,6 @@ class PushNotificationService : LifecycleJobService() {
 		Log.d(TAG, "Received onStartCommand, sender: " + intent?.getStringExtra("sender"))
 
 		if (atLeastOreo()) {
-			localNotificationsFacade.createNotificationChannels()
 			Log.d(TAG, "Starting foreground")
 			startForeground(1, localNotificationsFacade.makeConnectionNotification())
 		}

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
@@ -27,17 +27,17 @@ class PushNotificationService : LifecycleJobService() {
 		val keyStoreFacade = createAndroidKeyStoreFacade(crypto)
 		val sseStorage = SseStorage(appDatabase, keyStoreFacade)
 		val alarmNotificationsManager = AlarmNotificationsManager(
-			sseStorage,
-			crypto,
-			SystemAlarmFacade(this),
-			localNotificationsFacade
+				sseStorage,
+				crypto,
+				SystemAlarmFacade(this),
+				localNotificationsFacade
 		)
 		alarmNotificationsManager.reScheduleAlarms()
 		sseClient = SseClient(
-			crypto,
-			sseStorage,
-			NetworkObserver(this, this),
-			NotificationSseListener(localNotificationsFacade, sseStorage, alarmNotificationsManager)
+				crypto,
+				sseStorage,
+				NetworkObserver(this, this),
+				NotificationSseListener(localNotificationsFacade, sseStorage, alarmNotificationsManager)
 		)
 		sseStorage.observeUsers().observeForever { userInfos ->
 			Log.d(TAG, "sse storage updated " + userInfos.size)
@@ -51,11 +51,11 @@ class PushNotificationService : LifecycleJobService() {
 				finishJobIfNeeded()
 			} else {
 				sseClient.restartConnectionIfNeeded(
-					SseInfo(
-						sseStorage.getPushIdentifier()!!,
-						userIds,
-						sseStorage.getSseOrigin()!!
-					)
+						SseInfo(
+								sseStorage.getPushIdentifier()!!,
+								userIds,
+								sseStorage.getSseOrigin()!!
+						)
 				)
 			}
 		}
@@ -78,7 +78,7 @@ class PushNotificationService : LifecycleJobService() {
 		if (intent != null && intent.hasExtra(NOTIFICATION_DISMISSED_ADDR_EXTRA)) {
 			val dismissAddresses = intent.getStringArrayListExtra(NOTIFICATION_DISMISSED_ADDR_EXTRA)
 			localNotificationsFacade.notificationDismissed(
-				dismissAddresses, intent.getBooleanExtra(MainActivity.IS_SUMMARY_EXTRA, false)
+					dismissAddresses, intent.getBooleanExtra(MainActivity.IS_SUMMARY_EXTRA, false)
 			)
 		}
 
@@ -132,13 +132,13 @@ class PushNotificationService : LifecycleJobService() {
 	}
 
 	private inner class NotificationSseListener(
-		notificationsFacade: LocalNotificationsFacade,
-		sseStorage: SseStorage,
-		alarmNotificationsManager: AlarmNotificationsManager
+			notificationsFacade: LocalNotificationsFacade,
+			sseStorage: SseStorage,
+			alarmNotificationsManager: AlarmNotificationsManager
 	) : SseListener {
 
 		private val tutanotaNotificationsHandler =
-			TutanotaNotificationsHandler(notificationsFacade, sseStorage, alarmNotificationsManager)
+				TutanotaNotificationsHandler(notificationsFacade, sseStorage, alarmNotificationsManager)
 
 		override fun onStartingConnection(): Boolean {
 			return tutanotaNotificationsHandler.onConnect()


### PR DESCRIPTION
We need to move the startForeground call to the onStartCommand method so that it will be called everytime we start the
PushNotificationService. Furthermore, we should not create the notification channels multiple times while the
app is running.

fix #1654 