### PR TITLE
Fix grammar of no news message (in English)

### DIFF
--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -885,7 +885,7 @@ export default {
 		"noMoreSimilarContacts_msg": "No more similar contacts found.",
 		"nonConfidentialStatus_msg": "This message will not be sent end-to-end encrypted.",
 		"nonConfidential_action": "Not confidential",
-		"noNews_msg": "There are no news.",
+		"noNews_msg": "There is no news.",
 		"noPermission_title": "No Permission",
 		"noPreSharedPassword_msg": "Please provide an agreed password for each external recipient.",
 		"noReceivingMailbox_label": "Please select a receiving mailbox.",


### PR DESCRIPTION
The word 'news' is an uncountable noun, and so it will always get a singular treatment in English grammar, not plural treatment. Other options to fix the grammar would be:

- There are no news items
- There are no new messages

While the first alternative would perhaps be closest to the German source, I think the correction suggested in this change (there is no news) is the most common formulation and still quite close.