### PR TITLE
Fix few issues with PushNotificationService, fix #1654

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/LooperThread.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/LooperThread.kt
@@ -5,15 +5,18 @@ import android.os.Looper
 import android.util.Log
 
 internal class LooperThread(private val initRunnable: Runnable) : Thread() {
+	val handler: Handler
+		get() = _handler ?: error("LooperThread has not been started yet!")
+
 	@Volatile
-	var handler: Handler? = null
+	var _handler: Handler? = null
 		private set
 
 	override fun run() {
 		Log.d("LooperThread", "LooperThread is started")
 		Looper.prepare()
-		handler = Handler(Looper.myLooper()!!)
-		handler!!.post(initRunnable)
+		_handler = Handler(Looper.myLooper()!!)
+		_handler!!.post(initRunnable)
 		Looper.loop()
 	}
 }

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
@@ -91,7 +91,7 @@ class PushNotificationService : LifecycleJobService() {
 			}
 			if (userIds.isEmpty()) {
 				sseClient.stopConnection()
-				removeBackgroundServiceNotification()
+				removeForegroundNotification()
 				finishJobIfNeeded()
 			} else {
 				sseClient.restartConnectionIfNeeded(
@@ -107,8 +107,8 @@ class PushNotificationService : LifecycleJobService() {
 		localNotificationsFacade.createNotificationChannels()
 	}
 
-	private fun removeBackgroundServiceNotification() {
-		Log.d(TAG, "removeBackgroundServiceNotification")
+	private fun removeForegroundNotification() {
+		Log.d(TAG, "removeForegroundNotification")
 		stopForeground(true)
 	}
 
@@ -153,7 +153,7 @@ class PushNotificationService : LifecycleJobService() {
 	private fun scheduleJobFinish() {
 		Log.d(TAG, "scheduleJobFinish, will actually schedule: ${jobParameters != null}")
 		if (jobParameters != null) {
-			finishJobThread.handler!!.postDelayed({
+			finishJobThread.handler.postDelayed({
 				Log.d(TAG, "Executing scheduled jobFinished")
 				finishJobIfNeeded()
 			}, TimeUnit.SECONDS.toMillis(20))
@@ -208,13 +208,14 @@ class PushNotificationService : LifecycleJobService() {
 			Log.d(TAG, "onConnectionEstablished")
 			state = State.CONNECTED
 
-			removeBackgroundServiceNotification()
+			removeForegroundNotification()
 			// After establishing connection we finish in some time.
 			scheduleJobFinish()
 		}
 
 		override fun onConnectionBroken() {
 			Log.d(TAG, "onConnectionBroken")
+			state = State.CONNECTING
 		}
 
 		override fun onNotAuthorized(userId: String) {
@@ -227,7 +228,7 @@ class PushNotificationService : LifecycleJobService() {
 				State.CONNECTING -> State.STARTED
 				else -> state
 			}
-			removeBackgroundServiceNotification()
+			removeForegroundNotification()
 			finishJobIfNeeded()
 		}
 	}

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/SseClient.kt
@@ -31,8 +31,8 @@ class SseClient internal constructor(
 	private val httpsURLConnectionRef = AtomicReference<HttpURLConnection?>(null)
 	private val looperThread = LooperThread { connect() }
 	private fun reschedule(delayInSeconds: Int) {
-		if (looperThread.handler != null) {
-			looperThread.handler!!.postDelayed({ connect() }, TimeUnit.SECONDS.toMillis(delayInSeconds.toLong()))
+		if (looperThread._handler != null) {
+			looperThread._handler!!.postDelayed({ connect() }, TimeUnit.SECONDS.toMillis(delayInSeconds.toLong()))
 		} else {
 			Log.d(TAG, "looper thread is starting, skip additional reschedule")
 		}


### PR DESCRIPTION
 * The #1654 issue was caused by called startForeground at the wrong moment (`onCreate` instead of `onStartCommand`). It should have been relevant for boot only
 * We have not been tracking the state properly and we could have been calling `startForeground()` multiple times. It was mitigated by us calling `removeBackgroundServiceNotification` after every message
 * `scheduleJobFinish()` was creating the thread but it was never started meaning that `jobFinished()` would never be actually called
 * `SSEClient` would call `onConnectionEstablished` multiple times

fix #1654 