### PR TITLE
fix android notification shows only the time even for future events

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/LocalNotificationsFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/LocalNotificationsFacade.kt
@@ -18,6 +18,9 @@ import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import de.tutao.tutanota.*
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 import java.util.concurrent.ConcurrentHashMap
 
 const val NOTIFICATION_DISMISSED_ADDR_EXTRA = "notificationDismissed"
@@ -327,7 +330,10 @@ fun notificationDismissedIntent(
 }
 
 fun showAlarmNotification(context: Context, timestamp: Long, summary: String, intent: Intent) {
-	val contentText = String.format("%tR %s", timestamp, summary)
+	val contentText = when {
+		isSameDay(timestamp, Date().time) -> String.format("%tR %s", timestamp, summary)
+		else -> String.format("%1\$ta %1\$td %1\$tb %1\$tR %2\$s", timestamp, summary) // e.g. Fri 25 Nov 12:31 summary
+	}
 	val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 	@ColorInt val red = context.resources.getColor(R.color.red, context.theme)
 	notificationManager.notify(
@@ -342,6 +348,19 @@ fun showAlarmNotification(context: Context, timestamp: Long, summary: String, in
 					.setAutoCancel(true)
 					.build()
 	)
+}
+
+/**
+ * Returns whether two timestamps belong to the same day considering the time zone
+ * @param time1 epoch time 1 in milliseconds
+ * @param time2 epoch time 2 in milliseconds
+ * @param timeZone optional, should only be used for testing! | otherwise the default value is used
+ * @return boolean whether both timestamp are on the same day
+ */
+fun isSameDay(time1: Long, time2: Long, timeZone: TimeZone = TimeZone.getDefault()): Boolean {
+	val customDateFormat = SimpleDateFormat("yyyy-MM-dd")
+	customDateFormat.setTimeZone(timeZone)
+	return customDateFormat.format(time1).equals(customDateFormat.format(time2))
 }
 
 private fun openCalendarIntent(context: Context, alarmIntent: Intent): PendingIntent {

--- a/app-android/app/src/test/java/de/tutao/tutanota/AlarmModelTest.kt
+++ b/app-android/app/src/test/java/de/tutao/tutanota/AlarmModelTest.kt
@@ -5,6 +5,7 @@ import de.tutao.tutanota.alarms.AlarmModel.iterateAlarmOccurrences
 import de.tutao.tutanota.alarms.AlarmTrigger
 import de.tutao.tutanota.alarms.EndType
 import de.tutao.tutanota.alarms.RepeatPeriod
+import de.tutao.tutanota.push.isSameDay
 import org.junit.Assert
 import org.junit.Test
 import java.util.*
@@ -45,6 +46,84 @@ class AlarmModelTest {
 				getDate(timeZone, 2019, 4, 2, 0, 0) // No even on 4rd (because endDate is 4th)
 		)
 		Assert.assertArrayEquals(expected.toTypedArray(), occurrences.toTypedArray())
+	}
+
+	@Test
+	fun testSameDay() {
+		// same day
+		Assert.assertTrue(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 13, 7).time,
+				getDate(timeZone, 2022, 11, 25, 13, 7).time
+		))
+		Assert.assertTrue(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 13, 7).time,
+				getDate(timeZone, 2022, 11, 25, 0, 0).time
+		))
+		Assert.assertTrue(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 13, 7).time,
+				getDate(timeZone, 2022, 11, 25, 23, 59).time
+		))
+		Assert.assertTrue(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 0, 0).time,
+				getDate(timeZone, 2022, 11, 25, 23, 59).time
+		))
+		Assert.assertTrue(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 23, 59).time,
+				getDate(timeZone, 2022, 11, 25, 0, 0).time
+		))
+
+		// not same day
+		Assert.assertFalse(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 13, 7).time,
+				getDate(timeZone, 2022, 11, 26, 13, 7).time
+		))
+		Assert.assertFalse(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 13, 7).time,
+				getDate(timeZone, 2022, 11, 26, 0, 0).time
+		))
+		Assert.assertFalse(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 23, 59).time,
+				getDate(timeZone, 2022, 11, 26, 0, 0).time
+		))
+		Assert.assertFalse(isSameDay(
+				getDate(timeZone, 2022, 11, 25, 0, 0).time,
+				getDate(timeZone, 2022, 11, 24, 23, 59).time
+		))
+		Assert.assertFalse(isSameDay(
+				getDate(timeZone, 2021, 11, 25, 13, 7).time,
+				getDate(timeZone, 2022, 11, 25, 13, 7).time
+		))
+
+		// time zone test
+		val timeZoneGMT = TimeZone.getTimeZone("Europe/London")
+		val otherTimeZone = TimeZone.getTimeZone("Asia/Anadyr")
+		Assert.assertTrue(isSameDay(
+				getDate(timeZoneGMT, 2022, 11, 25, 22, 59).time,
+				getDate(timeZoneGMT, 2022, 11, 25, 23, 59).time,
+				timeZoneGMT
+		))
+		Assert.assertTrue(isSameDay(
+				getDate(timeZoneGMT, 2022, 11, 25, 22, 59).time,
+				getDate(timeZoneGMT, 2022, 11, 25, 23, 59).time,
+				otherTimeZone
+		))
+		// for berlin the next day starts between these two timestamps
+		Assert.assertFalse(isSameDay(
+				getDate(timeZoneGMT, 2022, 11, 25, 22, 59).time,
+				getDate(timeZoneGMT, 2022, 11, 25, 23, 59).time,
+				timeZone
+		))
+		Assert.assertEquals(
+				isSameDay(
+						getDate(timeZoneGMT, 2022, 11, 25, 22, 59).time,
+						getDate(timeZoneGMT, 2022, 11, 25, 23, 59).time
+				),
+				isSameDay(
+						getDate(timeZoneGMT, 2022, 11, 25, 22, 59).time,
+						getDate(timeZoneGMT, 2022, 11, 25, 23, 59).time,
+						TimeZone.getDefault()
+				)
+		)
 	}
 
 	private fun getDate(timeZone: TimeZone, year: Int, month: Int, day: Int, hour: Int, minute: Int): Date {


### PR DESCRIPTION
Previously, Android notifications only showed the time of an event, even if the notification was for an event in the future and not on the same day. Now, the notification text is generated depending on whether the notification is for the same day or not. On desktop this is already done in a similar way, see AlarmScheduler.

fix #3519