### PR TITLE
await loadSignupWizard to keep the progress dialog until it's ready

### DIFF
--- a/src/misc/LoginUtils.ts
+++ b/src/misc/LoginUtils.ts
@@ -185,7 +185,7 @@ export async function showSignupDialog(hashParams: Params) {
 		"loading_msg",
 		locator.worker.initialized.then(async () => {
 			const {loadSignupWizard} = await import("../subscription/UpgradeSubscriptionWizard")
-			loadSignupWizard(subscriptionParams, registrationDataId)
+			await loadSignupWizard(subscriptionParams, registrationDataId)
 		}),
 	)
 }


### PR DESCRIPTION
before, it just awaited the async import and dismiss the progress, but there's still other async work going on.

#4770