### PR TITLE
break feature list items

### DIFF
--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -502,6 +502,10 @@ styles.registerStyle("main", () => {
 			overflow: "hidden",
 			"word-break": "break-word",
 		},
+		".break-word": {
+			"word-break": "normal",
+			"overflow-wrap": "break-word"
+		},
 		".break-word-links a": {
 			"word-wrap": "break-word",
 		},
@@ -1654,7 +1658,6 @@ styles.registerStyle("main", () => {
 			top: "150%",
 			left: "50%",
 			"margin-left": "-120px",
-			"word-break": "break-word",
 		},
 		/* we're selecting every element that's after a summary tag and is inside an opened details tag */
 		"details[open] summary ~ *": {

--- a/src/subscription/BuyOptionBox.ts
+++ b/src/subscription/BuyOptionBox.ts
@@ -145,7 +145,7 @@ export class BuyOptionBox implements Component<BuyOptionBoxAttr> {
 			features.map((f) =>
 				m(this.featureListItemSelector, {key: f.key}, [
 					m(Icon, {icon: f.antiFeature ? Icons.Cancel : Icons.Checkmark}),
-					m('.small.text-left.align-self-center.pl-s.button-height.flex-grow.min-width-0', f.text),
+					m('.small.text-left.align-self-center.pl-s.button-height.flex-grow.min-width-0.break-word', f.text),
 					f.toolTip
 						//@ts-ignore
 						? m(InfoIcon, {text: f.toolTip})
@@ -228,7 +228,7 @@ export class InfoIcon implements Component<InfoIconAttrs> {
 					expanded: String(this.expanded),
 					tabindex: 0,
 				}, "i",
-				m('span.tooltiptext', attrs.text)
+				m('span.tooltiptext.break-word', attrs.text)
 			),
 		)
 	}


### PR DESCRIPTION
avoids usage of the deprecated "word-break": "break-word" css directive. instead, "word-break": "normal"
and "overflow-wrap": "break-word" are used as suggested on mdn

close #4773