### PR TITLE
make alias and storage buy boxes bigger

### DIFF
--- a/src/subscription/EmailAliasOptionsDialog.ts
+++ b/src/subscription/EmailAliasOptionsDialog.ts
@@ -4,8 +4,7 @@ import {BookingItemFeatureType} from "../api/common/TutanotaConstants"
 import type {BuyOptionBoxAttr} from "./BuyOptionBox"
 import {BuyOptionBox, updateBuyOptionBoxPriceInformation} from "./BuyOptionBox"
 import {neverNull} from "@tutao/tutanota-utils"
-import {CustomerTypeRef} from "../api/entities/sys/TypeRefs.js"
-import {CustomerInfoTypeRef} from "../api/entities/sys/TypeRefs.js"
+import {CustomerInfoTypeRef, CustomerTypeRef} from "../api/entities/sys/TypeRefs.js"
 import {logins} from "../api/main/LoginController"
 import {Dialog, DialogType} from "../gui/base/Dialog"
 import {Button, ButtonType} from "../gui/base/Button.js"
@@ -78,8 +77,8 @@ function createEmailAliasPackageBox(
 		price: lang.get("emptyString_msg"),
 		helpLabel: "emptyString_msg",
 		features: [],
-		width: 230,
-		height: 210,
+		width: 265,
+		height: 250,
 		paymentInterval: null,
 		showReferenceDiscount: false,
 	}

--- a/src/subscription/StorageCapacityOptionsDialog.ts
+++ b/src/subscription/StorageCapacityOptionsDialog.ts
@@ -6,8 +6,7 @@ import type {BuyOptionBoxAttr} from "./BuyOptionBox"
 import {BuyOptionBox, updateBuyOptionBoxPriceInformation} from "./BuyOptionBox"
 import {neverNull} from "@tutao/tutanota-utils"
 import {buyStorage} from "./SubscriptionUtils"
-import {CustomerTypeRef} from "../api/entities/sys/TypeRefs.js"
-import {CustomerInfoTypeRef} from "../api/entities/sys/TypeRefs.js"
+import {CustomerInfoTypeRef, CustomerTypeRef} from "../api/entities/sys/TypeRefs.js"
 import {logins} from "../api/main/LoginController"
 import {Dialog} from "../gui/base/Dialog"
 import {Button, ButtonType} from "../gui/base/Button.js"
@@ -108,8 +107,8 @@ function createStorageCapacityBoxAttr(
 		price: lang.get("emptyString_msg"),
 		helpLabel: "emptyString_msg",
 		features: [],
-		width: 230,
-		height: 210,
+		width: 265,
+		height: 250,
 		paymentInterval: null,
 		showReferenceDiscount: false,
 	}


### PR DESCRIPTION
adjusted to the size of the boxes on the website.
they appear in a dialog and are allowed to wrap, so this should be fine.

fix #4771