### PR TITLE
Offline storage clear excluded data on app close

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/SqlCipherFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/SqlCipherFacade.kt
@@ -34,4 +34,16 @@ interface SqlCipherFacade {
 		query: String,
 		params: List<TaggedSqlValue>,
 	): List<Map<String, TaggedSqlValue>>
+	/**
+	 * We want to lock the access to the "ranges" db when updating / reading the offline available mail list ranges for each mail list (referenced using the listId)
+	 */
+	 suspend fun lockRangesDbAccess(
+		listId: String,
+	): Unit
+	/**
+	 * This is the counterpart to the function "lockRangesDbAccess(listId)"
+	 */
+	 suspend fun unlockRangesDbAccess(
+		listId: String,
+	): Unit
 }

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/SqlCipherFacadeReceiveDispatcher.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/SqlCipherFacadeReceiveDispatcher.kt
@@ -62,6 +62,20 @@ class SqlCipherFacadeReceiveDispatcher(
 				)
 				return json.encodeToString(result)
 			}
+			"lockRangesDbAccess" -> {
+				val listId: String = json.decodeFromString(arg[0])
+				val result: Unit = this.facade.lockRangesDbAccess(
+					listId,
+				)
+				return json.encodeToString(result)
+			}
+			"unlockRangesDbAccess" -> {
+				val listId: String = json.decodeFromString(arg[0])
+				val result: Unit = this.facade.unlockRangesDbAccess(
+					listId,
+				)
+				return json.encodeToString(result)
+			}
 			else -> throw Error("unknown method for SqlCipherFacade: $method")
 		}
 	}

--- a/app-android/app/src/main/java/de/tutao/tutanota/offline/AndroidSqlCipherFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/offline/AndroidSqlCipherFacade.kt
@@ -35,22 +35,16 @@ class AndroidSqlCipherFacade(private val context: Context) : SqlCipherFacade {
 				closeDbSync()
 			}
 			db = SQLiteDatabase.openOrCreateDatabase(getDbFile(userId).path, dbKey.data, null)
+		}
 
-			// We are using the auto_vacuum=incremental mode to allow for a faster vacuum execution
-			// After changing the auto_vacuum mode we need to run "vacuum" once
-			// auto_vacuum mode: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
-			openedDb.query("PRAGMA auto_vacuum").use { cursor ->
-				if (cursor.moveToNext()) {
-					cursor.readRow().firstNotNullOf {
-						Log.i(TAG, "vacuum: ${it.value}")
-						if (it.value != TaggedSqlValue.Num(2)) {
-							db?.query("PRAGMA auto_vacuum = incremental")
-							db?.query("PRAGMA vacuum")
-							Log.i(TAG, "vacuum running...")
-						}
-					}
-				} else {
-					null
+		// We are using the auto_vacuum=incremental mode to allow for a faster vacuum execution
+		// After changing the auto_vacuum mode we need to run "vacuum" once
+		// auto_vacuum mode: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
+		openedDb.query("PRAGMA auto_vacuum").use { cursor ->
+			if (cursor.moveToFirst()) {
+				if (cursor.getInt(0) != 2) {
+					db?.query("PRAGMA auto_vacuum = incremental")
+					db?.query("PRAGMA vacuum")
 				}
 			}
 		}

--- a/app-android/app/src/main/java/de/tutao/tutanota/offline/AndroidSqlCipherFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/offline/AndroidSqlCipherFacade.kt
@@ -36,9 +36,9 @@ class AndroidSqlCipherFacade(private val context: Context) : SqlCipherFacade {
 			}
 			db = SQLiteDatabase.openOrCreateDatabase(getDbFile(userId).path, dbKey.data, null)
 
-			// We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
-			// After changing the auto_vacuum value we need to run "vacuum" once
-			// auto_vacuum options: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
+			// We are using the auto_vacuum=incremental mode to allow for a faster vacuum execution
+			// After changing the auto_vacuum mode we need to run "vacuum" once
+			// auto_vacuum mode: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
 			openedDb.query("PRAGMA auto_vacuum").use { cursor ->
 				if (cursor.moveToNext()) {
 					cursor.readRow().firstNotNullOf {

--- a/app-ios/tutanota/Info.plist
+++ b/app-ios/tutanota/Info.plist
@@ -58,7 +58,7 @@
 	<key>NSRemindersUsageDescription</key>
 	<string>Shows notification when new email arrives.</string>
 	<key>TutanotaApplicationPath</key>
-	<string>build/dist/</string>
+	<string>build/</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>ionicons.ttf</string>

--- a/app-ios/tutanota/Sources/AppDelegate.swift
+++ b/app-ios/tutanota/Sources/AppDelegate.swift
@@ -117,14 +117,19 @@ class AppDelegate : UIResponder,
       }
     }
 
-  func applicationWillTerminate(_ application: UIApplication) {
-    do {
-      try FileUtils.deleteSharedStorage()
-    } catch {
-      TUTSLog("failed to delete shared storage on shutdown: \(error)")
-    }
+  func applicationDidEnterBackground(_ application: UIApplication) {
+    self.viewController.onApplicationDidEnterBackground()
+
   }
 
+  func applicationWillTerminate(_ application: UIApplication) {
+    self.viewController.onApplicationWillTerminate()
+  	do {
+		try FileUtils.deleteSharedStorage()
+  	} catch {
+		TUTSLog("failed to delete shared storage on shutdown: \(error)")
+  	}
+  }
 }
 
 fileprivate func deviceTokenAsString(deviceToken: Data) -> String? {

--- a/app-ios/tutanota/Sources/GeneratedIpc/SqlCipherFacade.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/SqlCipherFacade.swift
@@ -31,4 +31,16 @@ public protocol SqlCipherFacade {
 		_ query: String,
 		_ params: [TaggedSqlValue]
 	) async throws -> [[String : TaggedSqlValue]]
+	/**
+	 * We want to lock the access to the "ranges" db when updating / reading the offline available mail list ranges for each mail list (referenced using the listId)
+	 */
+	func lockRangesDbAccess(
+		_ listId: String
+	) async throws -> Void
+	/**
+	 * This is the counterpart to the function "lockRangesDbAccess(listId)"
+	 */
+	func unlockRangesDbAccess(
+		_ listId: String
+	) async throws -> Void
 }

--- a/app-ios/tutanota/Sources/GeneratedIpc/SqlCipherFacadeReceiveDispatcher.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/SqlCipherFacadeReceiveDispatcher.swift
@@ -52,6 +52,18 @@ public class SqlCipherFacadeReceiveDispatcher {
 				params
 			)
 			return toJson(result)
+		case "lockRangesDbAccess":
+			let listId = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
+			try await self.facade.lockRangesDbAccess(
+				listId
+			)
+			return "null"
+		case "unlockRangesDbAccess":
+			let listId = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
+			try await self.facade.unlockRangesDbAccess(
+				listId
+			)
+			return "null"
 		default:
 			fatalError("licc messed up! \(method)")
 		}

--- a/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
+++ b/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
@@ -1,9 +1,20 @@
 import Foundation
+import Combine
+
+enum ListIdLockState {
+  case waitingForListIdUnlock
+  case listIdUnlocked
+}
 
 let OFFLINE_DB_CLOSED_DOMAIN = "de.tutao.tutanota.offline.OfflineDbClosedError"
 
 class IosSqlCipherFacade: SqlCipherFacade {
   private var db: SqlCipherDb? = nil
+
+  private var listIdLocks: [String: CurrentValueSubject<ListIdLockState, Never>] = [:]
+  // according to the docs the return value of sink should be held
+  // because otherwise the stream will be canceled
+  private var cancellables: [AnyCancellable] = []
 
   private func getDb() throws -> SqlCipherDb {
     guard let db = self.db else {
@@ -44,9 +55,9 @@ class IosSqlCipherFacade: SqlCipherFacade {
 
   func deleteDb(_ userId: String) async throws {
     if let db = self.db, db.userId == userId {
-        db.close()
+      db.close()
     }
-    
+
     do {
       try FileUtils.deleteFile(path: makeDbPath(userId))
     } catch {
@@ -60,5 +71,35 @@ class IosSqlCipherFacade: SqlCipherFacade {
         throw error
       }
     }
+  }
+
+  /**
+   * We want to lock the access to the "ranges" db when updating / reading the
+   * offline available mail list ranges for each mail list (referenced using the listId).
+   * @param listId the mail list that we want to lock
+   */
+  func lockRangesDbAccess(_ listId: String) async throws {
+    if (self.listIdLocks[listId] != nil) {
+      await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        let cancellable = self.listIdLocks[listId]!
+          .first(where: { $0 == .listIdUnlocked })
+          .sink { v in
+            continuation.resume()
+            self.listIdLocks[listId] = CurrentValueSubject<ListIdLockState, Never>(.waitingForListIdUnlock)
+          }
+        self.cancellables.append(cancellable)
+      }
+    } else {
+      self.listIdLocks[listId] = CurrentValueSubject<ListIdLockState, Never>(.waitingForListIdUnlock)
+    }
+  }
+
+  /**
+   * This is the counterpart to the function "lockRangesDbAccess(listId)".
+   * @param listId the mail list that we want to unlock
+   */
+  func unlockRangesDbAccess(_ listId: String) async throws {
+    self.listIdLocks.removeValue(forKey: listId)
+    self.listIdLocks[listId]?.send(.listIdUnlocked)
   }
 }

--- a/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
+++ b/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
@@ -11,7 +11,7 @@ let OFFLINE_DB_CLOSED_DOMAIN = "de.tutao.tutanota.offline.OfflineDbClosedError"
 class IosSqlCipherFacade: SqlCipherFacade {
   private var db: SqlCipherDb? = nil
 
-  private var listIdLocks: [String: CurrentValueSubject<ListIdLockState, Never>] = [:]
+  private var concurrentListIdLocks = ConcurrentListIdLocks()
   // according to the docs the return value of sink should be held
   // because otherwise the stream will be canceled
   private var cancellables: [AnyCancellable] = []
@@ -73,24 +73,32 @@ class IosSqlCipherFacade: SqlCipherFacade {
     }
   }
 
+  func vaccumDb() async throws {
+    if self.db == nil {
+      return
+    }
+    self.db!.vacuum()
+  }
+
   /**
    * We want to lock the access to the "ranges" db when updating / reading the
    * offline available mail list ranges for each mail list (referenced using the listId).
    * @param listId the mail list that we want to lock
    */
   func lockRangesDbAccess(_ listId: String) async throws {
-    if (self.listIdLocks[listId] != nil) {
+    let listIdLock = await concurrentListIdLocks.get(listId)
+    if let listIdLock = listIdLock {
       await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-        let cancellable = self.listIdLocks[listId]!
+        let cancellable = listIdLock
           .first(where: { $0 == .listIdUnlocked })
           .sink { v in
             continuation.resume()
-            self.listIdLocks[listId] = CurrentValueSubject<ListIdLockState, Never>(.waitingForListIdUnlock)
           }
         self.cancellables.append(cancellable)
       }
+      await self.concurrentListIdLocks.set(listId,CurrentValueSubject<ListIdLockState, Never>(.waitingForListIdUnlock))
     } else {
-      self.listIdLocks[listId] = CurrentValueSubject<ListIdLockState, Never>(.waitingForListIdUnlock)
+      await self.concurrentListIdLocks.set(listId, CurrentValueSubject<ListIdLockState, Never>(.waitingForListIdUnlock))
     }
   }
 
@@ -99,7 +107,24 @@ class IosSqlCipherFacade: SqlCipherFacade {
    * @param listId the mail list that we want to unlock
    */
   func unlockRangesDbAccess(_ listId: String) async throws {
-    self.listIdLocks.removeValue(forKey: listId)
-    self.listIdLocks[listId]?.send(.listIdUnlocked)
+    let listIdLock = await self.concurrentListIdLocks.removeValue(forKey: listId)
+    listIdLock?.send(.listIdUnlocked)
+  }
+}
+
+// We need this actor in order to make sure that access to the listIdLocks dictionary is thread safe
+actor ConcurrentListIdLocks {
+  private var listIdLocks: [String: CurrentValueSubject<ListIdLockState, Never>] = [:]
+
+  func get(_ listId: String) ->  CurrentValueSubject<ListIdLockState, Never>? {
+    listIdLocks[listId]
+  }
+
+  func set(_ listId: String,_ value: CurrentValueSubject<ListIdLockState, Never>) {
+    return listIdLocks[listId] = value
+  }
+
+  func removeValue(forKey listId: String) -> CurrentValueSubject<ListIdLockState, Never>? {
+    return listIdLocks.removeValue(forKey: listId)
   }
 }

--- a/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
+++ b/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
@@ -74,10 +74,7 @@ class IosSqlCipherFacade: SqlCipherFacade {
   }
 
   func vaccumDb() async throws {
-    if self.db == nil {
-      return
-    }
-    self.db!.vacuum()
+    self.db?.vacuum()
   }
 
   /**

--- a/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
+++ b/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
@@ -3,11 +3,11 @@ import Foundation
 class SqlCipherDb {
   private var db: OpaquePointer? = nil
   let userId: String
-  
+
   init(_ userId: String) {
     self.userId = userId
   }
-  
+
   func open(_ dbKey: Data) throws {
     TUTSLog("opening DB for \(userId)")
     let rawKeyData: NSData = dbKey as NSData
@@ -33,8 +33,11 @@ class SqlCipherDb {
     if !errors.isEmpty {
       throw TUTErrorFactory.createError(withDomain: TUT_CRYPTO_ERROR, message: "sqlcipher: \(errors.count) pages failed integrity check")
     }
+
+    // We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
+    try! self.prepare(query: "PRAGMA auto_vacuum = incremental").run()
   }
-  
+
   func prepare(query: String) throws -> SqlCipherStatement {
     var stmt: OpaquePointer? = nil
     let sqlCStr = UnsafeMutablePointer<CChar>(mutating: (query as NSString).utf8String)
@@ -46,8 +49,11 @@ class SqlCipherDb {
     }
     return SqlCipherStatement(db: self, query: query, stmt: stmt.unsafelyUnwrapped)
   }
-  
+
   func close() {
+    // We are performing defragmentation (incremental_vacuum) the database before closing
+	  try! self.prepare("PRAGMA incremental_vacuum").run()
+
     if sqlite3_close(self.db) != SQLITE_OK {
       let errmsg = self.getLastErrorMessage()
       TUTSLog("Error closing database: \(errmsg): \(self.getLastErrorMessage())")
@@ -55,11 +61,11 @@ class SqlCipherDb {
     }
     self.db = nil
   }
-  
+
   func getLastErrorMessage() -> String {
     return String(cString: sqlite3_errmsg(self.db))
   }
-  
+
   func getLastErrorCode() -> Int32 {
     return sqlite3_errcode(self.db)
   }

--- a/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
+++ b/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
@@ -3,11 +3,11 @@ import Foundation
 class SqlCipherDb {
   private var db: OpaquePointer? = nil
   let userId: String
-
+  
   init(_ userId: String) {
     self.userId = userId
   }
-
+  
   func open(_ dbKey: Data) throws {
     TUTSLog("opening DB for \(userId)")
     let rawKeyData: NSData = dbKey as NSData
@@ -33,18 +33,17 @@ class SqlCipherDb {
     if !errors.isEmpty {
       throw TUTErrorFactory.createError(withDomain: TUT_CRYPTO_ERROR, message: "sqlcipher: \(errors.count) pages failed integrity check")
     }
-
-    // FIXME run database close on app terminated
-
-	// We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
-	// After changing the auto_vacuum value we need to run "vacuum" once
-	// auto_vacuum options: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
-    if (try! self.prepare(query: "PRAGMA auto_vacuum").run() != 2) {
-        try! self.prepare(query: "PRAGMA auto_vacuum = incremental").run()
-        try! self.prepare(query: "PRAGMA vacuum").run()
+    
+    // We are using the auto_vacuum=incremental mode to allow for a faster vacuum execution
+    // After changing the auto_vacuum mode we need to run "vacuum" once
+    // auto_vacuum mode: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
+    let auto_vacuum_mode = try? self.prepare(query: "PRAGMA auto_vacuum").get()?.first?.value
+    if case let .number(auto_vaccum_mode_value) = auto_vacuum_mode, auto_vaccum_mode_value != 2 {
+      try! self.prepare(query: "PRAGMA auto_vacuum = incremental").run()
+      try! self.prepare(query: "PRAGMA vacuum").run()
     }
   }
-
+  
   func prepare(query: String) throws -> SqlCipherStatement {
     var stmt: OpaquePointer? = nil
     let sqlCStr = UnsafeMutablePointer<CChar>(mutating: (query as NSString).utf8String)
@@ -56,11 +55,8 @@ class SqlCipherDb {
     }
     return SqlCipherStatement(db: self, query: query, stmt: stmt.unsafelyUnwrapped)
   }
-
+  
   func close() {
-    // We are performing defragmentation (incremental_vacuum) the database before closing
-    try! self.prepare(query: "PRAGMA incremental_vacuum").run()
-
     if sqlite3_close(self.db) != SQLITE_OK {
       let errmsg = self.getLastErrorMessage()
       TUTSLog("Error closing database: \(errmsg): \(self.getLastErrorMessage())")
@@ -68,11 +64,16 @@ class SqlCipherDb {
     }
     self.db = nil
   }
-
+  
+  func vacuum() {
+    // We are performing defragmentation (incremental_vacuum) the database
+    try! self.prepare(query: "PRAGMA incremental_vacuum").run()
+  }
+  
   func getLastErrorMessage() -> String {
     return String(cString: sqlite3_errmsg(self.db))
   }
-
+  
   func getLastErrorCode() -> Int32 {
     return sqlite3_errcode(self.db)
   }

--- a/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
+++ b/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
@@ -3,11 +3,11 @@ import Foundation
 class SqlCipherDb {
   private var db: OpaquePointer? = nil
   let userId: String
-
+  
   init(_ userId: String) {
     self.userId = userId
   }
-
+  
   func open(_ dbKey: Data) throws {
     TUTSLog("opening DB for \(userId)")
     let rawKeyData: NSData = dbKey as NSData
@@ -33,11 +33,14 @@ class SqlCipherDb {
     if !errors.isEmpty {
       throw TUTErrorFactory.createError(withDomain: TUT_CRYPTO_ERROR, message: "sqlcipher: \(errors.count) pages failed integrity check")
     }
-
+    
+    // FIXME incremental -> do we need to do vacuum first
+    // FIXME run database close on app terminated
+    
     // We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
     try! self.prepare(query: "PRAGMA auto_vacuum = incremental").run()
   }
-
+  
   func prepare(query: String) throws -> SqlCipherStatement {
     var stmt: OpaquePointer? = nil
     let sqlCStr = UnsafeMutablePointer<CChar>(mutating: (query as NSString).utf8String)
@@ -49,11 +52,11 @@ class SqlCipherDb {
     }
     return SqlCipherStatement(db: self, query: query, stmt: stmt.unsafelyUnwrapped)
   }
-
+  
   func close() {
     // We are performing defragmentation (incremental_vacuum) the database before closing
-	  try! self.prepare("PRAGMA incremental_vacuum").run()
-
+    try! self.prepare(query: "PRAGMA incremental_vacuum").run()
+    
     if sqlite3_close(self.db) != SQLITE_OK {
       let errmsg = self.getLastErrorMessage()
       TUTSLog("Error closing database: \(errmsg): \(self.getLastErrorMessage())")
@@ -61,11 +64,11 @@ class SqlCipherDb {
     }
     self.db = nil
   }
-
+  
   func getLastErrorMessage() -> String {
     return String(cString: sqlite3_errmsg(self.db))
   }
-
+  
   func getLastErrorCode() -> Int32 {
     return sqlite3_errcode(self.db)
   }

--- a/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
+++ b/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
@@ -3,11 +3,11 @@ import Foundation
 class SqlCipherDb {
   private var db: OpaquePointer? = nil
   let userId: String
-  
+
   init(_ userId: String) {
     self.userId = userId
   }
-  
+
   func open(_ dbKey: Data) throws {
     TUTSLog("opening DB for \(userId)")
     let rawKeyData: NSData = dbKey as NSData
@@ -33,14 +33,18 @@ class SqlCipherDb {
     if !errors.isEmpty {
       throw TUTErrorFactory.createError(withDomain: TUT_CRYPTO_ERROR, message: "sqlcipher: \(errors.count) pages failed integrity check")
     }
-    
-    // FIXME incremental -> do we need to do vacuum first
+
     // FIXME run database close on app terminated
-    
-    // We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
-    try! self.prepare(query: "PRAGMA auto_vacuum = incremental").run()
+
+	// We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
+	// After changing the auto_vacuum value we need to run "vacuum" once
+	// auto_vacuum options: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
+    if (try! self.prepare(query: "PRAGMA auto_vacuum").run() != 2) {
+        try! self.prepare(query: "PRAGMA auto_vacuum = incremental").run()
+        try! self.prepare(query: "PRAGMA vacuum").run()
+    }
   }
-  
+
   func prepare(query: String) throws -> SqlCipherStatement {
     var stmt: OpaquePointer? = nil
     let sqlCStr = UnsafeMutablePointer<CChar>(mutating: (query as NSString).utf8String)
@@ -52,11 +56,11 @@ class SqlCipherDb {
     }
     return SqlCipherStatement(db: self, query: query, stmt: stmt.unsafelyUnwrapped)
   }
-  
+
   func close() {
     // We are performing defragmentation (incremental_vacuum) the database before closing
     try! self.prepare(query: "PRAGMA incremental_vacuum").run()
-    
+
     if sqlite3_close(self.db) != SQLITE_OK {
       let errmsg = self.getLastErrorMessage()
       TUTSLog("Error closing database: \(errmsg): \(self.getLastErrorMessage())")
@@ -64,11 +68,11 @@ class SqlCipherDb {
     }
     self.db = nil
   }
-  
+
   func getLastErrorMessage() -> String {
     return String(cString: sqlite3_errmsg(self.db))
   }
-  
+
   func getLastErrorCode() -> Int32 {
     return sqlite3_errcode(self.db)
   }

--- a/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
+++ b/app-ios/tutanota/Sources/Offline/SqlCipherDb.swift
@@ -3,11 +3,11 @@ import Foundation
 class SqlCipherDb {
   private var db: OpaquePointer? = nil
   let userId: String
-  
+
   init(_ userId: String) {
     self.userId = userId
   }
-  
+
   func open(_ dbKey: Data) throws {
     TUTSLog("opening DB for \(userId)")
     let rawKeyData: NSData = dbKey as NSData
@@ -33,17 +33,17 @@ class SqlCipherDb {
     if !errors.isEmpty {
       throw TUTErrorFactory.createError(withDomain: TUT_CRYPTO_ERROR, message: "sqlcipher: \(errors.count) pages failed integrity check")
     }
-    
+
     // We are using the auto_vacuum=incremental mode to allow for a faster vacuum execution
     // After changing the auto_vacuum mode we need to run "vacuum" once
     // auto_vacuum mode: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
-    let auto_vacuum_mode = try? self.prepare(query: "PRAGMA auto_vacuum").get()?.first?.value
-    if case let .number(auto_vaccum_mode_value) = auto_vacuum_mode, auto_vaccum_mode_value != 2 {
+    let autoVacuumMode = try? self.prepare(query: "PRAGMA auto_vacuum").get()?.first?.value
+    if case let .number(autoVacuumModeValue) = autoVacuumMode, autoVacuumModeValue != 2 {
       try! self.prepare(query: "PRAGMA auto_vacuum = incremental").run()
       try! self.prepare(query: "PRAGMA vacuum").run()
     }
   }
-  
+
   func prepare(query: String) throws -> SqlCipherStatement {
     var stmt: OpaquePointer? = nil
     let sqlCStr = UnsafeMutablePointer<CChar>(mutating: (query as NSString).utf8String)
@@ -55,7 +55,7 @@ class SqlCipherDb {
     }
     return SqlCipherStatement(db: self, query: query, stmt: stmt.unsafelyUnwrapped)
   }
-  
+
   func close() {
     if sqlite3_close(self.db) != SQLITE_OK {
       let errmsg = self.getLastErrorMessage()
@@ -64,16 +64,15 @@ class SqlCipherDb {
     }
     self.db = nil
   }
-  
+
   func vacuum() {
-    // We are performing defragmentation (incremental_vacuum) the database
     try! self.prepare(query: "PRAGMA incremental_vacuum").run()
   }
-  
+
   func getLastErrorMessage() -> String {
     return String(cString: sqlite3_errmsg(self.db))
   }
-  
+
   func getLastErrorCode() -> Int32 {
     return sqlite3_errcode(self.db)
   }

--- a/app-ios/tutanota/Sources/Remote/IosCommonSystemFacade.swift
+++ b/app-ios/tutanota/Sources/Remote/IosCommonSystemFacade.swift
@@ -7,7 +7,7 @@ enum InitState {
 }
 
 class IosCommonSystemFacade: CommonSystemFacade {
-  
+
   private let viewController: ViewController
   private var initialized = CurrentValueSubject<InitState, Never>(.waitingForInit)
   // according to the docs the return value of sink should be held
@@ -16,21 +16,21 @@ class IosCommonSystemFacade: CommonSystemFacade {
   init(viewController: ViewController) {
     self.viewController = viewController
   }
-  
+
   func initializeRemoteBridge() async throws {
     self.initialized.send(.initReceived)
   }
-  
+
   func reload(_ query: [String : String]) async throws {
     self.initialized = CurrentValueSubject(.waitingForInit)
     await self.viewController.loadMainPage(params: query)
   }
-  
+
   func getLog() async throws -> String {
     let entries = TUTLogger.sharedInstance().entries()
     return entries.joined(separator: "\n")
   }
-  
+
   func awaitForInit() async {
     /// awaiting for the first and hopefully only void object in this publisher
     /// could be simpler but .values is iOS > 15
@@ -43,7 +43,7 @@ class IosCommonSystemFacade: CommonSystemFacade {
       let cancellable = self.initialized
         .first { $0 == .initReceived }
         .sink { v in continuation.resume() }
-      
+
       self.cancellables.append(cancellable)
     }
   }

--- a/app-ios/tutanota/Sources/Remote/RemoteBridge.swift
+++ b/app-ios/tutanota/Sources/Remote/RemoteBridge.swift
@@ -11,8 +11,7 @@ class RemoteBridge : NSObject, NativeInterface {
   var commonNativeFacade: CommonNativeFacade!
   private var mobileFacade: MobileFacade!
   private var globalDispatcher: IosGlobalDispatcher!
-  // We make the IosSqlCipherFacade available in here in order to be able to close the offline database when the app terminates
-  private var sqlCipherFacade = IosSqlCipherFacade()
+  private var sqlCipherFacade: IosSqlCipherFacade!
 
   private let requestId = ManagedAtomic<Int64>(0)
   private let requestsLock = NSLock()
@@ -30,7 +29,8 @@ class RemoteBridge : NSObject, NativeInterface {
     alarmManager: AlarmManager,
     userPreferences: UserPreferenceFacade,
     keychainManager: KeychainManager,
-    webAuthnFacade: WebAuthnFacade
+    webAuthnFacade: WebAuthnFacade,
+    sqlCipherFacade: IosSqlCipherFacade
   ) {
     self.webView = webView
     self.viewController = viewController
@@ -38,6 +38,7 @@ class RemoteBridge : NSObject, NativeInterface {
     self.mobileFacade = nil
     self.commonNativeFacade = nil
     self.globalDispatcher = nil
+    self.sqlCipherFacade = sqlCipherFacade
 
 
     super.init()
@@ -56,7 +57,7 @@ class RemoteBridge : NSObject, NativeInterface {
       nativeCredentialsFacade: nativeCredentialsFacade,
       nativeCryptoFacade: nativeCryptoFacade,
       nativePushFacade: nativePushFacade,
-      sqlCipherFacade: self.sqlCipherFacade,
+      sqlCipherFacade: sqlCipherFacade,
       themeFacade: themeFacade,
       webAuthnFacade: webAuthnFacade
     )
@@ -170,18 +171,6 @@ class RemoteBridge : NSObject, NativeInterface {
       } else {
         return nil
       }
-    }
-  }
-
-  func vacuumOfflineDatabase() {
-    Task {
-      try await self.sqlCipherFacade.vaccumDb()
-    }
-  }
-
-  func closeOfflineDatabase() {
-    Task {
-      try await self.sqlCipherFacade.closeDb()
     }
   }
 }

--- a/app-ios/tutanota/Sources/ViewController.swift
+++ b/app-ios/tutanota/Sources/ViewController.swift
@@ -143,7 +143,7 @@ class ViewController : UIViewController, WKNavigationDelegate, UIScrollViewDeleg
 
   func onApplicationDidEnterBackground() {
     // When the user leaves the app we want to perform "incremental_vacuum" on the offline database.
-    // We perform vacuum onnce the app is put into background instead of when the app is terminated as on iOS
+    // We perform vacuum once the app is put into background instead of when the app is terminated as on iOS
     // we do not have enough time before the app is terminated by the system.
     self.bridge.vacuumOfflineDatabase()
   }

--- a/app-ios/tutanota/Sources/ViewController.swift
+++ b/app-ios/tutanota/Sources/ViewController.swift
@@ -118,7 +118,6 @@ class ViewController : UIViewController, WKNavigationDelegate, UIScrollViewDeleg
   private func onKeyboardDidShow(note: Notification) {
     let rect = note.userInfo![UIResponder.keyboardFrameEndUserInfoKey] as! CGRect
     self.onAnyKeyboardSizeChange(newHeight: rect.size.height)
-
   }
 
   @objc
@@ -140,6 +139,17 @@ class ViewController : UIViewController, WKNavigationDelegate, UIScrollViewDeleg
     Task {
       try await MobileFacadeSendDispatcher(transport: self.bridge).keyboardSizeChanged(self.keyboardSize)
     }
+  }
+
+  func onApplicationDidEnterBackground() {
+    // When the user leaves the app we want to perform "incremental_vacuum" on the offline database.
+    // We perform vacuum onnce the app is put into background instead of when the app is terminated as on iOS
+    // we do not have enough time before the app is terminated by the system.
+    self.bridge.vacuumOfflineDatabase()
+  }
+
+  func onApplicationWillTerminate() {
+    self.bridge.closeOfflineDatabase()
   }
 
   override func viewDidLoad() {

--- a/ipc-schema/facades/SqlCipherFacade.json5
+++ b/ipc-schema/facades/SqlCipherFacade.json5
@@ -68,6 +68,24 @@
 				}
 			],
 			ret: "List<Map<string, TaggedSqlValue>>"
+		},
+		lockRangesDbAccess: {
+			doc: "We want to lock the access to the \"ranges\" db when updating / reading the offline available mail list ranges for each mail list (referenced using the listId)",
+			arg: [
+				{
+					listId: "string"
+				}
+			],
+			ret: "void"
+		},
+		unlockRangesDbAccess: {
+			doc: "This is the counterpart to the function \"lockRangesDbAccess(listId)\"",
+			arg: [
+				{
+					listId: "string"
+				}
+			],
+			ret: "void"
 		}
 	}
 }

--- a/src/api/worker/WorkerLocator.ts
+++ b/src/api/worker/WorkerLocator.ts
@@ -118,6 +118,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 				new InterWindowEventFacadeSendDispatcher(worker),
 				new NoZoneDateProvider(),
 				new OfflineStorageMigrator(OFFLINE_STORAGE_MIGRATIONS, modelInfos),
+				worker,
 			)
 		} else {
 			return null

--- a/src/api/worker/WorkerLocator.ts
+++ b/src/api/worker/WorkerLocator.ts
@@ -118,7 +118,6 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 				new InterWindowEventFacadeSendDispatcher(worker),
 				new NoZoneDateProvider(),
 				new OfflineStorageMigrator(OFFLINE_STORAGE_MIGRATIONS, modelInfos),
-				worker,
 			)
 		} else {
 			return null

--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -26,7 +26,6 @@ import {InterWindowEventFacadeSendDispatcher} from "../../../native/common/gener
 import {SqlCipherFacade} from "../../../native/common/generatedipc/SqlCipherFacade.js"
 import {SqlValue, TaggedSqlValue, tagSqlValue, untagSqlObject} from "./SqlValue.js"
 import {WorkerImpl} from "../WorkerImpl.js"
-import {ProgressMonitorDelegate} from "../ProgressMonitorDelegate.js"
 
 function dateEncoder(data: Date, typ: string, options: EncodeOptions): TokenOrNestedTokens | null {
 	const time = data.getTime()
@@ -351,18 +350,13 @@ AND NOT(${firstIdBigger("elementId", upper)})`
 		const cutoffTimestamp = this.dateProvider.now() - timeRange * DAY_IN_MILLIS
 		const cutoffId = timestampToGeneratedId(cutoffTimestamp)
 
-		const folders = await this.getListElementsOfType(MailFolderTypeRef)
-		const progressMonitor = new ProgressMonitorDelegate(folders.length, this.worker)
-		for (const folder of folders) {
+		for (const folder of await this.getListElementsOfType(MailFolderTypeRef)) {
 			if (folder.folderType === MailFolderType.TRASH || folder.folderType === MailFolderType.SPAM) {
 				await this.deleteMailList(folder.mails, GENERATED_MAX_ID)
-				progressMonitor.workDone(1)
 			} else {
 				await this.deleteMailList(folder.mails, cutoffId)
-				progressMonitor.workDone(1)
 			}
 		}
-		progressMonitor.completed()
 	}
 
 	private async createTables() {

--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -25,7 +25,6 @@ import {EntityRestClient} from "../rest/EntityRestClient.js"
 import {InterWindowEventFacadeSendDispatcher} from "../../../native/common/generatedipc/InterWindowEventFacadeSendDispatcher.js"
 import {SqlCipherFacade} from "../../../native/common/generatedipc/SqlCipherFacade.js"
 import {SqlValue, TaggedSqlValue, tagSqlValue, untagSqlObject} from "./SqlValue.js"
-import {WorkerImpl} from "../WorkerImpl.js"
 
 function dateEncoder(data: Date, typ: string, options: EncodeOptions): TokenOrNestedTokens | null {
 	const time = data.getTime()
@@ -97,7 +96,6 @@ export class OfflineStorage implements CacheStorage, ExposedCacheStorage {
 		private readonly interWindowEventSender: InterWindowEventFacadeSendDispatcher,
 		private readonly dateProvider: DateProvider,
 		private readonly migrator: OfflineStorageMigrator,
-		private readonly worker: WorkerImpl,
 	) {
 		assert(isOfflineStorageAvailable() || isTest(), "Offline storage is not available.")
 	}

--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -345,8 +345,6 @@ AND NOT(${firstIdBigger("elementId", upper)})`
 	async clearExcludedData(timeRangeDays: number | null = this.timeRangeDays, userId: Id = this.getUserId()): Promise<void> {
 		const user = await this.get(UserTypeRef, null, userId)
 
-		console.log("Clearing excluded data ...")
-
 		// Free users always have default time range regardless of what is stored
 		const isFreeUser = user?.accountType === AccountType.FREE
 		const timeRange = isFreeUser || timeRangeDays == null ? OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS : timeRangeDays

--- a/src/api/worker/rest/CacheStorageProxy.ts
+++ b/src/api/worker/rest/CacheStorageProxy.ts
@@ -7,7 +7,6 @@ import {WorkerImpl} from "../WorkerImpl"
 import {EphemeralCacheStorage, EphemeralStorageInitArgs} from "./EphemeralCacheStorage"
 import {EntityRestClient} from "./EntityRestClient.js"
 import {CustomCacheHandlerMap} from "./CustomCacheHandler.js"
-import {InitCacheOptions} from "../facades/LoginFacade.js"
 
 export interface EphemeralStorageArgs extends EphemeralStorageInitArgs {
 	type: "ephemeral",
@@ -183,5 +182,9 @@ export class LateInitializedCacheStorageImpl implements CacheStorageLateInitiali
 
 	async deleteAllOwnedBy(owner: Id): Promise<void> {
 		return this.inner.deleteAllOwnedBy(owner)
+	}
+
+	clearExcludedData(): Promise<void> {
+		return this.inner.clearExcludedData()
 	}
 }

--- a/src/api/worker/rest/CacheStorageProxy.ts
+++ b/src/api/worker/rest/CacheStorageProxy.ts
@@ -187,4 +187,21 @@ export class LateInitializedCacheStorageImpl implements CacheStorageLateInitiali
 	clearExcludedData(): Promise<void> {
 		return this.inner.clearExcludedData()
 	}
+
+	/**
+	 * We want to lock the access to the "ranges" db when updating / reading the
+	 * offline available mail list ranges for each mail list (referenced using the listId)
+	 * @param listId the mail list that we want to lock
+	 */
+	lockRangesDbAccess(listId: Id): Promise<void> {
+		return this.inner.lockRangesDbAccess(listId)
+	}
+
+	/**
+	 * This is the counterpart to the function "lockRangesDbAccess(listId)"
+	 * @param listId the mail list that we want to unlock
+	 */
+	unlockRangesDbAccess(listId: Id): Promise<void> {
+		return this.inner.unlockRangesDbAccess(listId)
+	}
 }

--- a/src/api/worker/rest/CustomCacheHandler.ts
+++ b/src/api/worker/rest/CustomCacheHandler.ts
@@ -82,6 +82,9 @@ export class CustomCalendarEventCacheHandler implements CustomCacheHandler<Calen
 	}
 
 	async loadRange(storage: CacheStorage, listId: Id, start: Id, count: number, reverse: boolean): Promise<CalendarEvent[]> {
+		// We lock access to the "ranges" db here in order to prevent race conditions when accessing the ranges database.
+		await storage.lockRangesDbAccess(listId)
+
 		const range = await storage.getRangeForList(CalendarEventTypeRef, listId)
 
 		//if offline db for this list is empty load from server
@@ -105,6 +108,9 @@ export class CustomCalendarEventCacheHandler implements CustomCacheHandler<Calen
 			rawList = await storage.getWholeList(CalendarEventTypeRef, listId)
 			console.log(`CalendarEvent list ${listId} has ${rawList.length} events`)
 		}
+
+		// We unlock access to the "ranges" db here. We lock it in order to prevent race conditions when accessing the "ranges" database.
+		await storage.unlockRangesDbAccess(listId)
 
 		const typeModel = await resolveTypeReference(CalendarEventTypeRef)
 		const sortedList = reverse

--- a/src/api/worker/rest/CustomCacheHandler.ts
+++ b/src/api/worker/rest/CustomCacheHandler.ts
@@ -82,9 +82,6 @@ export class CustomCalendarEventCacheHandler implements CustomCacheHandler<Calen
 	}
 
 	async loadRange(storage: CacheStorage, listId: Id, start: Id, count: number, reverse: boolean): Promise<CalendarEvent[]> {
-		// We lock access to the "ranges" db here in order to prevent race conditions when accessing the ranges database.
-		await storage.lockRangesDbAccess(listId)
-
 		const range = await storage.getRangeForList(CalendarEventTypeRef, listId)
 
 		//if offline db for this list is empty load from server
@@ -101,6 +98,7 @@ export class CustomCalendarEventCacheHandler implements CustomCacheHandler<Calen
 			for (const event of rawList) {
 				await storage.put(event)
 			}
+
 			// we have all events now
 			await storage.setNewRangeForList(CalendarEventTypeRef, listId, CUSTOM_MIN_ID, CUSTOM_MAX_ID)
 		} else {
@@ -108,10 +106,6 @@ export class CustomCalendarEventCacheHandler implements CustomCacheHandler<Calen
 			rawList = await storage.getWholeList(CalendarEventTypeRef, listId)
 			console.log(`CalendarEvent list ${listId} has ${rawList.length} events`)
 		}
-
-		// We unlock access to the "ranges" db here. We lock it in order to prevent race conditions when accessing the "ranges" database.
-		await storage.unlockRangesDbAccess(listId)
-
 		const typeModel = await resolveTypeReference(CalendarEventTypeRef)
 		const sortedList = reverse
 			? rawList

--- a/src/api/worker/rest/DefaultEntityRestCache.ts
+++ b/src/api/worker/rest/DefaultEntityRestCache.ts
@@ -113,6 +113,8 @@ export interface ExposedCacheStorage {
 	getWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<T>>
 
 	getLastUpdateTime(): Promise<LastUpdateTime>
+
+	clearExcludedData(): Promise<void>
 }
 
 export interface CacheStorage extends ExposedCacheStorage {

--- a/src/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/api/worker/rest/EphemeralCacheStorage.ts
@@ -226,7 +226,6 @@ export class EphemeralCacheStorage implements CacheStorage {
 		return Promise.resolve();
 	}
 
-
 	async getLastUpdateTime(): Promise<LastUpdateTime> {
 		return this.lastUpdateTime ? {type: "recorded", time: this.lastUpdateTime} : {type: "never"}
 	}
@@ -277,5 +276,9 @@ export class EphemeralCacheStorage implements CacheStorage {
 		}
 
 		this.lastBatchIdPerGroup.delete(owner)
+	}
+
+	clearExcludedData(): Promise<void> {
+		return Promise.resolve()
 	}
 }

--- a/src/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/api/worker/rest/EphemeralCacheStorage.ts
@@ -281,4 +281,21 @@ export class EphemeralCacheStorage implements CacheStorage {
 	clearExcludedData(): Promise<void> {
 		return Promise.resolve()
 	}
+
+	/**
+	 * We want to lock the access to the "ranges" db when updating / reading the
+	 * offline available mail list ranges for each mail list (referenced using the listId)
+	 * @param listId the mail list that we want to lock
+	 */
+	lockRangesDbAccess(listId: string): Promise<void> {
+		return Promise.resolve()
+	}
+
+	/**
+	 * This is the counterpart to the function "lockRangesDbAccess(listId)"
+	 * @param listId the mail list that we want to unlock
+	 */
+	unlockRangesDbAccess(listId: string): Promise<void> {
+		return Promise.resolve()
+	}
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -145,9 +145,15 @@ import("./translations/en")
 		const {CachePostLoginAction} = await import("./offline/CachePostLoginAction")
 		logins.addPostLoginAction(new PostLoginActions(locator.credentialsProvider, locator.secondFactorHandler))
 		if (isOfflineStorageAvailable()) {
-			logins.addPostLoginAction(new CachePostLoginAction(
-				locator.calendarModel, locator.entityClient, locator.progressTracker, logins,
-			))
+			logins.addPostLoginAction(
+				new CachePostLoginAction(
+					locator.calendarModel,
+					locator.entityClient,
+					locator.progressTracker,
+					locator.cacheStorage,
+					logins,
+				)
+			)
 		}
 
 		styles.init()

--- a/src/desktop/DesktopSqlCipher.ts
+++ b/src/desktop/DesktopSqlCipher.ts
@@ -119,6 +119,20 @@ export class DesktopSqlCipher implements SqlCipherFacade {
 		return result.map(tagSqlObject)
 	}
 
+	/**
+	 * not implemented because we lock the "ranges" DB directly from the per-window facade
+	 */
+	lockRangesDbAccess(userId: Id): Promise<void> {
+		throw new ProgrammingError("Not implemented")
+	}
+
+	/**
+	 * not implemented because we unlock the "ranges" DB directly from the per-window facade
+	 */
+	unlockRangesDbAccess(userId: Id): Promise<void> {
+		throw new ProgrammingError("Not implemented")
+	}
+
 	private checkIntegrity() {
 		/**
 		 * Throws a CryptoError if MAC verification fails

--- a/src/desktop/DesktopSqlCipher.ts
+++ b/src/desktop/DesktopSqlCipher.ts
@@ -78,7 +78,12 @@ export class DesktopSqlCipher implements SqlCipherFacade {
 		this.db.pragma(`KEY = "${key}"`)
 
 		// We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
-		this.db.pragma("auto_vacuum = incremental")
+		// After changing the auto_vacuum value we need to run "vacuum" once
+		// auto_vacuum options: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
+		if (this.db.pragma("auto_vacuum", {simple: true}) != 2) {
+			this.db.pragma("auto_vacuum = incremental")
+			this.db.pragma("vacuum")
+		}
 
 		if (integrityCheck) {
 			this.checkIntegrity()

--- a/src/desktop/DesktopSqlCipher.ts
+++ b/src/desktop/DesktopSqlCipher.ts
@@ -121,16 +121,18 @@ export class DesktopSqlCipher implements SqlCipherFacade {
 
 	/**
 	 * not implemented because we lock the "ranges" DB directly from the per-window facade
+	 * we return Promise.resolve() in order to allow testing of the "clearExcludedData" function
 	 */
 	lockRangesDbAccess(userId: Id): Promise<void> {
-		throw new ProgrammingError("Not implemented")
+		return Promise.resolve()
 	}
 
 	/**
 	 * not implemented because we unlock the "ranges" DB directly from the per-window facade
+	 * we return Promise.resolve() in order to allow testing of the "clearExcludedData" function
 	 */
 	unlockRangesDbAccess(userId: Id): Promise<void> {
-		throw new ProgrammingError("Not implemented")
+		return Promise.resolve()
 	}
 
 	private checkIntegrity() {

--- a/src/desktop/DesktopSqlCipher.ts
+++ b/src/desktop/DesktopSqlCipher.ts
@@ -77,9 +77,9 @@ export class DesktopSqlCipher implements SqlCipherFacade {
 		const key = `x'${uint8ArrayToBase64(databaseKey)};`
 		this.db.pragma(`KEY = "${key}"`)
 
-		// We are using the auto_vacuum=incremental option to allow for a faster vacuum execution
-		// After changing the auto_vacuum value we need to run "vacuum" once
-		// auto_vacuum options: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
+		// We are using the auto_vacuum=incremental mode to allow for a faster vacuum execution
+		// After changing the auto_vacuum mode we need to run "vacuum" once
+		// auto_vacuum mode: 0 (NONE) | 1 (FULL) | 2 (INCREMENTAL)
 		if (this.db.pragma("auto_vacuum", {simple: true}) != 2) {
 			this.db.pragma("auto_vacuum = incremental")
 			this.db.pragma("vacuum")

--- a/src/native/common/generatedipc/SqlCipherFacade.ts
+++ b/src/native/common/generatedipc/SqlCipherFacade.ts
@@ -36,4 +36,18 @@ export interface SqlCipherFacade {
 		params: ReadonlyArray<TaggedSqlValue>,
 	): Promise<ReadonlyArray<Record<string, TaggedSqlValue>>>
 	
+	/**
+	 * We want to lock the access to the "ranges" db when updating / reading the offline available mail list ranges for each mail list (referenced using the listId)
+	 */
+	lockRangesDbAccess(
+		listId: string,
+	): Promise<void>
+	
+	/**
+	 * This is the counterpart to the function "lockRangesDbAccess(listId)"
+	 */
+	unlockRangesDbAccess(
+		listId: string,
+	): Promise<void>
+	
 }

--- a/src/native/common/generatedipc/SqlCipherFacadeReceiveDispatcher.ts
+++ b/src/native/common/generatedipc/SqlCipherFacadeReceiveDispatcher.ts
@@ -49,6 +49,18 @@ export class SqlCipherFacadeReceiveDispatcher {
 					params,
 				)
 			}
+			case "lockRangesDbAccess": {
+				const listId: string = arg[0]
+				return this.facade.lockRangesDbAccess(
+					listId,
+				)
+			}
+			case "unlockRangesDbAccess": {
+				const listId: string = arg[0]
+				return this.facade.unlockRangesDbAccess(
+					listId,
+				)
+			}
 		}
 	}
 }

--- a/src/native/common/generatedipc/SqlCipherFacadeSendDispatcher.ts
+++ b/src/native/common/generatedipc/SqlCipherFacadeSendDispatcher.ts
@@ -26,4 +26,10 @@ export class SqlCipherFacadeSendDispatcher implements SqlCipherFacade {
 	async all(...args: Parameters<SqlCipherFacade["all"]>) {
 		return this.transport.invokeNative("ipc",  ["SqlCipherFacade", "all", ...args])
 	}
+	async lockRangesDbAccess(...args: Parameters<SqlCipherFacade["lockRangesDbAccess"]>) {
+		return this.transport.invokeNative("ipc",  ["SqlCipherFacade", "lockRangesDbAccess", ...args])
+	}
+	async unlockRangesDbAccess(...args: Parameters<SqlCipherFacade["unlockRangesDbAccess"]>) {
+		return this.transport.invokeNative("ipc",  ["SqlCipherFacade", "unlockRangesDbAccess", ...args])
+	}
 }

--- a/src/native/main/WebMobileFacade.ts
+++ b/src/native/main/WebMobileFacade.ts
@@ -106,6 +106,9 @@ export class WebMobileFacade implements MobileFacade {
 			this.disconnectTimeoutId = setTimeout(() => {
 				locator.worker.closeEventBus(CloseEventBusOption.Pause)
 			}, 30 * SECOND_MS)
+
+			// clear excluded data in the cacheStorage (i.e. trash and spam lists, old data)
+			//await locator.cacheStorage.clearExcludedData()
 		}
 	}
 

--- a/src/native/main/WebMobileFacade.ts
+++ b/src/native/main/WebMobileFacade.ts
@@ -106,9 +106,6 @@ export class WebMobileFacade implements MobileFacade {
 			this.disconnectTimeoutId = setTimeout(() => {
 				locator.worker.closeEventBus(CloseEventBusOption.Pause)
 			}, 30 * SECOND_MS)
-
-			// clear excluded data in the cacheStorage (i.e. trash and spam lists, old data)
-			//await locator.cacheStorage.clearExcludedData()
 		}
 	}
 

--- a/src/offline/CachePostLoginAction.ts
+++ b/src/offline/CachePostLoginAction.ts
@@ -7,6 +7,7 @@ import {ProgressTracker} from "../api/main/ProgressTracker.js"
 import {promiseMap} from "@tutao/tutanota-utils"
 import {NoopProgressMonitor} from "../api/common/utils/ProgressMonitor.js"
 import {SessionType} from "../api/common/SessionType.js"
+import {ExposedCacheStorage} from "../api/worker/rest/DefaultEntityRestCache.js"
 
 
 export class CachePostLoginAction implements IPostLoginAction {
@@ -15,6 +16,7 @@ export class CachePostLoginAction implements IPostLoginAction {
 		private readonly calendarModel: CalendarModel,
 		private readonly entityClient: EntityClient,
 		private readonly progressTracker: ProgressTracker,
+		private readonly cacheStorage: ExposedCacheStorage,
 		private readonly logins: LoginController,
 	) {
 
@@ -38,6 +40,9 @@ export class CachePostLoginAction implements IPostLoginAction {
 			])
 		})
 		progressMonitor.completed()
+
+		// Clear the excluded data (i.e. trash and spam lists, old data) in the offline storage.
+		await this.cacheStorage.clearExcludedData()
 	}
 
 	async onPartialLoginSuccess(loggedInEvent: LoggedInEvent): Promise<void> {

--- a/test/tests/api/worker/offline/OfflineStorageTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageTest.ts
@@ -28,6 +28,7 @@ import {ElementEntity, ListElementEntity, SomeEntity} from "../../../../../src/a
 import {resolveTypeReference} from "../../../../../src/api/common/EntityFunctions.js"
 import {Type} from "../../../../../src/api/common/EntityConstants.js"
 import {expandId} from "../../../../../src/api/worker/rest/DefaultEntityRestCache.js"
+import {WorkerImpl} from "../../../../../src/api/worker/WorkerImpl.js"
 
 function incrementId(id: Id, ms: number) {
 	const timestamp = generatedIdToTimestamp(id)
@@ -70,6 +71,7 @@ o.spec("OfflineStorage", function () {
 	let storage: OfflineStorage
 	let migratorMock: OfflineStorageMigrator
 	let interWindowEventSenderMock: InterWindowEventFacadeSendDispatcher
+	let worker: WorkerImpl
 
 	o.beforeEach(async function () {
 		dbFacade = new DesktopSqlCipher(nativePath, database, false)
@@ -78,7 +80,8 @@ o.spec("OfflineStorage", function () {
 		migratorMock = instance(OfflineStorageMigrator)
 		interWindowEventSenderMock = instance(InterWindowEventFacadeSendDispatcher)
 		when(dateProviderMock.now()).thenReturn(now.getTime())
-		storage = new OfflineStorage(dbFacade, interWindowEventSenderMock, dateProviderMock, migratorMock)
+		worker = instance(WorkerImpl)
+		storage = new OfflineStorage(dbFacade, interWindowEventSenderMock, dateProviderMock, migratorMock, worker)
 	})
 
 	o.afterEach(async function () {

--- a/test/tests/api/worker/offline/OfflineStorageTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageTest.ts
@@ -1,7 +1,7 @@
 import o from "ospec"
 import {verify} from "@tutao/tutanota-test-utils"
 import {customTypeEncoders, OfflineStorage, sql} from "../../../../../src/api/worker/offline/OfflineStorage.js"
-import {instance, matchers, object, when} from "testdouble"
+import {instance, object, when} from "testdouble"
 import * as cborg from "cborg"
 import {GENERATED_MIN_ID, generatedIdToTimestamp, getElementId, timestampToGeneratedId} from "../../../../../src/api/common/utils/EntityUtils.js"
 import {firstThrow, getDayShifted, getTypeId, lastThrow, mapNullable, promiseMap, TypeRef} from "@tutao/tutanota-utils"
@@ -80,10 +80,7 @@ o.spec("OfflineStorage", function () {
 		migratorMock = instance(OfflineStorageMigrator)
 		interWindowEventSenderMock = instance(InterWindowEventFacadeSendDispatcher)
 		when(dateProviderMock.now()).thenReturn(now.getTime())
-		worker = instance(WorkerImpl)
-		when(worker.createProgressMonitor(matchers.anything())).thenResolve(42)
-		when(worker.progressWorkDone(matchers.anything(), matchers.anything())).thenResolve(undefined)
-		storage = new OfflineStorage(dbFacade, interWindowEventSenderMock, dateProviderMock, migratorMock, worker)
+		storage = new OfflineStorage(dbFacade, interWindowEventSenderMock, dateProviderMock, migratorMock)
 	})
 
 	o.afterEach(async function () {

--- a/test/tests/api/worker/rest/EntityRestCacheTest.ts
+++ b/test/tests/api/worker/rest/EntityRestCacheTest.ts
@@ -51,6 +51,7 @@ import {OfflineStorageMigrator} from "../../../../../src/api/worker/offline/Offl
 import {createEventElementId} from "../../../../../src/api/common/utils/CommonCalendarUtils.js"
 import {InterWindowEventFacadeSendDispatcher} from "../../../../../src/native/common/generatedipc/InterWindowEventFacadeSendDispatcher.js"
 import {func, instance, matchers, object, when} from "testdouble"
+import {WorkerImpl} from "../../../../../src/api/worker/WorkerImpl.js"
 
 const {anything} = matchers
 
@@ -82,11 +83,12 @@ async function getOfflineStorage(userId: Id): Promise<CacheStorage> {
 	})(null as any)
 
 	const migratorMock = instance(OfflineStorageMigrator)
+	const worker = instance(WorkerImpl)
 
 	const nativePath = buildOptions.sqliteNativePath
 	const sqlCipherFacade = new PerWindowSqlCipherFacade(odbManager)
 	const interWindowEventSender = instance(InterWindowEventFacadeSendDispatcher)
-	const offlineStorage = new OfflineStorage(sqlCipherFacade, interWindowEventSender, new NoZoneDateProvider(), migratorMock)
+	const offlineStorage = new OfflineStorage(sqlCipherFacade, interWindowEventSender, new NoZoneDateProvider(), migratorMock, worker)
 	await offlineStorage.init({userId, databaseKey: offlineDatabaseTestKey, timeRangeDays: 42, forceNewDatabase: false})
 	return offlineStorage
 }

--- a/test/tests/api/worker/rest/EntityRestCacheTest.ts
+++ b/test/tests/api/worker/rest/EntityRestCacheTest.ts
@@ -83,12 +83,11 @@ async function getOfflineStorage(userId: Id): Promise<CacheStorage> {
 	})(null as any)
 
 	const migratorMock = instance(OfflineStorageMigrator)
-	const worker = instance(WorkerImpl)
 
 	const nativePath = buildOptions.sqliteNativePath
 	const sqlCipherFacade = new PerWindowSqlCipherFacade(odbManager)
 	const interWindowEventSender = instance(InterWindowEventFacadeSendDispatcher)
-	const offlineStorage = new OfflineStorage(sqlCipherFacade, interWindowEventSender, new NoZoneDateProvider(), migratorMock, worker)
+	const offlineStorage = new OfflineStorage(sqlCipherFacade, interWindowEventSender, new NoZoneDateProvider(), migratorMock)
 	await offlineStorage.init({userId, databaseKey: offlineDatabaseTestKey, timeRangeDays: 42, forceNewDatabase: false})
 	return offlineStorage
 }


### PR DESCRIPTION
To improve (android) login performance, we want to clear excluded data
(i.e. trash and spam lists, old data) from the offline storage after the login.

We also want to activate "auto_vacuum = incremental" for the offline storage database
in order to allow for faster vacuum execution and run "incremental_vacuum" before
the database is closed.

Fixes #4723