### PR TITLE
Obscured recipients field 

### DIFF
--- a/src/gui/MailRecipientsTextField.ts
+++ b/src/gui/MailRecipientsTextField.ts
@@ -10,7 +10,7 @@ import {DropdownChildAttrs} from "./base/Dropdown.js"
 import {Contact} from "../api/entities/tutanota/TypeRefs.js"
 import {RecipientsSearchDropDown} from "./RecipientsSearchDropDown.js"
 import {RecipientsSearchModel} from "../misc/RecipientsSearchModel.js"
-import {assertNotNull, firstThrow} from "@tutao/tutanota-utils"
+import {firstThrow} from "@tutao/tutanota-utils"
 import {Dialog} from "./base/Dialog.js"
 
 export interface MailRecipientsTextFieldAttrs {
@@ -128,12 +128,12 @@ export class MailRecipientsTextField implements ClassComponent<MailRecipientsTex
 	}
 
 	private renderSuggestions(attrs: MailRecipientsTextFieldAttrs): Children {
-		return m(RecipientsSearchDropDown, {
+		return m(".rel", m(RecipientsSearchDropDown, {
 			suggestions: attrs.search.results(),
 			selectedSuggestionIndex: this.getSelectedSuggestionIdx(attrs),
 			onSuggestionSelected: idx => this.selectSuggestion(attrs, idx),
 			maxHeight: attrs.maxSuggestionsToShow ?? null
-		})
+		}))
 	}
 
 	private resolveInput(attrs: MailRecipientsTextFieldAttrs) {

--- a/src/gui/RecipientsSearchDropDown.ts
+++ b/src/gui/RecipientsSearchDropDown.ts
@@ -53,7 +53,7 @@ export class RecipientsSearchDropDown implements ClassComponent<RecipientsSearch
 		}
 
 		return m(
-			`.suggestions.abs.z4.full-width.elevated-bg.scroll.text-ellipsis${attrs.suggestions.length ? ".dropdown-shadow" : ""}`,
+			`.abs.z4.full-width.elevated-bg.scroll.text-ellipsis${attrs.suggestions.length ? ".dropdown-shadow" : ""}`,
 			{
 				oncreate: vnode => this.domSuggestions = vnode.dom as HTMLElement,
 				style: {

--- a/src/gui/base/Expander.ts
+++ b/src/gui/base/Expander.ts
@@ -116,10 +116,12 @@ export class ExpanderPanel implements Component<ExpanderPanelAttrs> {
 		const expanded = vnode.attrs.expanded
 		// getBoundingClientRect() gives us the correct size, with a fraction
 		this.lastCalculatedHeight = this.childDiv?.getBoundingClientRect().height ?? 0
-		// theoretically we don't need overflow: hidden here but better be safe
-		return m(".expander-panel.overflow-hidden",
-			// this is what will be actually clipping content. nothing must overflow it.
-			m(".overflow-hidden", {
+		return m(".expander-panel",
+			// it's conceivable that the content could overflow or influence the
+			// panel's size, but we did not observe this. overflow: hidden would
+			// solve that in case it becomes a problem, but majorly complicate
+			// putting dropdowns and similar elements inside the panel.
+			m("div", {
 					style: {
 						opacity: expanded ? "1" : "0",
 						height: expanded ? `${this.lastCalculatedHeight}px` : "0px",


### PR DESCRIPTION
the suggestion dropdown is an absolutely positioned element,
these get positioned relative to the next positioned ancestor.

The MailRecipientsTextField did not come with its own
positioned element, so positioning of the dropdown depends
on the environment it's displayed in.

this commit adds a position: relative wrapper around the dropdown

also removes overflow: hidden from Expander since it's cutting off the
dropdown and doesn't seem to do anything in any browser (the issue
mentioned in https://github.com/tutao/tutanota/commit/f9796135229c588b4c5b7e0d6c3a6019f354028c was visible in the
new mailviewer header expander, but it's currently not anymore even
without the overflow: hidden)


fix #4725