### PR TITLE
give ViewSlider the ability to handle browser history events

### DIFF
--- a/src/calendar/view/CalendarEventPopup.ts
+++ b/src/calendar/view/CalendarEventPopup.ts
@@ -186,7 +186,8 @@ export class CalendarEventPopup implements ModalComponent {
 	}
 
 	popState(e: Event): boolean {
-		return true
+		modal.remove(this)
+		return false
 	}
 
 	_isDeleteAvailable(): boolean {

--- a/src/gui/nav/ViewSlider.ts
+++ b/src/gui/nav/ViewSlider.ts
@@ -46,8 +46,8 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	private _busy: Promise<unknown>
 	private _parentName: string
 	private _isModalBackgroundVisible: boolean
-	private resizeListener: windowSizeListener = () => this._updateVisibleBackgroundColumns()
-	private handleHistoryEvent = () => {
+	private readonly resizeListener: windowSizeListener = () => this._updateVisibleBackgroundColumns()
+	private readonly handleHistoryEvent = () => {
 		const prev = this.getPreviousColumn()
 		if (prev != null && prev.columnType !== ColumnType.Foreground) {
 			this.focusPreviousColumn()

--- a/src/misc/WindowFacade.ts
+++ b/src/misc/WindowFacade.ts
@@ -5,6 +5,7 @@ import type {WorkerClient} from "../api/main/WorkerClient"
 import {client} from "./ClientDetector"
 import {logins} from "../api/main/LoginController"
 import type {Indexer} from "../api/worker/search/Indexer"
+import {remove} from "@tutao/tutanota-utils"
 
 assertMainOrNodeBoot()
 export type KeyboardSizeListener = (keyboardSize: number) => unknown
@@ -51,11 +52,7 @@ export class WindowFacade {
 	}
 
 	removeResizeListener(listener: windowSizeListener) {
-		let index = this._windowSizeListeners.indexOf(listener)
-
-		if (index > -1) {
-			this._windowSizeListeners.splice(index, 1)
-		}
+		remove(this._windowSizeListeners, listener)
 	}
 
 	addWindowCloseListener(listener: () => unknown): (...args: Array<any>) => any {
@@ -81,11 +78,7 @@ export class WindowFacade {
 	}
 
 	removeKeyboardSizeListener(listener: KeyboardSizeListener) {
-		const index = this._keyboardSizeListeners.indexOf(listener)
-
-		if (index > -1) {
-			this._keyboardSizeListeners.splice(index, 1)
-		}
+		remove(this._keyboardSizeListeners, listener)
 	}
 
 	openLink(href: string) {
@@ -189,11 +182,7 @@ export class WindowFacade {
 	}
 
 	removeHistoryEventListener(listener: (e: Event) => boolean): void {
-		const index = this._historyStateEventListeners.indexOf(listener)
-
-		if (index > -1) {
-			this._historyStateEventListeners.splice(index, 1)
-		}
+		remove(this._historyStateEventListeners, listener)
 	}
 
 	/**

--- a/src/misc/WindowFacade.ts
+++ b/src/misc/WindowFacade.ts
@@ -188,6 +188,14 @@ export class WindowFacade {
 		}
 	}
 
+	removeHistoryEventListener(listener: (e: Event) => boolean): void {
+		const index = this._historyStateEventListeners.indexOf(listener)
+
+		if (index > -1) {
+			this._historyStateEventListeners.splice(index, 1)
+		}
+	}
+
 	/**
 	 * calls the last history event listener that was added
 	 * and reverts the state change if it returns false


### PR DESCRIPTION
if the view slider has a previous (further left) column that's not a foreground column it can focus, it will do so and signal the window facade that the back button event has been handled.

otherwise, if the focused column is a foreground column, it will focus the next column to the right and signal the handled event. this has the effect of closing the drawer menu in our application.

fix #4731

Co-authored-by: nok <nok@tutao.de>