### PR TITLE
[desktop] Fix zoom shortcuts on macOS

### DIFF
--- a/src/desktop/integration/DesktopIntegratorDarwin.ts
+++ b/src/desktop/integration/DesktopIntegratorDarwin.ts
@@ -99,9 +99,6 @@ export class DesktopIntegratorDarwin implements DesktopIntegrator {
 				role: "window",
 				submenu: [
 					{
-						role: "minimize",
-					},
-					{
 						role: "close",
 					},
 					{
@@ -115,6 +112,15 @@ export class DesktopIntegratorDarwin implements DesktopIntegrator {
 					},
 					{
 						role: "front",
+					},
+					{
+						role: "zoomIn"
+					},
+					{
+						role: "zoomOut"
+					},
+					{
+						role: "resetZoom"
 					},
 					{
 						click: () => {


### PR DESCRIPTION
Barely any application supports zooming under macOS with cmd+scroll. The intended way to zoom specified by the operating system is by using the menu. This commit adds the options zoomIn, zoomOut and resetZoom to the menu.

fix #3739

Co-authored-by: ivk <ivk@tutao.de>