### PR TITLE
fix CalendarEventPopup not closing when using android system back button

### DIFF
--- a/src/calendar/view/CalendarEventPopup.ts
+++ b/src/calendar/view/CalendarEventPopup.ts
@@ -179,6 +179,7 @@ export class CalendarEventPopup implements ModalComponent {
 	}
 
 	onClose(): void {
+		this._close()
 	}
 
 	shortcuts(): Shortcut[] {


### PR DESCRIPTION
WebMobileFacade#handlebackPress calls the modals onClose method, which was not implemented so far by the CalendarEventPopup modal.

fix #4809