### PR TITLE
Make usage test ping sending more robust

### DIFF
--- a/src/misc/UsageTestModel.ts
+++ b/src/misc/UsageTestModel.ts
@@ -166,6 +166,7 @@ export class UsageTestModel implements PingAdapter {
 	private storageBehavior = StorageBehavior.Ephemeral
 	private customerProperties?: CustomerProperties
 	private lastOptInDecision: boolean | null = null
+	private lastPing = Promise.resolve()
 
 	constructor(
 		private readonly storages: { [key in StorageBehavior]: UsageTestStorage },
@@ -373,6 +374,11 @@ export class UsageTestModel implements PingAdapter {
 	}
 
 	async sendPing(test: UsageTest, stage: Stage): Promise<void> {
+		this.lastPing = this.lastPing.then(() => this.doSendPing(stage, test), () => this.doSendPing(stage, test))
+		return this.lastPing
+	}
+
+	private async doSendPing(stage: Stage, test: UsageTest) {
 		// Immediately stop sending pings if the user has opted out.
 		// Only applicable if the user opts out and then does not re-log.
 		if (this.storageBehavior === StorageBehavior.Persist && !this.getOptInDecision()) {


### PR DESCRIPTION
We always wait for the previous ping
to complete before attempting to send
the next one.