### PR TITLE
make news item take the dialog bg color

### DIFF
--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -2139,9 +2139,6 @@ styles.registerStyle("main", () => {
 			"margin": "0 auto",
 			"list-style": "disc",
 			"text-align": "left",
-		},
-		".news-item": {
-			background: theme.list_bg,
-		},
+		}
 	}
 })

--- a/src/misc/news/NewsList.ts
+++ b/src/misc/news/NewsList.ts
@@ -27,7 +27,7 @@ export class NewsList implements Component<NewsListAttrs> {
 		return m("", vnode.attrs.liveNewsIds.map(liveNewsId => {
 			const newsListItem = vnode.attrs.liveNewsListItems[liveNewsId.newsItemName]
 
-			return m(".news-item.pt.pl-l.pr-l.flex.fill.border-grey.left.list-border-bottom",
+			return m(".pt.pl-l.pr-l.flex.fill.border-grey.left.list-border-bottom",
 				{key: liveNewsId.newsItemId}, newsListItem.render(liveNewsId))
 		}))
 	}


### PR DESCRIPTION
from this 

![image](https://user-images.githubusercontent.com/29049728/206224226-f08ab074-8253-4f0f-9af2-7f60109ee405.png)

to this 

![image](https://user-images.githubusercontent.com/29049728/206224383-4eef77db-28bd-46b4-896b-fe76672a1d65.png)


## Test notes:
* [ ] create an account with news items
* [ ] change to the dark mode
* [ ] check that the items look OK
* [ ] check that it also looks OK in the other default themes.