### PR TITLE
Add "autocomplete" to login input fields to better support autofill

### DIFF
--- a/src/calendar/view/CalendarEventEditDialog.ts
+++ b/src/calendar/view/CalendarEventEditDialog.ts
@@ -4,7 +4,7 @@ import Stream from "mithril/stream"
 import {DatePicker} from "../../gui/date/DatePicker"
 import {Dialog} from "../../gui/base/Dialog"
 import m, {Children} from "mithril"
-import {AutocompleteValues, TextField, TextFieldType as TextFieldType} from "../../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType as TextFieldType} from "../../gui/base/TextField.js"
 import {lang} from "../../misc/LanguageViewModel"
 import type {DropDownSelectorAttrs, SelectorItemList} from "../../gui/base/DropDownSelector.js"
 import {DropDownSelector} from "../../gui/base/DropDownSelector.js"
@@ -239,7 +239,7 @@ export async function showCalendarEventDialog(
 
 					return m(TextField, {
 						value: viewModel.getGuestPassword(guest),
-						autocompleteValue: AutocompleteValues.off,
+						autocompleteAs: Autocomplete.off,
 						type: guestShowConfidential.get(guest.address.address) ? TextFieldType.Text : TextFieldType.Password,
 						label: () =>
 							lang.get("passwordFor_label", {

--- a/src/calendar/view/CalendarEventEditDialog.ts
+++ b/src/calendar/view/CalendarEventEditDialog.ts
@@ -4,7 +4,7 @@ import Stream from "mithril/stream"
 import {DatePicker} from "../../gui/date/DatePicker"
 import {Dialog} from "../../gui/base/Dialog"
 import m, {Children} from "mithril"
-import {TextField, TextFieldType as TextFieldType} from "../../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType as TextFieldType} from "../../gui/base/TextField.js"
 import {lang} from "../../misc/LanguageViewModel"
 import type {DropDownSelectorAttrs, SelectorItemList} from "../../gui/base/DropDownSelector.js"
 import {DropDownSelector} from "../../gui/base/DropDownSelector.js"
@@ -239,7 +239,7 @@ export async function showCalendarEventDialog(
 
 					return m(TextField, {
 						value: viewModel.getGuestPassword(guest),
-						preventAutofill: true,
+						autocompleteValue: AutocompleteValues.off,
 						type: guestShowConfidential.get(guest.address.address) ? TextFieldType.Text : TextFieldType.Password,
 						label: () =>
 							lang.get("passwordFor_label", {

--- a/src/gui/base/Dialog.ts
+++ b/src/gui/base/Dialog.ts
@@ -15,7 +15,7 @@ import type {ButtonAttrs} from "./Button.js"
 import {Button, ButtonType} from "./Button.js"
 import type {DialogHeaderBarAttrs} from "./DialogHeaderBar"
 import {DialogHeaderBar} from "./DialogHeaderBar"
-import {TextField, TextFieldType} from "./TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "./TextField.js"
 import type {DropDownSelectorAttrs, SelectorItemList} from "./DropDownSelector.js"
 import {DropDownSelector} from "./DropDownSelector.js"
 import {Keys} from "../../api/common/TutanotaConstants"
@@ -936,7 +936,7 @@ export class Dialog implements ModalComponent {
 						helpLabel: () => savedState.message,
 						value: value,
 						oninput: (newValue) => value = newValue,
-						preventAutofill: true,
+						autocompleteValue: AutocompleteValues.off,
 						type: TextFieldType.Password,
 						keyHandler: (key: KeyPress) => {
 							if (isKeyPressed(key.keyCode, Keys.RETURN)) {

--- a/src/gui/base/Dialog.ts
+++ b/src/gui/base/Dialog.ts
@@ -15,7 +15,7 @@ import type {ButtonAttrs} from "./Button.js"
 import {Button, ButtonType} from "./Button.js"
 import type {DialogHeaderBarAttrs} from "./DialogHeaderBar"
 import {DialogHeaderBar} from "./DialogHeaderBar"
-import {AutocompleteValues, TextField, TextFieldType} from "./TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "./TextField.js"
 import type {DropDownSelectorAttrs, SelectorItemList} from "./DropDownSelector.js"
 import {DropDownSelector} from "./DropDownSelector.js"
 import {Keys} from "../../api/common/TutanotaConstants"
@@ -936,7 +936,7 @@ export class Dialog implements ModalComponent {
 						helpLabel: () => savedState.message,
 						value: value,
 						oninput: (newValue) => value = newValue,
-						autocompleteValue: AutocompleteValues.off,
+						autocompleteAs: Autocomplete.off,
 						type: TextFieldType.Password,
 						keyHandler: (key: KeyPress) => {
 							if (isKeyPressed(key.keyCode, Keys.RETURN)) {

--- a/src/gui/base/TextField.ts
+++ b/src/gui/base/TextField.ts
@@ -13,7 +13,7 @@ export type TextFieldAttrs = {
 	id?: string
 	label: TranslationKey | lazy<string>
 	value: string
-	autocompleteValue?: AutocompleteValues
+	autocompleteAs?: Autocomplete
 	type?: TextFieldType
 	helpLabel?: lazy<Children> | null
 	alignRight?: boolean
@@ -45,7 +45,7 @@ export const enum TextFieldType {
 
 // relevant subset of possible values for the autocomplete html field
 // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
-export const enum AutocompleteValues {
+export const enum Autocomplete {
 	off = "off",
 	email = "email",
 	username = "username",
@@ -180,7 +180,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 			// that shouldn't be autofilled.
 			// since the autofill algorithm looks at inputs that come before and after the password field we need
 			// three dummies.
-			const autofillGuard: Children = a.autocompleteValue === AutocompleteValues.off
+			const autofillGuard: Children = a.autocompleteAs === Autocomplete.off
 				? [
 					m("input.abs", {
 						style: {
@@ -212,7 +212,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 				".flex-grow.rel",
 				autofillGuard.concat([
 					m("input.input" + (a.alignRight ? ".right" : ""), {
-						autocomplete: a.autocompleteValue ?? "",
+						autocomplete: a.autocompleteAs ?? "",
 						type: a.type,
 						"aria-label": lang.getMaybeLazy(a.label),
 						oncreate: vnode => {

--- a/src/gui/base/TextField.ts
+++ b/src/gui/base/TextField.ts
@@ -13,7 +13,6 @@ export type TextFieldAttrs = {
 	id?: string
 	label: TranslationKey | lazy<string>
 	value: string
-	preventAutofill?: boolean
 	autocompleteValue?: AutocompleteValues
 	type?: TextFieldType
 	helpLabel?: lazy<Children> | null
@@ -181,7 +180,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 			// that shouldn't be autofilled.
 			// since the autofill algorithm looks at inputs that come before and after the password field we need
 			// three dummies.
-			const autofillGuard: Children = a.preventAutofill
+			const autofillGuard: Children = a.autocompleteValue === AutocompleteValues.off
 				? [
 					m("input.abs", {
 						style: {
@@ -213,9 +212,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 				".flex-grow.rel",
 				autofillGuard.concat([
 					m("input.input" + (a.alignRight ? ".right" : ""), {
-						autocomplete: a.preventAutofill
-							? AutocompleteValues.off
-							: a.autocompleteValue ?? "",
+						autocomplete: a.autocompleteValue ?? "",
 						type: a.type,
 						"aria-label": lang.getMaybeLazy(a.label),
 						oncreate: vnode => {

--- a/src/gui/base/TextField.ts
+++ b/src/gui/base/TextField.ts
@@ -14,6 +14,7 @@ export type TextFieldAttrs = {
 	label: TranslationKey | lazy<string>
 	value: string
 	preventAutofill?: boolean
+	autocompleteValue?: AutocompleteValues
 	type?: TextFieldType
 	helpLabel?: lazy<Children> | null
 	alignRight?: boolean
@@ -41,6 +42,17 @@ export const enum TextFieldType {
 	Area = "area",
 	Number = "number",
 	Time = "time",
+}
+
+// relevant subset of possible values for the autocomplete html field
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete
+export const enum AutocompleteValues {
+	off = "off",
+	email = "email",
+	username = "username",
+	newPassword = "new-password",
+	currentPassword = "current-password",
+	oneTimeCode = "one-time-code"
 }
 
 export const inputLineHeight: number = size.font_size_base + 8
@@ -201,7 +213,9 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 				".flex-grow.rel",
 				autofillGuard.concat([
 					m("input.input" + (a.alignRight ? ".right" : ""), {
-						autocomplete: a.preventAutofill ? "off" : "",
+						autocomplete: a.preventAutofill
+							? AutocompleteValues.off
+							: a.autocompleteValue ?? "",
 						type: a.type,
 						"aria-label": lang.getMaybeLazy(a.label),
 						oncreate: vnode => {

--- a/src/login/ExternalLoginView.ts
+++ b/src/login/ExternalLoginView.ts
@@ -9,7 +9,7 @@ import {showProgressDialog} from "../gui/dialogs/ProgressDialog"
 import {Keys} from "../api/common/TutanotaConstants"
 import {progressIcon} from "../gui/base/Icon"
 import {Button, ButtonType} from "../gui/base/Button.js"
-import {AutocompleteValues, TextField, TextFieldType as TextFieldType} from "../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType as TextFieldType} from "../gui/base/TextField.js"
 import {Checkbox} from "../gui/base/Checkbox.js"
 import {logins} from "../api/main/LoginController"
 import {MessageBox} from "../gui/base/MessageBox.js"
@@ -235,7 +235,7 @@ export class ExternalLoginView implements CurrentView {
 				label: "password_label",
 				helpLabel: () => lang.get("enterPresharedPassword_msg"),
 				value: this.viewModel.password,
-				autocompleteValue: AutocompleteValues.currentPassword,
+				autocompleteAs: Autocomplete.currentPassword,
 				oninput: input => this.viewModel.password = input,
 			}),
 			m(Checkbox, {

--- a/src/login/ExternalLoginView.ts
+++ b/src/login/ExternalLoginView.ts
@@ -9,7 +9,7 @@ import {showProgressDialog} from "../gui/dialogs/ProgressDialog"
 import {Keys} from "../api/common/TutanotaConstants"
 import {progressIcon} from "../gui/base/Icon"
 import {Button, ButtonType} from "../gui/base/Button.js"
-import {TextField, TextFieldType as TextFieldType} from "../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType as TextFieldType} from "../gui/base/TextField.js"
 import {Checkbox} from "../gui/base/Checkbox.js"
 import {logins} from "../api/main/LoginController"
 import {MessageBox} from "../gui/base/MessageBox.js"
@@ -235,6 +235,7 @@ export class ExternalLoginView implements CurrentView {
 				label: "password_label",
 				helpLabel: () => lang.get("enterPresharedPassword_msg"),
 				value: this.viewModel.password,
+				autocompleteValue: AutocompleteValues.currentPassword,
 				oninput: input => this.viewModel.password = input,
 			}),
 			m(Checkbox, {

--- a/src/login/LoginForm.ts
+++ b/src/login/LoginForm.ts
@@ -5,7 +5,7 @@ import {BootstrapFeatureType} from "../api/common/TutanotaConstants"
 import {Button, ButtonType} from "../gui/base/Button.js"
 import {liveDataAttrs} from "../gui/AriaUtils"
 import {lang, TranslationKey} from "../misc/LanguageViewModel"
-import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {Checkbox} from "../gui/base/Checkbox.js"
 import {client} from "../misc/ClientDetector"
 import {getWhitelabelCustomizations} from "../misc/WhitelabelCustomizations"
@@ -83,7 +83,7 @@ export class LoginForm implements Component<LoginFormAttrs> {
 						value: a.mailAddress(),
 						oninput: a.mailAddress,
 						type: TextFieldType.Email,
-						autocompleteValue: AutocompleteValues.email,
+						autocompleteAs: Autocomplete.email,
 						onDomInputCreated: (dom) => {
 							if (!client.isMobileDevice()) {
 								dom.focus() // have email address auto-focus so the user can immediately type their username (unless on mobile)
@@ -105,7 +105,7 @@ export class LoginForm implements Component<LoginFormAttrs> {
 						value: a.password(),
 						oninput: a.password,
 						type: TextFieldType.Password,
-						autocompleteValue: AutocompleteValues.currentPassword,
+						autocompleteAs: Autocomplete.currentPassword,
 					}),
 				),
 				a.savePassword && !this._passwordDisabled()

--- a/src/login/LoginForm.ts
+++ b/src/login/LoginForm.ts
@@ -5,7 +5,7 @@ import {BootstrapFeatureType} from "../api/common/TutanotaConstants"
 import {Button, ButtonType} from "../gui/base/Button.js"
 import {liveDataAttrs} from "../gui/AriaUtils"
 import {lang, TranslationKey} from "../misc/LanguageViewModel"
-import {TextField, TextFieldType} from "../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {Checkbox} from "../gui/base/Checkbox.js"
 import {client} from "../misc/ClientDetector"
 import {getWhitelabelCustomizations} from "../misc/WhitelabelCustomizations"
@@ -83,6 +83,7 @@ export class LoginForm implements Component<LoginFormAttrs> {
 						value: a.mailAddress(),
 						oninput: a.mailAddress,
 						type: TextFieldType.Email,
+						autocompleteValue: AutocompleteValues.email,
 						onDomInputCreated: (dom) => {
 							if (!client.isMobileDevice()) {
 								dom.focus() // have email address auto-focus so the user can immediately type their username (unless on mobile)
@@ -104,6 +105,7 @@ export class LoginForm implements Component<LoginFormAttrs> {
 						value: a.password(),
 						oninput: a.password,
 						type: TextFieldType.Password,
+						autocompleteValue: AutocompleteValues.currentPassword,
 					}),
 				),
 				a.savePassword && !this._passwordDisabled()

--- a/src/login/contactform/ContactFormRequestDialog.ts
+++ b/src/login/contactform/ContactFormRequestDialog.ts
@@ -1,6 +1,6 @@
 import m, {Children} from "mithril"
 import {Dialog, DialogType} from "../../gui/base/Dialog"
-import {TextField, TextFieldType} from "../../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "../../gui/base/TextField.js"
 import {lang} from "../../misc/LanguageViewModel"
 import {formatStorageSize} from "../../misc/Formatter"
 import {ConversationType, Keys, MailMethod, MAX_ATTACHMENT_SIZE, PushServiceType} from "../../api/common/TutanotaConstants"
@@ -121,6 +121,7 @@ export class ContactFormRequestDialog {
 		const notificationEmailAddress = m(TextField, {
 			label: "mailAddress_label",
 			value: this._notificationEmailAddress,
+			autocompleteValue: AutocompleteValues.email,
 			helpLabel: () => lang.get("contactFormMailAddressInfo_msg"),
 			oninput: value => this._notificationEmailAddress = value.trim(),
 			type: TextFieldType.Area,

--- a/src/login/contactform/ContactFormRequestDialog.ts
+++ b/src/login/contactform/ContactFormRequestDialog.ts
@@ -1,6 +1,6 @@
 import m, {Children} from "mithril"
 import {Dialog, DialogType} from "../../gui/base/Dialog"
-import {AutocompleteValues, TextField, TextFieldType} from "../../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "../../gui/base/TextField.js"
 import {lang} from "../../misc/LanguageViewModel"
 import {formatStorageSize} from "../../misc/Formatter"
 import {ConversationType, Keys, MailMethod, MAX_ATTACHMENT_SIZE, PushServiceType} from "../../api/common/TutanotaConstants"
@@ -121,7 +121,7 @@ export class ContactFormRequestDialog {
 		const notificationEmailAddress = m(TextField, {
 			label: "mailAddress_label",
 			value: this._notificationEmailAddress,
-			autocompleteValue: AutocompleteValues.email,
+			autocompleteAs: Autocomplete.email,
 			helpLabel: () => lang.get("contactFormMailAddressInfo_msg"),
 			oninput: value => this._notificationEmailAddress = value.trim(),
 			type: TextFieldType.Area,

--- a/src/login/recover/RecoverLoginDialog.ts
+++ b/src/login/recover/RecoverLoginDialog.ts
@@ -4,7 +4,7 @@ import Stream from "mithril/stream"
 import {AccessBlockedError, AccessDeactivatedError, NotAuthenticatedError, TooManyRequestsError} from "../../api/common/error/RestError"
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog"
 import {isMailAddress} from "../../misc/FormatValidator"
-import {TextField, TextFieldType} from "../../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "../../gui/base/TextField.js"
 import {lang} from "../../misc/LanguageViewModel"
 import {PasswordForm, PasswordModel} from "../../settings/PasswordForm"
 import {Icons} from "../../gui/base/icons/Icons"
@@ -69,7 +69,7 @@ export function show(mailAddress?: string | null, resetAction?: ResetAction): Di
 					m(TextField, {
 						label: "mailAddress_label",
 						value: emailAddressStream(),
-						type: TextFieldType.Email,
+						autocompleteValue: AutocompleteValues.email,
 						oninput: emailAddressStream,
 					}),
 					m(editor),
@@ -88,6 +88,7 @@ export function show(mailAddress?: string | null, resetAction?: ResetAction): Di
 								label: "password_label",
 								type: TextFieldType.Password,
 								value: passwordValueStream(),
+								autocompleteValue: AutocompleteValues.currentPassword,
 								oninput: passwordValueStream,
 							}),
 				]

--- a/src/login/recover/RecoverLoginDialog.ts
+++ b/src/login/recover/RecoverLoginDialog.ts
@@ -4,7 +4,7 @@ import Stream from "mithril/stream"
 import {AccessBlockedError, AccessDeactivatedError, NotAuthenticatedError, TooManyRequestsError} from "../../api/common/error/RestError"
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog"
 import {isMailAddress} from "../../misc/FormatValidator"
-import {AutocompleteValues, TextField, TextFieldType} from "../../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "../../gui/base/TextField.js"
 import {lang} from "../../misc/LanguageViewModel"
 import {PasswordForm, PasswordModel} from "../../settings/PasswordForm"
 import {Icons} from "../../gui/base/icons/Icons"
@@ -69,7 +69,7 @@ export function show(mailAddress?: string | null, resetAction?: ResetAction): Di
 					m(TextField, {
 						label: "mailAddress_label",
 						value: emailAddressStream(),
-						autocompleteValue: AutocompleteValues.email,
+						autocompleteAs: Autocomplete.email,
 						oninput: emailAddressStream,
 					}),
 					m(editor),
@@ -88,7 +88,7 @@ export function show(mailAddress?: string | null, resetAction?: ResetAction): Di
 								label: "password_label",
 								type: TextFieldType.Password,
 								value: passwordValueStream(),
-								autocompleteValue: AutocompleteValues.currentPassword,
+								autocompleteAs: Autocomplete.currentPassword,
 								oninput: passwordValueStream,
 							}),
 				]

--- a/src/login/recover/TakeOverDeletedAddressDialog.ts
+++ b/src/login/recover/TakeOverDeletedAddressDialog.ts
@@ -4,7 +4,7 @@ import {AccessBlockedError, AccessDeactivatedError, InvalidDataError, NotAuthent
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog"
 import {isMailAddress} from "../../misc/FormatValidator"
 import {lang} from "../../misc/LanguageViewModel"
-import {AutocompleteValues, TextField} from "../../gui/base/TextField.js"
+import {Autocomplete, TextField} from "../../gui/base/TextField.js"
 import {Dialog, DialogType} from "../../gui/base/Dialog"
 import {HtmlEditor, HtmlEditorMode} from "../../gui/editor/HtmlEditor"
 import {locator} from "../../api/main/MainLocator"
@@ -40,7 +40,7 @@ export function showTakeOverDialog(mailAddress: string, password: string): Dialo
 					m(TextField, {
 						label: "targetAddress_label",
 						value: targetAccountAddress(),
-						autocompleteValue: AutocompleteValues.email,
+						autocompleteAs: Autocomplete.email,
 						oninput: targetAccountAddress,
 					}),
 					m(editor),

--- a/src/login/recover/TakeOverDeletedAddressDialog.ts
+++ b/src/login/recover/TakeOverDeletedAddressDialog.ts
@@ -4,7 +4,7 @@ import {AccessBlockedError, AccessDeactivatedError, InvalidDataError, NotAuthent
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog"
 import {isMailAddress} from "../../misc/FormatValidator"
 import {lang} from "../../misc/LanguageViewModel"
-import {TextField} from "../../gui/base/TextField.js"
+import {AutocompleteValues, TextField} from "../../gui/base/TextField.js"
 import {Dialog, DialogType} from "../../gui/base/Dialog"
 import {HtmlEditor, HtmlEditorMode} from "../../gui/editor/HtmlEditor"
 import {locator} from "../../api/main/MainLocator"
@@ -40,6 +40,7 @@ export function showTakeOverDialog(mailAddress: string, password: string): Dialo
 					m(TextField, {
 						label: "targetAddress_label",
 						value: targetAccountAddress(),
+						autocompleteValue: AutocompleteValues.email,
 						oninput: targetAccountAddress,
 					}),
 					m(editor),

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -29,7 +29,7 @@ import {isApp, isBrowser, isDesktop} from "../../api/common/Env"
 import {Icons} from "../../gui/base/icons/Icons"
 import {AnimationPromise, animations, height, opacity} from "../../gui/animation/Animations"
 import type {TextFieldAttrs} from "../../gui/base/TextField.js"
-import {AutocompleteValues, TextField, TextFieldType} from "../../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "../../gui/base/TextField.js"
 import {chooseAndAttachFile, cleanupInlineAttachments, createAttachmentButtonAttrs, getConfidentialStateMessage,} from "./MailEditorViewModel"
 import {ExpanderPanel} from "../../gui/base/Expander"
 import {windowFacade} from "../../misc/WindowFacade"
@@ -561,7 +561,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 							m("", String.fromCharCode(160))]
 						),
 						value: this.sendMailModel.getPassword(recipient.address),
-						autocompleteValue: AutocompleteValues.off,
+						autocompleteAs: Autocomplete.off,
 						type: this.isConfidentialPasswordRevealed(recipient.address) ? TextFieldType.Text : TextFieldType.Password,
 						oninput: val => this.sendMailModel.setPassword(recipient.address, val),
 						injectionsRight: () => this.renderRevealIcon(recipient.address)

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -29,7 +29,7 @@ import {isApp, isBrowser, isDesktop} from "../../api/common/Env"
 import {Icons} from "../../gui/base/icons/Icons"
 import {AnimationPromise, animations, height, opacity} from "../../gui/animation/Animations"
 import type {TextFieldAttrs} from "../../gui/base/TextField.js"
-import {TextField, TextFieldType} from "../../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "../../gui/base/TextField.js"
 import {chooseAndAttachFile, cleanupInlineAttachments, createAttachmentButtonAttrs, getConfidentialStateMessage,} from "./MailEditorViewModel"
 import {ExpanderPanel} from "../../gui/base/Expander"
 import {windowFacade} from "../../misc/WindowFacade"
@@ -561,7 +561,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 							m("", String.fromCharCode(160))]
 						),
 						value: this.sendMailModel.getPassword(recipient.address),
-						preventAutofill: true,
+						autocompleteValue: AutocompleteValues.off,
 						type: this.isConfidentialPasswordRevealed(recipient.address) ? TextFieldType.Text : TextFieldType.Password,
 						oninput: val => this.sendMailModel.setPassword(recipient.address, val),
 						injectionsRight: () => this.renderRevealIcon(recipient.address)

--- a/src/misc/2fa/SecondFactorAuthView.ts
+++ b/src/misc/2fa/SecondFactorAuthView.ts
@@ -6,7 +6,7 @@ import {Icon, progressIcon} from "../../gui/base/Icon"
 import {Icons, SecondFactorImage} from "../../gui/base/icons/Icons"
 import {theme} from "../../gui/theme"
 import type {Thunk} from "@tutao/tutanota-utils"
-import {TextField} from "../../gui/base/TextField.js"
+import {AutocompleteValues, TextField} from "../../gui/base/TextField.js"
 
 type WebauthnState =
 	| {state: "init"}
@@ -58,6 +58,7 @@ export class SecondFactorAuthView implements Component<SecondFactorViewAttrs> {
 			m(TextField, {
 				label: "totpCode_label",
 				value: otp.codeFieldValue,
+				autocompleteValue: AutocompleteValues.oneTimeCode,
 				oninput: value => otp.onValueChanged(value.trim()),
 				injectionsRight: () => (otp.inProgress ? m(".mr-s", progressIcon()) : null),
 			}),

--- a/src/misc/2fa/SecondFactorAuthView.ts
+++ b/src/misc/2fa/SecondFactorAuthView.ts
@@ -6,7 +6,7 @@ import {Icon, progressIcon} from "../../gui/base/Icon"
 import {Icons, SecondFactorImage} from "../../gui/base/icons/Icons"
 import {theme} from "../../gui/theme"
 import type {Thunk} from "@tutao/tutanota-utils"
-import {AutocompleteValues, TextField} from "../../gui/base/TextField.js"
+import {Autocomplete, TextField} from "../../gui/base/TextField.js"
 
 type WebauthnState =
 	| {state: "init"}
@@ -58,7 +58,7 @@ export class SecondFactorAuthView implements Component<SecondFactorViewAttrs> {
 			m(TextField, {
 				label: "totpCode_label",
 				value: otp.codeFieldValue,
-				autocompleteValue: AutocompleteValues.oneTimeCode,
+				autocompleteAs: Autocomplete.oneTimeCode,
 				oninput: value => otp.onValueChanged(value.trim()),
 				injectionsRight: () => (otp.inProgress ? m(".mr-s", progressIcon()) : null),
 			}),

--- a/src/settings/PasswordForm.ts
+++ b/src/settings/PasswordForm.ts
@@ -1,5 +1,5 @@
 import m, {Children, Component, Vnode} from "mithril"
-import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {CompletenessIndicator} from "../gui/CompletenessIndicator.js"
 import {getPasswordStrength, isSecurePassword, PASSWORD_MIN_SECURE_VALUE} from "../misc/passwords/PasswordUtils"
 import type {TranslationKey} from "../misc/LanguageViewModel"
@@ -245,7 +245,7 @@ export class PasswordForm implements Component<PasswordFormAttrs> {
 						value: attrs.model.getOldPassword(),
 						helpLabel: () => m(StatusField, {status: attrs.model.getOldPasswordStatus()}),
 						oninput: (input) => attrs.model.setOldPassword(input),
-						autocompleteValue: AutocompleteValues.currentPassword,
+						autocompleteAs: Autocomplete.currentPassword,
 						type: TextFieldType.Password,
 						fontSize: px(size.font_size_smaller),
 					})
@@ -264,7 +264,7 @@ export class PasswordForm implements Component<PasswordFormAttrs> {
 					]),
 					oninput: (input) => attrs.model.setNewPassword(input),
 					type: attrs.model.isPasswordRevealed() ? TextFieldType.Text : TextFieldType.Password,
-					autocompleteValue: AutocompleteValues.newPassword,
+					autocompleteAs: Autocomplete.newPassword,
 					fontSize: px(size.font_size_smaller),
 					injectionsRight: () => this.renderRevealIcon(attrs),
 				}),
@@ -273,7 +273,7 @@ export class PasswordForm implements Component<PasswordFormAttrs> {
 					? m(TextField, {
 						label: "repeatedPassword_label",
 						value: attrs.model.getRepeatedPassword(),
-						autocompleteValue: AutocompleteValues.newPassword,
+						autocompleteAs: Autocomplete.newPassword,
 						helpLabel: () =>
 							m(StatusField, {
 								status: attrs.model.getRepeatedPasswordStatus(),

--- a/src/settings/PasswordForm.ts
+++ b/src/settings/PasswordForm.ts
@@ -1,5 +1,5 @@
 import m, {Children, Component, Vnode} from "mithril"
-import {TextField, TextFieldType} from "../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {CompletenessIndicator} from "../gui/CompletenessIndicator.js"
 import {getPasswordStrength, isSecurePassword, PASSWORD_MIN_SECURE_VALUE} from "../misc/passwords/PasswordUtils"
 import type {TranslationKey} from "../misc/LanguageViewModel"
@@ -245,7 +245,7 @@ export class PasswordForm implements Component<PasswordFormAttrs> {
 						value: attrs.model.getOldPassword(),
 						helpLabel: () => m(StatusField, {status: attrs.model.getOldPasswordStatus()}),
 						oninput: (input) => attrs.model.setOldPassword(input),
-						preventAutofill: true,
+						autocompleteValue: AutocompleteValues.currentPassword,
 						type: TextFieldType.Password,
 						fontSize: px(size.font_size_smaller),
 					})
@@ -264,7 +264,7 @@ export class PasswordForm implements Component<PasswordFormAttrs> {
 					]),
 					oninput: (input) => attrs.model.setNewPassword(input),
 					type: attrs.model.isPasswordRevealed() ? TextFieldType.Text : TextFieldType.Password,
-					preventAutofill: true,
+					autocompleteValue: AutocompleteValues.newPassword,
 					fontSize: px(size.font_size_smaller),
 					injectionsRight: () => this.renderRevealIcon(attrs),
 				}),
@@ -273,6 +273,7 @@ export class PasswordForm implements Component<PasswordFormAttrs> {
 					? m(TextField, {
 						label: "repeatedPassword_label",
 						value: attrs.model.getRepeatedPassword(),
+						autocompleteValue: AutocompleteValues.newPassword,
 						helpLabel: () =>
 							m(StatusField, {
 								status: attrs.model.getRepeatedPasswordStatus(),

--- a/src/settings/login/secondfactor/SecondFactorEditDialog.ts
+++ b/src/settings/login/secondfactor/SecondFactorEditDialog.ts
@@ -4,7 +4,7 @@ import type {DropDownSelectorAttrs} from "../../../gui/base/DropDownSelector.js"
 import {DropDownSelector} from "../../../gui/base/DropDownSelector.js"
 import {lang} from "../../../misc/LanguageViewModel.js"
 import type {TextFieldAttrs} from "../../../gui/base/TextField.js"
-import {TextField} from "../../../gui/base/TextField.js"
+import {AutocompleteValues, TextField} from "../../../gui/base/TextField.js"
 import {isApp} from "../../../api/common/Env.js"
 import m, {Children} from "mithril"
 import {Button, ButtonType} from "../../../gui/base/Button.js"
@@ -139,6 +139,7 @@ export class SecondFactorEditDialog {
 			m(TextField, {
 				label: "totpCode_label",
 				value: this.model.totpCode,
+				autocompleteValue: AutocompleteValues.oneTimeCode,
 				oninput: newValue => this.model.onTotpValueChange(newValue),
 			}),
 		])

--- a/src/settings/login/secondfactor/SecondFactorEditDialog.ts
+++ b/src/settings/login/secondfactor/SecondFactorEditDialog.ts
@@ -4,7 +4,7 @@ import type {DropDownSelectorAttrs} from "../../../gui/base/DropDownSelector.js"
 import {DropDownSelector} from "../../../gui/base/DropDownSelector.js"
 import {lang} from "../../../misc/LanguageViewModel.js"
 import type {TextFieldAttrs} from "../../../gui/base/TextField.js"
-import {AutocompleteValues, TextField} from "../../../gui/base/TextField.js"
+import {Autocomplete, TextField} from "../../../gui/base/TextField.js"
 import {isApp} from "../../../api/common/Env.js"
 import m, {Children} from "mithril"
 import {Button, ButtonType} from "../../../gui/base/Button.js"
@@ -139,7 +139,7 @@ export class SecondFactorEditDialog {
 			m(TextField, {
 				label: "totpCode_label",
 				value: this.model.totpCode,
-				autocompleteValue: AutocompleteValues.oneTimeCode,
+				autocompleteAs: Autocomplete.oneTimeCode,
 				oninput: newValue => this.model.onTotpValueChange(newValue),
 			}),
 		])

--- a/src/settings/mailaddress/AddAliasDialog.ts
+++ b/src/settings/mailaddress/AddAliasDialog.ts
@@ -9,7 +9,7 @@ import {firstThrow, ofClass} from "@tutao/tutanota-utils"
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog.js"
 import {InvalidDataError, LimitReachedError, PreconditionFailedError} from "../../api/common/error/RestError.js"
 import {MailAddressTableModel} from "./MailAddressTableModel.js"
-import {AutocompleteValues, TextField} from "../../gui/base/TextField.js"
+import {Autocomplete, TextField} from "../../gui/base/TextField.js"
 
 const FAILURE_USER_DISABLED = "mailaddressaliasservice.group_disabled"
 
@@ -62,7 +62,7 @@ export function showAddAliasDialog(model: MailAddressTableModel) {
 						m(TextField, {
 							label: "mailName_label",
 							value: senderName,
-							autocompleteValue: AutocompleteValues.username,
+							autocompleteAs: Autocomplete.username,
 							oninput: (name) => senderName = name,
 						})
 					]

--- a/src/settings/mailaddress/AddAliasDialog.ts
+++ b/src/settings/mailaddress/AddAliasDialog.ts
@@ -9,7 +9,7 @@ import {firstThrow, ofClass} from "@tutao/tutanota-utils"
 import {showProgressDialog} from "../../gui/dialogs/ProgressDialog.js"
 import {InvalidDataError, LimitReachedError, PreconditionFailedError} from "../../api/common/error/RestError.js"
 import {MailAddressTableModel} from "./MailAddressTableModel.js"
-import {TextField} from "../../gui/base/TextField.js"
+import {AutocompleteValues, TextField} from "../../gui/base/TextField.js"
 
 const FAILURE_USER_DISABLED = "mailaddressaliasservice.group_disabled"
 
@@ -62,6 +62,7 @@ export function showAddAliasDialog(model: MailAddressTableModel) {
 						m(TextField, {
 							label: "mailName_label",
 							value: senderName,
+							autocompleteValue: AutocompleteValues.username,
 							oninput: (name) => senderName = name,
 						})
 					]

--- a/src/subscription/DeleteAccountDialog.ts
+++ b/src/subscription/DeleteAccountDialog.ts
@@ -2,7 +2,7 @@ import m from "mithril"
 import {Dialog} from "../gui/base/Dialog"
 import {lang} from "../misc/LanguageViewModel"
 import {InvalidDataError, LockedError, PreconditionFailedError} from "../api/common/error/RestError"
-import {TextFieldAttrs, TextField, TextFieldType} from "../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {neverNull, ofClass} from "@tutao/tutanota-utils"
 import {logins} from "../api/main/LoginController"
 import {getCleanedMailAddress} from "../misc/parsing/MailAddressParser"
@@ -32,6 +32,7 @@ export function showDeleteAccountDialog() {
 				m(TextField, {
 					label: "password_label",
 					value: password,
+					autocompleteValue: AutocompleteValues.currentPassword,
 					oninput: value => (password = value),
 					helpLabel: () => lang.get("passwordEnterNeutral_msg"),
 					type: TextFieldType.Password,

--- a/src/subscription/DeleteAccountDialog.ts
+++ b/src/subscription/DeleteAccountDialog.ts
@@ -2,7 +2,7 @@ import m from "mithril"
 import {Dialog} from "../gui/base/Dialog"
 import {lang} from "../misc/LanguageViewModel"
 import {InvalidDataError, LockedError, PreconditionFailedError} from "../api/common/error/RestError"
-import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {neverNull, ofClass} from "@tutao/tutanota-utils"
 import {logins} from "../api/main/LoginController"
 import {getCleanedMailAddress} from "../misc/parsing/MailAddressParser"
@@ -32,7 +32,7 @@ export function showDeleteAccountDialog() {
 				m(TextField, {
 					label: "password_label",
 					value: password,
-					autocompleteValue: AutocompleteValues.currentPassword,
+					autocompleteAs: Autocomplete.currentPassword,
 					oninput: value => (password = value),
 					helpLabel: () => lang.get("passwordEnterNeutral_msg"),
 					type: TextFieldType.Password,

--- a/src/termination/TerminationForm.ts
+++ b/src/termination/TerminationForm.ts
@@ -2,7 +2,7 @@ import m, {ChildArray, Children, Component, Vnode} from "mithril"
 import {lang} from "../misc/LanguageViewModel.js"
 import {client} from "../misc/ClientDetector.js"
 import {assertNotNull} from "@tutao/tutanota-utils"
-import {TextField, TextFieldType} from "../gui/base/TextField.js"
+import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {Button, ButtonType} from "../gui/base/Button.js"
 import {DropDownSelector} from "../gui/base/DropDownSelector.js"
 import {TerminationPeriodOptions} from "../api/common/TutanotaConstants.js"
@@ -55,6 +55,7 @@ export class TerminationForm implements Component<TerminationFormAttrs> {
 					m(TextField, {
 						label: "mailAddress_label",
 						value: a.mailAddress,
+						autocompleteValue: AutocompleteValues.email,
 						oninput: (value) => {
 							this.handleAutofill(a)
 							a.onMailAddressChanged(value)
@@ -79,6 +80,7 @@ export class TerminationForm implements Component<TerminationFormAttrs> {
 					m(TextField, {
 						label: "password_label",
 						value: a.password,
+						autocompleteValue: AutocompleteValues.currentPassword,
 						oninput: (value) => {
 							this.handleAutofill(a)
 							a.onPasswordChanged(value)

--- a/src/termination/TerminationForm.ts
+++ b/src/termination/TerminationForm.ts
@@ -2,7 +2,7 @@ import m, {ChildArray, Children, Component, Vnode} from "mithril"
 import {lang} from "../misc/LanguageViewModel.js"
 import {client} from "../misc/ClientDetector.js"
 import {assertNotNull} from "@tutao/tutanota-utils"
-import {AutocompleteValues, TextField, TextFieldType} from "../gui/base/TextField.js"
+import {Autocomplete, TextField, TextFieldType} from "../gui/base/TextField.js"
 import {Button, ButtonType} from "../gui/base/Button.js"
 import {DropDownSelector} from "../gui/base/DropDownSelector.js"
 import {TerminationPeriodOptions} from "../api/common/TutanotaConstants.js"
@@ -55,7 +55,7 @@ export class TerminationForm implements Component<TerminationFormAttrs> {
 					m(TextField, {
 						label: "mailAddress_label",
 						value: a.mailAddress,
-						autocompleteValue: AutocompleteValues.email,
+						autocompleteAs: Autocomplete.email,
 						oninput: (value) => {
 							this.handleAutofill(a)
 							a.onMailAddressChanged(value)
@@ -80,7 +80,7 @@ export class TerminationForm implements Component<TerminationFormAttrs> {
 					m(TextField, {
 						label: "password_label",
 						value: a.password,
-						autocompleteValue: AutocompleteValues.currentPassword,
+						autocompleteAs: Autocomplete.currentPassword,
 						oninput: (value) => {
 							this.handleAutofill(a)
 							a.onPasswordChanged(value)


### PR DESCRIPTION
androids example autofill app needs the "autocomplete" field in an input field to offer autofill. The value of the autocomplete field is an instruction how this field should be handled.

There are other possible "autocomplete" values like "new-password" which can be used as well. Wherever TextField is created, the "autocomplete" field will now be filled with the appropriate value, if reasonable.

#4499