### PR TITLE
closes old button in ContactFormRequestDialog

### DIFF
--- a/src/login/contactform/ContactFormRequestDialog.ts
+++ b/src/login/contactform/ContactFormRequestDialog.ts
@@ -357,9 +357,6 @@ export class ContactFormRequestDialog {
 
 function showConfirmDialog(userEmailAddress: string): Promise<void> {
 	return new Promise(resolve => {
-		// This old button has type login. New buttons with this type have rounded corner but this one should probably not have because
-		// it fills the dialog in the bottom (unless we want dialogs to have rounded corners in the future.
-		// Anyway, if you decide to replace it, take care of it.
 		const dialog = new Dialog(DialogType.EditMedium, {
 			view: () =>
 				m("", [


### PR DESCRIPTION
This commit simply removes an obsolete comment. The comment was written during migration from Button to ButtonN, but after this migration was performed ButtonN was renamed to Button. Furthermore, the in the comment mentioned round corners have since been removed from the Button.

close #4254