### PR TITLE
stop autocomplete on new mail address fields

### DIFF
--- a/Desktop.Jenkinsfile
+++ b/Desktop.Jenkinsfile
@@ -166,6 +166,7 @@ pipeline {
 			environment { PATH = "${env.NODE_PATH}:${env.PATH}" }
 			steps {
 				sh 'npm ci'
+				sh 'npm run build-packages'
 				sh 'rm -rf ./build/*'
 
 				dir('build') {

--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -11,8 +11,8 @@ android {
 		applicationId "de.tutao.tutanota"
 		minSdkVersion 23
 		targetSdkVersion 31
-		versionCode 396163
-		versionName "3.106.1"
+		versionCode 396164
+		versionName "3.106.2"
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
 		javaCompileOptions {

--- a/app-ios/tutanota/Info.plist
+++ b/app-ios/tutanota/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.106.1</string>
+	<string>3.106.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3.106.1</string>
+	<string>3.106.2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tutanota",
-	"version": "3.106.1",
+	"version": "3.106.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tutanota",
-			"version": "3.106.1",
+			"version": "3.106.2",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"workspaces": [
@@ -14,9 +14,9 @@
 			],
 			"dependencies": {
 				"@tutao/oxmsg": "0.0.9-beta.0",
-				"@tutao/tutanota-crypto": "3.106.1",
-				"@tutao/tutanota-usagetests": "3.106.1",
-				"@tutao/tutanota-utils": "3.106.1",
+				"@tutao/tutanota-crypto": "3.106.2",
+				"@tutao/tutanota-usagetests": "3.106.2",
+				"@tutao/tutanota-utils": "3.106.2",
 				"@types/better-sqlite3": "7.4.2",
 				"@types/dompurify": "2.3.3",
 				"@types/linkifyjs": "2.1.4",
@@ -48,8 +48,8 @@
 				"@rollup/plugin-json": "4.1.0",
 				"@rollup/plugin-node-resolve": "13.3.0",
 				"@rollup/plugin-typescript": "8.3.0",
-				"@tutao/licc": "3.106.1",
-				"@tutao/tutanota-test-utils": "3.106.1",
+				"@tutao/licc": "3.106.2",
+				"@tutao/tutanota-test-utils": "3.106.2",
 				"body-parser": "1.20.0",
 				"chokidar": "3.5.2",
 				"commander": "9.2.0",
@@ -8884,7 +8884,7 @@
 		},
 		"packages/licc": {
 			"name": "@tutao/licc",
-			"version": "3.106.1",
+			"version": "3.106.2",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {
@@ -8896,7 +8896,7 @@
 				"licc": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@tutao/tutanota-test-utils": "3.106.1",
+				"@tutao/tutanota-test-utils": "3.106.2",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 			}
 		},
@@ -8975,10 +8975,10 @@
 		},
 		"packages/tutanota-crypto": {
 			"name": "@tutao/tutanota-crypto",
-			"version": "3.106.1",
+			"version": "3.106.2",
 			"license": "GPL-3.0",
 			"devDependencies": {
-				"@tutao/tutanota-utils": "3.106.1",
+				"@tutao/tutanota-utils": "3.106.2",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "4.5.4"
 			}
@@ -8997,7 +8997,7 @@
 		},
 		"packages/tutanota-test-utils": {
 			"name": "@tutao/tutanota-test-utils",
-			"version": "3.106.1",
+			"version": "3.106.2",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"typescript": "4.5.4"
@@ -9021,7 +9021,7 @@
 		},
 		"packages/tutanota-usagetests": {
 			"name": "@tutao/tutanota-usagetests",
-			"version": "3.106.1",
+			"version": "3.106.2",
 			"license": "GLP-3.0",
 			"devDependencies": {
 				"@types/node-forge": "1.0.0",
@@ -9031,7 +9031,7 @@
 		},
 		"packages/tutanota-utils": {
 			"name": "@tutao/tutanota-utils",
-			"version": "3.106.1",
+			"version": "3.106.2",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
@@ -10065,7 +10065,7 @@
 		"@tutao/licc": {
 			"version": "file:packages/licc",
 			"requires": {
-				"@tutao/tutanota-test-utils": "3.106.1",
+				"@tutao/tutanota-test-utils": "3.106.2",
 				"commander": "9.3.0",
 				"json5": "^2.2.1",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
@@ -10131,7 +10131,7 @@
 		"@tutao/tutanota-crypto": {
 			"version": "file:packages/tutanota-crypto",
 			"requires": {
-				"@tutao/tutanota-utils": "3.106.1",
+				"@tutao/tutanota-utils": "3.106.2",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "4.5.4"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tutanota",
-	"version": "3.106.1",
+	"version": "3.106.2",
 	"license": "GPL-3.0",
 	"repository": {
 		"type": "git",
@@ -26,9 +26,9 @@
 	},
 	"dependencies": {
 		"@tutao/oxmsg": "0.0.9-beta.0",
-		"@tutao/tutanota-crypto": "3.106.1",
-		"@tutao/tutanota-usagetests": "3.106.1",
-		"@tutao/tutanota-utils": "3.106.1",
+		"@tutao/tutanota-crypto": "3.106.2",
+		"@tutao/tutanota-usagetests": "3.106.2",
+		"@tutao/tutanota-utils": "3.106.2",
 		"@types/better-sqlite3": "7.4.2",
 		"@types/dompurify": "2.3.3",
 		"@types/linkifyjs": "2.1.4",
@@ -59,8 +59,8 @@
 		"@rollup/plugin-json": "4.1.0",
 		"@rollup/plugin-node-resolve": "13.3.0",
 		"@rollup/plugin-typescript": "8.3.0",
-		"@tutao/tutanota-test-utils": "3.106.1",
-		"@tutao/licc": "3.106.1",
+		"@tutao/tutanota-test-utils": "3.106.2",
+		"@tutao/licc": "3.106.2",
 		"@electron/notarize": "1.2.3",
 		"body-parser": "1.20.0",
 		"chokidar": "3.5.2",

--- a/packages/licc/package.json
+++ b/packages/licc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/licc",
-	"version": "3.106.1",
+	"version": "3.106.2",
 	"bin": {
 		"licc": "dist/cli.js"
 	},
@@ -20,7 +20,7 @@
 		"zx": "6.1.0"
 	},
 	"devDependencies": {
-		"@tutao/tutanota-test-utils": "3.106.1",
+		"@tutao/tutanota-test-utils": "3.106.2",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-crypto/package.json
+++ b/packages/tutanota-crypto/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-crypto",
-	"version": "3.106.1",
+	"version": "3.106.2",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {
@@ -21,7 +21,7 @@
 	],
 	"devDependencies": {
 		"typescript": "4.5.4",
-		"@tutao/tutanota-utils": "3.106.1",
+		"@tutao/tutanota-utils": "3.106.2",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-test-utils/package.json
+++ b/packages/tutanota-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-test-utils",
-	"version": "3.106.1",
+	"version": "3.106.2",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {

--- a/packages/tutanota-usagetests/package.json
+++ b/packages/tutanota-usagetests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-usagetests",
-	"version": "3.106.1",
+	"version": "3.106.2",
 	"license": "GLP-3.0",
 	"description": "",
 	"main": "./dist/index.js",

--- a/packages/tutanota-utils/package.json
+++ b/packages/tutanota-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-utils",
-	"version": "3.106.1",
+	"version": "3.106.2",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/src/settings/SelectMailAddressForm.ts
+++ b/src/settings/SelectMailAddressForm.ts
@@ -11,7 +11,7 @@ import {locator} from "../api/main/MainLocator"
 import {assertMainOrNode} from "../api/common/Env"
 import {isTutanotaMailAddress} from "../mail/model/MailUtils.js";
 import {px, size} from "../gui/size.js"
-import {inputLineHeight, TextField} from "../gui/base/TextField.js"
+import {Autocomplete, inputLineHeight, TextField} from "../gui/base/TextField.js"
 import {attachDropdown, DropdownButtonAttrs} from "../gui/base/Dropdown.js"
 import {IconButton, IconButtonAttrs} from "../gui/base/IconButton.js"
 import {ButtonSize} from "../gui/base/ButtonSize.js"
@@ -68,6 +68,7 @@ export class SelectMailAddressForm implements Component<SelectMailAddressFormAtt
 			label: "mailAddress_label",
 			value: this.username,
 			alignRight: true,
+			autocompleteAs: Autocomplete.newPassword,
 			helpLabel: () => this.addressHelpLabel(),
 			fontSize: px(size.font_size_smaller),
 			oninput: (value) => {

--- a/src/settings/SelectMailAddressFormWithSuggestions.ts
+++ b/src/settings/SelectMailAddressFormWithSuggestions.ts
@@ -11,7 +11,7 @@ import {locator} from "../api/main/MainLocator"
 import {assertMainOrNode} from "../api/common/Env"
 import {isTutanotaMailAddress} from "../mail/model/MailUtils.js";
 import {px, size} from "../gui/size.js"
-import {inputLineHeight, TextField} from "../gui/base/TextField.js"
+import {Autocomplete, inputLineHeight, TextField} from "../gui/base/TextField.js"
 import {attachDropdown, DropdownButtonAttrs} from "../gui/base/Dropdown.js"
 import {IconButton, IconButtonAttrs} from "../gui/base/IconButton.js"
 import {ButtonSize} from "../gui/base/ButtonSize.js"
@@ -76,6 +76,7 @@ export class SelectMailAddressFormWithSuggestions implements Component<SelectMai
 				value: this.username,
 				alignRight: true,
 				helpLabel: () => this.addressHelpLabel(),
+				autocompleteAs: Autocomplete.newPassword,
 				fontSize: px(size.font_size_smaller),
 				oninput: (value) => {
 					this.username = value

--- a/src/subscription/SignupForm.ts
+++ b/src/subscription/SignupForm.ts
@@ -2,7 +2,7 @@ import m, {Children, Component, Vnode} from "mithril"
 import stream from "mithril/stream"
 import Stream from "mithril/stream"
 import {Dialog} from "../gui/base/Dialog"
-import {TextField} from "../gui/base/TextField.js"
+import {Autocomplete, TextField} from "../gui/base/TextField.js"
 import {Button, ButtonType} from "../gui/base/Button.js"
 import {getWhitelabelRegistrationDomains} from "../login/LoginView"
 import type {NewAccountData} from "./UpgradeSubscriptionWizard"
@@ -162,6 +162,7 @@ export class SignupForm implements Component<SignupFormAttrs> {
 					? m(TextField, {
 						label: "mailAddress_label",
 						value: a.prefilledMailAddress ?? "",
+						autocompleteAs: Autocomplete.newPassword,
 						disabled: true,
 					})
 					: [


### PR DESCRIPTION
it's not necessary for selecting a new mail address
since the address is new
the popup also obscures some suggestion UI

autocomplete = "new-password" is more reliable than
autocomplete = "off" since some browsers will still
ask to save the entered credentials and then
autocomplete anyway later (this can happen with
multiple accounts)

close https://github.com/tutao/tutanota/issues/4871

also contains the changes between 3.106.1 and 3.106.2