### PR TITLE
fix mail address is selected when closing mail recipient suggestion

### DIFF
--- a/src/gui/MailRecipientsTextField.ts
+++ b/src/gui/MailRecipientsTextField.ts
@@ -89,7 +89,7 @@ export class MailRecipientsTextField implements ClassComponent<MailRecipientsTex
 
 			},
 			onEnterKey: () => {
-				this.resolveInput(attrs)
+				this.resolveInput(attrs, true)
 				return true
 			},
 			onUpKey: () => {
@@ -105,7 +105,7 @@ export class MailRecipientsTextField implements ClassComponent<MailRecipientsTex
 			},
 			onBlur: () => {
 				this.focused = false
-				this.resolveInput(attrs)
+				this.resolveInput(attrs, false)
 				return true
 			},
 			disabled: attrs.disabled,
@@ -141,9 +141,14 @@ export class MailRecipientsTextField implements ClassComponent<MailRecipientsTex
 		}))
 	}
 
-	private resolveInput(attrs: MailRecipientsTextFieldAttrs) {
+	/**
+	 * Resolves a typed in mail address or one of the suggested ones.
+	 * @param selectSuggestion boolean value indicating whether a suggestion should be selected or not. Should be true if a suggestion is explicitly selected by
+	 * for example hitting the enter key and false e.g. if the dialog is closed
+	 */
+	private resolveInput(attrs: MailRecipientsTextFieldAttrs, selectSuggestion: boolean) {
 		const suggestions = attrs.search.results()
-		if (suggestions.length > 0) {
+		if (suggestions.length > 0 && selectSuggestion) {
 			this.selectSuggestion(attrs, this.getSelectedSuggestionIdx(attrs))
 		} else {
 			const parsed = parseMailAddress(attrs.text)


### PR DESCRIPTION
When no recipient from the suggestions is explicitly selected, none of the suggestions should be put to the recipient field. But currently when closing the recipient suggestion dropdown by for example clicking somewhere else the onBlur method is called and the current highlighted suggestion gets selected.

Still the input needs to be resolved, even if the dropdown is closed. This is for example necessary for external mail addresses.

fix #4831