### PR TITLE
[desktop] prevent sendResponse being called multiple times

### DIFF
--- a/packages/tutanota-utils/lib/Utils.ts
+++ b/packages/tutanota-utils/lib/Utils.ts
@@ -154,6 +154,23 @@ export function lazyMemoized<T>(source: () => T): () => T {
 	}
 }
 
+export type Callback<T> = (arg: T) => void
+
+/**
+ * accept a function taking exactly one argument and returning nothing and return a version of it
+ * that will call the original function on the first call and ignore any further calls.
+ * @param fn a function taking one argument and returning nothing
+ */
+export function makeSingleUse<T>(fn: Callback<T>): Callback<T> {
+	let called = false
+	return (arg) => {
+		if (!called) {
+			called = true
+			fn(arg)
+		}
+	}
+}
+
 /**
  * Returns a cached version of {@param fn}.
  * Cached function checks that argument is the same (with ===) and if it is then it returns the cached result.

--- a/packages/tutanota-utils/lib/index.ts
+++ b/packages/tutanota-utils/lib/index.ts
@@ -122,6 +122,7 @@ export {
 	downcast,
 	clone,
 	lazyMemoized,
+	makeSingleUse,
 	memoized,
 	identity,
 	noOp,


### PR DESCRIPTION
this (probably) happens inside ProtocolProxy.ts if the net modules throw any error after we already sent a response to the request originator. Since theres no case where we ever want to see more than the first response, error or timeout, we can safely drop any further calls.

* changed the callback registration for one-time events: .on -> .once
* made the actual sendResponse callback we get to return the response callable at most once

close #4612