### PR TITLE
[ios] Fix offline-related crash

### DIFF
--- a/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
+++ b/app-ios/tutanota/Sources/Offline/IosSqlCipherFade.swift
@@ -8,7 +8,7 @@ enum ListIdLockState {
 
 let OFFLINE_DB_CLOSED_DOMAIN = "de.tutao.tutanota.offline.OfflineDbClosedError"
 
-class IosSqlCipherFacade: SqlCipherFacade {
+actor IosSqlCipherFacade: SqlCipherFacade {
   private var db: SqlCipherDb? = nil
 
   private var concurrentListIdLocks = ConcurrentListIdLocks()


### PR DESCRIPTION
It seems like the reason for the crash in 4836 is concurrent access to the db pointer. When we run into the outdated credentials we close the db and it can happen while another operation is running. The crash was happening when get() would check that db is open and copy the db handle, the db would be closed in the meantime and then get() would fail when it would try to use the db. The only way to prevent this is to make all db usage serial and we achieve this by using actor. This probably impacts the performance because there can be no more concurrent calls but we believe that the impact is minimal in practice.

fix #4836