### PR TITLE
Fix mail phishing banner not being updated

### DIFF
--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -93,7 +93,6 @@ export class MailViewerViewModel {
 	private contentBlockingStatus: ContentBlockingStatus | null = null
 	private errorOccurred: boolean = false
 	private loadedInlineImages: InlineImages | null = null
-	private suspicious: boolean = false
 
 	private folderText: string | null
 	/** @see getRelevantRecipient */
@@ -269,7 +268,7 @@ export class MailViewerViewModel {
 	}
 
 	isMailSuspicious(): boolean {
-		return this.suspicious
+		return this.mail.phishingStatus === MailPhishingStatus.SUSPICIOUS
 	}
 
 	getMailId(): IdTuple {
@@ -608,9 +607,7 @@ export class MailViewerViewModel {
 	}
 
 	private checkMailForPhishing(mail: Mail, links: Array<HTMLElement>) {
-		if (mail.phishingStatus === MailPhishingStatus.SUSPICIOUS) {
-			this.suspicious = true
-		} else if (mail.phishingStatus === MailPhishingStatus.UNKNOWN) {
+		if (mail.phishingStatus === MailPhishingStatus.UNKNOWN) {
 			const linkObjects = links.map((link) => {
 				return {
 					href: link.getAttribute("href") || "",
@@ -620,7 +617,6 @@ export class MailViewerViewModel {
 
 			this.mailModel.checkMailForPhishing(mail, linkObjects).then((isSuspicious) => {
 				if (isSuspicious) {
-					this.suspicious = true
 					mail.phishingStatus = MailPhishingStatus.SUSPICIOUS
 
 					this.entityClient


### PR DESCRIPTION
We've been caching suspicious status and not updating it on when the mail was updated. The state is actually redundant as we overwrite the phishing status on mail directly as soon as we check for phishing so the issue resolved itself after we removed it.

fix #4606