### PR TITLE
[macos] fix uncaught error when clicking invalid links in mail

### DIFF
--- a/src/desktop/ApplicationWindow.ts
+++ b/src/desktop/ApplicationWindow.ts
@@ -7,6 +7,7 @@ import { Keys } from "../api/common/TutanotaConstants"
 import type { Key } from "../misc/KeyManager"
 import path from "path"
 import type { TranslationKey } from "../misc/LanguageViewModel"
+import { lang } from "../misc/LanguageViewModel"
 import { log } from "./DesktopLog"
 import { parseUrlOrNull } from "./PathUtils"
 import type { LocalShortcutManager } from "./electron-localshortcut/LocalShortcut"
@@ -412,7 +413,16 @@ export class ApplicationWindow {
 		} else {
 			// we never open any new windows directly from the renderer
 			// except for links in mails etc. so open them in the browser
-			this.electron.shell.openExternal(parsedUrl.toString())
+			this.electron.shell.openExternal(parsedUrl.toString()).catch((e) => {
+				log.warn("failed to open external url", details.url, e)
+				this.electron.dialog.showMessageBox({
+					title: lang.get("showURL_alt"),
+					buttons: [lang.get("ok_action")],
+					defaultId: 0,
+					message: lang.get("couldNotOpenLink_msg", { "{link}": details.url }),
+					type: "error",
+				})
+			})
 		}
 
 		return {

--- a/src/desktop/DesktopErrorHandler.ts
+++ b/src/desktop/DesktopErrorHandler.ts
@@ -30,9 +30,11 @@ export class DesktopErrorHandler {
 		this.wm = wm
 		process
 			.on("uncaughtException", (error) => {
+				console.log("unhandled exception")
 				this.handleUnexpectedFailure(error)
 			})
 			.on("unhandledRejection", (error: Error, p) => {
+				console.log("unhandled rejection")
 				this.handleUnexpectedFailure(error)
 			})
 

--- a/src/misc/TranslationKey.ts
+++ b/src/misc/TranslationKey.ts
@@ -1561,3 +1561,4 @@ export type TranslationKeyType =
 	| "yourMessage_label"
 	| "you_label"
 	| "emptyString_msg"
+	| "couldNotOpenLink_msg"

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1579,6 +1579,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "DEINE ORDNER",
 		"yourMessage_label": "Deine Nachricht",
-		"you_label": "Du"
+		"you_label": "Du",
+		"couldNotOpenLink_msg": "Keine Anwendung zum Öffnen von\n{link}\ngefunden",
 	}
 }

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -1579,6 +1579,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "Ihre ORDNER",
 		"yourMessage_label": "Ihre Nachricht",
-		"you_label": "Sie"
+		"you_label": "Sie",
+		"couldNotOpenLink_msg": "Keine Anwendung zum Öffnen von\n{link}\ngefunden",
 	}
 }

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1575,6 +1575,7 @@ export default {
 		"yourCalendars_label": "Your calendars",
 		"yourFolders_action": "YOUR FOLDERS",
 		"yourMessage_label": "Your message",
-		"you_label": "You"
+		"you_label": "You",
+		"couldNotOpenLink_msg": "Unable to find application to open link\n{link}",
 	}
 }

--- a/test/tests/desktop/ApplicationWindowTest.ts
+++ b/test/tests/desktop/ApplicationWindowTest.ts
@@ -11,9 +11,9 @@ import { verify } from "@tutao/tutanota-test-utils"
 import { ThemeFacade } from "../../../src/native/common/generatedipc/ThemeFacade.js"
 import { DesktopThemeFacade } from "../../../src/desktop/DesktopThemeFacade.js"
 import { RemoteBridge, SendingFacades } from "../../../src/desktop/ipc/RemoteBridge.js"
+import { OfflineDbManager } from "../../../src/desktop/db/PerWindowSqlCipherFacade.js"
 import Rectangle = Electron.Rectangle
 import BrowserWindow = Electron.BrowserWindow
-import { OfflineDbManager } from "../../../src/desktop/db/PerWindowSqlCipherFacade.js"
 
 const { anything } = matchers
 
@@ -245,7 +245,7 @@ o.spec("ApplicationWindow Test", function () {
 				},
 			}),
 			shell: {
-				openExternal: () => {},
+				openExternal: () => Promise.resolve(),
 			},
 			Menu: {
 				setApplicationMenu: () => {},


### PR DESCRIPTION
mac will throw an error when openExternal can't find an application to open the link. this can happen with custom protocols.

we now show a nice error message if this happens.

close #4952