### PR TITLE
ignore systemjs error with shortened URL

### DIFF
--- a/src/misc/ErrorHandlerImpl.ts
+++ b/src/misc/ErrorHandlerImpl.ts
@@ -50,7 +50,10 @@ export async function handleUncaughtErrorImpl(e: Error) {
 	}
 
 	// This is from the s.js and it shouldn't change. Unfortunately it is a plain Error.
-	if (e.message.includes("(SystemJS https://github.com/systemjs/systemjs/blob/master/docs/errors.md#")) {
+	if (
+		e.message.includes("(SystemJS https://github.com/systemjs/systemjs/blob/master/docs/errors.md#") ||
+		e.message.includes("(SystemJS https://git.io/JvFET#3)") // points to the above url
+	) {
 		handleImportError()
 		return
 	}


### PR DESCRIPTION
turns out that what shouldn't have changed changed after all. we had hundreds of reports of this in the last week.