### PR TITLE
Fix when onNewUrl() is called

### DIFF
--- a/src/calendar/view/CalendarView.ts
+++ b/src/calendar/view/CalendarView.ts
@@ -71,6 +71,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 	private readonly viewModel: CalendarViewModel
 	// For sanitizing event descriptions, which get rendered as html in the CalendarEventPopup
 	private readonly htmlSanitizer: Promise<HtmlSanitizer>
+	oncreate: Component["oncreate"]
 	onremove: Component["onremove"]
 
 	constructor(vnode: Vnode<CalendarViewAttrs>) {
@@ -301,7 +302,6 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 		const streamListeners: Stream<void>[] = []
 
 		this.oncreate = (vnode) => {
-			super.oncreate(vnode)
 			keyManager.registerShortcuts(shortcuts)
 			streamListeners.push(
 				this.viewModel.calendarInvitations.map(() => {

--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -64,6 +64,7 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 	viewSlider: ViewSlider
 	_contactList: ContactListView | null = null
 	private _multiContactViewer: MultiContactViewer
+	oncreate: TopLevelView["oncreate"]
 	onremove: TopLevelView["onremove"]
 	private _throttledSetUrl: (url: string) => void
 
@@ -138,7 +139,6 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 
 		const shortcuts = this.getShortcuts()
 		this.oncreate = (vnode) => {
-			super.oncreate(vnode)
 			keyManager.registerShortcuts(shortcuts)
 			locator.eventController.addEntityListener(this.entityListener)
 		}

--- a/src/gui/BaseTopLevelView.ts
+++ b/src/gui/BaseTopLevelView.ts
@@ -7,12 +7,12 @@ import { TopLevelAttrs } from "../TopLevelView.js"
 export abstract class BaseTopLevelView {
 	private lastPath: string = ""
 
-	oncreate({ attrs }: Vnode<TopLevelAttrs>) {
+	oninit({ attrs }: Vnode<TopLevelAttrs>) {
 		this.lastPath = attrs.requestedPath
 		this.onNewUrl(attrs.args, attrs.requestedPath)
 	}
 
-	onupdate({ attrs }: Vnode<TopLevelAttrs>) {
+	onbeforeupdate({ attrs }: Vnode<TopLevelAttrs>) {
 		// onupdate() is called on every re-render but we don't want to call onNewUrl all the time
 		if (this.lastPath !== attrs.requestedPath) {
 			this.lastPath = attrs.requestedPath

--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -84,8 +84,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	private readonly mailColumn: ViewColumn
 	private readonly viewSlider: ViewSlider
 	cache: MailViewCache
-	private editingFolderForMailGroup: Id | null = null
-
+	readonly oncreate: TopLevelView["oncreate"]
 	readonly onremove: TopLevelView["onremove"]
 
 	/**
@@ -167,7 +166,6 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 		const shortcuts = this._getShortcuts()
 
 		this.oncreate = (vnode) => {
-			super.oncreate(vnode)
 			this.countersStream = locator.mailModel.mailboxCounters.map(m.redraw)
 			keyManager.registerShortcuts(shortcuts)
 			this.mailboxSubscription = locator.mailModel.mailboxDetails.map((mailboxDetails) => this.onUpdateMailboxDetails(mailboxDetails))

--- a/src/search/view/SearchView.ts
+++ b/src/search/view/SearchView.ts
@@ -68,6 +68,7 @@ export interface SearchViewAttrs extends TopLevelAttrs {
 }
 
 export class SearchView extends BaseTopLevelView implements TopLevelView<SearchViewAttrs> {
+	oncreate: TopLevelView["oncreate"]
 	onremove: TopLevelView["onremove"]
 
 	private resultListColumn: ViewColumn
@@ -177,7 +178,6 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 		const shortcuts = this.getShortcuts()
 
 		this.oncreate = (vnode) => {
-			super.oncreate(vnode)
 			keyManager.registerShortcuts(shortcuts)
 			neverNull(header.searchBar).setReturnListener(() => this.resultListColumn.focus())
 			locator.eventController.addEntityListener(this.entityListener)

--- a/src/settings/SettingsView.ts
+++ b/src/settings/SettingsView.ts
@@ -375,7 +375,6 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 	}
 
 	oncreate(vnode: Vnode<SettingsViewAttrs>) {
-		super.oncreate(vnode)
 		locator.eventController.addEntityListener(this.entityListener)
 	}
 


### PR DESCRIPTION
With old view resolver updateUrl() would always be called before the view() method. With new view resolver and BaseTopLevelView this has changed and it would be called afterwards. When this got changed CalendarView would update it's state too late and would once redraw with the old state.

This commit reverts to the previous behavior so that we have a chance to set the state depending on the URL before we re-render.

fix #4998