### PR TITLE
[desktop/win] fix joinFiles not closing the output stream

### DIFF
--- a/src/desktop/net/DesktopDownloadManager.ts
+++ b/src/desktop/net/DesktopDownloadManager.ts
@@ -266,10 +266,7 @@ export class DesktopDownloadManager {
 				readStream.pipe(outStream, { end: false })
 			})
 		}
-		// Wait for the write stream to finish
-		await new Promise((resolve) => {
-			outStream.end(resolve)
-		})
+		await closeFileStream(outStream)
 		return fileUri
 	}
 

--- a/test/tests/desktop/net/DesktopDownloadManagerTest.ts
+++ b/test/tests/desktop/net/DesktopDownloadManagerTest.ts
@@ -619,7 +619,7 @@ o.spec("DesktopDownloadManagerTest", function () {
 			const rs = ReadStream.mockedInstances[0]
 			o(rs.pipe.callCount).equals(1)("stream was piped")
 			o(rs.pipe.args).deepEquals([ws, { end: false }])
-			o(ws.end.callCount).equals(1)
+			o(ws.close.callCount).equals(1)
 
 			o(joinedFile).equals("/tutanota/tmp/path/download/fileName.pdf")
 		})


### PR DESCRIPTION
on windows, we need to call close() to release the file handle and be able to open the joined file with other apps (or re-download the file)

fix #4946