### PR TITLE
[desktop] fix quit shortcut not working

### DIFF
--- a/src/api/common/TutanotaConstants.ts
+++ b/src/api/common/TutanotaConstants.ts
@@ -674,6 +674,10 @@ export const Keys = Object.freeze({
 		code: 80,
 		name: "P",
 	},
+	Q: {
+		code: 81,
+		name: "Q",
+	},
 	R: {
 		code: 82,
 		name: "R",

--- a/src/desktop/ApplicationWindow.ts
+++ b/src/desktop/ApplicationWindow.ts
@@ -108,6 +108,14 @@ export class ApplicationWindow {
 					},
 					help: "resetZoomFactor_action",
 				},
+				{
+					key: Keys["Q"],
+					ctrl: !isMac,
+					meta: isMac,
+					shift: !isMac,
+					exec: () => this.electron.app.quit(),
+					help: "quit_action",
+				},
 			] as Array<LocalShortcut>
 		).concat(
 			isMac

--- a/src/desktop/tray/NonMacTray.ts
+++ b/src/desktop/tray/NonMacTray.ts
@@ -24,7 +24,7 @@ export class NonMacTray implements PlatformTray {
 			}),
 			new MenuItem({
 				label: lang.get("quit_action"),
-				accelerator: "CmdOrCtrl+Q",
+				accelerator: "CmdOrCtrl+Shift+Q",
 				click: () => app.quit(),
 			}),
 		]

--- a/test/tests/desktop/ApplicationWindowTest.ts
+++ b/test/tests/desktop/ApplicationWindowTest.ts
@@ -425,6 +425,7 @@ o.spec("ApplicationWindow Test", function () {
 			"Control+P",
 			"F12",
 			"Control+0",
+			"Control+Shift+Q",
 			"F11",
 			"Alt+Right",
 			"Alt+Left",
@@ -442,6 +443,7 @@ o.spec("ApplicationWindow Test", function () {
 			"Control+P",
 			"F12",
 			"Control+0",
+			"Control+Shift+Q",
 			"F11",
 			"Alt+Right",
 			"Alt+Left",
@@ -455,7 +457,7 @@ o.spec("ApplicationWindow Test", function () {
 
 		const w = new ApplicationWindow(wmMock, desktopHtml, icon, electronMock, electronLocalshortcutMock, themeFacade, offlineDbFacade, remoteBridge, dictUrl)
 		downcast(w._browserWindow.webContents).callbacks["did-finish-load"]()
-		o(Object.keys(electronLocalshortcutMock.callbacks)).deepEquals(["Command+F", "Command+P", "F12", "Command+0", "Command+Control+F"])
+		o(Object.keys(electronLocalshortcutMock.callbacks)).deepEquals(["Command+F", "Command+P", "F12", "Command+0", "Command+Q", "Command+Control+F"])
 	})
 
 	function testShortcut(shortcuts: Array<string>, assertion: (sm: ReturnType<typeof standardMocks>) => void) {


### PR DESCRIPTION
* add Ctrl + Shift + Q for linux and window to quit app
* on mac, Cmd + Q still quits the app as before
* add the shortcut to the F1 menu for all platforms

fix #3378