### PR TITLE
Fix navigation in Mail view, fix view caching issue

### DIFF
--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -118,7 +118,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 		this.folderColumn = this.createFolderColumn(null, vnode.attrs.drawerAttrs)
 		this.listColumn = new ViewColumn(
 			{
-				view: () => m(".list-column", [this.cache.mailList ? m(this.cache.mailList) : null]),
+				view: () => m(".list-column", [this.cache.mailList ? m(this.cache.mailList, { mailView: this }) : null]),
 			},
 			ColumnType.Background,
 			size.second_col_min_width,
@@ -572,7 +572,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	 */
 	private showList(mailListId: Id, mailElementId: Id | null): boolean {
 		this.cache.mailList?.dispose()
-		this.cache.mailList = new MailListView(mailListId, this)
+		this.cache.mailList = new MailListView(mailListId)
 		let folder = locator.mailModel.getMailFolder(mailListId)
 
 		if (folder) {


### PR DESCRIPTION
After changing MailView to be a proper component we've introduced a cache to hold on to some state. Unfortunately we had to hold the whole MailListView in the cache because of how it is written. This was not done properly because we create it only once and would hold on to the first instance of MailView (which was used at creation time). If we switch to another view and back we need to get a new MailView instance.

We fixed it by updating the MailView reference together with lifecycle.

A proper solution would mean not requiring MailView in there and not holding on to the whole MailListView in the cache.'

fix #5026