### PR TITLE
close offlineDB when the closed event is emitted, not before

### DIFF
--- a/packages/tutanota-crypto/test/bootstrap.ts
+++ b/packages/tutanota-crypto/test/bootstrap.ts
@@ -1,10 +1,14 @@
 import { random } from "../lib/random/Randomizer.js"
+
 export async function bootstrapTests() {
 	const crypto = await import("crypto")
 	globalThis.crypto = {
 		getRandomValues: function (bytes: Uint8Array) {
 			let randomBytes = crypto.randomBytes(bytes.length)
 			bytes.set(randomBytes)
+		},
+		randomUUID: function () {
+			return "36b8f84d-df4e-4d49-b662-bcde71a8764f"
 		},
 		subtle: "We have to do this, because node's crypto is not compatible with SubtleCrypto. Sorry." as unknown as SubtleCrypto,
 	}

--- a/src/desktop/ApplicationWindow.ts
+++ b/src/desktop/ApplicationWindow.ts
@@ -109,7 +109,7 @@ export class ApplicationWindow {
 					help: "resetZoomFactor_action",
 				},
 				{
-					key: Keys["Q"],
+					key: Keys.Q,
 					ctrl: !isMac,
 					meta: isMac,
 					shift: !isMac,
@@ -315,7 +315,7 @@ export class ApplicationWindow {
 		this.manageDownloadsForSession(session, dictUrl)
 
 		this._browserWindow
-			.on("close", async () => {
+			.on("closed", async () => {
 				await this.closeDb()
 			})
 			.on("focus", () => this.localShortcut.enableAll(this._browserWindow))

--- a/test/tests/desktop/ApplicationWindowTest.ts
+++ b/test/tests/desktop/ApplicationWindowTest.ts
@@ -943,7 +943,7 @@ o.spec("ApplicationWindow Test", function () {
 		const userId = "123"
 		w.setUserId(userId)
 		const bwInstance = electronMock.BrowserWindow.mockedInstances[0]
-		;(bwInstance as any).callbacks["close"]()
+		;(bwInstance as any).callbacks["closed"]()
 
 		verify(offlineDbFacade.disposeDb(userId))
 	})


### PR DESCRIPTION
if the window is actually being closed is still up for negotiation when "close" is emitted. "closed" is emitted after the window is gone, so that's when we're sure the db is not used anymore.

fix #5029