### PR TITLE
Allow checking arbitrary domain records

### DIFF
--- a/src/api/entities/sys/ModelInfo.ts
+++ b/src/api/entities/sys/ModelInfo.ts
@@ -2,5 +2,5 @@ const modelInfo = {
 	version: 83,
 	compatibleSince: 83,
 }
-		
+
 export default modelInfo

--- a/src/api/entities/sys/Services.ts
+++ b/src/api/entities/sys/Services.ts
@@ -11,8 +11,8 @@ import {ChangePasswordDataTypeRef} from "./TypeRefs.js"
 import {CloseSessionServicePostTypeRef} from "./TypeRefs.js"
 import {CreateCustomerServerPropertiesDataTypeRef} from "./TypeRefs.js"
 import {CreateCustomerServerPropertiesReturnTypeRef} from "./TypeRefs.js"
-import {CustomDomainCheckDataTypeRef} from "./TypeRefs.js"
-import {CustomDomainCheckReturnTypeRef} from "./TypeRefs.js"
+import {CustomDomainCheckGetInTypeRef} from "./TypeRefs.js"
+import {CustomDomainCheckGetOutTypeRef} from "./TypeRefs.js"
 import {CustomDomainDataTypeRef} from "./TypeRefs.js"
 import {CustomDomainReturnTypeRef} from "./TypeRefs.js"
 import {CustomerAccountTerminationPostInTypeRef} from "./TypeRefs.js"
@@ -151,7 +151,7 @@ export const CreateCustomerServerProperties = Object.freeze({
 export const CustomDomainCheckService = Object.freeze({
 	app: "sys",
 	name: "CustomDomainCheckService",
-	get: {data: CustomDomainCheckDataTypeRef, return: CustomDomainCheckReturnTypeRef},
+	get: {data: CustomDomainCheckGetInTypeRef, return: CustomDomainCheckGetOutTypeRef},
 	post: null,
 	put: null,
 	delete: null,

--- a/src/api/entities/sys/TypeModels.js
+++ b/src/api/entities/sys/TypeModels.js
@@ -2579,8 +2579,8 @@ export const typeModels = {
         "app": "sys",
         "version": "83"
     },
-    "CustomDomainCheckData": {
-        "name": "CustomDomainCheckData",
+    "CustomDomainCheckGetIn": {
+        "name": "CustomDomainCheckGetIn",
         "since": 49,
         "type": "DATA_TRANSFER_TYPE",
         "id": 1586,
@@ -2607,12 +2607,23 @@ export const typeModels = {
                 "encrypted": false
             }
         },
-        "associations": {},
+        "associations": {
+            "customer": {
+                "final": false,
+                "name": "customer",
+                "id": 2053,
+                "since": 83,
+                "type": "ELEMENT_ASSOCIATION",
+                "cardinality": "ZeroOrOne",
+                "refType": "Customer",
+                "dependency": null
+            }
+        },
         "app": "sys",
         "version": "83"
     },
-    "CustomDomainCheckReturn": {
-        "name": "CustomDomainCheckReturn",
+    "CustomDomainCheckGetOut": {
+        "name": "CustomDomainCheckGetOut",
         "since": 49,
         "type": "DATA_TRANSFER_TYPE",
         "id": 1589,

--- a/src/api/entities/sys/TypeRefs.ts
+++ b/src/api/entities/sys/TypeRefs.ts
@@ -681,26 +681,28 @@ export type CreditCard = {
 	expirationYear: string;
 	number: string;
 }
-export const CustomDomainCheckDataTypeRef: TypeRef<CustomDomainCheckData> = new TypeRef("sys", "CustomDomainCheckData")
+export const CustomDomainCheckGetInTypeRef: TypeRef<CustomDomainCheckGetIn> = new TypeRef("sys", "CustomDomainCheckGetIn")
 
-export function createCustomDomainCheckData(values?: Partial<CustomDomainCheckData>): CustomDomainCheckData {
-	return Object.assign(create(typeModels.CustomDomainCheckData, CustomDomainCheckDataTypeRef), values)
+export function createCustomDomainCheckGetIn(values?: Partial<CustomDomainCheckGetIn>): CustomDomainCheckGetIn {
+	return Object.assign(create(typeModels.CustomDomainCheckGetIn, CustomDomainCheckGetInTypeRef), values)
 }
 
-export type CustomDomainCheckData = {
-	_type: TypeRef<CustomDomainCheckData>;
+export type CustomDomainCheckGetIn = {
+	_type: TypeRef<CustomDomainCheckGetIn>;
 
 	_format: NumberString;
 	domain: string;
-}
-export const CustomDomainCheckReturnTypeRef: TypeRef<CustomDomainCheckReturn> = new TypeRef("sys", "CustomDomainCheckReturn")
 
-export function createCustomDomainCheckReturn(values?: Partial<CustomDomainCheckReturn>): CustomDomainCheckReturn {
-	return Object.assign(create(typeModels.CustomDomainCheckReturn, CustomDomainCheckReturnTypeRef), values)
+	customer:  null | Id;
+}
+export const CustomDomainCheckGetOutTypeRef: TypeRef<CustomDomainCheckGetOut> = new TypeRef("sys", "CustomDomainCheckGetOut")
+
+export function createCustomDomainCheckGetOut(values?: Partial<CustomDomainCheckGetOut>): CustomDomainCheckGetOut {
+	return Object.assign(create(typeModels.CustomDomainCheckGetOut, CustomDomainCheckGetOutTypeRef), values)
 }
 
-export type CustomDomainCheckReturn = {
-	_type: TypeRef<CustomDomainCheckReturn>;
+export type CustomDomainCheckGetOut = {
+	_type: TypeRef<CustomDomainCheckGetOut>;
 
 	_format: NumberString;
 	checkResult: NumberString;

--- a/src/api/entities/tutanota/ModelInfo.ts
+++ b/src/api/entities/tutanota/ModelInfo.ts
@@ -1,6 +1,6 @@
 const modelInfo = {
 	version: 60,
-	compatibleSince: 60,
+	compatibleSince: 58,
 }
-		
+
 export default modelInfo

--- a/src/api/entities/tutanota/TypeModels.js
+++ b/src/api/entities/tutanota/TypeModels.js
@@ -1,6 +1,6 @@
 // This is an automatically generated file, please do not edit by hand!
 
-// You should not use it directly, please use `resolveTypReference()` instead.	
+// You should not use it directly, please use `resolveTypReference()` instead.
 // We do not want tsc to spend time either checking or inferring type of these huge expressions. Even when it does try to infer them they are still wrong.
 // The actual type is an object with keys as entities names and values as TypeModel.
 
@@ -5237,16 +5237,6 @@ export const typeModels = {
                 "refType": "MailFolderRef",
                 "dependency": null
             },
-            "mailDetailsDrafts": {
-                "final": false,
-                "name": "mailDetailsDrafts",
-                "id": 1318,
-                "since": 60,
-                "type": "AGGREGATION",
-                "cardinality": "ZeroOrOne",
-                "refType": "MailDetailsDraftsRef",
-                "dependency": null
-            },
             "mails": {
                 "final": true,
                 "name": "mails",
@@ -5507,40 +5497,6 @@ export const typeModels = {
                 "type": "AGGREGATION",
                 "cardinality": "One",
                 "refType": "MailDetails",
-                "dependency": null
-            }
-        },
-        "app": "tutanota",
-        "version": "60"
-    },
-    "MailDetailsDraftsRef": {
-        "name": "MailDetailsDraftsRef",
-        "since": 60,
-        "type": "AGGREGATED_TYPE",
-        "id": 1315,
-        "rootId": "CHR1dGFub3RhAAUj",
-        "versioned": false,
-        "encrypted": false,
-        "values": {
-            "_id": {
-                "final": true,
-                "name": "_id",
-                "id": 1316,
-                "since": 60,
-                "type": "CustomId",
-                "cardinality": "One",
-                "encrypted": false
-            }
-        },
-        "associations": {
-            "list": {
-                "final": true,
-                "name": "list",
-                "id": 1317,
-                "since": 60,
-                "type": "LIST_ASSOCIATION",
-                "cardinality": "One",
-                "refType": "MailDetailsDraft",
                 "dependency": null
             }
         },

--- a/src/settings/DomainDnsStatus.ts
+++ b/src/settings/DomainDnsStatus.ts
@@ -1,5 +1,5 @@
-import { createCustomDomainCheckData } from "../api/entities/sys/TypeRefs.js"
-import type { CustomDomainCheckReturn } from "../api/entities/sys/TypeRefs.js"
+import { createCustomDomainCheckGetIn } from "../api/entities/sys/TypeRefs.js"
+import type { CustomDomainCheckGetOut } from "../api/entities/sys/TypeRefs.js"
 import { CustomDomainCheckResult, DnsRecordType, DnsRecordValidation } from "../api/common/TutanotaConstants"
 import { LazyLoaded, noOp } from "@tutao/tutanota-utils"
 import { lang } from "../misc/LanguageViewModel"
@@ -10,19 +10,20 @@ import { CustomDomainCheckService } from "../api/entities/sys/Services"
 assertMainOrNode()
 
 export class DomainDnsStatus {
-	status: LazyLoaded<CustomDomainCheckReturn>
+	status: LazyLoaded<CustomDomainCheckGetOut>
 	domain: string
 
-	constructor(cleanDomainName: string) {
+	constructor(cleanDomainName: string, customerId?: Id) {
 		this.domain = cleanDomainName
 		this.status = new LazyLoaded(() => {
-			let data = createCustomDomainCheckData()
+			let data = createCustomDomainCheckGetIn()
 			data.domain = cleanDomainName
+			data.customer = customerId ?? null
 			return locator.serviceExecutor.get(CustomDomainCheckService, data)
 		})
 	}
 
-	getLoadedCustomDomainCheckReturn(): CustomDomainCheckReturn {
+	getLoadedCustomDomainCheckGetOut(): CustomDomainCheckGetOut {
 		return this.status.getLoaded()
 	}
 

--- a/src/settings/emaildomain/VerifyDnsRecordsPage.ts
+++ b/src/settings/emaildomain/VerifyDnsRecordsPage.ts
@@ -108,7 +108,7 @@ function _getDisplayableRecordValue(record: DnsRecord): string {
 }
 
 export function renderCheckResult(domainStatus: DomainDnsStatus, hideRefreshButton: boolean = false): Children {
-	const checkReturn = domainStatus.getLoadedCustomDomainCheckReturn()
+	const checkReturn = domainStatus.getLoadedCustomDomainCheckGetOut()
 	const { requiredRecords, missingRecords, invalidRecords } = checkReturn
 	const checkResult = assertEnumValue(CustomDomainCheckResult, checkReturn.checkResult)
 


### PR DESCRIPTION
Add customer ID as an optional field for support to assist with custom domain troubleshooting.

tutadb#1299

## Test notes

- [ ] Go to a customer in the admin client and click "Check DNS records for another domain...". Enter "gmail.com" and take note of t-verify value displayed.
    - [ ] Log into this customer in the Tutanota client, attempt to add "gmail.com" as a custom domain, and verify that it wants the same t-verify value to be added.
- [ ] Go to a different customer. Enter "gmail.com" in the admin client and verify it shows the same information except for a different hash after t-verify.
    - [ ] For the same customer, enter "hotmail.com" in the admin client and verify it still shows a different t-verify value.