### PR TITLE
[desktop] use a nonbroken electron-updater version on each platform

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -11,8 +11,8 @@ android {
 		applicationId "de.tutao.tutanota"
 		minSdkVersion 23
 		targetSdkVersion 31
-		versionCode 396178
-		versionName "3.108.6"
+		versionCode 396179
+		versionName "3.108.7"
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
 		javaCompileOptions {

--- a/app-ios/tutanota/Info.plist
+++ b/app-ios/tutanota/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.108.6</string>
+	<string>3.108.7</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3.108.6</string>
+	<string>3.108.7</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/buildSrc/DesktopBuilder.js
+++ b/buildSrc/DesktopBuilder.js
@@ -57,6 +57,7 @@ export async function buildDesktop({ dirname, version, platform, updateUrl, name
 		notarize,
 		unpacked,
 		sign: (process.env.DEBUG_SIGN && updateUrl !== "") || !!process.env.JENKINS_HOME,
+		linux: platform === "linux",
 	})
 	console.log("updateUrl is", updateUrl)
 	await fs.promises.writeFile("./build/dist/package.json", JSON.stringify(content), "utf-8")
@@ -115,7 +116,7 @@ async function rollupDesktop(dirname, outDir, version, platform, disableMinify) 
 		input: path.join(dirname, "src/desktop/DesktopMain.ts"),
 		// some transitive dep of a transitive dev-dep requires https://www.npmjs.com/package/url
 		// which rollup for some reason won't distinguish from the node builtin.
-		external: ["url", "util", "path", "fs", "os", "http", "https", "crypto", "child_process"],
+		external: ["url", "util", "path", "fs", "os", "http", "https", "crypto", "child_process", "electron-updater"],
 		preserveEntrySignatures: false,
 		plugins: [
 			typescript({

--- a/buildSrc/DevBuild.js
+++ b/buildSrc/DevBuild.js
@@ -120,6 +120,7 @@ async function buildDesktopPart({ version }) {
 			updateUrl: "http://localhost:9000/client/build",
 			iconPath: path.join(desktopIconsPath, "logo-solo-red.png"),
 			sign: false,
+			linux: process.platform === "linux",
 		})
 		const content = JSON.stringify(packageJSON, null, 2)
 

--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -1,6 +1,6 @@
 import path from "path"
 import { readFileSync } from "fs"
-import { getElectronVersion, getInstalledModuleVersion } from "./buildUtils.js"
+import { getElectronVersion } from "./buildUtils.js"
 
 /**
  * This is used for launching electron:
@@ -8,7 +8,7 @@ import { getElectronVersion, getInstalledModuleVersion } from "./buildUtils.js"
  * 2. copied to app-desktop/build/dist from dist.js (DesktopBuilder)
  */
 
-export default async function generateTemplate({ nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked }) {
+export default async function generateTemplate({ nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked, linux }) {
 	const appName = "tutanota-desktop" + nameSuffix
 	const appId = "de.tutao.tutanota" + nameSuffix
 	if (process.env.JENKINS_HOME && process.env.DEBUG_SIGN) throw new Error("Tried to DEBUG_SIGN in CI!")
@@ -68,7 +68,7 @@ export default async function generateTemplate({ nameSuffix, version, updateUrl,
 			},
 		},
 		dependencies: {
-			"electron-updater": await getInstalledModuleVersion("electron-updater", log),
+			"electron-updater": linux ? "5.3.0" : "6.0.0-alpha.8", //6.0.0-alpha.8 specifically doesn't work on linux, but 4.3.0 was fine there anyway.
 		},
 		build: {
 			electronVersion: await getElectronVersion(log),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tutanota",
-	"version": "3.108.6",
+	"version": "3.108.7",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tutanota",
-			"version": "3.108.6",
+			"version": "3.108.7",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"workspaces": [
@@ -14,9 +14,9 @@
 			],
 			"dependencies": {
 				"@tutao/oxmsg": "0.0.9-beta.0",
-				"@tutao/tutanota-crypto": "3.108.6",
-				"@tutao/tutanota-usagetests": "3.108.6",
-				"@tutao/tutanota-utils": "3.108.6",
+				"@tutao/tutanota-crypto": "3.108.7",
+				"@tutao/tutanota-usagetests": "3.108.7",
+				"@tutao/tutanota-utils": "3.108.7",
 				"@types/better-sqlite3": "7.4.2",
 				"@types/dompurify": "2.4.0",
 				"@types/linkifyjs": "2.1.4",
@@ -48,8 +48,8 @@
 				"@rollup/plugin-json": "4.1.0",
 				"@rollup/plugin-node-resolve": "13.3.0",
 				"@rollup/plugin-typescript": "8.3.0",
-				"@tutao/licc": "3.108.6",
-				"@tutao/tutanota-test-utils": "3.108.6",
+				"@tutao/licc": "3.108.7",
+				"@tutao/tutanota-test-utils": "3.108.7",
 				"@typescript-eslint/eslint-plugin": "5.15.0",
 				"body-parser": "1.20.0",
 				"chokidar": "3.5.2",
@@ -9703,7 +9703,7 @@
 		},
 		"packages/licc": {
 			"name": "@tutao/licc",
-			"version": "3.108.6",
+			"version": "3.108.7",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {
@@ -9715,7 +9715,7 @@
 				"licc": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@tutao/tutanota-test-utils": "3.108.6",
+				"@tutao/tutanota-test-utils": "3.108.7",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 			}
 		},
@@ -9821,17 +9821,17 @@
 		},
 		"packages/tutanota-crypto": {
 			"name": "@tutao/tutanota-crypto",
-			"version": "3.108.6",
+			"version": "3.108.7",
 			"license": "GPL-3.0",
 			"devDependencies": {
-				"@tutao/tutanota-utils": "3.108.6",
+				"@tutao/tutanota-utils": "3.108.7",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "4.9.4"
 			}
 		},
 		"packages/tutanota-test-utils": {
 			"name": "@tutao/tutanota-test-utils",
-			"version": "3.108.6",
+			"version": "3.108.7",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"typescript": "4.9.4"
@@ -9843,7 +9843,7 @@
 		},
 		"packages/tutanota-usagetests": {
 			"name": "@tutao/tutanota-usagetests",
-			"version": "3.108.6",
+			"version": "3.108.7",
 			"license": "GLP-3.0",
 			"devDependencies": {
 				"@types/node-forge": "1.0.0",
@@ -9853,7 +9853,7 @@
 		},
 		"packages/tutanota-utils": {
 			"name": "@tutao/tutanota-utils",
-			"version": "3.108.6",
+			"version": "3.108.7",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
@@ -10954,7 +10954,7 @@
 		"@tutao/licc": {
 			"version": "file:packages/licc",
 			"requires": {
-				"@tutao/tutanota-test-utils": "3.108.6",
+				"@tutao/tutanota-test-utils": "3.108.7",
 				"commander": "9.3.0",
 				"json5": "^2.2.1",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
@@ -11033,7 +11033,7 @@
 		"@tutao/tutanota-crypto": {
 			"version": "file:packages/tutanota-crypto",
 			"requires": {
-				"@tutao/tutanota-utils": "3.108.6",
+				"@tutao/tutanota-utils": "3.108.7",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "4.9.4"
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tutanota",
-	"version": "3.108.6",
+	"version": "3.108.7",
 	"license": "GPL-3.0",
 	"repository": {
 		"type": "git",
@@ -32,9 +32,9 @@
 	},
 	"dependencies": {
 		"@tutao/oxmsg": "0.0.9-beta.0",
-		"@tutao/tutanota-crypto": "3.108.6",
-		"@tutao/tutanota-usagetests": "3.108.6",
-		"@tutao/tutanota-utils": "3.108.6",
+		"@tutao/tutanota-crypto": "3.108.7",
+		"@tutao/tutanota-usagetests": "3.108.7",
+		"@tutao/tutanota-utils": "3.108.7",
 		"@types/better-sqlite3": "7.4.2",
 		"@types/dompurify": "2.4.0",
 		"@types/linkifyjs": "2.1.4",
@@ -65,8 +65,8 @@
 		"@rollup/plugin-json": "4.1.0",
 		"@rollup/plugin-node-resolve": "13.3.0",
 		"@rollup/plugin-typescript": "8.3.0",
-		"@tutao/tutanota-test-utils": "3.108.6",
-		"@tutao/licc": "3.108.6",
+		"@tutao/tutanota-test-utils": "3.108.7",
+		"@tutao/licc": "3.108.7",
 		"@typescript-eslint/eslint-plugin": "5.15.0",
 		"@electron/notarize": "1.2.3",
 		"body-parser": "1.20.0",

--- a/packages/licc/package.json
+++ b/packages/licc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/licc",
-	"version": "3.108.6",
+	"version": "3.108.7",
 	"bin": {
 		"licc": "dist/cli.js"
 	},
@@ -20,7 +20,7 @@
 		"zx": "6.1.0"
 	},
 	"devDependencies": {
-		"@tutao/tutanota-test-utils": "3.108.6",
+		"@tutao/tutanota-test-utils": "3.108.7",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-crypto/package.json
+++ b/packages/tutanota-crypto/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-crypto",
-	"version": "3.108.6",
+	"version": "3.108.7",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {
@@ -22,7 +22,7 @@
 	],
 	"devDependencies": {
 		"typescript": "4.9.4",
-		"@tutao/tutanota-utils": "3.108.6",
+		"@tutao/tutanota-utils": "3.108.7",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-test-utils/package.json
+++ b/packages/tutanota-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-test-utils",
-	"version": "3.108.6",
+	"version": "3.108.7",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {

--- a/packages/tutanota-usagetests/package.json
+++ b/packages/tutanota-usagetests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-usagetests",
-	"version": "3.108.6",
+	"version": "3.108.7",
 	"license": "GLP-3.0",
 	"description": "",
 	"main": "./dist/index.js",

--- a/packages/tutanota-utils/package.json
+++ b/packages/tutanota-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-utils",
-	"version": "3.108.6",
+	"version": "3.108.7",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
5.3.0 couldn't handle windows machines with a restricted powershell 6.0.0 fixed that, but the alpha that's currently available does not work on linux because it's opening the child process wrong.