### PR TITLE
Fix offline DB being deleted every time

### DIFF
--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -136,7 +136,9 @@ export class OfflineStorage implements CacheStorage, ExposedCacheStorage {
 			await this.migrator.migrate(this, this.sqlCipherFacade)
 		} catch (e) {
 			if (e instanceof OutOfSyncError) {
+				console.warn("Offline db is out of sync!", e)
 				await this.recreateDbFile(userId, databaseKey)
+				await this.migrator.migrate(this, this.sqlCipherFacade)
 			} else {
 				throw e
 			}

--- a/test/tests/api/worker/offline/OfflineStorageMigratorTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageMigratorTest.ts
@@ -99,12 +99,13 @@ o.spec("OfflineStorageMigrator", async function () {
 		verify(storage.setStoredModelVersion("tutanota", matchers.anything()), { times: 0 })
 	})
 
-	o("when migration exists and it the version is compatible the migration is not run", async function () {
-		// stored is older than current so we actually "migrate" something
-		when(storage.dumpMetadata()).thenResolve({ "tutanota-version": 41 })
+	o("when the stored version is newer than the runtime version throw OutOfSyncError", async function () {
+		// stored is new than the current
+		const currentModelVersion = modelInfos.tutanota.version
+		when(storage.dumpMetadata()).thenResolve({ "tutanota-version": currentModelVersion + 1 })
 		const migration: OfflineMigration = {
 			app: "tutanota",
-			version: 40,
+			version: modelInfos.tutanota.compatibleSince,
 			migrate: func() as OfflineMigration["migrate"],
 		}
 		migrations.push(migration)


### PR DESCRIPTION
DB downgrade check was not implemented properly where it would determine runtime version based on migrations. We run into a situation where we had multiple model versions with no migrations which made the check think that we are downgrading every time. Switching it to using modelInfo fixed the issue.

Another issue was not running migrations (and non populating metadata) after DB re-creation. We've added the code to run the migrator on the re-created database and handling for the old invalid state.

fix #5044