### PR TITLE
Fix trash, spam & subfolders getting stuck in the loading state

### DIFF
--- a/src/mail/view/MailListView.ts
+++ b/src/mail/view/MailListView.ts
@@ -421,18 +421,22 @@ export class MailListView implements Component<MailListViewAttrs> {
 					}
 				},
 			},
-			this.showingSpamOrTrash
-				? m(
-						ListColumnWrapper,
-						{
-							headerContent: m(".flex.flex-column.plr-l", [
-								m(".small.flex-grow.pt", lang.get("storageDeletion_msg")),
-								m(".mr-negative-s.align-self-end", m(Button, purgeButtonAttrs)),
-							]),
-						},
-						m(this.list),
-				  )
-				: m(this.list),
+			// always render the wrapper so that the list is not re-created from scratch when
+			// showingSpamOrTrash changes.
+			m(
+				ListColumnWrapper,
+				{
+					headerContent: this.showingSpamOrTrash
+						? [
+								m(".flex.flex-column.plr-l", [
+									m(".small.flex-grow.pt", lang.get("storageDeletion_msg")),
+									m(".mr-negative-s.align-self-end", m(Button, purgeButtonAttrs)),
+								]),
+						  ]
+						: null,
+				},
+				m(this.list),
+			),
 		)
 	}
 


### PR DESCRIPTION
The bug was introduced with the async check for the subfolders of trash and spam. To display the banner above the list we wrap both the list and the header in ListColumnWrapper but before we would only render the list inside the wrapper if we wanted to show the banner. With the async folder check the value of showingSpamOrTrash changes at an arbitrary moment of time and the list would be deleted and created at some moment of time as well. Some timing issue of re-creating the list would cause it to miss the state change for loading.

We worked around the issue by always rendering the wrapper which makes the DOM structure more stable and avoids re-creating the list. A better fix would also include changes to the List to make it more robust.

fix #5081