### PR TITLE
improve settings for account name and default sender

### DIFF
--- a/src/mail/model/MailUtils.ts
+++ b/src/mail/model/MailUtils.ts
@@ -240,9 +240,9 @@ export function getMailboxName(logins: LoginController, mailboxDetails: MailboxD
 	if (!logins.isInternalUserLoggedIn()) {
 		return lang.get("mailbox_label")
 	} else if (isUserMailbox(mailboxDetails)) {
-		return getGroupInfoDisplayName(logins.getUserController().userGroupInfo)
+		return logins.getUserController().props.defaultSender ?? logins.getUserController().userGroupInfo.mailAddress ?? lang.get("mailbox_label")
 	} else {
-		return getGroupInfoDisplayName(neverNull(mailboxDetails.mailGroupInfo))
+		return getGroupInfoDisplayName(assertNotNull(mailboxDetails.mailGroupInfo, "mailboxDetails without mailGroupInfo?"))
 	}
 }
 

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -403,7 +403,7 @@ export default {
 		"defaultGiftCardMessage_msg": "Ich hoffe dir gefällt die Sicherheit und Privatsphäre bei Tutanota!",
 		"defaultMailHandler_label": "Standardprogramm für E-Mail",
 		"defaultMailHandler_msg": "Registriere Tutanota Desktop als das Standard-E-Mail-Programm, z.B. um E-Mail-Adress-Links zu öffnen. Diese Aktion könnte Administratorrechte erfordern.",
-		"defaultSenderMailAddressInfo_msg": "Die voreingestellte Absendeadresse für neue E-Mails.",
+		"defaultSenderMailAddressInfo_msg": "Die voreingestellte Absendeadresse und -name für neue E-Mails. Du kannst deinen Absendernamen unten in der E-Mail-Adresstabelle konfigurieren.",
 		"defaultSenderMailAddress_label": "Standard-Absendeadresse",
 		"defaultShareGiftCardBody_msg": "Hallo,\n\nich habe dir einen Gutschein für Tutanota gekauft, benutze diesen Link, um ihn einzulösen!\n\n{link}\n\nFalls du noch keinen Account bei Tutanota hast, kannst du deine sichere Mailbox über den Link registrieren.\n\nSchöne Feiertage\n{username}",
 		"defaultShareGiftCardSubject_msg": "Du hast einen Gutschein für Tutanota erhalten!",

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -403,7 +403,7 @@ export default {
 		"defaultGiftCardMessage_msg": "Ich hoffe Ihnen gefällt die Sicherheit und Privatsphäre bei Tutanota!",
 		"defaultMailHandler_label": "Standardprogramm für E-Mail",
 		"defaultMailHandler_msg": "Registrieren Sie Tutanota Desktop als das Standard-E-Mail-Programm, z.B. um E-Mail-Adress-Links zu öffnen. Diese Aktion könnte Administratorrechte erfordern.",
-		"defaultSenderMailAddressInfo_msg": "Die voreingestellte Absendeadresse für neue E-Mails.",
+		"defaultSenderMailAddressInfo_msg": "Die voreingestellte Absendeadresse und -name für neue E-Mails. Sie können Ihren Absendernamen unten in der E-Mail-Adresstabelle konfigurieren.",
 		"defaultSenderMailAddress_label": "Standard-Absendeadresse",
 		"defaultShareGiftCardBody_msg": "Guten Tag,\n\nich habe Ihnen einen Gutschein für Tutanota gekauft, benutzen Sie den folgenden Link, um ihn einzulösen!\n\n{link}\n\nFalls Sie noch keinen Account bei Tutanota haben, können Sie Ihre sichere Mailbox über den Link registrieren.\n\nMit besten Grüßen\n{username}",
 		"defaultShareGiftCardSubject_msg": "Sie haben einen Gutschein für Tutanota erhalten",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -399,7 +399,7 @@ export default {
 		"defaultGiftCardMessage_msg": "I hope you enjoy the security & privacy you get with Tutanota!",
 		"defaultMailHandler_label": "Default email handler",
 		"defaultMailHandler_msg": "Register Tutanota Desktop as the default email handler, e.g. to open email address links. This operation may require administrator permissions.",
-		"defaultSenderMailAddressInfo_msg": "The default sender mail address for new emails.",
+		"defaultSenderMailAddressInfo_msg": "The default sender mail address and name for new emails. You can set the sender name in the mail address table below.",
 		"defaultSenderMailAddress_label": "Default sender",
 		"defaultShareGiftCardBody_msg": "Hi,\n\nI bought you a gift card for Tutanota, use this link to redeem it!\n\n{link}\n\nIf you do not have an account yet, you can use the link to sign up and reclaim your privacy.\n\nHappy Holidays,\n{username}",
 		"defaultShareGiftCardSubject_msg": "You have received a Tutanota gift card!",


### PR DESCRIPTION
* remove name setting from mail settings (it's still available in and only relevant to user management)
* show sender name along the default sender address in mail settings (only in the selected value field, where it will wrap. the dropdown still only shows the available sender addresses)
* improve wording of the default sender hint
* show in descending priority based on availability
  *  the currently selected default sender address 
  * the user's primary address
  * "Mailbox"
  above the folder column

close #5080