### PR TITLE
Fix getting into invalid login state

### DIFF
--- a/src/login/PostLoginActions.ts
+++ b/src/login/PostLoginActions.ts
@@ -87,9 +87,6 @@ export class PostLoginActions implements IPostLoginAction {
 			hourCycle: getHourCycle(logins.getUserController().userSettingsGroupRoot),
 		})
 
-		if (!isAdminClient() && loggedInEvent.sessionType !== SessionType.Temporary) {
-			await locator.mailModel.init()
-		}
 		if (isApp() || isDesktop()) {
 			// don't wait for it, just invoke
 			locator.fileApp.clearFileData().catch((e) => console.log("Failed to clean file data", e))
@@ -113,6 +110,8 @@ export class PostLoginActions implements IPostLoginAction {
 		this.secondFactorHandler.setupAcceptOtherClientLoginListener()
 
 		if (!isAdminClient()) {
+			// If it failed during the partial login due to missing cache entries we will give it another spin here. If it didn't fail then it's just a noop
+			await locator.mailModel.init()
 			await locator.calendarModel.init()
 			await this.remindActiveOutOfOfficeNotification()
 		}

--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -248,9 +248,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				if (isSelectedPrefix(MAIL_PREFIX)) {
 					this.setUrl(url)
 				} else {
-					if (typeof url === "undefined") {
-						throw new Error("undefined mail url!")
-					}
+					assertNotNull(url, "undefined mail url!")
 					navButtonRoutes.mailUrl = url
 				}
 			}
@@ -565,9 +563,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	}
 
 	private setUrl(url: string) {
-		if (typeof url === "undefined") {
-			throw new Error("undefined mail url!")
-		}
+		assertNotNull(url, "undefined mail url!")
 		navButtonRoutes.mailUrl = url
 
 		// do not change the url if the search view is active

--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -232,7 +232,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 		for (const detail of mailboxDetails) {
 			for (const { folder } of detail.folders.getIndentedList()) {
 				const folderElementId = getElementId(folder)
-				this.folderToUrl[folderElementId] = this.folderToUrl[folderElementId] ?? `/mail/${folder.mails}`
+				this.folderToUrl[folderElementId] = this.folderToUrl[folderElementId] ?? this.defaultUrlForFolder(folder)
 			}
 		}
 		if (this.cache.selectedFolder) {
@@ -248,10 +248,17 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				if (isSelectedPrefix(MAIL_PREFIX)) {
 					this.setUrl(url)
 				} else {
+					if (typeof url === "undefined") {
+						throw new Error("undefined mail url!")
+					}
 					navButtonRoutes.mailUrl = url
 				}
 			}
 		}
+	}
+
+	private defaultUrlForFolder(folder: MailFolder) {
+		return `/mail/${folder.mails}`
 	}
 
 	getViewSlider(): ViewSlider | null {
@@ -537,12 +544,14 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				if (typeof args.listId === "undefined") {
 					const inboxFolder = assertSystemFolderOfType(mailboxDetail.folders, MailFolderType.INBOX)
 					const inboxFolderId = getElementId(inboxFolder)
-					this.setUrl(this.folderToUrl[inboxFolderId])
+					// fall back to the default url if folderToUrl is not populated yet
+					this.setUrl(this.folderToUrl[inboxFolderId] ?? this.defaultUrlForFolder(inboxFolder))
 				} else {
 					if (!this.showList(args.listId, args.mailId)) {
 						const inboxFolder = assertSystemFolderOfType(mailboxDetail.folders, MailFolderType.INBOX)
 						const inboxFolderId = getElementId(inboxFolder)
-						this.setUrl(this.folderToUrl[inboxFolderId])
+						// fall back to the default url if folderToUrl is not populated yet
+						this.setUrl(this.folderToUrl[inboxFolderId] ?? this.defaultUrlForFolder(inboxFolder))
 					}
 				}
 
@@ -556,6 +565,9 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	}
 
 	private setUrl(url: string) {
+		if (typeof url === "undefined") {
+			throw new Error("undefined mail url!")
+		}
 		navButtonRoutes.mailUrl = url
 
 		// do not change the url if the search view is active


### PR DESCRIPTION
Login state is tracked differently for worker and page sides of the app. When `LoginFacade` (worker) thinks that the partial login is done `LoginController` (page) can still fail, mostly due to `MailModel#init()` being part of the login process.

We suspect that the issue happened due to page login failing. On the next try we would try to log in again even though the login is already done from the worker's perspective.

We had two main options: either aborting worker login when page login (including `PostLoginActions`) fails or taking `MailModel#init()` out of the login process. We went with the latter because most of the code was already written with the assumption that `MailModel` is initialized asynchronously. This has an added benefit of letting user into the app faster. Later we can add some placeholders for the MailView to improve the experience even further.

Since `MailModel#init()` is not part of the login anymore we had to find a way to retry the loading if it fails. We've adapted `MailModel` to make the retry work (which we would need to do in either case) and added another `init()` call on full login as well on using the mailModel. We've changed `MailModel` to not propagate the init errors to the rest of the app but to make them wait. This works better for most places because we don't need additional error handling.

fix #5094