### PR TITLE
Fix uncaught error because of invalid isDetailsDraft() check

### DIFF
--- a/src/api/common/MailWrapper.ts
+++ b/src/api/common/MailWrapper.ts
@@ -108,9 +108,9 @@ function isLegacy(details: LegacyDetails | NewDetails): details is LegacyDetails
 }
 
 export function isLegacyMail(mail: Mail): boolean {
-	return mail.mailDetails === null && mail.mailDetailsDraft === null
+	return mail.mailDetails == null && mail.mailDetailsDraft == null
 }
 
 export function isDetailsDraft(mail: Mail): boolean {
-	return mail.mailDetailsDraft !== null
+	return mail.mailDetailsDraft != null
 }


### PR DESCRIPTION
`isDetailsDraft()` would compare against the `null` strictly while in some cases the field would just not be set (probably from cbor). It would later proceed to try and use it in OfflineStorage#deleteMailList() which would throw an assertion error.

We fixed the check to match both.

Ideally we should also update the generated types to account for that.

fix #5108