### PR TITLE
fix SendMailModel allowing mixed-case sender addresses

### DIFF
--- a/src/mail/editor/SendMailModel.ts
+++ b/src/mail/editor/SendMailModel.ts
@@ -219,7 +219,13 @@ export class SendMailModel {
 		this.body = body
 	}
 
+	/**
+	 * set the mail address used to send the mail.
+	 * @param senderAddress the mail address that will show up lowercased in the sender field of the sent mail.
+	 */
 	setSender(senderAddress: string) {
+		// we can (and should) do this because we lowercase all addresses on signup and when creating aliases.
+		senderAddress = senderAddress.toLowerCase()
 		this.markAsChangedIfNecessary(this.senderAddress !== senderAddress)
 		this.senderAddress = senderAddress
 	}
@@ -423,7 +429,8 @@ export class SendMailModel {
 			promiseMap(recipientsFilter(bcc), async (r) => this.insertRecipient(RecipientField.BCC, r)),
 		])
 
-		this.senderAddress = senderMailAddress || this.getDefaultSender()
+		// .toLowerCase because all our aliases and accounts are lowercased on creation
+		this.senderAddress = senderMailAddress?.toLowerCase() || this.getDefaultSender()
 		this.confidential = confidential ?? !this.user().props.defaultUnconfidential
 		this.attachments = []
 


### PR DESCRIPTION
all of our accounts and aliases are case-insensitive (lowercased), so we should make sure that we're not sending mail with mixed-case senders.

The acute problem fixed by this is the following:

* create an event with at least one mixed-case internal address attendee, maybe from a contact (it's saved to the event as-is)
* try to reply to that invite from the attendees account ->  we're using the address from the event as a sender
* error out when sending the reply because there's no group that has the mixed-case address assigned

#5125