### PR TITLE
fix the unnecessary margin at the right of the news badge

### DIFF
--- a/src/gui/base/CounterBadge.ts
+++ b/src/gui/base/CounterBadge.ts
@@ -40,7 +40,6 @@ export class CounterBadge implements Component<CounterBadgeAttrs> {
 							right: position?.right,
 							left: position?.left,
 							height: position?.height,
-							marginRight: px(size.hpad_button),
 							"z-index": position?.zIndex,
 							background,
 							color,

--- a/src/mail/view/MailFolderRow.ts
+++ b/src/mail/view/MailFolderRow.ts
@@ -85,11 +85,13 @@ export class MailFolderRow implements Component<MailFolderRowAttrs> {
 					? m(IconButton, {
 							...rightButton,
 					  })
-					: m(CounterBadge, {
-							count,
-							color: theme.navigation_button_icon,
-							background: getNavButtonIconBackground(),
-					  }),
+					: m("", { style: { marginRight: px(size.hpad_button) } }, [
+							m(CounterBadge, {
+								count,
+								color: theme.navigation_button_icon,
+								background: getNavButtonIconBackground(),
+							}),
+					  ]),
 			],
 		)
 	}


### PR DESCRIPTION
The margin actually appeared for every CounterBadge, like unread counter, news item counter, minimized draft counter. Only in the case of the unread email counter the margin is needed. That's why I moved it from the component and wrapped the CounterBadge in case of the news badge in an extra div with the accurate margin.

fix #5160