### PR TITLE
[build] Make building packages faster

### DIFF
--- a/buildSrc/DevBuild.js
+++ b/buildSrc/DevBuild.js
@@ -10,6 +10,7 @@ import { fileURLToPath } from "url"
 import * as LaunchHtml from "./LaunchHtml.js"
 import os from "os"
 import { checkOfflineDatabaseMigrations } from "./checkOfflineDbMigratons.js"
+import { buildRuntimePackages } from "./packageBuilderFunctions.js"
 
 export async function runDevBuild({ stage, host, desktop, clean, ignoreMigrations }) {
 	if (clean) {
@@ -27,7 +28,7 @@ export async function runDevBuild({ stage, host, desktop, clean, ignoreMigration
 	})
 
 	await runStep("Packages", async () => {
-		await $`npm run build-runtime-packages`
+		await buildRuntimePackages()
 	})
 
 	const version = getTutanotaAppVersion()

--- a/buildSrc/buildPackages.js
+++ b/buildSrc/buildPackages.js
@@ -1,0 +1,20 @@
+// For programmatic use please prefer "./packageBuilderFunctions"
+// This is a wrapper mostly meant for npm.
+
+import { Argument, program } from "commander"
+import { buildPackages, buildRuntimePackages } from "./packageBuilderFunctions.js"
+
+program.name("buildPackages").description("A script to invoke tsc -b on the right packages")
+
+program
+	.addArgument(new Argument("type").choices(["runtime", "all"]))
+	.action(async (type) => {
+		if (type === "runtime") {
+			await buildRuntimePackages()
+		} else if (type === "all") {
+			await buildPackages()
+		} else {
+			throw new Error(`Unknown type ${type}`)
+		}
+	})
+	.parse()

--- a/buildSrc/packageBuilderFunctions.js
+++ b/buildSrc/packageBuilderFunctions.js
@@ -1,0 +1,17 @@
+/** @fileoverview build packages programmatically. */
+
+// it would be faster to just run from "../node_modules/.bin/tsc" because we wouldn't need to wait for the (sluggish) npm to start
+// but since we are imported from other places (like admin client) we don't have a luxury of knowing where our node_modules will end up.
+import { $ } from "zx"
+
+// packages that we actually need to build the app
+const RUNTIME_PACKAGES = ["tutanota-utils", "tutanota-crypto", "tutanota-usagetests"]
+
+export async function buildRuntimePackages(pathPrefix = ".") {
+	const packagesArg = RUNTIME_PACKAGES.map((p) => `${pathPrefix}/packages/${p}`)
+	await $`npx tsc -b ${packagesArg}`
+}
+
+export async function buildPackages(pathPrefix = ".") {
+	await $`npx tsc -b ${pathPrefix}/packages/*`
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 		"./buildSrc/*": "./buildSrc/*"
 	},
 	"scripts": {
-		"build-packages": "npm run build -ws",
-		"build-runtime-packages": "npm run build -w @tutao/tutanota-utils && npm run build -w @tutao/tutanota-crypto && npm run build -w @tutao/tutanota-usagetests",
+		"build-packages": "node buildSrc/buildPackages.js all",
+		"build-runtime-packages": "node buildSrc/buildPackages.js runtime",
 		"start": "./start-desktop.sh",
 		"test": "npm run --if-present test -ws && cd test && node test",
 		"test:app": "cd test && node test",

--- a/test/TestBuilder.js
+++ b/test/TestBuilder.js
@@ -7,6 +7,7 @@ import { build as esbuild } from "esbuild"
 import { getTutanotaAppVersion, runStep, sh, writeFile } from "../buildSrc/buildUtils.js"
 import { esbuildPluginAliasPath } from "esbuild-plugin-alias-path"
 import { keytarNativePlugin, libDeps, preludeEnvPlugin, sqliteNativePlugin } from "../buildSrc/esbuildUtils.js"
+import { buildPackages } from "../buildSrc/packageBuilderFunctions.js"
 
 export async function runTestBuild({ clean, fast = false }) {
 	if (clean) {
@@ -17,7 +18,7 @@ export async function runTestBuild({ clean, fast = false }) {
 
 	if (!fast) {
 		await runStep("Packages", async () => {
-			await $`npm run build-packages`
+			await buildPackages("..")
 		})
 
 		await runStep("Types", async () => {


### PR DESCRIPTION
Building packages is a part of most build invocations. Our old approach during dev builds was to

1. Invoke npm once to run build-packages
2. Invoke npm per each package to run tsc.

Unfortunately, npm is very slow. Additionally, the old approach was leading to tsc re-checking some packages multiple times because of dependencies between them. This would only worsen with time.

In our new approach we

1. invoke tsc only once
2. try to avoid invoking npm as much as possible

Unfortunately there is still one case where we invoke npx because we can't be sure that the location of node_modules/.bin is stable as we are sometimes used as a package. Without this we could reduce the time even further.