### PR TITLE
revert electron-updater update

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -11,8 +11,8 @@ android {
 		applicationId "de.tutao.tutanota"
 		minSdkVersion 23
 		targetSdkVersion 31
-		versionCode 396193
-		versionName "3.109.8"
+		versionCode 396194
+		versionName "3.109.9"
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
 		javaCompileOptions {

--- a/app-ios/tutanota/Info.plist
+++ b/app-ios/tutanota/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.109.8</string>
+	<string>3.109.9</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3.109.8</string>
+	<string>3.109.9</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -1,6 +1,6 @@
 import path from "path"
 import { readFileSync } from "fs"
-import { getElectronVersion, getInstalledModuleVersion } from "./buildUtils.js"
+import { getElectronVersion } from "./buildUtils.js"
 
 /**
  * This is used for launching electron:
@@ -68,7 +68,7 @@ export default async function generateTemplate({ nameSuffix, version, updateUrl,
 			},
 		},
 		dependencies: {
-			"electron-updater": await getInstalledModuleVersion("electron-updater", log),
+			"electron-updater": linux ? "5.3.0" : "6.0.0-alpha.6", //6.0.0-alpha.8 specifically doesn't work on linux, but 4.3.0 was fine there anyway.
 		},
 		build: {
 			electronVersion: await getElectronVersion(log),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tutanota",
-	"version": "3.109.8",
+	"version": "3.109.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tutanota",
-			"version": "3.109.8",
+			"version": "3.109.9",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"workspaces": [
@@ -14,9 +14,9 @@
 			],
 			"dependencies": {
 				"@tutao/oxmsg": "0.0.9-beta.0",
-				"@tutao/tutanota-crypto": "3.109.8",
-				"@tutao/tutanota-usagetests": "3.109.8",
-				"@tutao/tutanota-utils": "3.109.8",
+				"@tutao/tutanota-crypto": "3.109.9",
+				"@tutao/tutanota-usagetests": "3.109.9",
+				"@tutao/tutanota-utils": "3.109.9",
 				"@types/better-sqlite3": "7.4.2",
 				"@types/dompurify": "2.4.0",
 				"@types/linkifyjs": "2.1.4",
@@ -48,8 +48,8 @@
 				"@rollup/plugin-json": "4.1.0",
 				"@rollup/plugin-node-resolve": "13.3.0",
 				"@rollup/plugin-typescript": "8.3.0",
-				"@tutao/licc": "3.109.8",
-				"@tutao/tutanota-test-utils": "3.109.8",
+				"@tutao/licc": "3.109.9",
+				"@tutao/tutanota-test-utils": "3.109.9",
 				"@typescript-eslint/eslint-plugin": "5.15.0",
 				"body-parser": "1.20.0",
 				"chokidar": "3.5.2",
@@ -9654,7 +9654,7 @@
 		},
 		"packages/licc": {
 			"name": "@tutao/licc",
-			"version": "3.109.8",
+			"version": "3.109.9",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {
@@ -9666,7 +9666,7 @@
 				"licc": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@tutao/tutanota-test-utils": "3.109.8",
+				"@tutao/tutanota-test-utils": "3.109.9",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 			}
 		},
@@ -9772,17 +9772,17 @@
 		},
 		"packages/tutanota-crypto": {
 			"name": "@tutao/tutanota-crypto",
-			"version": "3.109.8",
+			"version": "3.109.9",
 			"license": "GPL-3.0",
 			"devDependencies": {
-				"@tutao/tutanota-utils": "3.109.8",
+				"@tutao/tutanota-utils": "3.109.9",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "4.9.4"
 			}
 		},
 		"packages/tutanota-test-utils": {
 			"name": "@tutao/tutanota-test-utils",
-			"version": "3.109.8",
+			"version": "3.109.9",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"typescript": "4.9.4"
@@ -9794,7 +9794,7 @@
 		},
 		"packages/tutanota-usagetests": {
 			"name": "@tutao/tutanota-usagetests",
-			"version": "3.109.8",
+			"version": "3.109.9",
 			"license": "GLP-3.0",
 			"devDependencies": {
 				"@types/node-forge": "1.0.0",
@@ -9804,7 +9804,7 @@
 		},
 		"packages/tutanota-utils": {
 			"name": "@tutao/tutanota-utils",
-			"version": "3.109.8",
+			"version": "3.109.9",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
@@ -10854,7 +10854,7 @@
 		"@tutao/licc": {
 			"version": "file:packages/licc",
 			"requires": {
-				"@tutao/tutanota-test-utils": "3.109.8",
+				"@tutao/tutanota-test-utils": "3.109.9",
 				"commander": "9.3.0",
 				"json5": "^2.2.1",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
@@ -10933,7 +10933,7 @@
 		"@tutao/tutanota-crypto": {
 			"version": "file:packages/tutanota-crypto",
 			"requires": {
-				"@tutao/tutanota-utils": "3.109.8",
+				"@tutao/tutanota-utils": "3.109.9",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "4.9.4"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"cborg": "1.5.4",
 				"dompurify": "2.4.3",
 				"electron": "23.1.1",
-				"electron-updater": "6.0.0-alpha.9",
+				"electron-updater": "6.0.0-alpha.6",
 				"jszip": "3.7.0",
 				"keytar": "git+https://github.com/tutao/node-keytar#12593c5809c9ed6bfc063ed3e862dd85a1506aca",
 				"linkifyjs": "3.0.5",
@@ -1337,9 +1337,9 @@
 			"link": true
 		},
 		"node_modules/@types/aws-lambda": {
-			"version": "8.10.110",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.110.tgz",
-			"integrity": "sha512-r6egf2Cwv/JaFTTrF9OXFVUB3j/SXTgM9BwrlbBRjWAa2Tu6GWoDoLflppAZ8uSfbUJdXvC7Br3DjuN9pQ2NUQ==",
+			"version": "8.10.111",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.111.tgz",
+			"integrity": "sha512-8HR9UjIKmoemEzE2BviVtFkeenxfbizSu8raFjnT2VXxguZZ2JTlNww7INOH7IA0J/zRa3TjOftkYq6hVNkxDA==",
 			"dev": true
 		},
 		"node_modules/@types/better-sqlite3": {
@@ -1480,9 +1480,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.13.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
+			"version": "18.14.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+			"integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
 		},
 		"node_modules/@types/node-forge": {
 			"version": "1.0.0",
@@ -1521,9 +1521,9 @@
 			"integrity": "sha512-uTuEgFXMknpun//Jj6b1R8T8LiMi9fNpH+cnhZr4b7col2HHTMmjYfm/WOZ7nzjuGpk+oTrpHhePe1qlWtHWTA=="
 		},
 		"node_modules/@types/react": {
-			"version": "18.0.27",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.27.tgz",
-			"integrity": "sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==",
+			"version": "18.0.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+			"integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
 			"dependencies": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -1563,9 +1563,9 @@
 			"integrity": "sha512-d1M6eDKBGWx7RbYy295VEFoOF9YDJkPI959QYnmzcmeaV+SP4D0xV7dEh3sN5XF3GvO3PhGzm+17Z598nvHQuQ=="
 		},
 		"node_modules/@types/trusted-types": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-			"integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+			"integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
 		},
 		"node_modules/@types/verror": {
 			"version": "1.10.6",
@@ -1575,9 +1575,9 @@
 			"optional": true
 		},
 		"node_modules/@types/which": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
-			"integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw=="
 		},
 		"node_modules/@types/winreg": {
 			"version": "1.2.31",
@@ -1642,15 +1642,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.51.0.tgz",
-			"integrity": "sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
+			"integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.51.0",
-				"@typescript-eslint/types": "5.51.0",
-				"@typescript-eslint/typescript-estree": "5.51.0",
+				"@typescript-eslint/scope-manager": "5.53.0",
+				"@typescript-eslint/types": "5.53.0",
+				"@typescript-eslint/typescript-estree": "5.53.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1670,14 +1670,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.51.0.tgz",
-			"integrity": "sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
+			"integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.51.0",
-				"@typescript-eslint/visitor-keys": "5.51.0"
+				"@typescript-eslint/types": "5.53.0",
+				"@typescript-eslint/visitor-keys": "5.53.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1688,13 +1688,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
-			"integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
+			"integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.51.0",
+				"@typescript-eslint/types": "5.53.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -1762,9 +1762,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.51.0.tgz",
-			"integrity": "sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
+			"integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
 			"dev": true,
 			"peer": true,
 			"engines": {
@@ -1776,14 +1776,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.51.0.tgz",
-			"integrity": "sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
+			"integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.51.0",
-				"@typescript-eslint/visitor-keys": "5.51.0",
+				"@typescript-eslint/types": "5.53.0",
+				"@typescript-eslint/visitor-keys": "5.53.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -1804,13 +1804,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
-			"integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
+			"integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.51.0",
+				"@typescript-eslint/types": "5.53.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -2201,9 +2201,9 @@
 			}
 		},
 		"node_modules/are-we-there-yet/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+			"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
 			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -2392,9 +2392,9 @@
 			"optional": true
 		},
 		"node_modules/aws-sdk": {
-			"version": "2.1312.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1312.0.tgz",
-			"integrity": "sha512-NG6ERxxxU6p+CDWrq7wLinp0siKRcCNN98iY0qr/2WKZbz5JCtDyiQV/l+6jLmNKP5qIT5z++jnDy9cgNP6ICQ==",
+			"version": "2.1323.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1323.0.tgz",
+			"integrity": "sha512-GoLwk2SuG9A6eWgc1mGmm548dklheDmkeptHRw2RhCvq2GZqlc4AzStFUjUURy4O4NQmd2ZiQIoeseue4RwurA==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -2520,9 +2520,9 @@
 			}
 		},
 		"node_modules/bl/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+			"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -2844,9 +2844,9 @@
 			}
 		},
 		"node_modules/cacache/node_modules/lru-cache": {
-			"version": "7.14.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-			"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+			"integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -2983,9 +2983,9 @@
 			"dev": true
 		},
 		"node_modules/ci-info": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-			"integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+			"integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3361,9 +3361,9 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
 			"optional": true,
 			"dependencies": {
 				"has-property-descriptors": "^1.0.0",
@@ -3804,12 +3804,12 @@
 			}
 		},
 		"node_modules/electron-updater": {
-			"version": "6.0.0-alpha.9",
-			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.0.0-alpha.9.tgz",
-			"integrity": "sha512-/si5U/p89JrUxcqz0d4jXv/c9vARnZXPW9wJWu4Pk1o/1vI67KcfRcUVXzB2RHrFVoDDiUaNahWpfSVt49ArwQ==",
+			"version": "6.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.0.0-alpha.6.tgz",
+			"integrity": "sha512-78UqMDUzgK8UGEXnsIInAQm/AMJZthFIrex95amEXCBZFQxfgz8ZzUdIVq9xKc4Jfc/hFBj/W9JgK0d8xSxHkg==",
 			"dependencies": {
 				"@types/semver": "^7.3.13",
-				"builder-util-runtime": "9.2.0-alpha.3",
+				"builder-util-runtime": "9.2.0-alpha.2",
 				"fs-extra": "^10.1.0",
 				"js-yaml": "^4.1.0",
 				"lazy-val": "^1.0.5",
@@ -3820,9 +3820,9 @@
 			}
 		},
 		"node_modules/electron-updater/node_modules/builder-util-runtime": {
-			"version": "9.2.0-alpha.3",
-			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.3.tgz",
-			"integrity": "sha512-1pOggEqknxVyhdASumips0/RaMaXwSCQMzwhk2jeOGOotBQuOHQHVy25kH5OaeXSFx9L7PckZHXjwZauD72zRw==",
+			"version": "9.2.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.2.tgz",
+			"integrity": "sha512-MFuU0OSYQ4TIa5uMmVis3aJd7i5buaC9qrb0GjGNPD/GVwQ2LqydquqlKSBlptCib6bjSnL15dHsTbD2xWlVqQ==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"sax": "^1.2.4"
@@ -3845,9 +3845,9 @@
 			}
 		},
 		"node_modules/electron/node_modules/@types/node": {
-			"version": "16.18.12",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
-			"integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw=="
+			"version": "16.18.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.13.tgz",
+			"integrity": "sha512-l0/3XZ153UTlNOnZK8xSNoJlQda9/WnYgiTdcKKPJSZjdjI9MU+A9oMXOesAWLSnqAaaJhj3qfQsU07Dr8OUwg=="
 		},
 		"node_modules/email-addresses": {
 			"version": "4.0.0",
@@ -4583,9 +4583,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
+			"integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
 			"dev": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -6570,9 +6570,9 @@
 			}
 		},
 		"node_modules/make-fetch-happen/node_modules/lru-cache": {
-			"version": "7.14.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-			"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+			"integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -7572,16 +7572,15 @@
 			]
 		},
 		"node_modules/quibble": {
-			"version": "0.6.15",
-			"resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
-			"integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
+			"version": "0.6.16",
+			"resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.16.tgz",
+			"integrity": "sha512-gq0HKVabRNwKOOZitqiHLVGTky/690XG5yOOdadi/tkBJ4WhvcSkbtmWplAgqqzIr2mjYN2wkvCKYqVA5dlldQ==",
 			"dependencies": {
 				"lodash": "^4.17.21",
-				"resolve": "^1.20.0"
+				"resolve": "^1.22.1"
 			},
 			"engines": {
-				"iojs": ">= 1.0.0",
-				"node": ">= 0.12.0"
+				"node": ">= 0.14.0"
 			}
 		},
 		"node_modules/quick-lru": {
@@ -7788,9 +7787,9 @@
 			}
 		},
 		"node_modules/readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -8763,9 +8762,9 @@
 			}
 		},
 		"node_modules/tar-stream/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+			"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -8776,9 +8775,9 @@
 			}
 		},
 		"node_modules/tar/node_modules/minipass": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.3.tgz",
-			"integrity": "sha512-OW2r4sQ0sI+z5ckEt5c1Tri4xTgZwYDxpE54eqWlQloQRoWtXjqt9udJ5Z4dSv7wK+nfFI7FRXyCpBSft+gpFw==",
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.4.tgz",
+			"integrity": "sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ==",
 			"engines": {
 				"node": ">=8"
 			}
@@ -8794,9 +8793,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.16.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.3.tgz",
-			"integrity": "sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==",
+			"version": "5.16.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
+			"integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -9401,9 +9400,9 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"node_modules/ws": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-			"integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+			"integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -9498,9 +9497,9 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "17.6.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"version": "17.7.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+			"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
 			"dev": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -10961,9 +10960,9 @@
 			}
 		},
 		"@types/aws-lambda": {
-			"version": "8.10.110",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.110.tgz",
-			"integrity": "sha512-r6egf2Cwv/JaFTTrF9OXFVUB3j/SXTgM9BwrlbBRjWAa2Tu6GWoDoLflppAZ8uSfbUJdXvC7Br3DjuN9pQ2NUQ==",
+			"version": "8.10.111",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.111.tgz",
+			"integrity": "sha512-8HR9UjIKmoemEzE2BviVtFkeenxfbizSu8raFjnT2VXxguZZ2JTlNww7INOH7IA0J/zRa3TjOftkYq6hVNkxDA==",
 			"dev": true
 		},
 		"@types/better-sqlite3": {
@@ -11104,9 +11103,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.13.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-			"integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
+			"version": "18.14.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+			"integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA=="
 		},
 		"@types/node-forge": {
 			"version": "1.0.0",
@@ -11145,9 +11144,9 @@
 			"integrity": "sha512-uTuEgFXMknpun//Jj6b1R8T8LiMi9fNpH+cnhZr4b7col2HHTMmjYfm/WOZ7nzjuGpk+oTrpHhePe1qlWtHWTA=="
 		},
 		"@types/react": {
-			"version": "18.0.27",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.27.tgz",
-			"integrity": "sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==",
+			"version": "18.0.28",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.28.tgz",
+			"integrity": "sha512-RD0ivG1kEztNBdoAK7lekI9M+azSnitIn85h4iOiaLjaTrMjzslhaqCGaI4IyCJ1RljWiLCEu4jyrLLgqxBTew==",
 			"requires": {
 				"@types/prop-types": "*",
 				"@types/scheduler": "*",
@@ -11187,9 +11186,9 @@
 			"integrity": "sha512-d1M6eDKBGWx7RbYy295VEFoOF9YDJkPI959QYnmzcmeaV+SP4D0xV7dEh3sN5XF3GvO3PhGzm+17Z598nvHQuQ=="
 		},
 		"@types/trusted-types": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-			"integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+			"integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
 		},
 		"@types/verror": {
 			"version": "1.10.6",
@@ -11199,9 +11198,9 @@
 			"optional": true
 		},
 		"@types/which": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
-			"integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-113D3mDkZDjo+EeUEHCFy0qniNc1ZpecGiAU7WSo7YDoSzolZIQKpYFHrPpjkB2nuyahcKfrmLXeQlh7gqJYdw=="
 		},
 		"@types/winreg": {
 			"version": "1.2.31",
@@ -11250,37 +11249,37 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.51.0.tgz",
-			"integrity": "sha512-fEV0R9gGmfpDeRzJXn+fGQKcl0inIeYobmmUWijZh9zA7bxJ8clPhV9up2ZQzATxAiFAECqPQyMDB4o4B81AaA==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.53.0.tgz",
+			"integrity": "sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.51.0",
-				"@typescript-eslint/types": "5.51.0",
-				"@typescript-eslint/typescript-estree": "5.51.0",
+				"@typescript-eslint/scope-manager": "5.53.0",
+				"@typescript-eslint/types": "5.53.0",
+				"@typescript-eslint/typescript-estree": "5.53.0",
 				"debug": "^4.3.4"
 			},
 			"dependencies": {
 				"@typescript-eslint/scope-manager": {
-					"version": "5.51.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.51.0.tgz",
-					"integrity": "sha512-gNpxRdlx5qw3yaHA0SFuTjW4rxeYhpHxt491PEcKF8Z6zpq0kMhe0Tolxt0qjlojS+/wArSDlj/LtE69xUJphQ==",
+					"version": "5.53.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.53.0.tgz",
+					"integrity": "sha512-Opy3dqNsp/9kBBeCPhkCNR7fmdSQqA+47r21hr9a14Bx0xnkElEQmhoHga+VoaoQ6uDHjDKmQPIYcUcKJifS7w==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@typescript-eslint/types": "5.51.0",
-						"@typescript-eslint/visitor-keys": "5.51.0"
+						"@typescript-eslint/types": "5.53.0",
+						"@typescript-eslint/visitor-keys": "5.53.0"
 					}
 				},
 				"@typescript-eslint/visitor-keys": {
-					"version": "5.51.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
-					"integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
+					"version": "5.53.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
+					"integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@typescript-eslint/types": "5.51.0",
+						"@typescript-eslint/types": "5.53.0",
 						"eslint-visitor-keys": "^3.3.0"
 					}
 				}
@@ -11316,21 +11315,21 @@
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.51.0.tgz",
-			"integrity": "sha512-SqOn0ANn/v6hFn0kjvLwiDi4AzR++CBZz0NV5AnusT2/3y32jdc0G4woXPWHCumWtUXZKPAS27/9vziSsC9jnw==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.53.0.tgz",
+			"integrity": "sha512-5kcDL9ZUIP756K6+QOAfPkigJmCPHcLN7Zjdz76lQWWDdzfOhZDTj1irs6gPBKiXx5/6O3L0+AvupAut3z7D2A==",
 			"dev": true,
 			"peer": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.51.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.51.0.tgz",
-			"integrity": "sha512-TSkNupHvNRkoH9FMA3w7TazVFcBPveAAmb7Sz+kArY6sLT86PA5Vx80cKlYmd8m3Ha2SwofM1KwraF24lM9FvA==",
+			"version": "5.53.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.53.0.tgz",
+			"integrity": "sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==",
 			"dev": true,
 			"peer": true,
 			"requires": {
-				"@typescript-eslint/types": "5.51.0",
-				"@typescript-eslint/visitor-keys": "5.51.0",
+				"@typescript-eslint/types": "5.53.0",
+				"@typescript-eslint/visitor-keys": "5.53.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -11339,13 +11338,13 @@
 			},
 			"dependencies": {
 				"@typescript-eslint/visitor-keys": {
-					"version": "5.51.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.51.0.tgz",
-					"integrity": "sha512-Oh2+eTdjHjOFjKA27sxESlA87YPSOJafGCR0md5oeMdh1ZcCfAGCIOL216uTBAkAIptvLIfKQhl7lHxMJet4GQ==",
+					"version": "5.53.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.53.0.tgz",
+					"integrity": "sha512-JqNLnX3leaHFZEN0gCh81sIvgrp/2GOACZNgO4+Tkf64u51kTpAyWFOY8XHx8XuXr3N2C9zgPPHtcpMg6z1g0w==",
 					"dev": true,
 					"peer": true,
 					"requires": {
-						"@typescript-eslint/types": "5.51.0",
+						"@typescript-eslint/types": "5.53.0",
 						"eslint-visitor-keys": "^3.3.0"
 					}
 				}
@@ -11636,9 +11635,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+					"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -11788,9 +11787,9 @@
 			}
 		},
 		"aws-sdk": {
-			"version": "2.1312.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1312.0.tgz",
-			"integrity": "sha512-NG6ERxxxU6p+CDWrq7wLinp0siKRcCNN98iY0qr/2WKZbz5JCtDyiQV/l+6jLmNKP5qIT5z++jnDy9cgNP6ICQ==",
+			"version": "2.1323.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1323.0.tgz",
+			"integrity": "sha512-GoLwk2SuG9A6eWgc1mGmm548dklheDmkeptHRw2RhCvq2GZqlc4AzStFUjUURy4O4NQmd2ZiQIoeseue4RwurA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -11892,9 +11891,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+					"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -12163,9 +12162,9 @@
 					}
 				},
 				"lru-cache": {
-					"version": "7.14.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-					"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+					"version": "7.17.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+					"integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
 					"dev": true
 				},
 				"minimatch": {
@@ -12266,9 +12265,9 @@
 			"dev": true
 		},
 		"ci-info": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-			"integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+			"integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
 			"dev": true
 		},
 		"clean-stack": {
@@ -12537,9 +12536,9 @@
 			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg=="
 		},
 		"define-properties": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+			"integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
 			"optional": true,
 			"requires": {
 				"has-property-descriptors": "^1.0.0",
@@ -12734,9 +12733,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "16.18.12",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
-					"integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw=="
+					"version": "16.18.13",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.13.tgz",
+					"integrity": "sha512-l0/3XZ153UTlNOnZK8xSNoJlQda9/WnYgiTdcKKPJSZjdjI9MU+A9oMXOesAWLSnqAaaJhj3qfQsU07Dr8OUwg=="
 				}
 			}
 		},
@@ -12895,12 +12894,12 @@
 			}
 		},
 		"electron-updater": {
-			"version": "6.0.0-alpha.9",
-			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.0.0-alpha.9.tgz",
-			"integrity": "sha512-/si5U/p89JrUxcqz0d4jXv/c9vARnZXPW9wJWu4Pk1o/1vI67KcfRcUVXzB2RHrFVoDDiUaNahWpfSVt49ArwQ==",
+			"version": "6.0.0-alpha.6",
+			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.0.0-alpha.6.tgz",
+			"integrity": "sha512-78UqMDUzgK8UGEXnsIInAQm/AMJZthFIrex95amEXCBZFQxfgz8ZzUdIVq9xKc4Jfc/hFBj/W9JgK0d8xSxHkg==",
 			"requires": {
 				"@types/semver": "^7.3.13",
-				"builder-util-runtime": "9.2.0-alpha.3",
+				"builder-util-runtime": "9.2.0-alpha.2",
 				"fs-extra": "^10.1.0",
 				"js-yaml": "^4.1.0",
 				"lazy-val": "^1.0.5",
@@ -12911,9 +12910,9 @@
 			},
 			"dependencies": {
 				"builder-util-runtime": {
-					"version": "9.2.0-alpha.3",
-					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.3.tgz",
-					"integrity": "sha512-1pOggEqknxVyhdASumips0/RaMaXwSCQMzwhk2jeOGOotBQuOHQHVy25kH5OaeXSFx9L7PckZHXjwZauD72zRw==",
+					"version": "9.2.0-alpha.2",
+					"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.0-alpha.2.tgz",
+					"integrity": "sha512-MFuU0OSYQ4TIa5uMmVis3aJd7i5buaC9qrb0GjGNPD/GVwQ2LqydquqlKSBlptCib6bjSnL15dHsTbD2xWlVqQ==",
 					"requires": {
 						"debug": "^4.3.4",
 						"sax": "^1.2.4"
@@ -13382,9 +13381,9 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-			"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
+			"integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
@@ -14929,9 +14928,9 @@
 			},
 			"dependencies": {
 				"lru-cache": {
-					"version": "7.14.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
-					"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
+					"version": "7.17.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
+					"integrity": "sha512-zSxlVVwOabhVyTi6E8gYv2cr6bXK+8ifYz5/uyJb9feXX6NACVDwY4p5Ut3WC3Ivo/QhpARHU3iujx2xGAYHbQ==",
 					"dev": true
 				}
 			}
@@ -15653,12 +15652,12 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
 		},
 		"quibble": {
-			"version": "0.6.15",
-			"resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
-			"integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
+			"version": "0.6.16",
+			"resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.16.tgz",
+			"integrity": "sha512-gq0HKVabRNwKOOZitqiHLVGTky/690XG5yOOdadi/tkBJ4WhvcSkbtmWplAgqqzIr2mjYN2wkvCKYqVA5dlldQ==",
 			"requires": {
 				"lodash": "^4.17.21",
-				"resolve": "^1.20.0"
+				"resolve": "^1.22.1"
 			}
 		},
 		"quick-lru": {
@@ -15822,9 +15821,9 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -16533,9 +16532,9 @@
 			},
 			"dependencies": {
 				"minipass": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.3.tgz",
-					"integrity": "sha512-OW2r4sQ0sI+z5ckEt5c1Tri4xTgZwYDxpE54eqWlQloQRoWtXjqt9udJ5Z4dSv7wK+nfFI7FRXyCpBSft+gpFw=="
+					"version": "4.2.4",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.4.tgz",
+					"integrity": "sha512-lwycX3cBMTvcejsHITUgYj6Gy6A7Nh4Q6h9NP4sTHY1ccJlC7yKzDmiShEHsJ16Jf1nKGDEaiHxiltsJEvk0nQ=="
 				}
 			}
 		},
@@ -16570,9 +16569,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"version": "3.6.1",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
+					"integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -16592,9 +16591,9 @@
 			}
 		},
 		"terser": {
-			"version": "5.16.3",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.3.tgz",
-			"integrity": "sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==",
+			"version": "5.16.5",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.5.tgz",
+			"integrity": "sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -17083,9 +17082,9 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
 		},
 		"ws": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-			"integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+			"version": "8.12.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.12.1.tgz",
+			"integrity": "sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==",
 			"dev": true,
 			"requires": {}
 		},
@@ -17150,9 +17149,9 @@
 			"integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw=="
 		},
 		"yargs": {
-			"version": "17.6.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-			"integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+			"version": "17.7.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+			"integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
 			"dev": true,
 			"requires": {
 				"cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tutanota",
-	"version": "3.109.8",
+	"version": "3.109.9",
 	"license": "GPL-3.0",
 	"repository": {
 		"type": "git",
@@ -32,9 +32,9 @@
 	},
 	"dependencies": {
 		"@tutao/oxmsg": "0.0.9-beta.0",
-		"@tutao/tutanota-crypto": "3.109.8",
-		"@tutao/tutanota-usagetests": "3.109.8",
-		"@tutao/tutanota-utils": "3.109.8",
+		"@tutao/tutanota-crypto": "3.109.9",
+		"@tutao/tutanota-usagetests": "3.109.9",
+		"@tutao/tutanota-utils": "3.109.9",
 		"@types/better-sqlite3": "7.4.2",
 		"@types/dompurify": "2.4.0",
 		"@types/linkifyjs": "2.1.4",
@@ -65,8 +65,8 @@
 		"@rollup/plugin-json": "4.1.0",
 		"@rollup/plugin-node-resolve": "13.3.0",
 		"@rollup/plugin-typescript": "8.3.0",
-		"@tutao/tutanota-test-utils": "3.109.8",
-		"@tutao/licc": "3.109.8",
+		"@tutao/tutanota-test-utils": "3.109.9",
+		"@tutao/licc": "3.109.9",
 		"@typescript-eslint/eslint-plugin": "5.15.0",
 		"@electron/notarize": "1.2.3",
 		"body-parser": "1.20.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"cborg": "1.5.4",
 		"dompurify": "2.4.3",
 		"electron": "23.1.1",
-		"electron-updater": "6.0.0-alpha.9",
+		"electron-updater": "6.0.0-alpha.6",
 		"jszip": "3.7.0",
 		"keytar": "git+https://github.com/tutao/node-keytar#12593c5809c9ed6bfc063ed3e862dd85a1506aca",
 		"linkifyjs": "3.0.5",

--- a/packages/licc/package.json
+++ b/packages/licc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/licc",
-	"version": "3.109.8",
+	"version": "3.109.9",
 	"bin": {
 		"licc": "dist/cli.js"
 	},
@@ -20,7 +20,7 @@
 		"zx": "6.1.0"
 	},
 	"devDependencies": {
-		"@tutao/tutanota-test-utils": "3.109.8",
+		"@tutao/tutanota-test-utils": "3.109.9",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-crypto/package.json
+++ b/packages/tutanota-crypto/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-crypto",
-	"version": "3.109.8",
+	"version": "3.109.9",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {
@@ -22,7 +22,7 @@
 	],
 	"devDependencies": {
 		"typescript": "4.9.4",
-		"@tutao/tutanota-utils": "3.109.8",
+		"@tutao/tutanota-utils": "3.109.9",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-test-utils/package.json
+++ b/packages/tutanota-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-test-utils",
-	"version": "3.109.8",
+	"version": "3.109.9",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {

--- a/packages/tutanota-usagetests/package.json
+++ b/packages/tutanota-usagetests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-usagetests",
-	"version": "3.109.8",
+	"version": "3.109.9",
 	"license": "GLP-3.0",
 	"description": "",
 	"main": "./dist/index.js",

--- a/packages/tutanota-utils/package.json
+++ b/packages/tutanota-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-utils",
-	"version": "3.109.8",
+	"version": "3.109.9",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
we can't use this version on MacOS because electron-builder does not manage to install it.

fix c184f8919d952cfa5441ba27ebc5dd4225717655