### PR TITLE
fix dropdowns in settings are not expandable by using the expand button

### DIFF
--- a/src/gui/base/DropDownSelector.ts
+++ b/src/gui/base/DropDownSelector.ts
@@ -69,7 +69,7 @@ export class DropDownSelector<T> implements ClassComponent<DropDownSelectorAttrs
 							m(IconButton, {
 								icon: a.icon ? a.icon : BootIcons.Expand,
 								title: "show_action",
-								click: noOp,
+								click: a.disabled ? noOp : this.createDropdown(a),
 								size: ButtonSize.Compact,
 							}),
 					  ),


### PR DESCRIPTION
Especially in the settings the dropdown relies on event propagation of the IconButton. In DropDownSelector the IconButton's click action is set to noOp, while only the click on the whole view of the settings element is handled.

fix #5181