### PR TITLE
fix to send the subject with the contact form

### DIFF
--- a/src/login/contactform/ContactFormRequestDialog.ts
+++ b/src/login/contactform/ContactFormRequestDialog.ts
@@ -84,7 +84,7 @@ export class ContactFormRequestDialog {
 			middle: () => lang.get("createContactRequest_action"),
 		}
 
-		this.view.bind(this)
+		this.view = this.view.bind(this)
 
 		this._dialog = Dialog.largeDialog(headerBarAttrs, this)
 			.addShortcut({


### PR DESCRIPTION
`this` was not correctly bound. That's why the subject was not updated as well as the notification mail address -> also fixes that no notification emails are sent.

fix #5197