### PR TITLE
Make subject always selectable in ConversationViewer

### DIFF
--- a/src/mail/view/ConversationViewer.ts
+++ b/src/mail/view/ConversationViewer.ts
@@ -157,7 +157,7 @@ export class ConversationViewer implements Component<ConversationViewerAttrs> {
 				},
 			},
 			m(
-				".b.h5.subject.text-break.text-ellipsis",
+				".b.h5.subject.text-break.text-ellipsis.selectable",
 				{
 					oncreate: ({ dom }) => {
 						this.floatingSubjectDom = dom as HTMLElement


### PR DESCRIPTION
The issue exists because we show floating subject on top of a normal subject even when we wouldn't have to. Ideally we should fix that issue but as an easy workaround we can make the floating subject selectable.

fix #5211