### PR TITLE
properly migrate persisted alarm notification on all platforms

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -78,6 +78,7 @@ android {
 
 	buildTypes.each {
 		it.buildConfigField 'String', 'FILE_PROVIDER_AUTHORITY', '"' + it.manifestPlaceholders['contentProviderAuthority'] + '"'
+		// keep in sync with src/native/main/NativePushServiceApp.ts
 		it.buildConfigField 'String', "SYS_MODEL_VERSION", '"85"'
 	}
 
@@ -92,6 +93,11 @@ android {
 	}
 	lint {
 		disable 'MissingTranslation'
+	}
+
+	sourceSets {
+		// Adds exported schema location as test app assets.
+		androidTest.assets.srcDirs += files("$projectDir/schemas".toString())
 	}
 
 	namespace 'de.tutao.tutanota'
@@ -157,4 +163,5 @@ dependencies {
 	androidTestImplementation 'androidx.test:rules:1.4.0'
 	androidTestImplementation "org.mockito:mockito-android:4.5.1"
 	androidTestImplementation 'org.codehaus.jackson:jackson-mapper-asl:1.9.2'
+	androidTestImplementation 'androidx.room:room-testing:2.4.2'
 }

--- a/app-android/app/schemas/de.tutao.tutanota.data.AppDatabase/1.json
+++ b/app-android/app/schemas/de.tutao.tutanota.data.AppDatabase/1.json
@@ -1,196 +1,190 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 1,
-    "identityHash": "1fe0e3b4ee146734bb2273e9ac67f4b2",
-    "entities": [
-      {
-        "tableName": "KeyValue",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, PRIMARY KEY(`key`))",
-        "fields": [
-          {
-            "fieldPath": "key",
-            "columnName": "key",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "value",
-            "columnName": "value",
-            "affinity": "TEXT",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "key"
-          ],
-          "autoGenerate": false
-        },
-        "indices": [],
-        "foreignKeys": []
-      },
-      {
-        "tableName": "PushIdentifierKey",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pushIdentifierId` TEXT NOT NULL, `deviceEncPushIdentifierKey` BLOB, PRIMARY KEY(`pushIdentifierId`))",
-        "fields": [
-          {
-            "fieldPath": "pushIdentifierId",
-            "columnName": "pushIdentifierId",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "deviceEncPushIdentifierKey",
-            "columnName": "deviceEncPushIdentifierKey",
-            "affinity": "BLOB",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "pushIdentifierId"
-          ],
-          "autoGenerate": false
-        },
-        "indices": [],
-        "foreignKeys": []
-      },
-      {
-        "tableName": "AlarmNotification",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`operation` INTEGER, `summary` TEXT, `eventStart` TEXT, `eventEnd` TEXT, `user` TEXT, `trigger` TEXT NOT NULL, `identifier` TEXT NOT NULL, `frequency` TEXT, `interval` TEXT, `timeZone` TEXT, `endType` TEXT, `endValue` TEXT, `excludedDates` TEXT, `keypushIdentifierSessionEncSessionKey` TEXT, `keylistId` TEXT, `keyelementId` TEXT, PRIMARY KEY(`identifier`))",
-        "fields": [
-          {
-            "fieldPath": "operation",
-            "columnName": "operation",
-            "affinity": "INTEGER",
-            "notNull": false
-          },
-          {
-            "fieldPath": "summary",
-            "columnName": "summary",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "eventStart",
-            "columnName": "eventStart",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "eventEnd",
-            "columnName": "eventEnd",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "user",
-            "columnName": "user",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "alarmInfo.trigger",
-            "columnName": "trigger",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "alarmInfo.identifier",
-            "columnName": "identifier",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "repeatRule.frequency",
-            "columnName": "frequency",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "repeatRule.interval",
-            "columnName": "interval",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "repeatRule.timeZone",
-            "columnName": "timeZone",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "repeatRule.endType",
-            "columnName": "endType",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "repeatRule.endValue",
-            "columnName": "endValue",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "repeatRule.excludedDates",
-            "columnName": "excludedDates",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "notificationSessionKey.pushIdentifierSessionEncSessionKey",
-            "columnName": "keypushIdentifierSessionEncSessionKey",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "notificationSessionKey.pushIdentifier.listId",
-            "columnName": "keylistId",
-            "affinity": "TEXT",
-            "notNull": false
-          },
-          {
-            "fieldPath": "notificationSessionKey.pushIdentifier.elementId",
-            "columnName": "keyelementId",
-            "affinity": "TEXT",
-            "notNull": false
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "identifier"
-          ],
-          "autoGenerate": false
-        },
-        "indices": [],
-        "foreignKeys": []
-      },
-      {
-        "tableName": "User",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, PRIMARY KEY(`userId`))",
-        "fields": [
-          {
-            "fieldPath": "userId",
-            "columnName": "userId",
-            "affinity": "TEXT",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "columnNames": [
-            "userId"
-          ],
-          "autoGenerate": false
-        },
-        "indices": [],
-        "foreignKeys": []
-      }
-    ],
-    "views": [],
-    "setupQueries": [
-      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1fe0e3b4ee146734bb2273e9ac67f4b2')"
-    ]
+	"version": 1,
+	"identityHash": "3fdf02a27fc9c0d4d5b94be098cfdda1",
+	"entities": [
+	  {
+		"tableName": "KeyValue",
+		"createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, PRIMARY KEY(`key`))",
+		"fields": [
+		  {
+			"fieldPath": "key",
+			"columnName": "key",
+			"affinity": "TEXT",
+			"notNull": true
+		  },
+		  {
+			"fieldPath": "value",
+			"columnName": "value",
+			"affinity": "TEXT",
+			"notNull": false
+		  }
+		],
+		"primaryKey": {
+		  "columnNames": [
+			"key"
+		  ],
+		  "autoGenerate": false
+		},
+		"indices": [],
+		"foreignKeys": []
+	  },
+	  {
+		"tableName": "PushIdentifierKey",
+		"createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pushIdentifierId` TEXT NOT NULL, `deviceEncPushIdentifierKey` BLOB, PRIMARY KEY(`pushIdentifierId`))",
+		"fields": [
+		  {
+			"fieldPath": "pushIdentifierId",
+			"columnName": "pushIdentifierId",
+			"affinity": "TEXT",
+			"notNull": true
+		  },
+		  {
+			"fieldPath": "deviceEncPushIdentifierKey",
+			"columnName": "deviceEncPushIdentifierKey",
+			"affinity": "BLOB",
+			"notNull": false
+		  }
+		],
+		"primaryKey": {
+		  "columnNames": [
+			"pushIdentifierId"
+		  ],
+		  "autoGenerate": false
+		},
+		"indices": [],
+		"foreignKeys": []
+	  },
+	  {
+		"tableName": "AlarmNotification",
+		"createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`operation` INTEGER, `summary` TEXT, `eventStart` TEXT, `eventEnd` TEXT, `user` TEXT, `trigger` TEXT NOT NULL, `identifier` TEXT NOT NULL, `frequency` TEXT, `interval` TEXT, `timeZone` TEXT, `endType` TEXT, `endValue` TEXT, `keypushIdentifierSessionEncSessionKey` TEXT, `keylistId` TEXT, `keyelementId` TEXT, PRIMARY KEY(`identifier`))",
+		"fields": [
+		  {
+			"fieldPath": "operation",
+			"columnName": "operation",
+			"affinity": "INTEGER",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "summary",
+			"columnName": "summary",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "eventStart",
+			"columnName": "eventStart",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "eventEnd",
+			"columnName": "eventEnd",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "user",
+			"columnName": "user",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "alarmInfo.trigger",
+			"columnName": "trigger",
+			"affinity": "TEXT",
+			"notNull": true
+		  },
+		  {
+			"fieldPath": "alarmInfo.identifier",
+			"columnName": "identifier",
+			"affinity": "TEXT",
+			"notNull": true
+		  },
+		  {
+			"fieldPath": "repeatRule.frequency",
+			"columnName": "frequency",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "repeatRule.interval",
+			"columnName": "interval",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "repeatRule.timeZone",
+			"columnName": "timeZone",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "repeatRule.endType",
+			"columnName": "endType",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "repeatRule.endValue",
+			"columnName": "endValue",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "notificationSessionKey.pushIdentifierSessionEncSessionKey",
+			"columnName": "keypushIdentifierSessionEncSessionKey",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "notificationSessionKey.pushIdentifier.listId",
+			"columnName": "keylistId",
+			"affinity": "TEXT",
+			"notNull": false
+		  },
+		  {
+			"fieldPath": "notificationSessionKey.pushIdentifier.elementId",
+			"columnName": "keyelementId",
+			"affinity": "TEXT",
+			"notNull": false
+		  }
+		],
+		"primaryKey": {
+		  "columnNames": [
+			"identifier"
+		  ],
+		  "autoGenerate": false
+		},
+		"indices": [],
+		"foreignKeys": []
+	  },
+	  {
+		"tableName": "User",
+		"createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, PRIMARY KEY(`userId`))",
+		"fields": [
+		  {
+			"fieldPath": "userId",
+			"columnName": "userId",
+			"affinity": "TEXT",
+			"notNull": true
+		  }
+		],
+		"primaryKey": {
+		  "columnNames": [
+			"userId"
+		  ],
+		  "autoGenerate": false
+		},
+		"indices": [],
+		"foreignKeys": []
+	  }
+	],
+	"views": [],
+	"setupQueries": [
+	  "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+	  "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '3fdf02a27fc9c0d4d5b94be098cfdda1')"
+	]
   }
 }

--- a/app-android/app/schemas/de.tutao.tutanota.data.AppDatabase/2.json
+++ b/app-android/app/schemas/de.tutao.tutanota.data.AppDatabase/2.json
@@ -1,0 +1,196 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "1fe0e3b4ee146734bb2273e9ac67f4b2",
+    "entities": [
+      {
+        "tableName": "KeyValue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT, PRIMARY KEY(`key`))",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "key"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "PushIdentifierKey",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pushIdentifierId` TEXT NOT NULL, `deviceEncPushIdentifierKey` BLOB, PRIMARY KEY(`pushIdentifierId`))",
+        "fields": [
+          {
+            "fieldPath": "pushIdentifierId",
+            "columnName": "pushIdentifierId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceEncPushIdentifierKey",
+            "columnName": "deviceEncPushIdentifierKey",
+            "affinity": "BLOB",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "pushIdentifierId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "AlarmNotification",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`operation` INTEGER, `summary` TEXT, `eventStart` TEXT, `eventEnd` TEXT, `user` TEXT, `trigger` TEXT NOT NULL, `identifier` TEXT NOT NULL, `frequency` TEXT, `interval` TEXT, `timeZone` TEXT, `endType` TEXT, `endValue` TEXT, `excludedDates` TEXT, `keypushIdentifierSessionEncSessionKey` TEXT, `keylistId` TEXT, `keyelementId` TEXT, PRIMARY KEY(`identifier`))",
+        "fields": [
+          {
+            "fieldPath": "operation",
+            "columnName": "operation",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "eventStart",
+            "columnName": "eventStart",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "eventEnd",
+            "columnName": "eventEnd",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "user",
+            "columnName": "user",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "alarmInfo.trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alarmInfo.identifier",
+            "columnName": "identifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "repeatRule.frequency",
+            "columnName": "frequency",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "repeatRule.interval",
+            "columnName": "interval",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "repeatRule.timeZone",
+            "columnName": "timeZone",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "repeatRule.endType",
+            "columnName": "endType",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "repeatRule.endValue",
+            "columnName": "endValue",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "repeatRule.excludedDates",
+            "columnName": "excludedDates",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationSessionKey.pushIdentifierSessionEncSessionKey",
+            "columnName": "keypushIdentifierSessionEncSessionKey",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationSessionKey.pushIdentifier.listId",
+            "columnName": "keylistId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notificationSessionKey.pushIdentifier.elementId",
+            "columnName": "keyelementId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "identifier"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "User",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`userId` TEXT NOT NULL, PRIMARY KEY(`userId`))",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "userId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1fe0e3b4ee146734bb2273e9ac67f4b2')"
+    ]
+  }
+}

--- a/app-android/app/src/androidTest/java/de/tutao/tutanota/MigrationTest.kt
+++ b/app-android/app/src/androidTest/java/de/tutao/tutanota/MigrationTest.kt
@@ -1,0 +1,43 @@
+package de.tutao.tutanota
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import de.tutao.tutanota.data.AppDatabase
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+	private val TEST_DB = "migration-test"
+
+
+	@get:Rule
+	val helper: MigrationTestHelper = MigrationTestHelper(
+		InstrumentationRegistry.getInstrumentation(),
+		AppDatabase::class.java,
+		listOf(),
+	)
+
+	@Test
+	@Throws(IOException::class)
+	fun migrateAll() {
+		// Create earliest version of the database.
+		helper.createDatabase(TEST_DB, 1).apply {
+			close()
+		}
+
+		// Open latest version of the database. Room will validate the schema
+		// once all migrations execute.
+		Room.databaseBuilder(
+			InstrumentationRegistry.getInstrumentation().targetContext,
+			AppDatabase::class.java,
+			TEST_DB
+		).build().apply {
+			openHelper.writableDatabase.close()
+		}
+	}
+}

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotificationsManager.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/AlarmNotificationsManager.kt
@@ -39,7 +39,7 @@ class AlarmNotificationsManager(
 			if (pushIdentifierSessionKey != null) {
 				val pushIdentifierSessionEncSessionKey =
 						encNotificationSessionKey.pushIdentifierSessionEncSessionKey.base64ToBytes()
-				return crypto.decryptKey(pushIdentifierSessionKey, pushIdentifierSessionEncSessionKey)
+				return crypto.decryptKey(encryptionKey =pushIdentifierSessionKey, encryptedKeyWithoutIV = pushIdentifierSessionEncSessionKey)
 			}
 		} catch (e: UnrecoverableEntryException) {
 			Log.w(TAG, "could not decrypt session key", e)

--- a/app-android/app/src/main/java/de/tutao/tutanota/alarms/EncryptedRepeatRule.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/alarms/EncryptedRepeatRule.kt
@@ -1,5 +1,6 @@
 package de.tutao.tutanota.alarms
 
+import androidx.room.ColumnInfo
 import androidx.room.TypeConverter
 import androidx.room.TypeConverters
 import de.tutao.tutanota.AndroidNativeCryptoFacade
@@ -26,10 +27,11 @@ class EncryptedRepeatRule(
 ) {
 	internal class ExcludedDateWrapperConverter {
 		@TypeConverter
-		fun listToString(excludedDatesList: List<EncryptedDateWrapper>) = excludedDatesList.map { it.date }.joinToString(",")
+		fun listToString(excludedDatesList: List<EncryptedDateWrapper>) =
+			excludedDatesList.joinToString(",") { it.date }
 
 		@TypeConverter
-		fun stringToList(string: String) = if (string.isNotEmpty()) string.split(",").map { EncryptedDateWrapper(it) } else emptyList()
+		fun stringToList(string: String?) = if (string != null && string.isNotEmpty()) string.split(",").map { EncryptedDateWrapper(it) } else emptyList()
 	}
 }
 

--- a/app-android/app/src/main/java/de/tutao/tutanota/data/AppDatabase.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/data/AppDatabase.kt
@@ -1,12 +1,15 @@
 package de.tutao.tutanota.data
 
 import android.content.Context
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import de.tutao.tutanota.alarms.AlarmNotificationEntity
 
-@Database(version = 1, entities = [KeyValue::class, PushIdentifierKey::class, AlarmNotificationEntity::class, User::class])
+@Database(version = 2, entities = [KeyValue::class, PushIdentifierKey::class, AlarmNotificationEntity::class, User::class], autoMigrations = [
+	AutoMigration(from = 1, to = 2)
+])
 abstract class AppDatabase : RoomDatabase() {
 	abstract fun keyValueDao(): KeyValueDao
 	abstract fun userInfoDao(): UserInfoDao

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/NativePushFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/NativePushFacade.kt
@@ -30,4 +30,10 @@ interface NativePushFacade {
 	 suspend fun scheduleAlarms(
 		alarms: List<EncryptedAlarmNotification>,
 	): Unit
+	/**
+	 * Unschedule and remove alarms belonging to a specific user from the persistent storage
+	 */
+	 suspend fun invalidateAlarmsForUser(
+		userId: String,
+	): Unit
 }

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/NativePushFacadeReceiveDispatcher.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/NativePushFacadeReceiveDispatcher.kt
@@ -53,6 +53,13 @@ class NativePushFacadeReceiveDispatcher(
 				)
 				return json.encodeToString(result)
 			}
+			"invalidateAlarmsForUser" -> {
+				val userId: String = json.decodeFromString(arg[0])
+				val result: Unit = this.facade.invalidateAlarmsForUser(
+					userId,
+				)
+				return json.encodeToString(result)
+			}
 			else -> throw Error("unknown method for NativePushFacade: $method")
 		}
 	}

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/AndroidNativePushFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/AndroidNativePushFacade.kt
@@ -9,16 +9,22 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class AndroidNativePushFacade(
-		private val activity: MainActivity,
-		private val sseStorage: SseStorage,
-		private val alarmNotificationsManager: AlarmNotificationsManager,
+	private val activity: MainActivity,
+	private val sseStorage: SseStorage,
+	private val alarmNotificationsManager: AlarmNotificationsManager,
 ) : NativePushFacade {
 
 	override suspend fun getPushIdentifier(): String? {
 		return sseStorage.getPushIdentifier()
 	}
 
-	override suspend fun storePushIdentifierLocally(identifier: String, userId: String, sseOrigin: String, pushIdentifierId: String, pushIdentifierSessionKey: DataWrapper) {
+	override suspend fun storePushIdentifierLocally(
+		identifier: String,
+		userId: String,
+		sseOrigin: String,
+		pushIdentifierId: String,
+		pushIdentifierSessionKey: DataWrapper
+	) {
 		sseStorage.storePushIdentifier(identifier, sseOrigin)
 		sseStorage.storePushIdentifierSessionKey(userId, pushIdentifierId, pushIdentifierSessionKey.data)
 	}
@@ -32,16 +38,20 @@ class AndroidNativePushFacade(
 
 	override suspend fun closePushNotifications(addressesArray: List<String>) {
 		activity.startService(
-				notificationDismissedIntent(
-						activity,
-						ArrayList(addressesArray),
-						"Native",
-						false
-				)
+			notificationDismissedIntent(
+				activity,
+				ArrayList(addressesArray),
+				"Native",
+				false
+			)
 		)
 	}
 
 	override suspend fun scheduleAlarms(alarms: List<EncryptedAlarmNotification>) {
 		alarmNotificationsManager.scheduleNewAlarms(alarms)
+	}
+
+	override suspend fun invalidateAlarmsForUser(userId: String) {
+		alarmNotificationsManager.unscheduleAlarms(userId)
 	}
 }

--- a/app-ios/tutanota.xcodeproj/project.pbxproj
+++ b/app-ios/tutanota.xcodeproj/project.pbxproj
@@ -162,7 +162,7 @@
 		3D9B12B42721A1E2002B46A1 /* TUTErrorFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D9B12B22721A1E2002B46A1 /* TUTErrorFactory.m */; };
 		3DA047BF212C1BBE0062C36C /* CompatibilityTestData.json in Resources */ = {isa = PBXBuildFile; fileRef = 3DA047BE212C1BBD0062C36C /* CompatibilityTestData.json */; };
 		3DAA23A9267A208200219051 /* UIColorExtensionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAA23A8267A208200219051 /* UIColorExtensionsTest.swift */; };
-		3DAED2AF29A6267D00806DEA /* NotificatoinsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAED2AE29A6267D00806DEA /* NotificatoinsHandler.swift */; };
+		3DAED2AF29A6267D00806DEA /* NotificationsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAED2AE29A6267D00806DEA /* NotificationsHandler.swift */; };
 		3DB07C7B27303F0600BFBB4D /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DB07C7A27303F0600BFBB4D /* Keys.swift */; };
 		3DBA56C72850AAA6004416BE /* FileFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBA56B72850AAA6004416BE /* FileFacade.swift */; };
 		3DBA56C82850AAA6004416BE /* MobileFacadeSendDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBA56B82850AAA6004416BE /* MobileFacadeSendDispatcher.swift */; };
@@ -403,7 +403,7 @@
 		3DA047BE212C1BBD0062C36C /* CompatibilityTestData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = CompatibilityTestData.json; sourceTree = "<group>"; };
 		3DAA23A5267A202000219051 /* tutanotaTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "tutanotaTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		3DAA23A8267A208200219051 /* UIColorExtensionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensionsTest.swift; sourceTree = "<group>"; };
-		3DAED2AE29A6267D00806DEA /* NotificatoinsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificatoinsHandler.swift; sourceTree = "<group>"; };
+		3DAED2AE29A6267D00806DEA /* NotificationsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsHandler.swift; sourceTree = "<group>"; };
 		3DB07C7A27303F0600BFBB4D /* Keys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
 		3DBA56B72850AAA6004416BE /* FileFacade.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileFacade.swift; sourceTree = "<group>"; };
 		3DBA56B82850AAA6004416BE /* MobileFacadeSendDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MobileFacadeSendDispatcher.swift; sourceTree = "<group>"; };
@@ -1162,7 +1162,7 @@
 		3DAED2AD29A6266800806DEA /* Push */ = {
 			isa = PBXGroup;
 			children = (
-				3DAED2AE29A6267D00806DEA /* NotificatoinsHandler.swift */,
+				3DAED2AE29A6267D00806DEA /* NotificationsHandler.swift */,
 			);
 			path = Push;
 			sourceTree = "<group>";
@@ -1694,7 +1694,7 @@
 				3D4E16F4273D2F8A00256630 /* SyncCompletion.swift in Sources */,
 				3D84F56B2721B92C00858A58 /* MissedNotification.swift in Sources */,
 				3DC5DED52858CB58007364FF /* NativeCryptoFacade.swift in Sources */,
-				3DAED2AF29A6267D00806DEA /* NotificatoinsHandler.swift in Sources */,
+				3DAED2AF29A6267D00806DEA /* NotificationsHandler.swift in Sources */,
 				3DC5DEC728576621007364FF /* NativeInterface.swift in Sources */,
 				3D220202293F752D00366FD2 /* WebauthnKeyDescriptor.swift in Sources */,
 				3DCE7AAC27200E0A0085E40D /* WebviewHacks.m in Sources */,

--- a/app-ios/tutanota/Sources/Alarms/IosNativePushFacade.swift
+++ b/app-ios/tutanota/Sources/Alarms/IosNativePushFacade.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 class IosNativePushFacade : NativePushFacade {
+  
 
   private let appDelegate: AppDelegate
   private let alarmManager: AlarmManager
@@ -53,5 +54,9 @@ class IosNativePushFacade : NativePushFacade {
 
   func scheduleAlarms(_ alarms: [EncryptedAlarmNotification]) async throws {
     try self.alarmManager.processNewAlarms(alarms)
+  }
+  
+  func invalidateAlarmsForUser(_ userId: String) async throws {
+    alarmManager.unscheduleAllAlarms(userId: userId)
   }
 }

--- a/app-ios/tutanota/Sources/GeneratedIpc/NativePushFacade.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/NativePushFacade.swift
@@ -27,4 +27,10 @@ public protocol NativePushFacade {
 	func scheduleAlarms(
 		_ alarms: [EncryptedAlarmNotification]
 	) async throws -> Void
+	/**
+	 * Unschedule and remove alarms belonging to a specific user from the persistent storage
+	 */
+	func invalidateAlarmsForUser(
+		_ userId: String
+	) async throws -> Void
 }

--- a/app-ios/tutanota/Sources/GeneratedIpc/NativePushFacadeReceiveDispatcher.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/NativePushFacadeReceiveDispatcher.swift
@@ -44,6 +44,12 @@ public class NativePushFacadeReceiveDispatcher {
 				alarms
 			)
 			return "null"
+		case "invalidateAlarmsForUser":
+			let userId = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
+			try await self.facade.invalidateAlarmsForUser(
+				userId
+			)
+			return "null"
 		default:
 			fatalError("licc messed up! \(method)")
 		}

--- a/app-ios/tutanota/Sources/Utils/Utils.swift
+++ b/app-ios/tutanota/Sources/Utils/Utils.swift
@@ -4,6 +4,7 @@ func translate(_ key: String, default defaultValue: String) -> String {
   return Bundle.main.localizedString(forKey: key, value: defaultValue, table: "InfoPlist")
 }
 
+// // keep in sync with src/native/main/NativePushServiceApp.ts
 let SYS_MODEL_VERSION = 85
 
 func addSystemModelHeaders(to headers: inout [String : String]) {

--- a/ipc-schema/facades/NativePushFacade.json
+++ b/ipc-schema/facades/NativePushFacade.json
@@ -31,6 +31,11 @@
 		"scheduleAlarms": {
 			"arg": [{ "alarms": "List<EncryptedAlarmNotification>" }],
 			"ret": "void"
+		},
+		"invalidateAlarmsForUser": {
+			"arg": [{ "userId": "string" }],
+			"ret": "void",
+			"doc": "Unschedule and remove alarms belonging to a specific user from the persistent storage"
 		}
 	}
 }

--- a/packages/licc/package.json
+++ b/packages/licc/package.json
@@ -8,7 +8,7 @@
 	"main": "index.js",
 	"type": "module",
 	"scripts": {
-		"build": "tsc -b",
+		"build": "npx tsc -b",
 		"test": "rm -rf ./test/build && tsc -b test && cd test/build && node test/Suite.js",
 		"preinstall": "node preinstall.js"
 	},

--- a/src/api/worker/facades/lazy/CalendarFacade.ts
+++ b/src/api/worker/facades/lazy/CalendarFacade.ts
@@ -6,6 +6,7 @@ import {
 	createAlarmNotification,
 	createAlarmServicePost,
 	createCalendarEventRef,
+	createDateWrapper,
 	createNotificationSessionKey,
 	createRepeatRule,
 	createUserAlarmInfo,
@@ -504,7 +505,7 @@ function createRepeatRuleForCalendarRepeatRule(calendarRepeatRule: CalendarRepea
 		frequency: calendarRepeatRule.frequency,
 		interval: calendarRepeatRule.interval,
 		timeZone: calendarRepeatRule.timeZone,
-		excludedDates: calendarRepeatRule.excludedDates,
+		excludedDates: calendarRepeatRule.excludedDates.map(({ date }) => createDateWrapper({ date })),
 	})
 }
 

--- a/src/desktop/sse/DesktopNativePushFacade.ts
+++ b/src/desktop/sse/DesktopNativePushFacade.ts
@@ -41,4 +41,8 @@ export class DesktopNativePushFacade implements NativePushFacade {
 		await this.sse.storePushIdentifier(identifier, userId, sseOrigin)
 		await this.alarmStorage.storePushIdentifierSessionKey(pushIdentifierId, pushIdentifierSessionKey)
 	}
+
+	async invalidateAlarmsForUser(userId: string): Promise<void> {
+		await this.alarmScheduler.unscheduleAllAlarms(userId)
+	}
 }

--- a/src/misc/DeviceConfig.ts
+++ b/src/misc/DeviceConfig.ts
@@ -20,7 +20,7 @@ export const defaultThemeId: ThemeId = "light"
 interface ConfigObject {
 	_version: number
 	_credentials: Map<Id, PersistentCredentials>
-	_scheduledAlarmUsers: Id[]
+	scheduledAlarmModelVersionPerUser: Record<Id, number>
 	_themeId: ThemeId
 	_language: LanguageCode | null
 	_defaultCalendarView: Record<Id, CalendarViewType | null>
@@ -79,7 +79,7 @@ export class DeviceConfig implements CredentialsStorage, UsageTestStorage, NewsI
 			_encryptedCredentialsKey: loadedConfig._encryptedCredentialsKey ?? null,
 			acknowledgedNewsItems: loadedConfig.acknowledgedNewsItems ?? [],
 			_themeId: loadedConfig._themeId ?? defaultThemeId,
-			_scheduledAlarmUsers: loadedConfig._scheduledAlarmUsers ?? [],
+			scheduledAlarmModelVersionPerUser: loadedConfig.scheduledAlarmModelVersionPerUser ?? {},
 			_language: loadedConfig._language ?? null,
 			_defaultCalendarView: loadedConfig._defaultCalendarView ?? {},
 			_hiddenCalendars: loadedConfig._hiddenCalendars ?? {},
@@ -146,26 +146,17 @@ export class DeviceConfig implements CredentialsStorage, UsageTestStorage, NewsI
 		return this.config._signupToken
 	}
 
-	hasScheduledAlarmsForUser(userId: Id): boolean {
-		return this.config._scheduledAlarmUsers.includes(userId)
+	getScheduledAlarmsModelVersion(userId: Id): number | null {
+		return this.config.scheduledAlarmModelVersionPerUser[userId] ?? null
 	}
 
-	setAlarmsScheduledForUser(userId: Id, setScheduled: boolean) {
-		const scheduledIndex = this.config._scheduledAlarmUsers.indexOf(userId)
-
-		const scheduledSaved = scheduledIndex !== -1
-
-		if (setScheduled && !scheduledSaved) {
-			this.config._scheduledAlarmUsers.push(userId)
-		} else if (!setScheduled && scheduledSaved) {
-			this.config._scheduledAlarmUsers.splice(scheduledIndex, 1)
-		}
-
+	setScheduledAlarmsModelVersion(userId: Id, version: number): void {
+		this.config.scheduledAlarmModelVersionPerUser[userId] = version
 		this.writeToStorage()
 	}
 
 	setNoAlarmsScheduled() {
-		this.config._scheduledAlarmUsers = []
+		this.config.scheduledAlarmModelVersionPerUser = {}
 		this.writeToStorage()
 	}
 

--- a/src/native/common/generatedipc/NativePushFacade.ts
+++ b/src/native/common/generatedipc/NativePushFacade.ts
@@ -23,4 +23,9 @@ export interface NativePushFacade {
 	closePushNotifications(addressesArray: ReadonlyArray<string>): Promise<void>
 
 	scheduleAlarms(alarms: ReadonlyArray<EncryptedAlarmNotification>): Promise<void>
+
+	/**
+	 * Unschedule and remove alarms belonging to a specific user from the persistent storage
+	 */
+	invalidateAlarmsForUser(userId: string): Promise<void>
 }

--- a/src/native/common/generatedipc/NativePushFacadeReceiveDispatcher.ts
+++ b/src/native/common/generatedipc/NativePushFacadeReceiveDispatcher.ts
@@ -29,6 +29,10 @@ export class NativePushFacadeReceiveDispatcher {
 				const alarms: ReadonlyArray<EncryptedAlarmNotification> = arg[0]
 				return this.facade.scheduleAlarms(alarms)
 			}
+			case "invalidateAlarmsForUser": {
+				const userId: string = arg[0]
+				return this.facade.invalidateAlarmsForUser(userId)
+			}
 		}
 	}
 }

--- a/src/native/common/generatedipc/NativePushFacadeSendDispatcher.ts
+++ b/src/native/common/generatedipc/NativePushFacadeSendDispatcher.ts
@@ -22,4 +22,7 @@ export class NativePushFacadeSendDispatcher implements NativePushFacade {
 	async scheduleAlarms(...args: Parameters<NativePushFacade["scheduleAlarms"]>) {
 		return this.transport.invokeNative("ipc", ["NativePushFacade", "scheduleAlarms", ...args])
 	}
+	async invalidateAlarmsForUser(...args: Parameters<NativePushFacade["invalidateAlarmsForUser"]>) {
+		return this.transport.invokeNative("ipc", ["NativePushFacade", "invalidateAlarmsForUser", ...args])
+	}
 }

--- a/test/tests/misc/DeviceConfigTest.ts
+++ b/test/tests/misc/DeviceConfigTest.ts
@@ -88,7 +88,7 @@ o.spec("DeviceConfig", function () {
 				_encryptedCredentialsKey: "somekey",
 				acknowledgedNewsItems: [],
 				_themeId: "mytheme",
-				_scheduledAlarmUsers: ["userId"],
+				scheduledAlarmModelVersionPerUser: {},
 				_language: "en",
 				_defaultCalendarView: {},
 				_hiddenCalendars: {},


### PR DESCRIPTION
it's possible for us to have stored old alarm notifications that don't contain exclusions that have been added by newer client (backported).

we're now unscheduling all alarms, deleting the stored alarms and do a complete re-download to get at the exclusions we missed after we log in.

we also added some migrations so new clients can deal with the old notifications.

fix #5319