### PR TITLE
register window size event handler in Windowfacade ctor instead of init

### DIFF
--- a/src/misc/WindowFacade.ts
+++ b/src/misc/WindowFacade.ts
@@ -42,6 +42,25 @@ export class WindowFacade {
 				this.addPageInBackgroundListener()
 			}
 		})
+
+		const onresize = () => {
+			// see https://developer.mozilla.org/en-US/docs/Web/Events/resize
+			if (!this.resizeTimeout) {
+				const cb = () => {
+					this.resizeTimeout = null
+
+					this._resize() // The actualResizeHandler will execute at a rate of 15fps
+				}
+
+				// On mobile devices there's usaually no resize but when changing orientation it's to early to
+				// measure the size in requestAnimationFrame (it's usually incorrect size at this point)
+				this.resizeTimeout = client.isMobileDevice() ? setTimeout(cb, 66) : requestAnimationFrame(cb)
+			}
+		}
+		window.onresize = onresize
+		// specifially for iOS: rotation through the unsupported orientation (e.g, 90 degrees 3 times) will not trigger the resize and we wouldn't resize
+		// some things so we react to both, it is throttled anyway
+		window.onorientationchange = onresize
 	}
 
 	/**
@@ -92,24 +111,6 @@ export class WindowFacade {
 
 	init(logins: LoginController) {
 		this.logins = logins
-		const onresize = () => {
-			// see https://developer.mozilla.org/en-US/docs/Web/Events/resize
-			if (!this.resizeTimeout) {
-				const cb = () => {
-					this.resizeTimeout = null
-
-					this._resize() // The actualResizeHandler will execute at a rate of 15fps
-				}
-
-				// On mobile devices there's usaually no resize but when changing orientation it's to early to
-				// measure the size in requestAnimationFrame (it's usually incorrect size at this point)
-				this.resizeTimeout = client.isMobileDevice() ? setTimeout(cb, 66) : requestAnimationFrame(cb)
-			}
-		}
-		window.onresize = onresize
-		// specifially for iOS: rotation through the unsupported orientation (e.g, 90 degrees 3 times) will not trigger the resize and we wouldn't resize
-		// some things so we react to both, it is throttled anyway
-		window.onorientationchange = onresize
 
 		if (window.addEventListener && !isApp()) {
 			window.addEventListener("beforeunload", (e) => this._beforeUnload(e))

--- a/src/misc/WindowFacade.ts
+++ b/src/misc/WindowFacade.ts
@@ -52,7 +52,7 @@ export class WindowFacade {
 					this._resize() // The actualResizeHandler will execute at a rate of 15fps
 				}
 
-				// On mobile devices there's usaually no resize but when changing orientation it's to early to
+				// On mobile devices there's usually no resize but when changing orientation it's to early to
 				// measure the size in requestAnimationFrame (it's usually incorrect size at this point)
 				this.resizeTimeout = client.isMobileDevice() ? setTimeout(cb, 66) : requestAnimationFrame(cb)
 			}
@@ -135,11 +135,15 @@ export class WindowFacade {
 				}
 			})
 		}
+
+		// call the resize listeners once to make sure everyone
+		// has the current window size once we're done initializing
+		this._resize()
 	}
 
 	_resize() {
 		try {
-			for (let listener of this._windowSizeListeners) {
+			for (const listener of this._windowSizeListeners) {
 				listener(window.innerWidth, window.innerHeight)
 			}
 		} finally {


### PR DESCRIPTION
* windowfacade.init() depends on login
* window facade registered the resize handler in init
* therefore, if logins is slow, styles might miss early resize events

fix #5349