### PR TITLE
treat luxon error as ParserError

### DIFF
--- a/src/calendar/export/CalendarParser.ts
+++ b/src/calendar/export/CalendarParser.ts
@@ -738,9 +738,17 @@ export function parseTime(
 			: {},
 		components,
 	)
-	return {
-		date: toValidJSDate(DateTime.fromObject(filledComponents, { zone: effectiveZone }), value, zone ?? null),
-		allDay,
+
+	try {
+		const dateTime = DateTime.fromObject(filledComponents, { zone: effectiveZone })
+		return { date: toValidJSDate(dateTime, value, zone ?? null), allDay }
+	} catch (e) {
+		if (e instanceof ParserError) {
+			throw e
+		}
+		throw new ParserError(
+			`failed to parse time from ${value} to ${JSON.stringify(filledComponents)}, effectiveZone: ${effectiveZone}, original error: ${e.message}`,
+		)
 	}
 }
 


### PR DESCRIPTION
we've had reports of calendar updates failing to be applied because calendarModel.getCalendarDataForUpdate fails to parse the start time of an event update.

we now convert the luxon error into a parser error, which causes the update to be skipped.

fix #5330