### PR TITLE
fix that the side menu is not closed when clicking today in calendar

### DIFF
--- a/src/calendar/view/CalendarView.ts
+++ b/src/calendar/view/CalendarView.ts
@@ -6,7 +6,7 @@ import { ViewSlider } from "../../gui/nav/ViewSlider.js"
 import type { Shortcut } from "../../misc/KeyManager"
 import { keyManager } from "../../misc/KeyManager"
 import { Icons } from "../../gui/base/icons/Icons"
-import { downcast, first, getStartOfDay, incrementDate, LazyLoaded, memoized, ofClass } from "@tutao/tutanota-utils"
+import { downcast, getStartOfDay, incrementDate, LazyLoaded, memoized, ofClass } from "@tutao/tutanota-utils"
 import type { CalendarEvent, GroupSettings, UserSettingsGroupRoot } from "../../api/entities/tutanota/TypeRefs.js"
 import { CalendarEventTypeRef, createGroupSettings } from "../../api/entities/tutanota/TypeRefs.js"
 import { defaultCalendarColor, GroupType, Keys, ShareCapability, TimeFormat } from "../../api/common/TutanotaConstants"
@@ -103,6 +103,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 													label: "today_label",
 													click: () => {
 														this._setUrl(m.route.param("view"), new Date())
+														this.viewSlider.focus(this.contentColumn)
 													},
 													colors: ButtonColor.Nav,
 													type: ButtonType.Primary,


### PR DESCRIPTION
the viewslider is now closed in the same way as for the navigation buttons

fix #5263