### PR TITLE
fix, the displayed default sender is not updated when disabling alias

### DIFF
--- a/src/settings/MailSettingsViewer.ts
+++ b/src/settings/MailSettingsViewer.ts
@@ -107,6 +107,7 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 	}
 
 	view(): Children {
+		this._defaultSender = getDefaultSenderFromUser(locator.logins.getUserController())
 		const defaultSenderAttrs: DropDownSelectorAttrs<string> = {
 			label: "defaultSenderMailAddress_label",
 			items: getEnabledMailAddressesForGroupInfo(locator.logins.getUserController().userGroupInfo)


### PR DESCRIPTION
the default sender should be updated on every redraw (whenever the view function is called) since it can be changed in other places in the background

fix #5321