### PR TITLE
[ci] add .githooks/ with pre-commit formatting

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# pre-commit hook to check & fix formatting. does not deal with spaces in paths.
+
+#     get staged files     exclude deleted files    | only match what prettier matches  | transform newline & whitespace into spaces
+CHG=$(git diff --name-only --diff-filter=d --cached | grep -E ".*\.(ts|js|json|json5)$" | tr [:space:] " ")
+# run prettier fix on them
+npx prettier -w  $CHG > /dev/null
+# re-add the fixed files
+git add $CHG > /dev/null

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"fasttest": "cd test && node test -f",
 		"types": "tsc --incremental true --noEmit true",
 		"prebuild": "node buildSrc/prebuild.js",
+		"preinstall": "git config core.hooksPath githooks",
 		"postinstall": "node buildSrc/postinstall.js",
 		"bump-version": "node buildSrc/bump-version.js",
 		"generate-ipc": "npm run build -w @tutao/licc && licc ./ipc-schema",


### PR DESCRIPTION
we may have to test that this works on MacOs and make changes to it so the `/dev/null` redirects redirect to `nul` on windows.