### PR TITLE
chore: add shortcut for dev tools

### DIFF
--- a/src/desktop/ApplicationWindow.ts
+++ b/src/desktop/ApplicationWindow.ts
@@ -100,6 +100,14 @@ export class ApplicationWindow {
 					help: "toggleDevTools_action",
 				},
 				{
+					key: Keys.I,
+					meta: isMac,
+					ctrl: !isMac,
+					shift: !isMac,
+					exec: () => this.toggleDevTools(),
+					help: "toggleDevTools_action",
+				},
+				{
 					key: Keys["0"],
 					meta: isMac,
 					ctrl: !isMac,


### PR DESCRIPTION
When running Tutanota from source, one thing that always bothered me is that I couldn't do `CTRL` + `SHIFT` + `I` to open dev tools. ^-^'

This is a standard shortcut available in both Firefox and Chromium-based browsers.

In all the Electron applications that I've used which include access to dev tools on production builds, `CTRL` + `SHIFT` + `I` was the supported method, which is where my habit of using that instead of `F12` came from anyway:
* [Element](https://element.io/), specifically allows `CTRL` + `SHIFT` + `I` but not `F12` for some reason. :thinking:  
* Discord, when I last used it, allowed `CTRL` + `SHIFT` + `I` but not `F12`.

Mind if we add this as a supported shortcut? ^-^'

### References

> You can open the Firefox Developer Tools from the menu by selecting **Tools > Web Developer > Web Developer Tools** or use the keyboard shortcut **`Ctrl`** + **`Shift`** + **`I`** or **`F12`** on Windows and Linux, or **`Cmd`** + **`Opt`** + **`I`** on macOS.
> 
> — https://firefox-source-docs.mozilla.org/devtools-user/index.html#the-core-tools

> | Action | Mac | Windows / Linux |
> |---|---|---|
> | Open whatever panel you used last | `Command+Option+I` | `F12` or `Control+Shift+I`|
> 
> — https://developer.chrome.com/docs/devtools/shortcuts/#open

> Firefox, Ctrl + Shift + I: Toggle developer tools  
> Microsoft Edge (Chromium), Ctrl + Shift + I: Open Developer Tools  
> Vivaldi, Ctrl + Shift + I: Developer tools
> Discord, Ctrl + Shift + I: Open developer console
> 
> — https://defkey.com/what-means/ctrl-shift-i#general