### PR TITLE
move delete account from the "plan" settings to the "general" settings

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -11,8 +11,8 @@ android {
 		applicationId "de.tutao.tutanota"
 		minSdkVersion 23
 		targetSdkVersion 31
-		versionCode 396221
-		versionName "3.112.15"
+		versionCode 396222
+		versionName "3.112.16"
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
 		javaCompileOptions {

--- a/app-ios/tutanota/Info.plist
+++ b/app-ios/tutanota/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.112.15</string>
+	<string>3.112.16</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -33,7 +33,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>3.112.15</string>
+	<string>3.112.16</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tutanota",
-	"version": "3.112.15",
+	"version": "3.112.16",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tutanota",
-			"version": "3.112.15",
+			"version": "3.112.16",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"workspaces": [
@@ -14,9 +14,9 @@
 			],
 			"dependencies": {
 				"@tutao/oxmsg": "0.0.9-beta.0",
-				"@tutao/tutanota-crypto": "3.112.15",
-				"@tutao/tutanota-usagetests": "3.112.15",
-				"@tutao/tutanota-utils": "3.112.15",
+				"@tutao/tutanota-crypto": "3.112.16",
+				"@tutao/tutanota-usagetests": "3.112.16",
+				"@tutao/tutanota-utils": "3.112.16",
 				"@types/better-sqlite3": "7.4.2",
 				"@types/dompurify": "2.4.0",
 				"@types/linkifyjs": "2.1.4",
@@ -49,8 +49,8 @@
 				"@rollup/plugin-node-resolve": "15.0.1",
 				"@rollup/plugin-terser": "0.4.0",
 				"@rollup/plugin-typescript": "11.0.0",
-				"@tutao/licc": "3.112.15",
-				"@tutao/tutanota-test-utils": "3.112.15",
+				"@tutao/licc": "3.112.16",
+				"@tutao/tutanota-test-utils": "3.112.16",
 				"@typescript-eslint/eslint-plugin": "5.15.0",
 				"body-parser": "1.20.0",
 				"chokidar": "3.5.2",
@@ -10247,7 +10247,7 @@
 		},
 		"packages/licc": {
 			"name": "@tutao/licc",
-			"version": "3.112.15",
+			"version": "3.112.16",
 			"hasInstallScript": true,
 			"license": "GPL-3.0",
 			"dependencies": {
@@ -10259,7 +10259,7 @@
 				"licc": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@tutao/tutanota-test-utils": "3.112.15",
+				"@tutao/tutanota-test-utils": "3.112.16",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "5.0.3"
 			}
@@ -10366,17 +10366,17 @@
 		},
 		"packages/tutanota-crypto": {
 			"name": "@tutao/tutanota-crypto",
-			"version": "3.112.15",
+			"version": "3.112.16",
 			"license": "GPL-3.0",
 			"devDependencies": {
-				"@tutao/tutanota-utils": "3.112.15",
+				"@tutao/tutanota-utils": "3.112.16",
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",
 				"typescript": "5.0.3"
 			}
 		},
 		"packages/tutanota-test-utils": {
 			"name": "@tutao/tutanota-test-utils",
-			"version": "3.112.15",
+			"version": "3.112.16",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"typescript": "5.0.3"
@@ -10388,7 +10388,7 @@
 		},
 		"packages/tutanota-usagetests": {
 			"name": "@tutao/tutanota-usagetests",
-			"version": "3.112.15",
+			"version": "3.112.16",
 			"license": "GLP-3.0",
 			"devDependencies": {
 				"@types/node-forge": "1.0.0",
@@ -10398,7 +10398,7 @@
 		},
 		"packages/tutanota-utils": {
 			"name": "@tutao/tutanota-utils",
-			"version": "3.112.15",
+			"version": "3.112.16",
 			"license": "GPL-3.0",
 			"devDependencies": {
 				"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tutanota",
-	"version": "3.112.15",
+	"version": "3.112.16",
 	"license": "GPL-3.0",
 	"repository": {
 		"type": "git",
@@ -33,9 +33,9 @@
 	},
 	"dependencies": {
 		"@tutao/oxmsg": "0.0.9-beta.0",
-		"@tutao/tutanota-crypto": "3.112.15",
-		"@tutao/tutanota-usagetests": "3.112.15",
-		"@tutao/tutanota-utils": "3.112.15",
+		"@tutao/tutanota-crypto": "3.112.16",
+		"@tutao/tutanota-usagetests": "3.112.16",
+		"@tutao/tutanota-utils": "3.112.16",
 		"@types/better-sqlite3": "7.4.2",
 		"@types/dompurify": "2.4.0",
 		"@types/linkifyjs": "2.1.4",
@@ -68,8 +68,8 @@
 		"@rollup/plugin-node-resolve": "15.0.1",
 		"@rollup/plugin-terser": "0.4.0",
 		"@rollup/plugin-typescript": "11.0.0",
-		"@tutao/licc": "3.112.15",
-		"@tutao/tutanota-test-utils": "3.112.15",
+		"@tutao/licc": "3.112.16",
+		"@tutao/tutanota-test-utils": "3.112.16",
 		"@typescript-eslint/eslint-plugin": "5.15.0",
 		"body-parser": "1.20.0",
 		"chokidar": "3.5.2",

--- a/packages/licc/package.json
+++ b/packages/licc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/licc",
-	"version": "3.112.15",
+	"version": "3.112.16",
 	"bin": {
 		"licc": "dist/cli.js"
 	},
@@ -21,7 +21,7 @@
 	},
 	"devDependencies": {
 		"typescript": "5.0.3",
-		"@tutao/tutanota-test-utils": "3.112.15",
+		"@tutao/tutanota-test-utils": "3.112.16",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-crypto/package.json
+++ b/packages/tutanota-crypto/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-crypto",
-	"version": "3.112.15",
+	"version": "3.112.16",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {
@@ -22,7 +22,7 @@
 	],
 	"devDependencies": {
 		"typescript": "5.0.3",
-		"@tutao/tutanota-utils": "3.112.15",
+		"@tutao/tutanota-utils": "3.112.16",
 		"ospec": "https://github.com/tutao/ospec.git#0472107629ede33be4c4d19e89f237a6d7b0cb11"
 	}
 }

--- a/packages/tutanota-test-utils/package.json
+++ b/packages/tutanota-test-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-test-utils",
-	"version": "3.112.15",
+	"version": "3.112.16",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"repository": {

--- a/packages/tutanota-usagetests/package.json
+++ b/packages/tutanota-usagetests/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-usagetests",
-	"version": "3.112.15",
+	"version": "3.112.16",
 	"license": "GLP-3.0",
 	"description": "",
 	"main": "./dist/index.js",

--- a/packages/tutanota-utils/package.json
+++ b/packages/tutanota-utils/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tutao/tutanota-utils",
-	"version": "3.112.15",
+	"version": "3.112.16",
 	"license": "GPL-3.0",
 	"main": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/src/settings/GlobalSettingsViewer.ts
+++ b/src/settings/GlobalSettingsViewer.ts
@@ -46,6 +46,8 @@ import { assertMainOrNode } from "../api/common/Env"
 import { DropDownSelector } from "../gui/base/DropDownSelector.js"
 import { ButtonSize } from "../gui/base/ButtonSize.js"
 import { SettingsExpander } from "./SettingsExpander.js"
+import { Button, ButtonType } from "../gui/base/Button.js"
+import { showDeleteAccountDialog } from "../subscription/DeleteAccountDialog.js"
 
 assertMainOrNode()
 // Number of days for that we load rejected senders
@@ -73,6 +75,7 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 	private requirePasswordUpdateAfterReset = false
 	private saveIpAddress = false
 	private readonly usageDataExpanded = stream(false)
+	private readonly deleteAccountExpanded = stream(false)
 	private readonly customerProperties = new LazyLoaded(() =>
 		locator.entityClient
 			.load(CustomerTypeRef, neverNull(locator.logins.getUserController().user.customer))
@@ -275,6 +278,33 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 								: null,
 					  )
 					: null,
+				m(
+					".mb-l",
+					m(
+						SettingsExpander,
+						{
+							title: "adminDeleteAccount_action",
+							buttonText: "adminDeleteAccount_action",
+							expanded: this.deleteAccountExpanded,
+						},
+						m(
+							".flex-center",
+							m(
+								"",
+								{
+									style: {
+										width: "200px",
+									},
+								},
+								m(Button, {
+									label: "adminDeleteAccount_action",
+									click: showDeleteAccountDialog,
+									type: ButtonType.Login,
+								}),
+							),
+						),
+					),
+				),
 			]),
 		]
 	}

--- a/src/subscription/SubscriptionViewer.ts
+++ b/src/subscription/SubscriptionViewer.ts
@@ -25,14 +25,12 @@ import { showUpgradeWizard } from "./UpgradeSubscriptionWizard"
 import { showSwitchDialog } from "./SwitchSubscriptionDialog"
 import stream from "mithril/stream"
 import Stream from "mithril/stream"
-import { showDeleteAccountDialog } from "./DeleteAccountDialog"
 import * as SignOrderAgreementDialog from "./SignOrderProcessingAgreementDialog"
 import * as SwitchToBusinessInvoiceDataDialog from "./SwitchToBusinessInvoiceDataDialog"
 import { NotFoundError } from "../api/common/error/RestError"
 import type { EntityUpdateData } from "../api/main/EventController"
 import { isUpdateForTypeRef } from "../api/main/EventController"
 import { getCurrentCount, getTotalAliases, getTotalStorageCapacity, isBusinessFeatureActive, isSharingActive, isWhitelabelActive } from "./SubscriptionUtils"
-import { Button, ButtonType } from "../gui/base/Button.js"
 import { TextField } from "../gui/base/TextField.js"
 import { Dialog, DialogType } from "../gui/base/Dialog"
 import { ColumnWidth, Table } from "../gui/base/Table.js"
@@ -326,33 +324,6 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 							}),
 						]),
 				}),
-				m(
-					".mb-l",
-					m(
-						SettingsExpander,
-						{
-							title: "adminDeleteAccount_action",
-							buttonText: "adminDeleteAccount_action",
-							expanded: deleteAccountExpanded,
-						},
-						m(
-							".flex-center",
-							m(
-								"",
-								{
-									style: {
-										width: "200px",
-									},
-								},
-								m(Button, {
-									label: "adminDeleteAccount_action",
-									click: showDeleteAccountDialog,
-									type: ButtonType.Login,
-								}),
-							),
-						),
-					),
-				),
 			])
 		}
 


### PR DESCRIPTION
this makes delete account available for free users in the ios app which do not see the "plan" settings

includes a minor refactor and improvement to the DeleteAccountDialog.ts because the ios app immediately crashes after deleting the account when it receives the event for the group deletion.