### PR TITLE
move delete account from the "plan" settings to the "general" settings

### DIFF
--- a/src/settings/GlobalSettingsViewer.ts
+++ b/src/settings/GlobalSettingsViewer.ts
@@ -46,6 +46,8 @@ import { assertMainOrNode } from "../api/common/Env"
 import { DropDownSelector } from "../gui/base/DropDownSelector.js"
 import { ButtonSize } from "../gui/base/ButtonSize.js"
 import { SettingsExpander } from "./SettingsExpander.js"
+import { Button, ButtonType } from "../gui/base/Button.js"
+import { showDeleteAccountDialog } from "../subscription/DeleteAccountDialog.js"
 
 assertMainOrNode()
 // Number of days for that we load rejected senders
@@ -73,6 +75,7 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 	private requirePasswordUpdateAfterReset = false
 	private saveIpAddress = false
 	private readonly usageDataExpanded = stream(false)
+	private readonly deleteAccountExpanded = stream(false)
 	private readonly customerProperties = new LazyLoaded(() =>
 		locator.entityClient
 			.load(CustomerTypeRef, neverNull(locator.logins.getUserController().user.customer))
@@ -275,6 +278,33 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 								: null,
 					  )
 					: null,
+				m(
+					".mb-l",
+					m(
+						SettingsExpander,
+						{
+							title: "adminDeleteAccount_action",
+							buttonText: "adminDeleteAccount_action",
+							expanded: this.deleteAccountExpanded,
+						},
+						m(
+							".flex-center",
+							m(
+								"",
+								{
+									style: {
+										width: "200px",
+									},
+								},
+								m(Button, {
+									label: "adminDeleteAccount_action",
+									click: showDeleteAccountDialog,
+									type: ButtonType.Login,
+								}),
+							),
+						),
+					),
+				),
 			]),
 		]
 	}

--- a/src/subscription/SubscriptionViewer.ts
+++ b/src/subscription/SubscriptionViewer.ts
@@ -205,33 +205,6 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 							}),
 					  ]
 					: [],
-				m(
-					".mb-l",
-					m(
-						SettingsExpander,
-						{
-							title: "adminDeleteAccount_action",
-							buttonText: "adminDeleteAccount_action",
-							expanded: deleteAccountExpanded,
-						},
-						m(
-							".flex-center",
-							m(
-								"",
-								{
-									style: {
-										width: "200px",
-									},
-								},
-								m(Button, {
-									label: "adminDeleteAccount_action",
-									click: showDeleteAccountDialog,
-									type: ButtonType.Login,
-								}),
-							),
-						),
-					),
-				),
 			])
 		}
 


### PR DESCRIPTION
this makes delete account available for free users in the ios app which do not see the "plan" settings

includes a minor refactor and improvement to the DeleteAccountDialog.ts because the ios app immediately crashes after deleting the account when it receives the event for the group deletion.