### PR TITLE
improve display of short file names in attachment bubble

### DIFF
--- a/src/gui/AttachmentBubble.ts
+++ b/src/gui/AttachmentBubble.ts
@@ -29,14 +29,13 @@ export class AttachmentBubble implements Component<AttachmentBubbleAttrs> {
 	view(vnode: Vnode<AttachmentBubbleAttrs>): Children {
 		const { attachment } = vnode.attrs
 		const extension = getFileExtension(attachment.name)
-		const spacedExtension = extension.length > 0 ? extension + " " : extension
 		const rest = getFileBaseName(attachment.name)
 		return m(Button, {
 			label: () => rest,
 			title: () => attachment.name,
 			icon: () => Icons.Attachment,
 			type: ButtonType.Bubble,
-			staticRightText: `${spacedExtension}(${formatStorageSize(Number(attachment.size))})`,
+			staticRightText: `${extension}, ${formatStorageSize(Number(attachment.size))}`,
 			click: async () => {
 				await showAttachmentDetailsPopup(this.dom!, vnode.attrs)
 				this.dom?.focus()

--- a/src/gui/base/Button.ts
+++ b/src/gui/base/Button.ts
@@ -145,7 +145,7 @@ export class Button implements ClassComponent<ButtonAttrs> {
 					this._getLabelElement(a),
 					a.staticRightText
 						? m(
-								".pl-s",
+								"span",
 								{
 									style: this._getLabelStyle(a),
 								},


### PR DESCRIPTION
we can remove the right padding on the static right text in the bubble if we use a comma.
this enables us to have no difference between the unsplit name in the expanded bubble and the split name in the collapsed bubble for short names that do not get ellipsed.

since the space right of the ellipsis is added by the browser, we're
unable to remove it easily.

fixes dee136a0c13c5be60188c5d2ba83c487bce4e060

Screencast before: 
[Screencast from 02.06.2023 13:40:29.webm](https://github.com/tutao/tutanota/assets/29049728/3edb3365-6b94-4e3a-99fb-fa22e3cd248c)

Screencast after:
[Screencast from 02.06.2023 13:42:27.webm](https://github.com/tutao/tutanota/assets/29049728/db83336e-8b5e-4978-ae8d-9103748cbd1a)

