### PR TITLE
Inform the user upon reaching maximum alias count

### DIFF
--- a/src/settings/emaildomain/AddEmailAddressesPage.ts
+++ b/src/settings/emaildomain/AddEmailAddressesPage.ts
@@ -175,7 +175,7 @@ export class AddEmailAddressesPageAttrs implements WizardPageAttrs<AddDomainData
 					return true
 				})
 				.catch(ofClass(InvalidDataError, () => Dialog.message("mailAddressNA_msg").then(() => false)))
-				.catch(ofClass(LimitReachedError, () => Dialog.message("adminMaxNbrOfAliasesReached_msg").then(() => false)))
+				.catch(ofClass(LimitReachedError, () => false))
 		}
 	}
 }

--- a/src/settings/mailaddress/AddAliasDialog.ts
+++ b/src/settings/mailaddress/AddAliasDialog.ts
@@ -1,16 +1,18 @@
 import { lang, TranslationKey } from "../../misc/LanguageViewModel.js"
 import stream from "mithril/stream"
 import { Dialog } from "../../gui/base/Dialog.js"
-import { NewPaidPlans, TUTANOTA_MAIL_ADDRESS_DOMAINS } from "../../api/common/TutanotaConstants.js"
+import { NewPaidPlans, PlanType, TUTANOTA_MAIL_ADDRESS_DOMAINS } from "../../api/common/TutanotaConstants.js"
 import m from "mithril"
 import { SelectMailAddressForm } from "../SelectMailAddressForm.js"
 import { ExpanderPanel } from "../../gui/base/Expander.js"
-import { getFirstOrThrow, ofClass } from "@tutao/tutanota-utils"
+import { getFirstOrThrow, noOp, ofClass } from "@tutao/tutanota-utils"
 import { showProgressDialog } from "../../gui/dialogs/ProgressDialog.js"
 import { InvalidDataError, LimitReachedError, PreconditionFailedError } from "../../api/common/error/RestError.js"
 import { MailAddressTableModel } from "./MailAddressTableModel.js"
 import { Autocomplete, TextField } from "../../gui/base/TextField.js"
 import { showPlanUpgradeRequiredDialog } from "../../misc/SubscriptionDialogs.js"
+import { loadUpgradePrices } from "../../subscription/UpgradeSubscriptionWizard.js"
+import { mapUpgradePriceData } from "../../subscription/PriceUtils.js"
 
 const FAILURE_USER_DISABLED = "mailaddressaliasservice.group_disabled"
 
@@ -80,11 +82,7 @@ export function showAddAliasDialog(model: MailAddressTableModel) {
 function addAlias(model: MailAddressTableModel, alias: string, senderName: string): Promise<void> {
 	return showProgressDialog("pleaseWait_msg", model.addAlias(alias, senderName))
 		.catch(ofClass(InvalidDataError, () => Dialog.message("mailAddressNA_msg")))
-		.catch(
-			ofClass(LimitReachedError, () => {
-				showPlanUpgradeRequiredDialog(NewPaidPlans, "moreAliasesRequired_msg")
-			}),
-		)
+		.catch(ofClass(LimitReachedError, noOp))
 		.catch(
 			ofClass(PreconditionFailedError, (e) => {
 				let errorMsg = e.toString()

--- a/src/subscription/PriceUtils.ts
+++ b/src/subscription/PriceUtils.ts
@@ -2,7 +2,7 @@ import { BookingItemFeatureType, Const, PaymentMethodType, PlanType } from "../a
 import { assertTranslation, lang, TranslationKey } from "../misc/LanguageViewModel"
 import { assertNotNull, downcast, neverNull } from "@tutao/tutanota-utils"
 import type { AccountingInfo, PlanPrices, PriceData, PriceItemData } from "../api/entities/sys/TypeRefs.js"
-import { createUpgradePriceServiceData, PlanPricesTypeRef, UpgradePriceServiceReturn } from "../api/entities/sys/TypeRefs.js"
+import { createUpgradePriceServiceData, UpgradePriceServiceReturn } from "../api/entities/sys/TypeRefs.js"
 import { SubscriptionPlanPrices, UpgradePriceType, WebsitePlanPrices } from "./FeatureListProvider"
 import { locator } from "../api/main/MainLocator"
 import { UpgradePriceService } from "../api/entities/sys/Services"
@@ -113,6 +113,25 @@ export function getPriceFromPriceData(priceData: PriceData | null, featureType: 
 	}
 }
 
+/**
+ * Convert an instance of UpgradePriceServiceReturn into an instance of SubscriptionPlanPrices
+ */
+export function mapUpgradePriceData(upgradePriceData: UpgradePriceServiceReturn): SubscriptionPlanPrices {
+	return {
+		[PlanType.Free]: upgradePriceData.freePrices,
+		[PlanType.Premium]: upgradePriceData.premiumPrices,
+		[PlanType.PremiumBusiness]: upgradePriceData.premiumBusinessPrices,
+		[PlanType.Teams]: upgradePriceData.teamsPrices,
+		[PlanType.TeamsBusiness]: upgradePriceData.teamsBusinessPrices,
+		[PlanType.Pro]: upgradePriceData.proPrices,
+		[PlanType.Revolutionary]: upgradePriceData.revolutionaryPrices,
+		[PlanType.Legend]: upgradePriceData.legendaryPrices,
+		[PlanType.Essential]: upgradePriceData.essentialPrices,
+		[PlanType.Advanced]: upgradePriceData.advancedPrices,
+		[PlanType.Unlimited]: upgradePriceData.unlimitedPrices,
+	}
+}
+
 export class PriceAndConfigProvider {
 	private upgradePriceData: UpgradePriceServiceReturn | null = null
 	private planPrices: SubscriptionPlanPrices | null = null
@@ -128,19 +147,7 @@ export class PriceAndConfigProvider {
 		})
 		this.upgradePriceData = await serviceExecutor.get(UpgradePriceService, data)
 		this.isReferralCodeSignup = referralCode != null
-		this.planPrices = {
-			[PlanType.Free]: this.upgradePriceData.freePrices,
-			[PlanType.Premium]: this.upgradePriceData.premiumPrices,
-			[PlanType.PremiumBusiness]: this.upgradePriceData.premiumBusinessPrices,
-			[PlanType.Teams]: this.upgradePriceData.teamsPrices,
-			[PlanType.TeamsBusiness]: this.upgradePriceData.teamsBusinessPrices,
-			[PlanType.Pro]: this.upgradePriceData.proPrices,
-			[PlanType.Revolutionary]: this.upgradePriceData.revolutionaryPrices,
-			[PlanType.Legend]: this.upgradePriceData.legendaryPrices,
-			[PlanType.Essential]: this.upgradePriceData.essentialPrices,
-			[PlanType.Advanced]: this.upgradePriceData.advancedPrices,
-			[PlanType.Unlimited]: this.upgradePriceData.unlimitedPrices,
-		}
+		this.planPrices = mapUpgradePriceData(this.upgradePriceData)
 	}
 
 	static async getInitializedInstance(


### PR DESCRIPTION
If the user books more aliases than any plan allows, we do not want to misinform the user that they can upgrade. So, we query the server and check if any available plans have more aliases than what the user has booked.

tutadb#1476