### PR TITLE
fix offline database migration for new pricing

### DIFF
--- a/src/api/worker/offline/migrations/sys-v86.ts
+++ b/src/api/worker/offline/migrations/sys-v86.ts
@@ -1,13 +1,18 @@
 import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage } from "../OfflineStorage.js"
 import { deleteInstancesOfType } from "../StandardMigrations.js"
-import { CustomerInfoTypeRef } from "../../../entities/sys/TypeRefs.js"
+import { BookingTypeRef, CustomerInfoTypeRef, GroupInfoTypeRef, GroupTypeRef, UserTypeRef } from "../../../entities/sys/TypeRefs.js"
 
 export const sys86: OfflineMigration = {
 	app: "sys",
 	version: 86,
 	async migrate(storage: OfflineStorage) {
 		// delete stored CustomerInfo for new pricing model values and force client to retrieve a new one
-		deleteInstancesOfType(storage, CustomerInfoTypeRef)
+		await deleteInstancesOfType(storage, CustomerInfoTypeRef)
+		await deleteInstancesOfType(storage, GroupTypeRef)
+		await deleteInstancesOfType(storage, BookingTypeRef)
+		// We also delete GroupInfo and UserType ref to disable offline login. Otherwise clients will see an unexpected error message with pure offline login.
+		await deleteInstancesOfType(storage, GroupInfoTypeRef)
+		await deleteInstancesOfType(storage, UserTypeRef)
 	},
 }


### PR DESCRIPTION
# Test notes
- [ ]  create offline database with v3.112.x and then upgrade to 3.113.3 and try offline login. Verify that no unexpected error occurs but offline login should not be possible.
- [ ]  create offline database with v 3.112.x and then upgrade to 3.113.3 and try online login