### PR TITLE
Better mailto handling

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.graphics.Rect
 import android.net.MailTo
+import android.net.ParseException
 import android.net.Uri
 import android.os.Bundle
 import android.os.PowerManager
@@ -573,11 +574,16 @@ class MainActivity : FragmentActivity() {
 		} else {
 			files = listOf()
 		}
-		val mailToUrlString: String = if (intent.data != null && MailTo.isMailTo(intent.dataString)) {
-			intent.dataString ?: ""
-		} else {
-			""
+
+		val mailTo = try {
+			MailTo.parse(intent.dataString.orEmpty())
+		} catch (e: ParseException) {
+			Log.w(TAG, e)
+			null
 		}
+
+		val mailToUrlString: String = if (mailTo != null && !mailTo.isEmpty) intent.dataString.orEmpty() else ""
+
 		try {
 			commonNativeFacade.createMailEditor(
 					files,

--- a/app-android/app/src/main/java/de/tutao/tutanota/Utils.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/Utils.kt
@@ -4,6 +4,7 @@ package de.tutao.tutanota
 
 import android.content.Context
 import android.content.res.Resources
+import android.net.MailTo
 import android.net.Uri
 import android.os.Build
 import android.provider.OpenableColumns
@@ -145,3 +146,6 @@ fun HttpURLConnection.iterateDataAsLines(action: (line: String) -> Unit) =
 fun Int.toPx(): Int = (this * Resources.getSystem().displayMetrics.density).toInt()
 
 fun Int.toDp(): Int = (this / Resources.getSystem().displayMetrics.density).toInt()
+
+val MailTo.isEmpty: Boolean
+	get() = headers?.all { entry -> entry.value.isNullOrEmpty() } ?: true


### PR DESCRIPTION
Hi,

When using the Android Developers' [recommendations](https://developer.android.com/guide/components/intents-common#ComposeEmail) for sending email intents with the `mailto` scheme, Tutanota will use it (even though empty) to create the mail editor, ignoring the other fields like addresses and subject (cf. [WebCommonNativeFacade.ts#L35-L61](https://github.com/tutao/tutanota/blob/fb7d98ec8b4688d0b13954886b0a80acb583aaff/src/native/main/WebCommonNativeFacade.ts#L35-L61)).

This PR aims at improving the way the app handles an email intent by checking that the scheme is not empty (i.e. that it contains at least one valid field).
If the scheme does not hold any meaningful data, then `mailToUrlString` will be empty, and the mail editor will be created using the fields from the intent's extras.

Thanks.