### PR TITLE
Show per-user if the user is expected to have multiple users enabled

### DIFF
--- a/src/subscription/SwitchSubscriptionDialog.ts
+++ b/src/subscription/SwitchSubscriptionDialog.ts
@@ -8,6 +8,7 @@ import {
 	AccountType,
 	AvailablePlanType,
 	BookingFailureReason,
+	BookingItemFeatureType,
 	Const,
 	FeatureType,
 	InvoiceData,
@@ -51,7 +52,7 @@ export async function showSwitchDialog(
 		"pleaseWait_msg",
 		Promise.all([FeatureListProvider.getInitializedInstance(), PriceAndConfigProvider.getInitializedInstance(null, locator.serviceExecutor, null)]),
 	)
-	const model = new SwitchSubscriptionDialogModel(customer, accountingInfo, await locator.logins.getUserController().getPlanType())
+	const model = new SwitchSubscriptionDialogModel(customer, accountingInfo, await locator.logins.getUserController().getPlanType(), lastBooking)
 	const cancelAction = () => {
 		dialog.close()
 		deferred.resolve(customerInfo.plan as PlanType)
@@ -71,6 +72,8 @@ export async function showSwitchDialog(
 	const currentPlanInfo = model.currentPlanInfo
 	const businessUse = stream(currentPlanInfo.businessUse)
 	const paymentInterval = stream(PaymentInterval.Yearly) // always default to yearly
+	const multipleUsersAllowed = model.multipleUsersStillSupportedLegacy()
+
 	const dialog: Dialog = Dialog.largeDialog(headerBarAttrs, {
 		view: () =>
 			m(
@@ -90,7 +93,7 @@ export async function showSwitchDialog(
 					actionButtons: subscriptionActionButtons,
 					featureListProvider: featureListProvider,
 					priceAndConfigProvider,
-					multipleUsersAllowed: isCustomizationEnabledForCustomer(customer, FeatureType.MultipleUsers),
+					multipleUsersAllowed,
 				}),
 			),
 	})

--- a/src/subscription/SwitchSubscriptionDialogModel.ts
+++ b/src/subscription/SwitchSubscriptionDialogModel.ts
@@ -1,6 +1,7 @@
-import { PlanType } from "../api/common/TutanotaConstants"
-import type { AccountingInfo, Customer } from "../api/entities/sys/TypeRefs.js"
+import { BookingItemFeatureType, FeatureType, PlanType } from "../api/common/TutanotaConstants"
+import type { AccountingInfo, Booking, Customer } from "../api/entities/sys/TypeRefs.js"
 import { asPaymentInterval, PaymentInterval } from "./PriceUtils"
+import { isCustomizationEnabledForCustomer } from "../api/common/utils/Utils.js"
 
 export type CurrentPlanInfo = {
 	businessUse: boolean
@@ -11,7 +12,12 @@ export type CurrentPlanInfo = {
 export class SwitchSubscriptionDialogModel {
 	currentPlanInfo: CurrentPlanInfo
 
-	constructor(private readonly customer: Customer, private readonly accountingInfo: AccountingInfo, private readonly planType: PlanType) {
+	constructor(
+		private readonly customer: Customer,
+		private readonly accountingInfo: AccountingInfo,
+		private readonly planType: PlanType,
+		private readonly lastBooking: Booking,
+	) {
 		this.currentPlanInfo = this._initCurrentPlanInfo()
 	}
 
@@ -22,5 +28,33 @@ export class SwitchSubscriptionDialogModel {
 			planType: this.planType,
 			paymentInterval,
 		}
+	}
+
+	/**
+	 * Check if the user's current plan has multiple users due to a legacy agreement and will continue to do so if the user switches plans.
+	 *
+	 * @return true if multiple users are supported due to legacy, false if not; note that returning false does not mean that the current plan does not actually support multiple users
+	 */
+	multipleUsersStillSupportedLegacy(): boolean {
+		if (isCustomizationEnabledForCustomer(this.customer, FeatureType.MultipleUsers)) {
+			return true
+		}
+
+		if (this.planType === PlanType.Premium) {
+			const userItem = this.lastBooking.items.find((item) => item.featureType === BookingItemFeatureType.LegacyUsers)
+			const sharedMailItem = this.lastBooking.items.find((item) => item.featureType === BookingItemFeatureType.SharedMailGroup)
+			const localAdminItem = this.lastBooking.items.find((item) => item.featureType === BookingItemFeatureType.LocalAdminGroup)
+
+			// A user that has PlanType.Premium will always have LegacyUsers booked.
+			const userCount = Number(userItem?.currentCount)
+
+			// These may be booked but not always.
+			const sharedMailCount = sharedMailItem ? Number(sharedMailItem.currentCount) : 0
+			const localAdminCount = localAdminItem ? Number(localAdminItem.currentCount) : 0
+
+			return userCount + sharedMailCount + localAdminCount > 1
+		}
+
+		return false
 	}
 }

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -132,8 +132,6 @@ export default {
 		"bookingSummary_label": "Buchungsübersicht",
 		"boughtGiftCardPosting_label": "Gutschein gekauft",
 		"breakLink_action": "Hyperlink entfernen",
-		"businessFeatureRequiredGeneral_msg": "Um diese Funktion zu benutzen, musst du das Business-Feature buchen.",
-		"businessFeatureRequiredInvite_msg": "Um Kalender-Einladungen zu versenden, musst du das Business-Feature buchen.",
 		"buyGiftCard_label": "Gutschein kaufen",
 		"buy_action": "Kaufen",
 		"by_label": "von",

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -132,8 +132,6 @@ export default {
 		"bookingSummary_label": "Buchungsübersicht",
 		"boughtGiftCardPosting_label": "Gutschein gekauft",
 		"breakLink_action": "Hyperlink entfernen",
-		"businessFeatureRequiredGeneral_msg": "Um diese Funktion zu benutzen, müssen Sie das Business-Feature buchen.",
-		"businessFeatureRequiredInvite_msg": "Um Kalender-Einladungen zu versenden, müssen Sie das Business-Feature buchen.",
 		"buyGiftCard_label": "Gutschein kaufen",
 		"buy_action": "Kaufen",
 		"by_label": "von",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1540,7 +1540,5 @@ export default {
 		"noCalendar_msg": "Please select a calendar for the event.",
 		"cannotEditFullEvent_msg": "You can only edit parts of this event because it does not originate in your calendar.",
 		"upgradeRequired_msg": "This feature is not available on your plan, please upgrade to one of the following plans:",
-		"businessFeatuseRequiredGeneral_msg": "To use this function you have to order the business feature.",
-		"businessFeatureRequiredInvite_msg": "To send event invites you have to order the business feature.",
 	}
 }

--- a/test/tests/subscription/SwitchSubscriptionDialogModelTest.ts
+++ b/test/tests/subscription/SwitchSubscriptionDialogModelTest.ts
@@ -1,0 +1,90 @@
+import { createAccountingInfo, createBooking, createBookingItem, createCustomer, createFeature } from "../../../src/api/entities/sys/TypeRefs.js"
+import { AccountType, BookingItemFeatureType, FeatureType, PlanType } from "../../../src/api/common/TutanotaConstants.js"
+import o from "ospec"
+import { SwitchSubscriptionDialogModel } from "../../../src/subscription/SwitchSubscriptionDialogModel.js"
+import { PaymentInterval } from "../../../src/subscription/PriceUtils.js"
+
+o.spec("SwitchSubscriptionDialogModelTest", function () {
+	const paidPlanType = PlanType.Premium
+	const premiumCustomer = createCustomer({
+		type: AccountType.PREMIUM,
+	})
+	const yearlyIntervalAccountingInfo = createAccountingInfo({
+		paymentInterval: "" + PaymentInterval.Yearly,
+	})
+	o("multipleUsersStillSupportedLegacy - MultipleUsers enabled", function () {
+		const premiumCustomerWithMultipleUsers = createCustomer({
+			customizations: [
+				createFeature({
+					feature: FeatureType.MultipleUsers,
+				}),
+			],
+		})
+		const booking = createBooking({
+			items: [
+				createBookingItem({
+					featureType: BookingItemFeatureType.Revolutionary,
+					currentCount: "1",
+				}),
+			],
+		})
+		const model = new SwitchSubscriptionDialogModel(premiumCustomerWithMultipleUsers, yearlyIntervalAccountingInfo, paidPlanType, booking)
+		o(model.multipleUsersStillSupportedLegacy()).equals(true)
+	})
+	o("multipleUsersStillSupportedLegacy - customer has multiple users booked", function () {
+		const booking = createBooking({
+			items: [
+				createBookingItem({
+					featureType: BookingItemFeatureType.LegacyUsers,
+					currentCount: "2",
+				}),
+			],
+		})
+		const model = new SwitchSubscriptionDialogModel(premiumCustomer, yearlyIntervalAccountingInfo, paidPlanType, booking)
+		o(model.multipleUsersStillSupportedLegacy()).equals(true)
+	})
+	o("multipleUsersStillSupportedLegacy - customer has shared mailbox booked", function () {
+		const booking = createBooking({
+			items: [
+				createBookingItem({
+					featureType: BookingItemFeatureType.LegacyUsers,
+					currentCount: "1",
+				}),
+				createBookingItem({
+					featureType: BookingItemFeatureType.SharedMailGroup,
+					currentCount: "1",
+				}),
+			],
+		})
+		const model = new SwitchSubscriptionDialogModel(premiumCustomer, yearlyIntervalAccountingInfo, paidPlanType, booking)
+		o(model.multipleUsersStillSupportedLegacy()).equals(true)
+	})
+	o("multipleUsersStillSupportedLegacy - customer has a local admin group booked", function () {
+		const booking = createBooking({
+			items: [
+				createBookingItem({
+					featureType: BookingItemFeatureType.LegacyUsers,
+					currentCount: "1",
+				}),
+				createBookingItem({
+					featureType: BookingItemFeatureType.LocalAdminGroup,
+					currentCount: "1",
+				}),
+			],
+		})
+		const model = new SwitchSubscriptionDialogModel(premiumCustomer, yearlyIntervalAccountingInfo, paidPlanType, booking)
+		o(model.multipleUsersStillSupportedLegacy()).equals(true)
+	})
+	o("multipleUsersStillSupportedLegacy - customer only has one user and does not have multiple users enabled", function () {
+		const booking = createBooking({
+			items: [
+				createBookingItem({
+					featureType: BookingItemFeatureType.LegacyUsers,
+					currentCount: "1",
+				}),
+			],
+		})
+		const model = new SwitchSubscriptionDialogModel(premiumCustomer, yearlyIntervalAccountingInfo, paidPlanType, booking)
+		o(model.multipleUsersStillSupportedLegacy()).equals(false)
+	})
+})


### PR DESCRIPTION
New personal plans do not have multiple users enabled, but we want users to switch anyway.

As such, if the user is expected to keep having multiple users, they should see "per user".

This will happen if they have multiple users already booked prior to switching.

Also actually make SwitchSubscriptionDialogModelTest a test.

tutadb#1505