### PR TITLE
Fix constant redraw loop

### DIFF
--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -267,7 +267,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				key: getElementId(viewModel.primaryMail),
 				viewModel: viewModel,
 				// this assumes that the viewSlider focus animation is already started
-				delayBodyRendering: this.viewSlider.waitForAnimation().then(m.redraw),
+				delayBodyRendering: this.viewSlider.waitForAnimation(),
 			}),
 		})
 	}


### PR DESCRIPTION
MailView was scheduling another redraw on every render my chaining redraw after a promise. This redraw is anyway unnecessary as redraw would anyway be triggered in MailViewModel.

fix #5586
fix #5547