### PR TITLE
Fix layout bugs caused by scrollbars

### DIFF
--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -167,18 +167,20 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 								title: lang.get("contacts_label"),
 								columnType: "other",
 							}),
-						columnLayout: m(
-							".fill-absolute.flex.col.scroll",
-							this.showingListView()
-								? m(MultiContactViewer, {
-										selectedEntities: contacts,
-										selectNone: () => this.contactViewModel.listModel.selectNone(),
-								  })
-								: m(ContactCardViewer, {
-										contact: contacts[0],
-										onWriteMail: writeMail,
-								  }),
-						),
+						columnLayout:
+							// see comment for .scrollbar-gutter-stable-or-fallback
+							m(
+								".fill-absolute.flex.col.overflow-y-scroll",
+								this.showingListView()
+									? m(MultiContactViewer, {
+											selectedEntities: contacts,
+											selectNone: () => this.contactViewModel.listModel.selectNone(),
+									  })
+									: m(ContactCardViewer, {
+											contact: contacts[0],
+											onWriteMail: writeMail,
+									  }),
+							),
 					})
 				},
 			},

--- a/src/contacts/view/ContactViewer.ts
+++ b/src/contacts/view/ContactViewer.ts
@@ -41,7 +41,7 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 
 	view({ attrs }: Vnode<ContactViewerAttrs>): Children {
 		const { contact, onWriteMail } = attrs
-		return m(".scroll.plr-l.pb-floating.mlr-safe-inset", [
+		return m(".plr-l.pb-floating.mlr-safe-inset", [
 			m("", [
 				m(
 					".flex-space-between.flex-wrap.mt-m",

--- a/src/gui/DesktopToolbars.ts
+++ b/src/gui/DesktopToolbars.ts
@@ -21,20 +21,33 @@ export const DesktopListToolbar = pureComponent((__, children) => {
 
 /** Toolbar layout that is used in the third/viewer column. */
 export const DesktopViewerToolbar = pureComponent((__, children) => {
+	// The viewer below will (or at least should) reserve some space for the scrollbar. To match that we put `scrollbar-gutter: stable` and for it to have
+	// effect we put `overflow-y: hidden`.
+	//
+	// The outer wrapper will give us margins and padding for the scrollbar and the inner one will actually have to visible background
+	//
+	// see comment for .scrollbar-gutter-stable-or-fallback
 	return m(
-		".flex.pt-xs.pb-xs.plr-m.list-bg",
+		".scrollbar-gutter-stable-or-fallback.overflow-y-hidden",
 		{
 			class: responsiveCardHMargin(),
 			style: {
-				"border-radius": `0 ${size.border_radius_big}px ${size.border_radius_big}px 0`,
 				marginLeft: 0,
 				marginBottom: px(size.hpad_large),
 			},
 		},
-		[
-			// Height keeps the toolbar showing for consistency, even if there are no actions
-			m(".flex-grow", { style: { height: px(size.button_height) } }),
-			children,
-		],
+		m(
+			".flex.list-bg.pt-xs.pb-xs.plr-m",
+			{
+				style: {
+					"border-radius": `0 ${size.border_radius_big}px ${size.border_radius_big}px 0`,
+				},
+			},
+			[
+				// Height keeps the toolbar showing for consistency, even if there are no actions
+				m(".flex-grow", { style: { height: px(size.button_height) } }),
+				children,
+			],
+		),
 	)
 })

--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -123,7 +123,7 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 		const oldAttrs = this.lastAttrs
 		this.lastAttrs = attrs
 		return m(
-			".list-container.scroll.nofocus.overflow-x-hidden.fill-absolute",
+			".list-container.overflow-y-scroll.nofocus.overflow-x-hidden.fill-absolute",
 			{
 				oncreate: ({ dom }: VnodeDOM) => {
 					this.containerDom = dom as HTMLElement

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -34,6 +34,7 @@ export function getFonts(): string {
 const boxShadow = `0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23)`
 const searchBarShadow = "0px 2px 4px rgb(0, 0, 0, 0.12)"
 
+const scrollbarWidthHeight = "18px"
 styles.registerStyle("main", () => {
 	return {
 		"#link-tt": isElectronClient()
@@ -199,6 +200,10 @@ styles.registerStyle("main", () => {
 		},
 		".overflow-y-visible": {
 			"overflow-y": "visible !important",
+		},
+		".overflow-y-scroll": {
+			"overflow-y": "scroll",
+			"webkit-overflow-scrolling": "touch",
 		},
 		".overflow-visible": {
 			overflow: "visible",
@@ -698,7 +703,6 @@ styles.registerStyle("main", () => {
 		".scroll": {
 			"overflow-y": client.overflowAuto,
 			"-webkit-overflow-scrolling": "touch",
-			"-ms-overflow-style": "-ms-autohiding-scrollbar",
 		},
 		".scroll-no-overlay": {
 			"overflow-y": "auto",
@@ -707,7 +711,6 @@ styles.registerStyle("main", () => {
 		".scroll-x": {
 			"overflow-x": "auto",
 			"-webkit-overflow-scrolling": "touch",
-			"-ms-overflow-style": "-ms-autohiding-scrollbar",
 		},
 		"*": {
 			"scrollbar-color": `${theme.content_button} transparent`,
@@ -716,8 +719,8 @@ styles.registerStyle("main", () => {
 		"::-webkit-scrollbar": !client.isMobileDevice()
 			? {
 					background: "transparent",
-					width: "18px", // width of vertical scrollbar
-					height: "18px", // width of horizontal scrollbar
+					width: scrollbarWidthHeight, // width of vertical scrollbar
+					height: scrollbarWidthHeight, // width of horizontal scrollbar
 			  }
 			: {},
 		"::-webkit-scrollbar-thumb": !client.isMobileDevice()
@@ -740,6 +743,19 @@ styles.registerStyle("main", () => {
 		".visible-scrollbar::-webkit-scrollbar-thumb": {
 			background: theme.content_button,
 			"border-radius": "3px",
+		},
+		// we are trying to handle 3 cases:
+		// gecko/FF: supports scrollbar-gutter but not custom scrollbars
+		// blink/Chrome: supports scrollbar-gutter and custom scrollbars
+		// webkit/Safari: supports custom scrollbars but not scrollbar-gutter
+		// so for scrolling containers we just force the scrollbars with `overflow: scroll` and for non-scrolling ones we fall back to padding
+		".scrollbar-gutter-stable-or-fallback": {
+			"scrollbar-gutter": "stable",
+		},
+		"@supports not (scrollbar-gutter: stable)": {
+			".scrollbar-gutter-stable-or-fallback": {
+				"padding-right": scrollbarWidthHeight,
+			},
 		},
 		//TODO: migrate to .text-center
 		".center": {

--- a/src/mail/view/ConversationViewer.ts
+++ b/src/mail/view/ConversationViewer.ts
@@ -71,8 +71,9 @@ export class ConversationViewer implements Component<ConversationViewerAttrs> {
 		this.doScroll(viewModel, this.lastItems)
 
 		return m(".fill-absolute.nav-bg.flex.col", [
+			// see comment for .scrollbar-gutter-stable-or-fallback
 			m(
-				".flex-grow.scroll",
+				".flex-grow.overflow-y-scroll",
 				{
 					oncreate: (vnode) => {
 						this.containerDom = vnode.dom as HTMLElement

--- a/src/search/view/SearchView.ts
+++ b/src/search/view/SearchView.ts
@@ -281,12 +281,17 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 						multicolumnActions: () => actions,
 						primaryAction: () => this.renderHeaderRightView(),
 					}),
-				columnLayout: isMultiselect
-					? m(MultiContactViewer, {
-							selectedEntities: selectedContacts,
-							selectNone: () => this.searchViewModel.listModel.selectNone(),
-					  })
-					: m(ContactCardViewer, { contact: selectedContacts[0], onWriteMail: writeMail }),
+				columnLayout:
+					// see comment for .scrollbar-gutter-stable-or-fallback
+					m(
+						".fill-absolute.flex.col.overflow-y-scroll",
+						isMultiselect
+							? m(MultiContactViewer, {
+									selectedEntities: selectedContacts,
+									selectNone: () => this.searchViewModel.listModel.selectNone(),
+							  })
+							: m(ContactCardViewer, { contact: selectedContacts[0], onWriteMail: writeMail }),
+					),
 			})
 		} else if (getCurrentSearchMode() === "mail") {
 			const selectedMails = this.searchViewModel.getSelectedMails()


### PR DESCRIPTION
No browsers support overlay scrollbars anymore and only some support `scrollbar-gutter` property.

To get a stable layout we force the containers that we expect to scroll to always reserve the space for the scrollbar and we try to match it in the toolbar.

fix #5595