### PR TITLE
fix sanitizeHtml removing tutatemplate: links

### DIFF
--- a/src/misc/HtmlSanitizer.ts
+++ b/src/misc/HtmlSanitizer.ts
@@ -79,10 +79,14 @@ const FORBID_TAGS = Object.freeze([
 	"style",
 ] as const)
 
+/** restricts the allowed protocols to some standard ones + our tutatemplate protocol that allows the knowledge base to link to email templates. */
+const ALLOWED_URI_REGEXP = /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|tutatemplate):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i
+
 const HTML_CONFIG: DOMPurify.Config & { RETURN_DOM_FRAGMENT?: undefined; RETURN_DOM?: undefined } = Object.freeze({
 	ADD_ATTR: ADD_ATTR.slice(),
 	ADD_URI_SAFE_ATTR: ADD_URI_SAFE_ATTR.slice(),
 	FORBID_TAGS: FORBID_TAGS.slice(),
+	ALLOWED_URI_REGEXP,
 } as const)
 const SVG_CONFIG: DOMPurify.Config & { RETURN_DOM_FRAGMENT?: undefined; RETURN_DOM?: undefined } = Object.freeze({
 	ADD_ATTR: ADD_ATTR.slice(),
@@ -95,7 +99,7 @@ const FRAGMENT_CONFIG: DOMPurify.Config & { RETURN_DOM_FRAGMENT: true } = Object
 	ADD_URI_SAFE_ATTR: ADD_URI_SAFE_ATTR.slice(),
 	FORBID_TAGS: FORBID_TAGS.slice(),
 	RETURN_DOM_FRAGMENT: true,
-	ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|tutatemplate):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i,
+	ALLOWED_URI_REGEXP,
 } as const)
 
 type BaseConfig = typeof HTML_CONFIG | typeof SVG_CONFIG | typeof FRAGMENT_CONFIG

--- a/test/tests/misc/HtmlSanitizerTest.ts
+++ b/test/tests/misc/HtmlSanitizerTest.ts
@@ -78,6 +78,17 @@ o.spec(
 			o(sanitizedLink.includes('rel="noopener noreferrer"')).equals(true)
 			o(sanitizedLink.includes(">here</a>")).equals(true)
 		})
+		o("tutatemplate links in html", function () {
+			let tutatemplateLink = '<a href="tutatemplate:some-id/some-entry">#hashtag</a>'
+			let sanitized = htmlSanitizer.sanitizeHTML(tutatemplateLink).html
+			o(sanitized.includes('href="tutatemplate:some-id/some-entry"')).equals(true)
+		})
+		o("tutatemplate links in fragment", function () {
+			const tutatemplateLink = '<a href="tutatemplate:some-id/some-entry">#hashtag</a>'
+			const sanitized = htmlSanitizer.sanitizeFragment(tutatemplateLink).fragment
+			const a = sanitized.querySelector("a")
+			o(a != null && a.href.includes("tutatemplate:some-id/some-entry")).equals(true)
+		})
 		o("notification mail template link", function () {
 			let simpleHtmlLink = '<a href=" {link} ">here</a>'
 			let sanitizedLink = htmlSanitizer.sanitizeHTML(simpleHtmlLink, {


### PR DESCRIPTION
the regex allowing the tutatemplate: protocol
was only added to the sanitizeFragment config.

using sanitizeFragment for sanitizing knowledge
base entries would require us to insert the result manually into the DOM since mithril does not support trusting fragments and we don't want to serialize
to a string and then trust.

so we add the regex to the sanitizeHtml config as well

fix #5640