### PR TITLE
Fix gift cards in Safari, fix preserving hash on redirect

### DIFF
--- a/src/serviceworker/sw.ts
+++ b/src/serviceworker/sw.ts
@@ -148,8 +148,10 @@ export class ServiceWorker {
 	}
 
 	_redirectToDefaultPage(url: string): Response {
-		let hash = url.indexOf("#")
-		const withoutBasePath = url.substring(this._selfLocation.length, hash != -1 ? hash : url.length)
+		// We keep the hash in the url. This might lead to a situation where the client
+		// has the hash twice (once encoded in "r" part and once in the url directly) but
+		// the webapp has been trained to deal with it (see getStartUrl() in app.ts)
+		const withoutBasePath = url.substring(this._selfLocation.length)
 		const params = new URLSearchParams({
 			r: withoutBasePath,
 		})


### PR DESCRIPTION
Service worker has been throwing out the hash part of the URL when redirecting. Most browsers preseve the has on redirects but not Safari.

After changing that we needed to make sure that our redirect system does not result in double hashes concatenated into the URL.

fix #4564