### PR TITLE
Return after catching UpgradeRequiredError

### DIFF
--- a/src/settings/emaildomain/AddEmailAddressesPage.ts
+++ b/src/settings/emaildomain/AddEmailAddressesPage.ts
@@ -184,6 +184,7 @@ export class AddEmailAddressesPageAttrs implements WizardPageAttrs<AddDomainData
 					return false
 				} else if (e instanceof UpgradeRequiredError) {
 					await showPlanUpgradeRequiredDialog(e.plans, e.message)
+					return false
 				}
 				throw e
 			}

--- a/src/settings/emaildomain/AddEmailAddressesPage.ts
+++ b/src/settings/emaildomain/AddEmailAddressesPage.ts
@@ -179,14 +179,14 @@ export class AddEmailAddressesPageAttrs implements WizardPageAttrs<AddDomainData
 			} catch (e) {
 				if (e instanceof InvalidDataError) {
 					await Dialog.message("mailAddressNA_msg")
-					return false
 				} else if (e instanceof LimitReachedError) {
-					return false
+					// ignore
 				} else if (e instanceof UpgradeRequiredError) {
 					await showPlanUpgradeRequiredDialog(e.plans, e.message)
-					return false
+				} else {
+					throw e
 				}
-				throw e
+				return false
 			}
 		}
 	}


### PR DESCRIPTION
Fix re-throwing UpgradeRequiredError when adding an alias from the custom domain wizard.

tutadb#1569