### PR TITLE
fix excessive route changes with mass mail operations

### DIFF
--- a/src/misc/RouteChange.ts
+++ b/src/misc/RouteChange.ts
@@ -1,19 +1,33 @@
 import m from "mithril"
 import { assertMainOrNodeBoot } from "../api/common/Env"
+import { lazyMemoized } from "@tutao/tutanota-utils"
 
 assertMainOrNodeBoot()
 
 export type RouteSetFn = (path: string, args: Record<string, any>) => void
 
-export function throttleRoute(): RouteSetFn {
+/** return a replacement for m.route.set that replaces the last history
+ * state for reroutes that happen quickly enough instead of adding a
+ * new history entry. will also latch to the route, ignoring any
+ * followup calls to the same route.  */
+export const throttleRoute = lazyMemoized((): RouteSetFn => {
 	const limit = 200
 	let lastCall = 0
+	let lastUrl: string | null = null
+	let lastArgs: Record<string, any> = {}
+	let lastRoute = m.route.get()
 	return function (url: string, args: Record<string, any>) {
+		// someone might have called m.route.set() without us, so if the route changed, we need to
+		// call m.route.set() in any case.
+		if (m.route.get() === lastRoute && url === lastUrl && shallowCompare(lastArgs, args)) return
+		lastUrl = url
+		lastArgs = args
 		const now = new Date().getTime()
 		try {
 			m.route.set(url, args, {
 				replace: now - lastCall < limit,
 			})
+			lastRoute = m.route.get()
 		} catch (e) {
 			if (e.message.includes("can't access dead object")) {
 				console.log(`Caught error: ${e.message}`)
@@ -24,6 +38,14 @@ export function throttleRoute(): RouteSetFn {
 
 		lastCall = now
 	}
+})
+
+/** return true if a and b contain the same keys with values that are the same when compared with === */
+function shallowCompare(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+	if (a === b) return true
+	const aEntries = Object.entries(a)
+	const bEntries = Object.entries(b)
+	return aEntries.length === bEntries.length && !aEntries.some(([key, value]) => b[key] !== value)
 }
 
 export const MAIL_PREFIX = "/mail"


### PR DESCRIPTION
when moving a lot of mail or applying entity events, the new mail list tends to re-route to the same path over and over again. throttleRoute now ignores such calls and only actually calls m.route if the arguments are different from the last ones and the route did not change in some other way.

we should consolidate our custom routing logic at some point to make sure all parts of the app play by the same rules.

fix #5651