### PR TITLE
fix not showing all attendees in a single event editor

### DIFF
--- a/src/calendar/view/eventeditor/AttendeeListEditor.ts
+++ b/src/calendar/view/eventeditor/AttendeeListEditor.ts
@@ -50,7 +50,7 @@ export class AttendeeListEditor implements Component<AttendeeListEditorAttrs> {
 
 	private renderInvitationField(attrs: AttendeeListEditorAttrs): Children {
 		const { model, recipientsSearch, logins } = attrs
-
+		if (!model.editModels.whoModel.canModifyGuests) return null
 		return m(".flex.flex-column.flex-grow", [
 			m(MailRecipientsTextField, {
 				label: "addGuest_label",
@@ -190,7 +190,7 @@ function showOrganizerDropdown(editModel: CalendarEventWhoModel, e: MouseEvent) 
 	createDropdown({ lazyButtons, width: 300 })(e, e.target as HTMLElement)
 }
 
-export function renderOrganizer(organizer: Guest, { model }: Pick<AttendeeListEditorAttrs, "model">): Children {
+function renderOrganizer(organizer: Guest, { model }: Pick<AttendeeListEditorAttrs, "model">): Children {
 	const { whoModel } = model.editModels
 	const { address, name, status } = organizer
 	const isMe = organizer.address === whoModel.ownGuest?.address

--- a/src/calendar/view/eventeditor/CalendarEventEditView.ts
+++ b/src/calendar/view/eventeditor/CalendarEventEditView.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { ExpanderButton, ExpanderPanel } from "../../../gui/base/Expander.js"
-import { AttendeeListEditor, AttendeeListEditorAttrs, renderOrganizer } from "./AttendeeListEditor.js"
+import { AttendeeListEditor, AttendeeListEditorAttrs } from "./AttendeeListEditor.js"
 import { locator } from "../../../api/main/MainLocator.js"
 import { EventTimeEditor, EventTimeEditorAttrs } from "./EventTimeEditor.js"
 import { RepeatRuleEditor, RepeatRuleEditorAttrs } from "./RepeatRuleEditor.js"
@@ -47,7 +47,7 @@ export class CalendarEventEditView implements Component<CalendarEventEditViewAtt
 	constructor(vnode: Vnode<CalendarEventEditViewAttrs>) {
 		this.timeFormat = vnode.attrs.timeFormat
 		this.startOfTheWeekOffset = vnode.attrs.startOfTheWeekOffset
-		this.attendeesExpanded = vnode.attrs.model.editModels.whoModel.guests.length > 0
+		this.attendeesExpanded = vnode.attrs.model.editModels.whoModel.canModifyGuests && vnode.attrs.model.editModels.whoModel.guests.length > 0
 		this.recipientsSearch = vnode.attrs.recipientsSearch
 	}
 
@@ -91,7 +91,7 @@ export class CalendarEventEditView implements Component<CalendarEventEditViewAtt
 	}
 
 	private renderGuestsExpanderButton(attrs: CalendarEventEditViewAttrs): Children {
-		if (!attrs.model.editModels.whoModel.canModifyGuests) return null
+		if (!attrs.model.editModels.whoModel.canModifyGuests && attrs.model.editModels.whoModel.guests.length === 0) return null
 		return m(
 			".mr-s",
 			m(ExpanderButton, {
@@ -130,23 +130,18 @@ export class CalendarEventEditView implements Component<CalendarEventEditViewAtt
 
 	private renderAttendees(attrs: CalendarEventEditViewAttrs): Children {
 		const { model } = attrs
-		if (!model.editModels.whoModel.canModifyGuests) {
-			const { organizer } = model.editModels.whoModel
-			return organizer && renderOrganizer(organizer, { model })
-		} else {
-			return m(
-				".mb.rel",
-				m(
-					ExpanderPanel,
-					{ expanded: this.attendeesExpanded },
-					m(AttendeeListEditor, {
-						model,
-						recipientsSearch: this.recipientsSearch,
-						logins: locator.logins,
-					} satisfies AttendeeListEditorAttrs),
-				),
-			)
-		}
+		return m(
+			".mb.rel",
+			m(
+				ExpanderPanel,
+				{ expanded: this.attendeesExpanded },
+				m(AttendeeListEditor, {
+					model,
+					recipientsSearch: this.recipientsSearch,
+					logins: locator.logins,
+				} satisfies AttendeeListEditorAttrs),
+			),
+		)
 	}
 
 	private renderEventTimeEditor(attrs: CalendarEventEditViewAttrs): Children {


### PR DESCRIPTION
we can just show the attendee list editor in a readonly mode. being able to collapse the attendee list is useful even if you're not able to modify guests

fix #5691
fix 3a68f207dd02637603419b2d661d68c46ba6645e