### PR TITLE
fix uncaught error when responding to imported invites

### DIFF
--- a/src/calendar/view/eventpopup/CalendarEventPopupViewModel.ts
+++ b/src/calendar/view/eventpopup/CalendarEventPopupViewModel.ts
@@ -86,8 +86,13 @@ export class CalendarEventPopupViewModel {
 		return this._ownAttendee
 	}
 
-	/** return an object enabling us to set and display the participation correctly if this is an invite we're invited to, null otherwise. */
-	getParticipationSetterAndThen(action: Thunk): null | { ownAttendee: CalendarEventAttendee; setParticipation: (status: CalendarAttendeeStatus) => unknown } {
+	/** return an object enabling us to set and display the participation correctly if this is an invite we're invited to, null otherwise.
+	 * note that the Promise<unknown> type on setParticipation prevents us from leaking errors when consumers call it and try to catch errors without
+	 * awaiting it (they get a async call without await warning) */
+	getParticipationSetterAndThen(action: Thunk): null | {
+		ownAttendee: CalendarEventAttendee
+		setParticipation: (status: CalendarAttendeeStatus) => Promise<unknown>
+	} {
 		if (this.ownAttendee == null || this.eventType !== EventType.INVITE) return null
 		return {
 			ownAttendee: this.ownAttendee,

--- a/src/mail/view/EventBanner.ts
+++ b/src/mail/view/EventBanner.ts
@@ -57,7 +57,7 @@ export class EventBanner implements Component<EventBannerAttrs> {
 			} else if (this.ReplyButtons.isLoaded()) {
 				return m(this.ReplyButtons.getLoaded(), {
 					ownAttendee,
-					setParticipation: (status: CalendarAttendeeStatus) => sendResponse(event, recipient, status, mail),
+					setParticipation: async (status: CalendarAttendeeStatus) => sendResponse(event, recipient, status, mail),
 				})
 			} else {
 				this.ReplyButtons.reload().then(m.redraw)


### PR DESCRIPTION
free users can import invites manually and then
try to use the response feature from the popup.
the resulting UpgradeRequiredError was not caught.

fix #5694
fix 54947127118faf09f41bb4eea42500e3612029ed