### PR TITLE
fix not using the default sender as a default organizer

### DIFF
--- a/buildSrc/postinstall.js
+++ b/buildSrc/postinstall.js
@@ -1,5 +1,5 @@
 /**
- * @file Script to do postinstall tasks without resorting to shell (or batch) scropts.
+ * @file Script to do postinstall tasks without resorting to shell (or batch) scripts.
  */
 
 import { spawnSync } from "node:child_process"

--- a/packages/tutanota-test-utils/package.json
+++ b/packages/tutanota-test-utils/package.json
@@ -20,7 +20,7 @@
 		"LICENSE.txt",
 		"tsconfig.json"
 	],
-	"peerDependencies": {
+	"dependencies": {
 		"@tutao/otest": "3.116.1",
 		"testdouble": "3.18.0"
 	},

--- a/src/calendar/date/eventeditor/CalendarEventModel.ts
+++ b/src/calendar/date/eventeditor/CalendarEventModel.ts
@@ -590,7 +590,8 @@ function getPreselectedCalendar(calendars: ReadonlyMap<Id, CalendarInfo>, event?
 }
 
 /** get the list of mail addresses that are enabled for this mailbox with the configured sender names
- * will put the sender that matches the default sender address in the first spot. */
+ * will put the sender that matches the default sender address in the first spot. this enables us to use
+ * it as an easy default without having to pass it around separately */
 function getOwnMailAddressesWithDefaultSenderInFront(
 	logins: LoginController,
 	mailboxDetail: MailboxDetail,

--- a/src/mail/model/MailUtils.ts
+++ b/src/mail/model/MailUtils.ts
@@ -238,9 +238,9 @@ export function getDefaultSender(logins: LoginController, mailboxDetails: Mailbo
 		let props = logins.getUserController().props
 		return props.defaultSender && contains(getEnabledMailAddressesWithUser(mailboxDetails, logins.getUserController().userGroupInfo), props.defaultSender)
 			? props.defaultSender
-			: neverNull(logins.getUserController().userGroupInfo.mailAddress)
+			: assertNotNull(logins.getUserController().userGroupInfo.mailAddress, "mailAdress on userGroupInfo was null")
 	} else {
-		return neverNull(mailboxDetails.mailGroupInfo.mailAddress)
+		return assertNotNull(mailboxDetails.mailGroupInfo.mailAddress, "mailAddress on mailGroupInfo was null")
 	}
 }
 

--- a/src/mail/model/MailUtils.ts
+++ b/src/mail/model/MailUtils.ts
@@ -238,9 +238,9 @@ export function getDefaultSender(logins: LoginController, mailboxDetails: Mailbo
 		let props = logins.getUserController().props
 		return props.defaultSender && contains(getEnabledMailAddressesWithUser(mailboxDetails, logins.getUserController().userGroupInfo), props.defaultSender)
 			? props.defaultSender
-			: assertNotNull(logins.getUserController().userGroupInfo.mailAddress, "mailAdress on userGroupInfo was null")
+			: assertNotNull(logins.getUserController().userGroupInfo.mailAddress)
 	} else {
-		return assertNotNull(mailboxDetails.mailGroupInfo.mailAddress, "mailAddress on mailGroupInfo was null")
+		return assertNotNull(mailboxDetails.mailGroupInfo.mailAddress)
 	}
 }
 

--- a/test/tests/mail/SendMailModelTest.ts
+++ b/test/tests/mail/SendMailModelTest.ts
@@ -157,7 +157,9 @@ o.spec("SendMailModel", function () {
 		const mailboxDetails: MailboxDetail = {
 			mailbox: createMailBox(),
 			folders: new FolderSystem([]),
-			mailGroupInfo: createGroupInfo(),
+			mailGroupInfo: createGroupInfo({
+				mailAddress: "mailgroup@addre.ss",
+			}),
 			mailGroup: createGroup(),
 			mailboxGroupRoot: createMailboxGroupRoot(),
 		}


### PR DESCRIPTION
for now, we're just putting the default sender in front. to make it more clear, we could pass it around separately, but that would make a fair amount of the logic around handling organizers/attendees more complicated.

fix #5665
fix 54947127118faf09f41bb4eea42500e3612029ed