### PR TITLE
fix altered instances not being excluded on import

### DIFF
--- a/src/api/worker/facades/lazy/CalendarFacade.ts
+++ b/src/api/worker/facades/lazy/CalendarFacade.ts
@@ -62,6 +62,7 @@ import { NativePushFacade } from "../../../../native/common/generatedipc/NativeP
 import { ExposedOperationProgressTracker, OperationId } from "../../../main/OperationProgressTracker.js"
 import { InfoMessageHandler } from "../../../../gui/InfoMessageHandler.js"
 import { ProgrammingError } from "../../../common/error/ProgrammingError.js"
+import { EventWrapper } from "../../../../calendar/export/CalendarImporterDialog.js"
 
 assertWorkerOrNode()
 
@@ -102,15 +103,9 @@ export class CalendarFacade {
 		this.entityClient = new EntityClient(this.entityRestCache)
 	}
 
-	async saveImportedCalendarEvents(
-		eventsWrapper: Array<{
-			event: CalendarEvent
-			alarms: Array<AlarmInfo>
-		}>,
-		operationId: OperationId,
-	): Promise<void> {
+	async saveImportedCalendarEvents(eventWrappers: Array<EventWrapper>, operationId: OperationId): Promise<void> {
 		// it is safe to assume that all event uids are set at this time
-		return this.saveCalendarEvents(eventsWrapper, (percent) => this.operationProgressTracker.onProgress(operationId, percent))
+		return this.saveCalendarEvents(eventWrappers, (percent) => this.operationProgressTracker.onProgress(operationId, percent))
 	}
 
 	/**
@@ -121,13 +116,7 @@ export class CalendarFacade {
 	 * @param eventsWrapper the events and alarmNotifications to be created.
 	 * @param onProgress
 	 */
-	private async saveCalendarEvents(
-		eventsWrapper: Array<{
-			event: CalendarEvent
-			alarms: ReadonlyArray<AlarmInfo>
-		}>,
-		onProgress: (percent: number) => Promise<void>,
-	): Promise<void> {
+	private async saveCalendarEvents(eventsWrapper: Array<EventWrapper>, onProgress: (percent: number) => Promise<void>): Promise<void> {
 		let currentProgress = 10
 		await onProgress(currentProgress)
 
@@ -300,7 +289,7 @@ export class CalendarFacade {
 	 * Load all events that have an alarm assigned.
 	 * @return: Map from concatenated ListId of an event to list of UserAlarmInfos for that event
 	 */
-	async loadAlarmEvents(): Promise<Array<EventWithAlarmInfos>> {
+	async loadAlarmEvents(): Promise<Array<EventWithUserAlarmInfos>> {
 		const alarmInfoList = this.userFacade.getLoggedInUser().alarmInfoList
 
 		if (!alarmInfoList) {
@@ -487,7 +476,7 @@ export class CalendarFacade {
 	}
 }
 
-export type EventWithAlarmInfos = {
+export type EventWithUserAlarmInfos = {
 	event: CalendarEvent
 	userAlarmInfos: Array<UserAlarmInfo>
 }

--- a/src/calendar/export/CalendarImporter.ts
+++ b/src/calendar/export/CalendarImporter.ts
@@ -34,10 +34,10 @@ export type ParsedCalendarData = {
 }
 
 /** given an ical datafile, get the parsed calendar events with their alarms as well as the ical method */
-export async function parseCalendarFile(file: DataFile): Promise<ParsedCalendarData> {
+export function parseCalendarFile(file: DataFile): ParsedCalendarData {
 	try {
 		const stringData = utf8Uint8ArrayToString(file.data)
-		return await parseCalendarStringData(stringData, getTimeZone())
+		return parseCalendarStringData(stringData, getTimeZone())
 	} catch (e) {
 		if (e instanceof ParserError) {
 			throw new ParserError(e.message, file.name)

--- a/test/tests/api/worker/facades/CalendarFacadeTest.ts
+++ b/test/tests/api/worker/facades/CalendarFacadeTest.ts
@@ -1,5 +1,5 @@
 import o from "@tutao/otest"
-import type { CalendarEventAlteredInstance, EventWithAlarmInfos } from "../../../../../src/api/worker/facades/lazy/CalendarFacade.js"
+import type { CalendarEventAlteredInstance, EventWithUserAlarmInfos } from "../../../../../src/api/worker/facades/lazy/CalendarFacade.js"
 import { CalendarFacade, sortByRecurrenceId } from "../../../../../src/api/worker/facades/lazy/CalendarFacade.js"
 import { EntityRestClientMock } from "../rest/EntityRestClientMock.js"
 import { DefaultEntityRestCache } from "../../../../../src/api/worker/rest/DefaultEntityRestCache.js"
@@ -53,7 +53,7 @@ o.spec("CalendarFacadeTest", async function () {
 	let cryptoFacade: CryptoFacade
 	let infoMessageHandler: InfoMessageHandler
 
-	function sortEventsWithAlarmInfos(eventsWithAlarmInfos: Array<EventWithAlarmInfos>) {
+	function sortEventsWithAlarmInfos(eventsWithAlarmInfos: Array<EventWithUserAlarmInfos>) {
 		const idCompare = (el1, el2) => getLetId(el1).join("").localeCompare(getLetId(el2).join(""))
 
 		eventsWithAlarmInfos.sort((a, b) => idCompare(a.event, b.event))


### PR DESCRIPTION
we're now grouping events by uid before checking if they
should be created or not.
the first event of a group without a recurrenceId
is the designated progenitor (the rest is dropped
as duplicate). if it has a repeat rule and we
encounter altered instances in that group,
their recurrenceIds are added as excluded instances
on the progenitor.

this does not handle updating existing progenitors
when new altered instances are imported or adding
existing altered instances on newly imported
progenitors

fix #5708
fix ed27db58b2735268d70a6119ed1deeb27e8a8919