### PR TITLE
Fix applying and displaying system theme

### DIFF
--- a/src/settings/whitelabel/CustomColorsEditorViewModel.ts
+++ b/src/settings/whitelabel/CustomColorsEditorViewModel.ts
@@ -139,7 +139,7 @@ export class CustomColorsEditorViewModel {
 	}
 
 	async resetActiveClientTheme(): Promise<void> {
-		return this._themeController.applyCustomizations(
+		await this._themeController.applyCustomizations(
 			downcast(
 				Object.assign(
 					{},


### PR DESCRIPTION
One issue was missing load of theme preference on init so settings did show the resolved theme id which came from native.

Another issue was not reloading the theme when there was a theme passed in the URL. Because of that we did not get a correctly resolved theme on the first start.

fix #5831
fix #5832