### PR TITLE
Forbid the usage of foreach

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,12 @@
 		"@typescript-eslint/no-explicit-any": 0,
 		"@typescript-eslint/no-unused-vars": 0,
 		"@typescript-eslint/no-inferrable-types": 0,
-		"unicorn/prefer-node-protocol": 2
+		"unicorn/prefer-node-protocol": 2,
+		// foreach is a legacy ad-hoc thing that should be avoided. for..of loops
+		//   1. have proper control flow (e.g. break)
+		//   2. work with async/await
+		//   3. work with static code analysis, e.g. type checking
+		//   4. work with any iterable object
+		"unicorn/no-array-for-each": 2
 	}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,6 +55,7 @@
 		//   2. work with async/await
 		//   3. work with static code analysis, e.g. type checking
 		//   4. work with any iterable object
-		"unicorn/no-array-for-each": 2
+		"unicorn/no-array-for-each": 2,
+		"unicorn/prefer-array-some": 2
 	}
 }

--- a/buildSrc/fixFdroidDeps.js
+++ b/buildSrc/fixFdroidDeps.js
@@ -4,7 +4,7 @@ import fs from "node:fs"
 
 const packageJson = JSON.parse(fs.readFileSync("./package.json", "utf8"))
 
-;[
+const devDependencies = [
 	"electron",
 	"electron-builder",
 	"electron-localshortcut",
@@ -19,12 +19,15 @@ const packageJson = JSON.parse(fs.readFileSync("./package.json", "utf8"))
 	"rcedit",
 	"winreg",
 	"node-forge",
-].forEach((dep) => {
+]
+for (const dep of devDependencies) {
 	delete packageJson.devDependencies[dep]
-})
-;["keytar"].forEach((dep) => {
+}
+
+const dependencies = ["keytar"]
+for (const dep of dependencies) {
 	delete packageJson.dependencies[dep]
-})
+}
 
 delete packageJson.scripts["postinstall"]
 

--- a/buildSrc/graph.js
+++ b/buildSrc/graph.js
@@ -4,11 +4,11 @@ function toDot(modules, output) {
 	let buffer = "digraph G {\n"
 	buffer += "edge [dir=back]\n"
 
-	modules.forEach((m) => {
-		m.deps.forEach((dep) => {
+	for (const m of modules) {
+		for (const dep of m.deps) {
 			buffer += `"${dep}" -> "${m.id}"\n`
-		})
-	})
+		}
+	}
 	buffer += "}\n"
 	fs.writeFileSync(output, buffer, { encoding: "utf8" })
 }
@@ -23,9 +23,9 @@ function prune(modules) {
 	//    console.log("pruning", id);
 	let index = modules.indexOf(avail[0])
 	modules.splice(index, 1)
-	modules.forEach((m) => {
+	for (const m of modules) {
 		m.deps = m.deps.filter((dep) => dep != id)
-	})
+	}
 	prune(modules)
 }
 
@@ -63,7 +63,7 @@ export default function plugin(options = {}) {
 			let strip = (str) => (str.startsWith(prefix) ? str.substring(prefix.length) : str)
 
 			let modules = []
-			ids.forEach((id) => {
+			for (const id of ids) {
 				let m = {
 					id: strip(id),
 					deps: this.getModuleInfo(id)
@@ -72,10 +72,10 @@ export default function plugin(options = {}) {
 						.map(strip),
 				}
 				if (exclude(m.id)) {
-					return
+					continue
 				}
 				modules.push(m)
-			})
+			}
 			if (options.prune) {
 				prune(modules)
 			}

--- a/buildSrc/prepareMobileBuild.js
+++ b/buildSrc/prepareMobileBuild.js
@@ -36,7 +36,7 @@ export async function prepareMobileBuild(buildType) {
 	if (fs.existsSync(imagesPath)) {
 		const imageFiles = await globby(prefix + "images/*")
 		for (let file of imageFiles) {
-			const doDiscard = !imagesToKeep.find((name) => file.endsWith(name))
+			const doDiscard = !imagesToKeep.some((name) => file.endsWith(name))
 			if (doDiscard) {
 				console.log("unlinking ", file)
 				fs.unlinkSync(file)

--- a/packages/licc/lib/Accumulator.ts
+++ b/packages/licc/lib/Accumulator.ts
@@ -25,10 +25,10 @@ export class Accumulator {
 	): this {
 		const lineJoiner = opts?.suffix ?? ""
 		const trailingJoiner = opts?.trailing ?? false
-		lines.forEach((line, idx) => {
+		for (const [idx, line] of lines.entries()) {
 			const joiner = trailingJoiner || idx < lines.length - 1 ? lineJoiner : ""
 			this.line(line + joiner)
-		})
+		}
 		return this
 	}
 

--- a/packages/tutanota-crypto/lib/random/Randomizer.ts
+++ b/packages/tutanota-crypto/lib/random/Randomizer.ts
@@ -25,16 +25,16 @@ export class Randomizer {
 			data: number | Array<number>
 		}>,
 	): Promise<void> {
-		entropyCache.forEach((entry) => {
+		for (const entry of entropyCache) {
 			this.random.addEntropy(entry.data, entry.entropy, entry.source)
-		})
+		}
 		return Promise.resolve()
 	}
 
 	addStaticEntropy(bytes: Uint8Array) {
-		bytes.forEach((byte) => {
+		for (const byte of bytes) {
 			this.random.addEntropy(byte, 8, "static")
-		})
+		}
 	}
 
 	/**

--- a/packages/tutanota-crypto/test/RandomizerTest.ts
+++ b/packages/tutanota-crypto/test/RandomizerTest.ts
@@ -63,7 +63,7 @@ o.spec("Randomizer", function () {
 
 		for (var i = 1; i <= runs; i++) {
 			let r = random.generateRandomData(bytesPerRun)
-			r.forEach((number) => {
+			for (const number of r) {
 				results[number]++
 
 				if (number >= 128) {
@@ -71,12 +71,12 @@ o.spec("Randomizer", function () {
 				} else {
 					lowerHalfCount++
 				}
-			})
+			}
 		}
 
-		results.forEach((count) => {
+		for (const count of results) {
 			o(count >= 500).equals(true) // uniform distribution would mean that each possible number occured 625 times (80%)
-		})
+		}
 		let lowerHalfPercent = (100 / (runs * bytesPerRun)) * lowerHalfCount
 		o(lowerHalfPercent > 49 && lowerHalfPercent < 51).equals(true)("distribution should be nearly uniform") // FIXME generate image from RNG to visualize performance:
 		// http://boallen.com/random-numbers.html

--- a/packages/tutanota-test-utils/lib/TestUtils.ts
+++ b/packages/tutanota-test-utils/lib/TestUtils.ts
@@ -83,9 +83,9 @@ export const mock = <T>(obj: T, mocker: (arg0: any) => any): T => {
 
 export function mapToObject<K extends string | number | symbol, V>(map: Map<K, V>): Record<K, V> {
 	const obj = {} as Record<K, V>
-	map.forEach((value, key) => {
+	for (const [key, value] of map.entries()) {
 		obj[key] = value
-	})
+	}
 	return obj
 }
 

--- a/packages/tutanota-utils/lib/ArrayUtils.ts
+++ b/packages/tutanota-utils/lib/ArrayUtils.ts
@@ -5,10 +5,10 @@ export function concat(...arrays: Uint8Array[]): Uint8Array {
 	let length = arrays.reduce((previous, current) => previous + current.length, 0)
 	let result = new Uint8Array(length)
 	let index = 0
-	arrays.forEach((array) => {
+	for (const array of arrays) {
 		result.set(array, index)
 		index += array.length
-	})
+	}
 	return result
 }
 
@@ -251,9 +251,9 @@ export function addAll(array: Array<any>, elements: Array<any>) {
 }
 
 export function removeAll(array: Array<any>, elements: Array<any>) {
-	elements.forEach((element) => {
+	for (const element of elements) {
 		remove(array, element)
-	})
+	}
 }
 
 /**
@@ -410,13 +410,13 @@ export function zip<A, B>(arr1: Array<A>, arr2: Array<B>): Array<[A, B]> {
 
 export function deduplicate<T>(arr: Array<T>, comp: (arg0: T, arg1: T) => boolean = (a, b) => a === b): Array<T> {
 	const deduplicated: T[] = []
-	arr.forEach((a) => {
+	for (const a of arr) {
 		const isDuplicate = deduplicated.some((b) => comp(a, b))
 
 		if (!isDuplicate) {
 			deduplicated.push(a)
 		}
-	})
+	}
 	return deduplicated
 }
 

--- a/packages/tutanota-utils/lib/MapUtils.ts
+++ b/packages/tutanota-utils/lib/MapUtils.ts
@@ -7,13 +7,13 @@ import { neverNull } from "./Utils.js"
 export function mergeMaps<T>(maps: Map<string, T>[]): Map<string, T[]> {
 	return maps.reduce((mergedMap: Map<string, T[]>, map: Map<string, T>) => {
 		// merge same key of multiple attributes
-		map.forEach((value: T, key: string) => {
+		for (const [key, value] of map.entries()) {
 			if (mergedMap.has(key)) {
 				neverNull(mergedMap.get(key)).push(value)
 			} else {
 				mergedMap.set(key, [value])
 			}
-		})
+		}
 		return mergedMap
 	}, new Map())
 }

--- a/packages/tutanota-utils/test/ArrayUtilsTest.ts
+++ b/packages/tutanota-utils/test/ArrayUtilsTest.ts
@@ -831,8 +831,11 @@ o.spec("array utils", function () {
 				],
 			],
 		]
-		// @ts-ignore
-		testcases.forEach(test)
+
+		for (const testCase of testcases) {
+			// @ts-ignore
+			test(testCase)
+		}
 
 		o("rejection in partitionAsync is propagated", async function () {
 			// can't use assertThrows because of circular dependency

--- a/src/api/common/utils/EntityUtils.ts
+++ b/src/api/common/utils/EntityUtils.ts
@@ -141,7 +141,7 @@ export function haveSameId(entity1: SomeEntity, entity2: SomeEntity): boolean {
 }
 
 export function containsId(ids: ReadonlyArray<Id | IdTuple>, id: Id | IdTuple): boolean {
-	return ids.find((idInArray) => isSameId(idInArray, id)) != null
+	return ids.some((idInArray) => isSameId(idInArray, id))
 }
 
 export interface Element {

--- a/src/api/common/utils/FileUtils.ts
+++ b/src/api/common/utils/FileUtils.ts
@@ -143,9 +143,9 @@ export function isFileReference(file: Attachment): file is FileReference {
 }
 
 export function assertOnlyFileReferences(files: Array<Attachment>): asserts files is Array<FileReference> {
-	if (files.find((f) => !isFileReference(f)) != null) throw new TypeError("not only FileReference")
+	if (files.some((f) => !isFileReference(f))) throw new TypeError("not only FileReference")
 }
 
 export function assertOnlyDataFiles(files: Array<Attachment>): asserts files is Array<DataFile> {
-	if (files.find((f) => !isDataFile(f)) != null) throw new TypeError("not only DataFiles")
+	if (files.some((f) => !isDataFile(f))) throw new TypeError("not only DataFiles")
 }

--- a/src/api/common/utils/PlainTextSearch.ts
+++ b/src/api/common/utils/PlainTextSearch.ts
@@ -80,11 +80,11 @@ function _findMatchInEntry<T>(
 		nestedEntry[attributeName] = splittedValue.join("")
 	}
 
-	findResult.matchedQueryWords.forEach((queryWord) => {
+	for (const queryWord of findResult.matchedQueryWords) {
 		if (searchMatch.matchedWords.indexOf(queryWord) === -1) {
 			searchMatch.matchedWords.push(queryWord)
 		}
-	})
+	}
 
 	if (findResult.hits > 0) {
 		searchMatch.partialWordMatches += findResult.hits
@@ -111,10 +111,8 @@ export function _search<T extends Record<string, any>>(
 			partialWordMatches: 0,
 			matchedWords: [],
 		}
-		attributeNames.forEach((name, index) => {
+		for (const name of attributeNames) {
 			const nestedAttributes = name.split(".")
-			let value = null
-
 			if (nestedAttributes.length === 1) {
 				// no nesting regular value check
 				_findMatchInEntry(entry, nestedAttributes[0], queryString, queryWords, searchMatch, markHits)
@@ -125,12 +123,12 @@ export function _search<T extends Record<string, any>>(
 				const nestedArray: Array<Record<string, any>> = entry[nestedArrayName]
 
 				if (Array.isArray(nestedArray)) {
-					nestedArray.forEach((nestedEntry) => {
+					for (const nestedEntry of nestedArray) {
 						_findMatchInEntry(nestedEntry, nestedEntryAttributeName, queryString, queryWords, searchMatch, markHits)
-					})
+					}
 				}
 			}
-		})
+		}
 		return searchMatch
 	})
 }

--- a/src/api/common/utils/Utils.ts
+++ b/src/api/common/utils/Utils.ts
@@ -63,7 +63,7 @@ export function getCustomMailDomains(customerInfo: CustomerInfo): Array<DomainIn
 }
 
 export function containsEventOfType(events: ReadonlyArray<EntityUpdateData>, type: OperationType, elementId: Id): boolean {
-	return events.find((event) => event.operation === type && event.instanceId === elementId) != null
+	return events.some((event) => event.operation === type && event.instanceId === elementId)
 }
 
 export function getEventOfType(events: ReadonlyArray<EntityUpdate>, type: OperationType, elementId: Id): EntityUpdate | null {
@@ -150,7 +150,7 @@ const ErrorNameToType = {
 }
 
 export function isCustomizationEnabledForCustomer(customer: Customer, feature: FeatureType): boolean {
-	return !!customer.customizations.find((customization) => customization.feature === feature)
+	return customer.customizations.some((customization) => customization.feature === feature)
 }
 
 export function isSecurityError(e: any): boolean {

--- a/src/api/main/UserController.ts
+++ b/src/api/main/UserController.ts
@@ -83,7 +83,7 @@ export class UserController {
 	 */
 	isGlobalAdmin(): boolean {
 		if (this.isInternalUser()) {
-			return this.user.memberships.find((m) => m.groupType === GroupType.Admin) != null
+			return this.user.memberships.some((m) => m.groupType === GroupType.Admin)
 		} else {
 			return false
 		}
@@ -91,7 +91,7 @@ export class UserController {
 
 	isGlobalOrLocalAdmin(): boolean {
 		if (this.isInternalUser()) {
-			return this.user.memberships.find((m) => m.groupType === GroupType.Admin || m.groupType === GroupType.LocalAdmin) != null
+			return this.user.memberships.some((m) => m.groupType === GroupType.Admin || m.groupType === GroupType.LocalAdmin)
 		} else {
 			return false
 		}

--- a/src/api/worker/facades/lazy/CalendarFacade.ts
+++ b/src/api/worker/facades/lazy/CalendarFacade.ts
@@ -138,7 +138,9 @@ export class CalendarFacade {
 			}
 			throw e
 		}
-		eventsWithAlarms.forEach(({ event, alarmInfoIds }) => (event.alarmInfos = alarmInfoIds))
+		for (const { event, alarmInfoIds } of eventsWithAlarms) {
+			event.alarmInfos = alarmInfoIds
+		}
 		currentProgress = 33
 		await onProgress(currentProgress)
 		const eventsWithAlarmsByEventListId = groupBy(eventsWithAlarms, (eventWrapper) => getListId(eventWrapper.event))

--- a/src/api/worker/facades/lazy/MailFacade.ts
+++ b/src/api/worker/facades/lazy/MailFacade.ts
@@ -357,7 +357,7 @@ export class MailFacade {
 			// check which attachments have been removed
 			for (const fileId of existingFileIds) {
 				if (
-					!attachments.find(
+					!attachments.some(
 						(attachment) => attachment._type !== "DataFile" && attachment._type !== "FileReference" && isSameId(getLetId(attachment), fileId),
 					)
 				) {

--- a/src/api/worker/facades/lazy/MailFacade.ts
+++ b/src/api/worker/facades/lazy/MailFacade.ts
@@ -355,7 +355,7 @@ export class MailFacade {
 		if (providedFiles != null) {
 			let attachments = providedFiles
 			// check which attachments have been removed
-			existingFileIds.forEach((fileId) => {
+			for (const fileId of existingFileIds) {
 				if (
 					!attachments.find(
 						(attachment) => attachment._type !== "DataFile" && attachment._type !== "FileReference" && isSameId(getLetId(attachment), fileId),
@@ -363,7 +363,7 @@ export class MailFacade {
 				) {
 					removedAttachmentIds.push(fileId)
 				}
-			})
+			}
 		}
 
 		return removedAttachmentIds
@@ -766,13 +766,13 @@ export class MailFacade {
 	 * @param markers only phishing (not spam) markers will be sent as event bus updates
 	 */
 	phishingMarkersUpdateReceived(markers: ReportedMailFieldMarker[]) {
-		markers.forEach((marker) => {
+		for (const marker of markers) {
 			if (marker.status === PhishingMarkerStatus.INACTIVE) {
 				this.phishingMarkers.delete(marker.marker)
 			} else {
 				this.phishingMarkers.add(marker.marker)
 			}
-		})
+		}
 	}
 
 	getRecipientKeyData(mailAddress: string): Promise<PublicKeyReturn | null> {

--- a/src/api/worker/search/ContactIndexer.ts
+++ b/src/api/worker/search/ContactIndexer.ts
@@ -132,10 +132,10 @@ export class ContactIndexer {
 		let indexUpdate = _createNewIndexUpdate(typeRefToTypeInfo(ContactTypeRef))
 		try {
 			const contacts = await this._entity.loadAll(ContactTypeRef, contactList.contacts)
-			contacts.forEach((contact) => {
+			for (const contact of contacts) {
 				let keyToIndexEntries = this.createContactIndexEntries(contact)
 				this._core.encryptSearchIndexEntries(contact._id, neverNull(contact._ownerGroup), keyToIndexEntries, indexUpdate)
-			})
+			}
 			return Promise.all([
 				this._core.writeIndexUpdate(
 					[

--- a/src/api/worker/search/GroupInfoIndexer.ts
+++ b/src/api/worker/search/GroupInfoIndexer.ts
@@ -98,11 +98,11 @@ export class GroupInfoIndexer {
 
 				let indexUpdate = _createNewIndexUpdate(typeRefToTypeInfo(GroupInfoTypeRef))
 
-				allUserGroupInfos.concat(allTeamGroupInfos).forEach((groupInfo) => {
+				for (const groupInfo of allUserGroupInfos.concat(allTeamGroupInfos)) {
 					let keyToIndexEntries = this.createGroupInfoIndexEntries(groupInfo)
 
 					this._core.encryptSearchIndexEntries(groupInfo._id, neverNull(groupInfo._ownerGroup), keyToIndexEntries, indexUpdate)
-				})
+				}
 				return Promise.all([
 					this._core.writeIndexUpdate(
 						[

--- a/src/api/worker/search/IndexUtils.ts
+++ b/src/api/worker/search/IndexUtils.ts
@@ -169,11 +169,11 @@ export function typeRefToTypeInfo(typeRef: TypeRef<any>): TypeInfo {
 }
 
 export function userIsLocalOrGlobalAdmin(user: User): boolean {
-	return user.memberships.find((m) => m.groupType === GroupType.Admin || m.groupType === GroupType.LocalAdmin) != null
+	return user.memberships.some((m) => m.groupType === GroupType.Admin || m.groupType === GroupType.LocalAdmin)
 }
 
 export function userIsGlobalAdmin(user: User): boolean {
-	return user.memberships.find((m) => m.groupType === GroupType.Admin) != null
+	return user.memberships.some((m) => m.groupType === GroupType.Admin)
 }
 
 export function filterIndexMemberships(user: User): GroupMembership[] {

--- a/src/api/worker/search/Indexer.ts
+++ b/src/api/worker/search/Indexer.ts
@@ -400,8 +400,8 @@ export class Indexer {
 							type: group.value.groupType,
 						}
 					})
-					let deletedGroups = oldGroups.filter((oldGroup) => currentGroups.find((m) => m.id === oldGroup.id) == null)
-					let newGroups = currentGroups.filter((m) => oldGroups.find((oldGroup) => m.id === oldGroup.id) == null)
+					let deletedGroups = oldGroups.filter((oldGroup) => !currentGroups.some((m) => m.id === oldGroup.id))
+					let newGroups = currentGroups.filter((m) => !oldGroups.some((oldGroup) => m.id === oldGroup.id))
 					return {
 						deletedGroups,
 						newGroups,

--- a/src/api/worker/search/Indexer.ts
+++ b/src/api/worker/search/Indexer.ts
@@ -505,9 +505,9 @@ export class Indexer {
 		}[],
 		t2: DbTransaction,
 	): Promise<void> {
-		groupBatches.forEach((groupIdToLastBatchId) => {
+		for (const groupIdToLastBatchId of groupBatches) {
 			t2.put(GroupDataOS, groupIdToLastBatchId.groupId, groupIdToLastBatchId.groupData)
-		})
+		}
 		return t2.wait()
 	}
 

--- a/src/api/worker/search/MailIndexer.ts
+++ b/src/api/worker/search/MailIndexer.ts
@@ -514,11 +514,11 @@ export class MailIndexer {
 				}
 			})
 			.filter(isNotNull)
-		mailWithBodyAndFiles.forEach((element) => {
+		for (const element of mailWithBodyAndFiles) {
 			let keyToIndexEntries = this.createMailIndexEntries(element.mailWrapper, element.files)
 
 			this._core.encryptSearchIndexEntries(element.mail._id, neverNull(element.mail._ownerGroup), keyToIndexEntries, indexUpdate)
-		})
+		}
 		return mailWithBodyAndFiles.length
 	}
 
@@ -645,7 +645,7 @@ export class MailIndexer {
 // export just for testing
 export function _getCurrentIndexTimestamp(groupIndexTimestamps: number[]): number {
 	let currentIndexTimestamp = NOTHING_INDEXED_TIMESTAMP
-	groupIndexTimestamps.forEach((t, index) => {
+	for (const [index, t] of groupIndexTimestamps.entries()) {
 		if (index === 0) {
 			currentIndexTimestamp = t
 		} else if (t === NOTHING_INDEXED_TIMESTAMP) {
@@ -660,7 +660,7 @@ export function _getCurrentIndexTimestamp(groupIndexTimestamps: number[]): numbe
 			// set the oldest index timestamp as current timestamp so all mailboxes can index to this timestamp during log in.
 			currentIndexTimestamp = t
 		}
-	})
+	}
 	return currentIndexTimestamp
 }
 
@@ -759,12 +759,12 @@ class IndexLoader {
 
 	loadAttachments(detailsList: MailWrapper[]): Promise<TutanotaFile[]> {
 		const attachmentIds: IdTuple[] = []
-		detailsList.forEach((d) => {
+		for (const d of detailsList) {
 			attachmentIds.push(...d.getAttachmentIds())
-		})
+		}
 		const filesByList = groupBy(attachmentIds, (a) => a[0])
 		const fileLoadingPromises: Array<Promise<Array<TutanotaFile>>> = []
-		filesByList.forEach((fileIds, listId) => {
+		for (const [listId, fileIds] of filesByList.entries()) {
 			fileLoadingPromises.push(
 				this.loadInChunks(
 					FileTypeRef,
@@ -772,7 +772,7 @@ class IndexLoader {
 					fileIds.map((f) => f[1]),
 				),
 			)
-		})
+		}
 		// if (this._indexingCancelled) throw new CancelledError("cancelled indexing in loading attachments")
 		return Promise.all(fileLoadingPromises).then((filesResults: TutanotaFile[][]) => filesResults.flat())
 	}

--- a/src/api/worker/search/SearchFacade.ts
+++ b/src/api/worker/search/SearchFacade.ts
@@ -221,7 +221,7 @@ export class SearchFacade {
 					return Promise.resolve(normalizeQuery(entity[attributeName]).indexOf(suggestionToken) !== -1)
 				} else {
 					let words = tokenize(entity[attributeName])
-					return Promise.resolve(words.find((w) => w.startsWith(suggestionToken)) != null)
+					return Promise.resolve(words.some((w) => w.startsWith(suggestionToken)))
 				}
 			} else if (model.associations[attributeName] && model.associations[attributeName].type === AssociationType.Aggregation && entity[attributeName]) {
 				let aggregates = model.associations[attributeName].cardinality === Cardinality.Any ? entity[attributeName] : [entity[attributeName]]
@@ -605,7 +605,7 @@ export class SearchFacade {
 	_reduceToUniqueElementIds(results: ReadonlyArray<DecryptedSearchIndexEntry>, previousResult: SearchResult): ReadonlyArray<MoreResultsIndexEntry> {
 		const uniqueIds = new Set<string>()
 		return results.filter((entry) => {
-			if (!uniqueIds.has(entry.id) && !previousResult.results.find((r) => r[1] === entry.id)) {
+			if (!uniqueIds.has(entry.id) && !previousResult.results.some((r) => r[1] === entry.id)) {
 				uniqueIds.add(entry.id)
 				return true
 			} else {

--- a/src/api/worker/search/SearchFacade.ts
+++ b/src/api/worker/search/SearchFacade.ts
@@ -492,24 +492,24 @@ export class SearchFacade {
 	 */
 	_filterByEncryptedId(results: KeyToEncryptedIndexEntries[]): KeyToEncryptedIndexEntries[] {
 		// let matchingEncIds = null
-		let matchingEncIds: Set<number>
-		results.forEach((keyToEncryptedIndexEntry) => {
+		let matchingEncIds: Set<number> | null = null
+		for (const keyToEncryptedIndexEntry of results) {
 			if (matchingEncIds == null) {
 				matchingEncIds = new Set(keyToEncryptedIndexEntry.indexEntries.map((entry) => entry.idHash))
 			} else {
 				const filtered = new Set<number>()
-				keyToEncryptedIndexEntry.indexEntries.forEach((indexEntry) => {
+				for (const indexEntry of keyToEncryptedIndexEntry.indexEntries) {
 					if (matchingEncIds.has(indexEntry.idHash)) {
 						filtered.add(indexEntry.idHash)
 					}
-				})
+				}
 				matchingEncIds = filtered
 			}
-		})
+		}
 		return results.map((r) => {
 			return {
 				indexKey: r.indexKey,
-				indexEntries: r.indexEntries.filter((entry) => matchingEncIds.has(entry.idHash)),
+				indexEntries: r.indexEntries.filter((entry) => matchingEncIds?.has(entry.idHash)),
 			}
 		})
 	}
@@ -529,30 +529,30 @@ export class SearchFacade {
 
 		const minIncludedId = timestampToGeneratedId(endTimestamp)
 		const maxExcludedId = restriction.start ? timestampToGeneratedId(restriction.start + 1) : null
-		results.forEach((result) => {
+		for (const result of results) {
 			result.indexEntries = result.indexEntries.filter((entry) => {
 				return this._isValidAttributeAndTime(restriction, entry, minIncludedId, maxExcludedId)
 			})
-		})
+		}
 		// now filter all ids that are in all of the search words
-		let matchingIds: Set<Id>
-		results.forEach((keyToIndexEntry) => {
+		let matchingIds: Set<Id> | null = null
+		for (const keyToIndexEntry of results) {
 			if (!matchingIds) {
 				matchingIds = new Set(keyToIndexEntry.indexEntries.map((entry) => entry.id))
 			} else {
 				let filtered = new Set<Id>()
-				keyToIndexEntry.indexEntries.forEach((entry) => {
+				for (const entry of keyToIndexEntry.indexEntries) {
 					if (matchingIds.has(entry.id)) {
 						filtered.add(entry.id)
 					}
-				})
+				}
 				matchingIds = filtered
 			}
-		})
+		}
 		return results.map((r) => {
 			return {
 				indexKey: r.indexKey,
-				indexEntries: r.indexEntries.filter((entry) => matchingIds.has(entry.id)),
+				indexEntries: r.indexEntries.filter((entry) => matchingIds?.has(entry.id)),
 			}
 		})
 	}

--- a/src/api/worker/search/SearchIndexEncoding.ts
+++ b/src/api/worker/search/SearchIndexEncoding.ts
@@ -279,7 +279,7 @@ export function decodeNumbers(binaryNumbers: Uint8Array, offset: number = 0): nu
  * @param offset At which offset they should be written
  */
 export function encodeNumbers(numbers: number[], target: Uint8Array, offset: number = 0): void {
-	numbers.forEach((number) => {
+	for (const number of numbers) {
 		offset += encodeNumberBlock(number, target, offset)
-	})
+	}
 }

--- a/src/api/worker/search/SuggestionFacade.ts
+++ b/src/api/worker/search/SuggestionFacade.ts
@@ -31,7 +31,7 @@ export class SuggestionFacade<T> {
 	}
 
 	addSuggestions(words: string[]): void {
-		words.forEach((word) => {
+		for (const word of words) {
 			if (word.length > 0) {
 				let key = word.charAt(0)
 
@@ -51,7 +51,7 @@ export class SuggestionFacade<T> {
 					this._suggestions[key] = [word]
 				}
 			}
-		})
+		}
 	}
 
 	getSuggestions(word: string): string[] {

--- a/src/api/worker/search/WhitelabelChildIndexer.ts
+++ b/src/api/worker/search/WhitelabelChildIndexer.ts
@@ -89,11 +89,11 @@ export class WhitelabelChildIndexer {
 							return children.then((allChildren) => {
 								let indexUpdate = _createNewIndexUpdate(typeRefToTypeInfo(WhitelabelChildTypeRef))
 
-								allChildren.forEach((child) => {
+								for (const child of allChildren) {
 									let keyToIndexEntries = this.createWhitelabelChildIndexEntries(child)
 
 									this._core.encryptSearchIndexEntries(child._id, neverNull(child._ownerGroup), keyToIndexEntries, indexUpdate)
-								})
+								}
 								return Promise.all([
 									this._core.writeIndexUpdate(
 										[

--- a/src/calendar/date/CalendarNotificationSender.ts
+++ b/src/calendar/date/CalendarNotificationSender.ts
@@ -68,13 +68,13 @@ export class CalendarNotificationSender {
 				// and just exclude them from sending out updates but leave the event untouched for other recipients
 				const invalidRecipients = e.message.split("\n")
 				let hasRemovedRecipient = false
-				invalidRecipients.forEach((invalidRecipient) => {
+				for (const invalidRecipient of invalidRecipients) {
 					const recipientInfo = findRecipientWithAddress(sendMailModel.bccRecipients(), invalidRecipient)
 
 					if (recipientInfo) {
 						hasRemovedRecipient = sendMailModel.removeRecipient(recipientInfo, RecipientField.BCC, false) || hasRemovedRecipient
 					}
-				})
+				}
 
 				// only try sending again if we successfully removed a recipient and there are still other recipients
 				if (hasRemovedRecipient && sendMailModel.allRecipients().length) {
@@ -172,7 +172,7 @@ function newLine(label: string, content: string): string {
 
 function attendeesLine(event: CalendarEvent): string {
 	const { organizer } = event
-	var attendees = ""
+	let attendees = ""
 
 	// If organizer is already in the attendees, we don't have to add them separately.
 	if (organizer && !findAttendeeInAddresses(event.attendees, [organizer.address])) {

--- a/src/calendar/date/CalendarUtils.ts
+++ b/src/calendar/date/CalendarUtils.ts
@@ -1270,7 +1270,7 @@ export function getEventType(
 		if (canWrite) {
 			const organizerAddress = cleanMailAddress(existingOrganizer?.address ?? "")
 			const wouldRequireUpdates: boolean =
-				existingEvent.attendees != null && existingEvent.attendees.filter((a) => cleanMailAddress(a.address.address) !== organizerAddress).length > 0
+				existingEvent.attendees != null && existingEvent.attendees.some((a) => cleanMailAddress(a.address.address) !== organizerAddress)
 			return wouldRequireUpdates ? EventType.LOCKED : EventType.SHARED_RW
 		} else {
 			return EventType.SHARED_RO

--- a/src/calendar/date/CalendarUtils.ts
+++ b/src/calendar/date/CalendarUtils.ts
@@ -292,7 +292,7 @@ export function layOutEvents(
 	const children: Array<Children> = []
 	// Cache for calculation events
 	const calcEvents = new Map()
-	events.forEach((e) => {
+	for (const e of events) {
 		const calcEvent = getFromMap(calcEvents, e, () => getCalculationEvent(e, zone, layoutMode))
 		// Check if a new event group needs to be started
 		if (
@@ -344,7 +344,7 @@ export function layOutEvents(
 		if (lastEventStart == null || lastEventStart.getTime() < calcEvent.startTime.getTime()) {
 			lastEventStart = calcEvent.startTime
 		}
-	})
+	}
 	children.push(...renderer(columns))
 	return children
 }

--- a/src/calendar/export/CalendarParser.ts
+++ b/src/calendar/export/CalendarParser.ts
@@ -178,9 +178,9 @@ export function parseProperty(data: string): Property {
 	const params: Record<string, string> = {}
 
 	if (sequence[1]) {
-		sequence[1][1].forEach(([name, eq, value]) => {
+		for (const [name, _eq, value] of sequence[1][1]) {
 			params[name] = value
-		})
+		}
 	}
 
 	const value = sequence[3]
@@ -205,11 +205,11 @@ const valuesSeparatedBySemicolonParser: Parser<Array<[string, string, string]>> 
  * Parses multiple key=value pair on the right side of the semicolon (value side)
  */
 export function parsePropertyKeyValue(data: string): Record<string, string> {
-	const value = valuesSeparatedBySemicolonParser(new StringIterator(data))
+	const values = valuesSeparatedBySemicolonParser(new StringIterator(data))
 	const result: Record<string, string> = {}
-	value.forEach(([key, eq, value]) => {
+	for (const [key, _eq, value] of values) {
 		result[key] = value
-	})
+	}
 	return result
 }
 
@@ -564,20 +564,20 @@ export function parseCalendarEvents(icalObject: ICalObject, zone: string): Parse
 		}
 
 		const alarms: AlarmInfo[] = []
-		eventObj.children.forEach((alarmChild) => {
+		for (const alarmChild of eventObj.children) {
 			if (alarmChild.type === "VALARM") {
 				const newAlarm = parseAlarm(alarmChild, event)
 				if (newAlarm) alarms.push(newAlarm)
 			}
-		})
+		}
 		let attendees: CalendarEventAttendee[] = []
-		eventObj.properties.forEach((property) => {
+		for (const property of eventObj.properties) {
 			if (property.name === "ATTENDEE") {
 				const attendeeAddress = parseMailtoValue(property.value)
 
 				if (!attendeeAddress || !isMailAddress(attendeeAddress, false)) {
 					console.log("attendee has no address or address is invalid, ignoring: ", attendeeAddress)
-					return
+					continue
 				}
 
 				const partStatString = property.params["PARTSTAT"]
@@ -585,7 +585,7 @@ export function parseCalendarEvents(icalObject: ICalObject, zone: string): Parse
 
 				if (!status) {
 					console.log(`attendee has invalid partsat: ${partStatString}, ignoring`)
-					return
+					continue
 				}
 
 				attendees.push(
@@ -598,7 +598,7 @@ export function parseCalendarEvents(icalObject: ICalObject, zone: string): Parse
 					}),
 				)
 			}
-		})
+		}
 		event.attendees = attendees
 		const organizerProp = eventObj.properties.find((p) => p.name === "ORGANIZER")
 

--- a/src/calendar/view/CalendarMonthView.ts
+++ b/src/calendar/view/CalendarMonthView.ts
@@ -312,13 +312,13 @@ export class CalendarMonthView implements Component<CalendarMonthAttrs>, ClassCo
 								)
 								return this.renderEvent(event, position, eventStart, firstDayOfWeek, firstDayOfNextWeek, eventEnd, attrs)
 							} else {
-								week.forEach((dayInWeek, dayIndex) => {
+								for (const [dayIndex, dayInWeek] of week.entries()) {
 									const eventsForDay = attrs.eventsForDays.get(dayInWeek.date.getTime())
 
 									if (eventsForDay && eventsForDay.indexOf(event) !== -1) {
 										moreEventsForDay[dayIndex]++
 									}
-								})
+								}
 								return null
 							}
 						})

--- a/src/calendar/view/CalendarViewModel.ts
+++ b/src/calendar/view/CalendarViewModel.ts
@@ -425,11 +425,11 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 					const calendarMemberships = this.logins.getUserController().getCalendarMemberships()
 					return this._calendarInfos.getAsync().then((calendarInfos) => {
 						// Remove calendars we no longer have membership in
-						calendarInfos.forEach((ci, group) => {
+						for (const group of calendarInfos.keys()) {
 							if (calendarMemberships.every((mb) => group !== mb.group)) {
 								this._hiddenCalendars.delete(group)
 							}
-						})
+						}
 						const oldGroupIds = new Set(calendarInfos.keys())
 						const newGroupIds = new Set(calendarMemberships.map((m) => m.group))
 						const diff = symmetricDifference(oldGroupIds, newGroupIds)
@@ -569,11 +569,9 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 		if (oldEvent.endTime.getTime() !== eventToRemove.endTime.getTime() || !areRepeatRulesEqual(oldEvent.repeatRule, eventToRemove.repeatRule)) {
 			const newMap = this._cloneEvents()
 
-			newMap.forEach(
-				(
-					dayEvents, // finding all because event can overlap with itself so a day can have multiple occurrences of the same event in it
-				) => findAllAndRemove(dayEvents, (e) => isSameId(e._id, oldEvent._id)),
-			)
+			for (const dayEvents of newMap.values()) {
+				findAllAndRemove(dayEvents, (e) => isSameId(e._id, oldEvent._id))
+			}
 
 			this._replaceEvents(newMap)
 		}
@@ -611,7 +609,9 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 	_removeDaysForEvent(id: IdTuple, ownerGroupId: Id) {
 		const newMap = this._cloneEvents()
 
-		newMap.forEach((dayEvents) => findAllAndRemove(dayEvents, (e) => isSameId(e._id, id)))
+		for (const dayEvents of newMap.values()) {
+			findAllAndRemove(dayEvents, (e) => isSameId(e._id, id))
+		}
 
 		this._replaceEvents(newMap)
 

--- a/src/calendar/view/MultiDayCalendarView.ts
+++ b/src/calendar/view/MultiDayCalendarView.ts
@@ -116,7 +116,7 @@ export class MultiDayCalendarView implements Component<Attrs> {
 		return m(
 			".fill-absolute.flex.col.calendar-column-border.mlr-safe-inset.content-bg",
 			{
-				oncreate: (vnode) => {
+				oncreate: () => {
 					this._redrawIntervalId = setInterval(m.redraw, 1000 * 60)
 				},
 				onremove: () => {
@@ -160,11 +160,11 @@ export class MultiDayCalendarView implements Component<Attrs> {
 						},
 						onscroll: (event: Event) => {
 							if (thisWeek === mainWeek) {
-								this._domElements.forEach((dom) => {
+								for (const dom of this._domElements) {
 									if (dom !== event.target) {
 										dom.scrollTop = (event.target as HTMLElement).scrollTop
 									}
-								})
+								}
 
 								this._scrollPosition = (event.target as HTMLElement).scrollTop
 							}

--- a/src/contacts/ContactMergeUtils.ts
+++ b/src/contacts/ContactMergeUtils.ts
@@ -209,7 +209,7 @@ export function _compareMailAddresses(
  */
 export function _getMergedEmailAddresses(mailAddresses1: ContactMailAddress[], mailAddresses2: ContactMailAddress[]): ContactMailAddress[] {
 	let filteredMailAddresses2 = mailAddresses2.filter((ma2) => {
-		return !mailAddresses1.find((ma1) => ma1.address.toLowerCase() === ma2.address.toLowerCase())
+		return !mailAddresses1.some((ma1) => ma1.address.toLowerCase() === ma2.address.toLowerCase())
 	})
 	return mailAddresses1.concat(filteredMailAddresses2)
 }
@@ -270,7 +270,7 @@ function _areSocialIdsEqual(contact1SocialIds: ContactSocialId[], contact2Social
  */
 export function _getMergedSocialIds(socialIds1: ContactSocialId[], socialIds2: ContactSocialId[]): ContactSocialId[] {
 	let filteredSocialIds2 = socialIds2.filter((ma2) => {
-		return !socialIds1.find((ma1) => ma1.socialId === ma2.socialId)
+		return !socialIds1.some((ma1) => ma1.socialId === ma2.socialId)
 	})
 	return socialIds1.concat(filteredSocialIds2)
 }
@@ -289,7 +289,7 @@ function _areAddressesEqual(contact1Addresses: ContactAddress[], contact2Address
  */
 export function _getMergedAddresses(addresses1: ContactAddress[], addresses2: ContactAddress[]): ContactAddress[] {
 	let filteredAddresses2 = addresses2.filter((ma2) => {
-		return !addresses1.find((ma1) => ma1.address === ma2.address)
+		return !addresses1.some((ma1) => ma1.address === ma2.address)
 	})
 	return addresses1.concat(filteredAddresses2)
 }

--- a/src/contacts/VCardExporter.ts
+++ b/src/contacts/VCardExporter.ts
@@ -27,9 +27,9 @@ export function exportContacts(contacts: Contact[]): Promise<void> {
  */
 export function contactsToVCard(contacts: Contact[]): string {
 	let vCardFile = ""
-	contacts.forEach((contact) => {
+	for (const contact of contacts) {
 		vCardFile += _contactToVCard(contact)
-	})
+	}
 	return vCardFile
 }
 

--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -674,9 +674,9 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 					).then((confirmed) => {
 						if (confirmed) {
 							// delete async in the background
-							mergeableAndDuplicates.deletable.forEach((dc) => {
+							for (const dc of mergeableAndDuplicates.deletable) {
 								locator.entityClient.erase(dc)
-							})
+							}
 						}
 					})
 				}

--- a/src/desktop/ApplicationWindow.ts
+++ b/src/desktop/ApplicationWindow.ts
@@ -439,7 +439,7 @@ export class ApplicationWindow {
 	private reRegisterShortcuts() {
 		this.localShortcut.unregisterAll(this._browserWindow)
 
-		this.shortcuts.forEach((s) => {
+		for (const s of this.shortcuts) {
 			// build the accelerator string localShortcut understands
 			let shortcutString = ""
 			shortcutString += s.meta ? "Command+" : ""
@@ -449,7 +449,7 @@ export class ApplicationWindow {
 			shortcutString += capitalizeFirstLetter(typedKeys(Keys).filter((k) => s.key === Keys[k])[0])
 
 			this.localShortcut.register(this._browserWindow, shortcutString, s.exec)
-		})
+		}
 	}
 
 	private sendShortcutstoRender(): void {

--- a/src/desktop/DesktopContextMenu.ts
+++ b/src/desktop/DesktopContextMenu.ts
@@ -78,15 +78,13 @@ export class DesktopContextMenu {
 		const submenu = new this.electron.Menu()
 
 		if (misspelledWord !== "") {
-			dictionarySuggestions
-				.map(
-					(s) =>
-						new this.electron.MenuItem({
-							label: s,
-							click: (mi, bw) => bw && bw.webContents && bw.webContents.replaceMisspelling(s),
-						}),
-				)
-				.forEach((mi) => submenu.append(mi))
+			for (const s of dictionarySuggestions) {
+				const menuItem = new this.electron.MenuItem({
+					label: s,
+					click: (mi, bw) => bw && bw.webContents && bw.webContents.replaceMisspelling(s),
+				})
+				submenu.append(menuItem)
+			}
 			submenu.append(
 				new this.electron.MenuItem({
 					type: "separator",

--- a/src/desktop/DesktopMain.ts
+++ b/src/desktop/DesktopMain.ts
@@ -280,7 +280,7 @@ async function startupInstance(components: Components) {
 			if (wm.getAll().length === 0) {
 				await wm.newWindow(true)
 			} else {
-				wm.getAll().forEach((w) => w.show())
+				for (const w of wm.getAll()) w.show()
 			}
 
 			await handleMailto(findMailToUrlInArgv(args), components)

--- a/src/desktop/DesktopWindowManager.ts
+++ b/src/desktop/DesktopWindowManager.ts
@@ -134,7 +134,9 @@ export class WindowManager {
 			})
 			.on("did-navigate", () => {
 				// electron likes to override the zoom factor when the URL changes.
-				windows.forEach((w) => w.setZoomFactor(this._currentBounds.scale))
+				for (const w of windows) {
+					w.setZoomFactor(this._currentBounds.scale)
+				}
 			})
 
 		w.setContextMenuHandler((params) => this._contextMenu.open(params))
@@ -190,12 +192,16 @@ export class WindowManager {
 		if (process.platform === "darwin") {
 			app.hide() // hide all windows & give active app status to previous app
 		} else {
-			windows.forEach((w) => w.hide())
+			for (const w of windows) {
+				w.hide()
+			}
 		}
 	}
 
 	minimize() {
-		windows.forEach((w) => w.minimize())
+		for (const w of windows) {
+			w.minimize()
+		}
 	}
 
 	changeZoom(scale: number) {
@@ -204,7 +210,9 @@ export class WindowManager {
 		} else if (scale < 0.5) scale = 0.5
 
 		this._currentBounds.scale = scale
-		windows.forEach((w) => w.setZoomFactor(scale))
+		for (const w of windows) {
+			w.setZoomFactor(scale)
+		}
 	}
 
 	get(id: number): ApplicationWindow | null {

--- a/src/desktop/electron-localshortcut/LocalShortcut.ts
+++ b/src/desktop/electron-localshortcut/LocalShortcut.ts
@@ -225,11 +225,11 @@ export function register(win: BrowserWindow, accelerator: Accelerator, callback:
 	let wc = win.webContents
 
 	if (Array.isArray(accelerator)) {
-		accelerator.forEach((accelerator) => {
-			if (typeof accelerator === "string") {
-				register(win, accelerator, callback)
+		for (const acceleratorValue of accelerator) {
+			if (typeof acceleratorValue === "string") {
+				register(win, acceleratorValue, callback)
 			}
-		})
+		}
 		return
 	}
 	const acceleratorString: string = accelerator
@@ -258,14 +258,18 @@ export function register(win: BrowserWindow, accelerator: Accelerator, callback:
 			// Enable shortcut on current windows
 			const windows = BrowserWindow.getAllWindows()
 
-			windows.forEach((win) => enableAppShortcuts(null, win))
+			for (const win of windows) {
+				enableAppShortcuts(null, win)
+			}
 
 			// Enable shortcut on future windows
 			app.on("browser-window-created", enableAppShortcuts)
 
 			shortcutsOfWindow.removeListener = () => {
 				const windows = BrowserWindow.getAllWindows()
-				windows.forEach((win) => win.webContents.removeListener("before-input-event", keyHandler))
+				for (const win of windows) {
+					win.webContents.removeListener("before-input-event", keyHandler)
+				}
 				app.removeListener("browser-window-created", enableAppShortcuts)
 			}
 		} else {
@@ -308,11 +312,11 @@ export function unregister(win: BrowserWindow | typeof ANY_WINDOW, accelerator: 
 	let wc = win instanceof BrowserWindow ? win.webContents : ANY_WINDOW
 
 	if (Array.isArray(accelerator)) {
-		accelerator.forEach((accelerator) => {
-			if (typeof accelerator === "string") {
-				unregister(win, accelerator)
+		for (const nestedAccelerator of accelerator) {
+			if (typeof nestedAccelerator === "string") {
+				unregister(win, nestedAccelerator)
 			}
-		})
+		}
 		return
 	}
 

--- a/src/desktop/sse/DesktopAlarmScheduler.ts
+++ b/src/desktop/sse/DesktopAlarmScheduler.ts
@@ -52,11 +52,11 @@ export class DesktopAlarmScheduler implements NativeAlarmScheduler {
 
 	async unscheduleAllAlarms(userId: Id | null = null): Promise<void> {
 		const alarms = await this.alarmStorage.getScheduledAlarms()
-		alarms.forEach((alarm) => {
+		for (const alarm of alarms) {
 			if (userId == null || alarm.user === userId) {
 				this.cancelAlarms(alarm)
 			}
-		})
+		}
 		return this.alarmStorage.deleteAllAlarms(userId)
 	}
 

--- a/src/desktop/sse/DesktopSseClient.ts
+++ b/src/desktop/sse/DesktopSseClient.ts
@@ -225,7 +225,9 @@ export class DesktopSseClient {
 					const lines = resData.split("\n")
 					resData = lines.pop() ?? "" // put the last line back into the buffer
 
-					lines.forEach((l) => this._processSseData(l, userId))
+					for (const l of lines) {
+						this._processSseData(l, userId)
+					}
 				})
 					.on("close", () => {
 						log.debug("sse response closed")
@@ -372,8 +374,12 @@ export class DesktopSseClient {
 					if (mn.notificationInfos && mn.notificationInfos.length === 0 && mn.alarmNotifications && mn.alarmNotifications.length === 0) {
 						log.debug("MissedNotification is empty")
 					} else {
-						mn.notificationInfos.forEach((ni: NotificationInfo) => this._handleNotificationInfo(this._lang.get("pushNewMail_msg"), ni))
-						mn.alarmNotifications.forEach((an: EncryptedAlarmNotification) => this._alarmScheduler.handleAlarmNotification(an))
+						for (const ni of mn.notificationInfos as Array<NotificationInfo>) {
+							this._handleNotificationInfo(this._lang.get("pushNewMail_msg"), ni)
+						}
+						for (const an of mn.alarmNotifications as Array<EncryptedAlarmNotification>) {
+							this._alarmScheduler.handleAlarmNotification(an)
+						}
 					}
 				})
 				.catch((e) => {

--- a/src/desktop/tray/DesktopTray.ts
+++ b/src/desktop/tray/DesktopTray.ts
@@ -6,7 +6,6 @@ import type { DesktopNotifier } from "../DesktopNotifier"
 import { lang } from "../../misc/LanguageViewModel"
 import { MacTray } from "./MacTray"
 import { NonMacTray } from "./NonMacTray"
-import { getResourcePath } from "../resources"
 import { BuildConfigKey, DesktopConfigKey } from "../config/ConfigKeys"
 import { log } from "../DesktopLog.js"
 
@@ -71,7 +70,7 @@ export class DesktopTray {
 				}),
 			)
 
-			this._wm.getAll().forEach((w) => {
+			for (const w of this._wm.getAll()) {
 				let label = w.getTitle()
 
 				if (notifier.hasNotificationsForWindow(w)) {
@@ -86,10 +85,12 @@ export class DesktopTray {
 						click: () => w.show(),
 					}),
 				)
-			})
+			}
 		}
 
-		platformTray.getPlatformMenuItems().forEach((mi) => m.append(mi))
+		for (const mi of platformTray.getPlatformMenuItems()) {
+			m.append(mi)
+		}
 		platformTray.attachMenuToTray(m, this._tray)
 	}
 

--- a/src/gui/ThemeController.ts
+++ b/src/gui/ThemeController.ts
@@ -139,7 +139,9 @@ export class ThemeController {
 		// see theme.js
 
 		// Clear all the keys first.
-		Object.keys(this.theme).forEach((key) => delete downcast(this.theme)[key])
+		for (const key of Object.keys(this.theme)) {
+			delete downcast(this.theme)[key]
+		}
 		// Write new keys on it later. First default theme as base (so that optional values are correctly filled in) and then the new theme.
 		Object.assign(this.theme, this.getDefaultTheme(), newTheme)
 		this._themeId = newThemeId

--- a/src/gui/animation/Animations.ts
+++ b/src/gui/animation/Animations.ts
@@ -112,7 +112,9 @@ class Animations {
 			.map((mutation) => mutation.willChange())
 			.filter((willChange) => willChange.length)
 			.join(" ")
-		targetsArray.forEach((t) => (t.style.willChange = willChange))
+		for (const t of targetsArray) {
+			t.style.willChange = willChange
+		}
 		const animations: Animation[] = []
 		const promise = new Promise((resolve) => {
 			let start = this.activeAnimations.length ? false : true

--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -568,9 +568,9 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 			this.domSwipeSpacerLeft.style.transform = `translateX(${-translateX}px) translateY(0px)`
 			this.domSwipeSpacerRight.style.transform = `translateX(${translateX}px) translateY(0px)`
 
-			this.rows.forEach((row) => {
+			for (const row of this.rows) {
 				row.domElement && applySafeAreaInsetMarginLR(row.domElement)
-			})
+			}
 
 			this.domSwipeSpacerLeft.style.opacity = "1"
 			this.domSwipeSpacerRight.style.opacity = "1"

--- a/src/gui/base/NotificationOverlay.ts
+++ b/src/gui/base/NotificationOverlay.ts
@@ -92,14 +92,14 @@ function showNextNotification() {
 	}
 
 	// close the notification by default when pressing any button
-	allButtons.forEach((b) => {
+	for (const b of allButtons) {
 		const originClickHandler: clickHandler | undefined = b.click
 
 		b.click = (e, dom) => {
 			originClickHandler?.(e, dom)
 			closeAndOpenNext()
 		}
-	})
+	}
 	// add the postpone button
 	const closeFinalAttrs: ButtonAttrs = Object.assign(
 		{},

--- a/src/gui/editor/Editor.ts
+++ b/src/gui/editor/Editor.ts
@@ -266,7 +266,7 @@ export class Editor implements ImageHandler, Component {
 		}
 
 		// font
-		this.styles.c = pathSegments.find((f) => f.includes("monospace")) !== undefined
+		this.styles.c = pathSegments.some((f) => f.includes("monospace"))
 		// decorations
 		this.styles.b = this.squire.hasFormat("b")
 		this.styles.u = this.squire.hasFormat("u")

--- a/src/gui/nav/ViewSlider.ts
+++ b/src/gui/nav/ViewSlider.ts
@@ -86,7 +86,9 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 
 		this.busy = Promise.resolve()
 		this.isModalBackgroundVisible = false
-		this.viewColumns.forEach((column) => column.setRole(this.getColumnRole(column)))
+		for (const column of this.viewColumns) {
+			column.setRole(this.getColumnRole(column))
+		}
 
 		this.view = ({ attrs }): Children => {
 			const mainSliderColumns = this.getColumnsForMainSlider()
@@ -197,7 +199,9 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 
 		this.setWidthForHiddenColumns(visibleColumns)
 
-		this.viewColumns.forEach((column) => (column.visible = visibleColumns.includes(column)))
+		for (const column of this.viewColumns) {
+			column.visible = visibleColumns.includes(column)
+		}
 		this.updateOffsets()
 		this.visibleBackgroundColumns = visibleColumns
 
@@ -253,7 +257,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	 */
 	private distributeRemainingSpace(visibleColumns: ViewColumn[], remainingSpace: number) {
 		let spacePerColumn = remainingSpace / visibleColumns.length
-		visibleColumns.forEach((visibleColumn: ViewColumn, index) => {
+		for (const [index, visibleColumn] of visibleColumns.entries()) {
 			if (visibleColumns.length - 1 === index) {
 				// ignore max width for the last visible column
 				visibleColumn.setWidth(visibleColumn.minWidth + remainingSpace)
@@ -262,7 +266,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 				remainingSpace -= spaceForThisColumn
 				visibleColumn.setWidth(visibleColumn.minWidth + spaceForThisColumn)
 			}
-		})
+		}
 	}
 
 	private setWidthForHiddenColumns(visibleColumns: ViewColumn[]) {
@@ -273,7 +277,9 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 
 		// if only one column is visible set the same width for all columns ignoring max width
 		if (visibleColumns.length === 1) {
-			this.viewColumns.forEach((column) => column.setWidth(visibleColumns[0].width))
+			for (const column of this.viewColumns) {
+				column.setWidth(visibleColumns[0].width)
+			}
 		}
 
 		// Reduce the width of the foreground button to keep always a small part of the background button visible.

--- a/src/knowledgebase/model/KnowledgeBaseModel.ts
+++ b/src/knowledgebase/model/KnowledgeBaseModel.ts
@@ -95,11 +95,11 @@ export class KnowledgeBaseModel {
 		this._allKeywords = []
 		this._matchedKeywordsInContent = []
 
-		this._allEntries.array.forEach((entry) => {
-			entry.keywords.forEach((keyword) => {
+		for (const entry of this._allEntries.array) {
+			for (const keyword of entry.keywords) {
 				this._allKeywords.push(keyword.keyword)
-			})
-		})
+			}
+		}
 	}
 
 	isSelectedEntry(entry: KnowledgeBaseEntry): boolean {
@@ -133,11 +133,11 @@ export class KnowledgeBaseModel {
 		this._matchedKeywordsInContent = []
 		const emailContentNoTags = emailContent.replace(/(<([^>]+)>)/gi, "") // remove all html tags
 
-		this._allKeywords.forEach((keyword) => {
+		for (const keyword of this._allKeywords) {
 			if (emailContentNoTags.includes(keyword)) {
 				this._matchedKeywordsInContent.push(keyword)
 			}
-		})
+		}
 
 		this._allEntries = SortedArray.from(this._allEntries.array, (a, b) => this._compareEntriesByMatchedKeywords(a, b))
 		this._filterValue = ""
@@ -152,11 +152,11 @@ export class KnowledgeBaseModel {
 
 	_getMatchedKeywordsNumber(entry: KnowledgeBaseEntry): number {
 		let matches = 0
-		entry.keywords.forEach((k) => {
+		for (const k of entry.keywords) {
 			if (this._matchedKeywordsInContent.includes(k.keyword)) {
 				matches++
 			}
-		})
+		}
 		return matches
 	}
 

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -704,7 +704,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 				if (!contactListId) return
 				const id: IdTuple = [contactListId, contactElementId]
 				entity.load(ContactTypeRef, id).then((contact) => {
-					if (contact.mailAddresses.find((ma) => cleanMatch(ma.address, mailAddress))) {
+					if (contact.mailAddresses.some((ma) => cleanMatch(ma.address, mailAddress))) {
 						recipient.setName(getContactDisplayName(contact))
 						recipient.setContact(contact)
 					} else {

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -260,7 +260,9 @@ export class MailEditor implements Component<MailEditorAttrs> {
 				help: "formatTextUnderline_msg",
 			},
 		]
-		shortcuts.forEach(dialog.addShortcut.bind(dialog))
+		for (const shortcut of shortcuts) {
+			dialog.addShortcut(shortcut)
+		}
 		this.editor.initialized.promise.then(() => {
 			a.knowledgeBaseInjection(this.editor).then((injection) => {
 				this.knowledgeBaseInjection = injection
@@ -685,7 +687,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 	}
 
 	private async getRecipientClickedContextButtons(recipient: ResolvableRecipient, field: RecipientField): Promise<DropdownChildAttrs[]> {
-		const { logins, entity, contactModel } = this.sendMailModel
+		const { entity, contactModel } = this.sendMailModel
 
 		const canEditBubbleRecipient = locator.logins.getUserController().isInternalUser() && !locator.logins.isEnabled(FeatureType.DisableContacts)
 

--- a/src/mail/editor/MailEditorViewModel.ts
+++ b/src/mail/editor/MailEditorViewModel.ts
@@ -134,7 +134,7 @@ export const cleanupInlineAttachments: (arg0: HTMLElement, arg1: Array<HTMLEleme
 		// briefly, e.g. if some text is inserted before/after the element, Squire would put it into another diff and this
 		// means removal + insertion.
 		const elementsToRemove: HTMLElement[] = []
-		inlineImageElements.forEach((inlineImage) => {
+		for (const inlineImage of inlineImageElements) {
 			if (domElement && !domElement.contains(inlineImage)) {
 				const cid = inlineImage.getAttribute("cid")
 				const attachmentIndex = attachments.findIndex((a) => a.cid === cid)
@@ -145,7 +145,7 @@ export const cleanupInlineAttachments: (arg0: HTMLElement, arg1: Array<HTMLEleme
 					m.redraw()
 				}
 			}
-		})
+		}
 		findAllAndRemove(inlineImageElements, (imageElement) => elementsToRemove.includes(imageElement))
 	},
 )

--- a/src/mail/editor/SendMailModel.ts
+++ b/src/mail/editor/SendMailModel.ts
@@ -1028,7 +1028,7 @@ export class SendMailModel {
 						)
 						for (const recipient of matching) {
 							// if the mail address no longer exists on the contact then delete the recipient
-							if (!contact.mailAddresses.find((ma) => cleanMatch(ma.address, recipient.address))) {
+							if (!contact.mailAddresses.some((ma) => cleanMatch(ma.address, recipient.address))) {
 								changed = changed || this.removeRecipient(recipient, fieldType, true)
 							} else {
 								// else just modify the recipient

--- a/src/mail/editor/SendMailModel.ts
+++ b/src/mail/editor/SendMailModel.ts
@@ -1026,7 +1026,7 @@ export class SendMailModel {
 						const matching = this.getRecipientList(fieldType).filter(
 							(recipient) => recipient.contact && isSameId(recipient.contact._id, contact._id),
 						)
-						matching.forEach((recipient) => {
+						for (const recipient of matching) {
 							// if the mail address no longer exists on the contact then delete the recipient
 							if (!contact.mailAddresses.find((ma) => cleanMatch(ma.address, recipient.address))) {
 								changed = changed || this.removeRecipient(recipient, fieldType, true)
@@ -1036,7 +1036,7 @@ export class SendMailModel {
 								recipient.setContact(contact)
 								changed = true
 							}
-						})
+						}
 					}
 				})
 			} else if (operation === OperationType.DELETE) {

--- a/src/mail/model/MailModel.ts
+++ b/src/mail/model/MailModel.ts
@@ -377,9 +377,9 @@ export class MailModel {
 	_mailboxCountersUpdates(counters: WebsocketCounterData) {
 		const normalized = this.mailboxCounters() || {}
 		const group = normalized[counters.mailGroup] || {}
-		counters.counterValues.forEach((value) => {
+		for (const value of counters.counterValues) {
 			group[value.mailListId] = Number(value.count) || 0
-		})
+		}
 		normalized[counters.mailGroup] = group
 		this.mailboxCounters(normalized)
 	}

--- a/src/mail/model/MailUtils.ts
+++ b/src/mail/model/MailUtils.ts
@@ -337,14 +337,14 @@ export function checkAttachmentSize(files: ReadonlyArray<Attachment>, maxAttachm
 	let totalSize = 0
 	const attachableFiles: Array<Attachment> = []
 	const tooBigFiles: Array<string> = []
-	files.forEach((file) => {
+	for (const file of files) {
 		if (totalSize + Number(file.size) > maxAttachmentSize) {
 			tooBigFiles.push(file.name)
 		} else {
 			totalSize += Number(file.size)
 			attachableFiles.push(file)
 		}
-	})
+	}
 	return {
 		attachableFiles,
 		tooBigFiles,

--- a/src/mail/model/MinimizedMailEditorViewModel.ts
+++ b/src/mail/model/MinimizedMailEditorViewModel.ts
@@ -58,7 +58,7 @@ export class MinimizedMailEditorViewModel {
 		dialog.close()
 
 		// disallow creation of duplicate minimized mails
-		if (!this._minimizedEditors.find((editor) => editor.dialog === dialog)) {
+		if (!this._minimizedEditors.some((editor) => editor.dialog === dialog)) {
 			this._minimizedEditors.push({
 				sendMailModel: sendMailModel,
 				dialog: dialog,

--- a/src/mail/view/MailGuiUtils.ts
+++ b/src/mail/view/MailGuiUtils.ts
@@ -174,7 +174,7 @@ export function replaceCidsWithInlineImages(
 		imageElements.push(...shadowImageElements)
 	}
 	const elementsWithCid: HTMLElement[] = []
-	imageElements.forEach((imageElement) => {
+	for (const imageElement of imageElements) {
 		const cid = imageElement.getAttribute("cid")
 
 		if (cid) {
@@ -228,18 +228,18 @@ export function replaceCidsWithInlineImages(
 				}
 			}
 		}
-	})
+	}
 	return elementsWithCid
 }
 
 export function replaceInlineImagesWithCids(dom: HTMLElement): HTMLElement {
 	const domClone = dom.cloneNode(true) as HTMLElement
 	const inlineImages: Array<HTMLElement> = Array.from(domClone.querySelectorAll("img[cid]"))
-	inlineImages.forEach((inlineImage) => {
+	for (const inlineImage of inlineImages) {
 		const cid = inlineImage.getAttribute("cid")
 		inlineImage.setAttribute("src", "cid:" + (cid || ""))
 		inlineImage.removeAttribute("cid")
-	})
+	}
 	return domClone
 }
 
@@ -269,7 +269,7 @@ function createInlineImageReference(file: DataFile, cid: string): InlineImageRef
 
 export function cloneInlineImages(inlineImages: InlineImages): InlineImages {
 	const newMap = new Map()
-	inlineImages.forEach((v, k) => {
+	for (const [k, v] of inlineImages.entries()) {
 		const blob = new Blob([v.blob])
 		const objectUrl = URL.createObjectURL(blob)
 		newMap.set(k, {
@@ -277,14 +277,14 @@ export function cloneInlineImages(inlineImages: InlineImages): InlineImages {
 			objectUrl,
 			blob,
 		})
-	})
+	}
 	return newMap
 }
 
 export function revokeInlineImages(inlineImages: InlineImages): void {
-	inlineImages.forEach((v, k) => {
+	for (const v of inlineImages.values()) {
 		URL.revokeObjectURL(v.objectUrl)
-	})
+	}
 }
 
 export async function loadInlineImages(fileController: FileController, attachments: Array<TutanotaFile>, referencedCids: Array<string>): Promise<InlineImages> {

--- a/src/mail/view/MailListView.ts
+++ b/src/mail/view/MailListView.ts
@@ -148,7 +148,7 @@ export class MailListView implements Component<MailListViewAttrs> {
 			// if the mail being dragged is not included in the mails that are selected, then we only drag
 			// the mail that is currently being dragged, to match the behaviour of regular in-app dragging and dropping
 			// which seemingly behaves how it does just by default
-			const draggedMails = selected.find((mail) => haveSameId(mail, mailUnderCursor)) ? selected.slice() : [mailUnderCursor]
+			const draggedMails = selected.some((mail) => haveSameId(mail, mailUnderCursor)) ? selected.slice() : [mailUnderCursor]
 
 			this._doExportDrag(draggedMails)
 		} else if (styles.isDesktopLayout()) {

--- a/src/mail/view/MailViewerHeader.ts
+++ b/src/mail/view/MailViewerHeader.ts
@@ -476,7 +476,9 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 
 			// Get the total size of the attachments
 			let totalAttachmentSize = 0
-			attachments.forEach((attachment) => (totalAttachmentSize += Number(attachment.size)))
+			for (const attachment of attachments) {
+				totalAttachmentSize += Number(attachment.size)
+			}
 
 			return [
 				m(".flex" + "." + responsiveCardHMargin(), liveDataAttrs(), [

--- a/src/misc/2fa/webauthn/WebauthnClient.ts
+++ b/src/misc/2fa/webauthn/WebauthnClient.ts
@@ -124,7 +124,9 @@ export class WebauthnClient {
 		// get the length of the credential ID
 		const dataView = new DataView(new ArrayBuffer(2))
 		const idLenBytes = authData.slice(53, 55)
-		idLenBytes.forEach((value, index) => dataView.setUint8(index, value))
+		for (const [index, value] of idLenBytes.entries()) {
+			dataView.setUint8(index, value)
+		}
 		const credentialIdLength = dataView.getUint16(0)
 		// get the public key object
 		const publicKeyBytes = authData.slice(55 + credentialIdLength)

--- a/src/misc/HtmlSanitizer.ts
+++ b/src/misc/HtmlSanitizer.ts
@@ -290,7 +290,7 @@ export class HtmlSanitizer {
 	}
 
 	private replaceAttributeValue(htmlNode: HTMLElement, config: SanitizeConfig) {
-		EXTERNAL_CONTENT_ATTRS.forEach((attrName) => {
+		for (const attrName of EXTERNAL_CONTENT_ATTRS) {
 			let attribute = htmlNode.attributes.getNamedItem(attrName)
 
 			if (attribute) {
@@ -317,7 +317,7 @@ export class HtmlSanitizer {
 					htmlNode.style.maxWidth = "100px"
 				}
 			}
-		})
+		}
 	}
 
 	/** NB! {@param cssStyleAttributeName} is a *CSS* name ("border-image-source" as opposed to "borderImageSource"). */

--- a/src/misc/KeyManager.ts
+++ b/src/misc/KeyManager.ts
@@ -209,7 +209,9 @@ class KeyManager {
 	 * @private
 	 */
 	_applyOperation(shortcuts: ReadonlyArray<Shortcut>, operation: (id: string, s: Shortcut) => unknown) {
-		shortcuts.forEach((s) => operation(createKeyIdentifier(s.key.code, s.ctrl, s.alt, s.shift, s.meta), s))
+		for (const s of shortcuts) {
+			operation(createKeyIdentifier(s.key.code, s.ctrl, s.alt, s.shift, s.meta), s)
+		}
 	}
 }
 

--- a/src/misc/UsageTestModel.ts
+++ b/src/misc/UsageTestModel.ts
@@ -346,19 +346,19 @@ export class UsageTestModel implements PingAdapter {
 
 			for (const [index, stageConfig] of usageTestAssignment.stages.entries()) {
 				const stage = new Stage(index, test, Number(stageConfig.minPings), Number(stageConfig.maxPings))
-				stageConfig.metrics.forEach((metricConfig) => {
+				for (const metricConfig of stageConfig.metrics) {
 					const configValues = new Map<string, string>()
 
-					metricConfig.configValues.forEach((metricConfigValue) => {
+					for (const metricConfigValue of metricConfig.configValues) {
 						configValues.set(metricConfigValue.key, metricConfigValue.value)
-					})
+					}
 
 					stage.setMetricConfig({
 						name: metricConfig.name,
 						type: metricConfig.type,
 						configValues,
 					})
-				})
+				}
 
 				test.addStage(stage)
 			}

--- a/src/misc/WindowFacade.ts
+++ b/src/misc/WindowFacade.ts
@@ -88,7 +88,9 @@ export class WindowFacade {
 	}
 
 	_notifyCloseListeners(e: Event) {
-		this._windowCloseListeners.forEach((f) => f(e))
+		for (const f of this._windowCloseListeners) {
+			f(e)
+		}
 	}
 
 	addKeyboardSizeListener(listener: KeyboardSizeListener) {

--- a/src/search/view/SearchViewModel.ts
+++ b/src/search/view/SearchViewModel.ts
@@ -455,7 +455,7 @@ export class SearchViewModel {
 
 	isInSearchResult(typeRef: TypeRef<unknown>, id: IdTuple): boolean {
 		const result = this._searchResult
-		return !!(result && isSameTypeRef(typeRef, result.restriction.type) && result.results.find((r) => isSameId(r, id)))
+		return !!(result && isSameTypeRef(typeRef, result.restriction.type) && result.results.some((r) => isSameId(r, id)))
 	}
 
 	private async loadSearchResults<T extends SearchableTypes>(
@@ -523,7 +523,7 @@ export class SearchViewModel {
 			for (let i = toLoad.length - 1; i >= 0; i--) {
 				const toLoadId = toLoad[i]
 
-				if (instances.find((instance) => isSameId(instance._id, toLoadId)) == null) {
+				if (!instances.some((instance) => isSameId(instance._id, toLoadId))) {
 					currentResult.results.splice(startIndex + i, 1)
 
 					if (instances.length === toLoad.length) {

--- a/src/serviceworker/sw.ts
+++ b/src/serviceworker/sw.ts
@@ -203,14 +203,14 @@ const init = (sw: ServiceWorker) => {
 			data: error.data,
 		}
 		// @ts-ignore
-		return scope.clients.matchAll().then((allClients) =>
-			allClients.forEach((c: Client) =>
+		return scope.clients.matchAll().then((allClients) => {
+			for (const c of allClients) {
 				c.postMessage({
 					type: "error",
 					value: serializedError,
-				}),
-			),
-		)
+				})
+			}
+		})
 	})
 }
 

--- a/src/settings/DomainDnsStatus.ts
+++ b/src/settings/DomainDnsStatus.ts
@@ -64,17 +64,17 @@ export class DomainDnsStatus {
 
 			if (result.checkResult === CustomDomainCheckResult.CUSTOM_DOMAIN_CHECK_RESULT_OK) {
 				let mxOk =
-					!result.missingRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_MX) &&
-					!result.invalidRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_MX)
+					!result.missingRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_MX) &&
+					!result.invalidRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_MX)
 				let spfOk =
-					!result.missingRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_TXT_SPF) &&
-					!result.invalidRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_TXT_SPF)
+					!result.missingRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_TXT_SPF) &&
+					!result.invalidRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_TXT_SPF)
 				let dkimOk =
-					!result.missingRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_DKIM) &&
-					!result.invalidRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_DKIM)
+					!result.missingRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_DKIM) &&
+					!result.invalidRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_DKIM)
 				let mtaStsOk =
-					!result.missingRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_MTA_STS) &&
-					!result.invalidRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_MTA_STS)
+					!result.missingRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_MTA_STS) &&
+					!result.invalidRecords.some((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_CNAME_MTA_STS)
 				let dmarcWarn = result.missingRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_TXT_DMARC)
 				let dmarcBad = result.invalidRecords.find((r) => r.type === DnsRecordType.DNS_RECORD_TYPE_TXT_DMARC)
 				return (

--- a/src/settings/EditOutOfOfficeNotificationDialogModel.ts
+++ b/src/settings/EditOutOfOfficeNotificationDialogModel.ts
@@ -60,7 +60,7 @@ export class EditOutOfOfficeNotificationDialogModel {
 			this.enabled(outOfOfficeNotification.enabled)
 			let defaultEnabled = false
 			let organizationEnabled = false
-			outOfOfficeNotification.notifications.forEach((notification) => {
+			for (const notification of outOfOfficeNotification.notifications) {
 				if (notification.type === OutOfOfficeNotificationMessageType.Default) {
 					defaultEnabled = true
 					this.defaultSubject(notification.subject)
@@ -70,7 +70,7 @@ export class EditOutOfOfficeNotificationDialogModel {
 					this.organizationSubject(notification.subject)
 					this.organizationMessage(notification.message)
 				}
-			})
+			}
 
 			if (defaultEnabled && organizationEnabled) {
 				this.recipientMessageTypes(RecipientMessageType.INTERNAL_AND_EXTERNAL)

--- a/src/settings/GlobalSettingsViewer.ts
+++ b/src/settings/GlobalSettingsViewer.ts
@@ -532,7 +532,7 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 		let customDomainInfos = getCustomMailDomains(customerInfo)
 		// remove dns status instances for all removed domains
 		for (const domain of Object.keys(this.domainDnsStatus)) {
-			if (!customDomainInfos.find((di) => di.domain === domain)) {
+			if (!customDomainInfos.some((di) => di.domain === domain)) {
 				delete this.domainDnsStatus[domain]
 			}
 		}

--- a/src/settings/GlobalSettingsViewer.ts
+++ b/src/settings/GlobalSettingsViewer.ts
@@ -531,11 +531,11 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 		const customerInfo = await this.customerInfo.getAsync()
 		let customDomainInfos = getCustomMailDomains(customerInfo)
 		// remove dns status instances for all removed domains
-		Object.keys(this.domainDnsStatus).forEach((domain) => {
+		for (const domain of Object.keys(this.domainDnsStatus)) {
 			if (!customDomainInfos.find((di) => di.domain === domain)) {
 				delete this.domainDnsStatus[domain]
 			}
-		})
+		}
 		return promiseMap(customDomainInfos, (domainInfo) => {
 			// create dns status instances for all new domains
 			if (!this.domainDnsStatus[domainInfo.domain]) {

--- a/src/settings/ImportUsersViewer.ts
+++ b/src/settings/ImportUsersViewer.ts
@@ -101,7 +101,7 @@ function checkAndGetErrorMessage(userData: UserImportDetails[], availableDomains
 				errorMessageArray.push("enterMissingPassword_msg")
 			}
 
-			if (userData.find((otherUser) => otherUser.mailAddress === mailAddress && otherUser !== u)) {
+			if (userData.some((otherUser) => otherUser.mailAddress === mailAddress && otherUser !== u)) {
 				errorMessageArray.push("duplicatedMailAddressInUserList_msg")
 			}
 

--- a/src/settings/SetDomainCertificateDialog.ts
+++ b/src/settings/SetDomainCertificateDialog.ts
@@ -78,7 +78,7 @@ export function show(customerInfo: CustomerInfo): void {
 
 			if (!isDomainName(domainAllLowercase) || domainAllLowercase.split(".").length < 3) {
 				Dialog.message("notASubdomain_msg")
-			} else if (customerInfo.domainInfos.find((di) => !di.whitelabelConfig && di.domain === domainAllLowercase)) {
+			} else if (customerInfo.domainInfos.some((di) => !di.whitelabelConfig && di.domain === domainAllLowercase)) {
 				Dialog.message("customDomainErrorDomainNotAvailable_msg")
 			} else {
 				orderWhitelabelCertificate(domainAllLowercase, dialog)

--- a/src/settings/SettingsView.ts
+++ b/src/settings/SettingsView.ts
@@ -621,7 +621,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 	}
 
 	_isGlobalOrLocalAdmin(user: User): boolean {
-		return user.memberships.find((m) => m.groupType === GroupType.Admin || m.groupType === GroupType.LocalAdmin) != null
+		return user.memberships.some((m) => m.groupType === GroupType.Admin || m.groupType === GroupType.LocalAdmin)
 	}
 
 	focusSettingsDetailsColumn() {
@@ -640,7 +640,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 				const user = this.logins.getUserController().user
 
 				// the user admin status might have changed
-				if (!this._isGlobalOrLocalAdmin(user) && this._currentViewer && this._adminFolders.find((f) => f.isActive())) {
+				if (!this._isGlobalOrLocalAdmin(user) && this._currentViewer && this._adminFolders.some((f) => f.isActive())) {
 					this._setUrl(this._userFolders[0].url)
 				}
 

--- a/src/settings/TemplateEditorModel.ts
+++ b/src/settings/TemplateEditorModel.ts
@@ -83,11 +83,11 @@ export class TemplateEditorModel {
 			// the current edited template should not be included in find()
 			return this._entityClient.loadAll(EmailTemplateTypeRef, this._templateGroupRoot.templates).then((allTemplates) => {
 				const filteredTemplates = allTemplates.filter((template) => !isSameId(getElementId(this.template), getElementId(template)))
-				return !!filteredTemplates.find((template) => template.tag.toLowerCase() === this.template.tag.toLowerCase())
+				return filteredTemplates.some((template) => template.tag.toLowerCase() === this.template.tag.toLowerCase())
 			})
 		} else {
 			return this._entityClient.loadAll(EmailTemplateTypeRef, this._templateGroupRoot.templates).then((allTemplates) => {
-				return !!allTemplates.find((template) => template.tag.toLowerCase() === this.template.tag.toLowerCase())
+				return allTemplates.some((template) => template.tag.toLowerCase() === this.template.tag.toLowerCase())
 			})
 		}
 	}

--- a/src/settings/UserViewer.ts
+++ b/src/settings/UserViewer.ts
@@ -463,7 +463,7 @@ export class UserViewer implements UpdatableSettingsDetailsViewer {
 	}
 
 	private isAdminUser(user: User): boolean {
-		return user.memberships.find((m) => m.groupType === GroupType.Admin) != null
+		return user.memberships.some((m) => m.groupType === GroupType.Admin)
 	}
 
 	private async deleteUser() {

--- a/src/settings/contactform/ContactFormEditor.ts
+++ b/src/settings/contactform/ContactFormEditor.ts
@@ -359,7 +359,7 @@ export class ContactFormEditor {
 							.filter((t) => {
 								if (t.code.endsWith("_sie")) {
 									return false
-								} else if (this._languages.find((l) => l.code === t.code) == null) {
+								} else if (!this._languages.some((l) => l.code === t.code)) {
 									return true
 								}
 
@@ -499,7 +499,7 @@ export class ContactFormEditor {
 			size: ButtonSize.Compact,
 			click: () => {
 				let availableGroupInfos = this._allUserGroupInfos.filter(
-					(g) => this._participantGroupInfoList.find((alreadyAdded) => isSameId(alreadyAdded._id, g._id)) == null,
+					(g) => !this._participantGroupInfoList.some((alreadyAdded) => isSameId(alreadyAdded._id, g._id)),
 				)
 
 				if (availableGroupInfos.length > 0) {

--- a/src/settings/groups/GroupDetailsModel.ts
+++ b/src/settings/groups/GroupDetailsModel.ts
@@ -303,7 +303,7 @@ export class GroupDetailsModel {
 				return false
 			} else {
 				// only show users that are not deleted and not already in the group.
-				return !userGroupInfo.deleted && this.members.getLoaded().find((m) => isSameId(m._id, userGroupInfo._id)) == null
+				return !userGroupInfo.deleted && !this.members.getLoaded().some((m) => isSameId(m._id, userGroupInfo._id))
 			}
 		})
 

--- a/src/settings/login/RecoverCodeDialog.ts
+++ b/src/settings/login/RecoverCodeDialog.ts
@@ -18,7 +18,7 @@ assertMainOrNode()
 
 export function showRecoverCodeDialogAfterPasswordVerificationAndInfoDialog(user: User) {
 	// We only show the recovery code if it is for the current user and it is a global admin
-	if (!isSameId(getEtId(locator.logins.getUserController().user), getEtId(user)) || !user.memberships.find((gm) => gm.groupType === GroupType.Admin)) {
+	if (!isSameId(getEtId(locator.logins.getUserController().user), getEtId(user)) || !user.memberships.some((gm) => gm.groupType === GroupType.Admin)) {
 		return
 	}
 

--- a/src/settings/whitelabel/CustomColorsEditorViewModel.ts
+++ b/src/settings/whitelabel/CustomColorsEditorViewModel.ts
@@ -198,11 +198,11 @@ export class CustomColorsEditorViewModel {
 	_filterAndReturnCustomizations(): ThemeCustomizations {
 		const colorValues = Object.entries(this.customizations).filter(([n, v]) => n !== "themeId" && n !== "base" && n !== "logo")
 		const filteredColorValues = colorValues.filter(([n, v]) => this._isValidColorValue(downcast(v)))
-		Object.entries(this.customizations).forEach(([n, v]) => {
+		for (const [n, v] of Object.entries(this.customizations)) {
 			if (n === "themeId" || n === "base" || n === "logo") {
 				filteredColorValues.push([n, v])
 			}
-		})
+		}
 		return downcast(Object.fromEntries(filteredColorValues))
 	}
 }

--- a/src/settings/whitelabel/WhitelabelSettingsViewer.ts
+++ b/src/settings/whitelabel/WhitelabelSettingsViewer.ts
@@ -285,7 +285,7 @@ export class WhitelabelSettingsViewer implements UpdatableSettingsViewer {
 	_isWhitelabelRegistrationVisible(): boolean {
 		return (
 			this._customer.isLoaded() &&
-			this._customer.getLoaded().customizations.find((c) => c.feature === FeatureType.WhitelabelParent) != null &&
+			this._customer.getLoaded().customizations.some((c) => c.feature === FeatureType.WhitelabelParent) &&
 			this._customerInfo.isLoaded() &&
 			getWhitelabelDomain(this._customerInfo.getLoaded()) != null
 		)

--- a/src/settings/whitelabel/WhitelabelThemeSettings.ts
+++ b/src/settings/whitelabel/WhitelabelThemeSettings.ts
@@ -62,11 +62,11 @@ export class WhitelabelThemeSettings implements Component<WhitelabelThemeSetting
 		const confirmed = await Dialog.confirm("confirmDeactivateCustomColors_msg")
 
 		if (confirmed) {
-			Object.keys(customTheme).forEach((key) => {
+			for (const key of Object.keys(customTheme)) {
 				if (key !== "logo") {
 					delete downcast(customTheme)[key]
 				}
-			})
+			}
 			this.saveCustomTheme(customTheme, whitelabelConfig, whitelabelDomainInfo)
 
 			if (locator.logins.isWhitelabel()) {

--- a/src/sharing/view/ReceivedGroupInvitationDialog.ts
+++ b/src/sharing/view/ReceivedGroupInvitationDialog.ts
@@ -28,10 +28,10 @@ export function showGroupInvitationDialog(invitation: ReceivedGroupInvitation) {
 	const colorStream = stream("#" + color)
 	const isDefaultGroupName = invitation.sharedGroupName === getDefaultGroupName(downcast(invitation.groupType))
 	const nameStream = stream(isDefaultGroupName ? texts.sharedGroupDefaultCustomName(invitation) : invitation.sharedGroupName)
-	const isMember = !!locator.logins
+	const isMember = locator.logins
 		.getUserController()
 		.getCalendarMemberships()
-		.find((ms) => isSameId(ms.group, invitation.sharedGroup))
+		.some((ms) => isSameId(ms.group, invitation.sharedGroup))
 	let dialog: Dialog
 
 	const onAcceptClicked = () => {

--- a/src/subscription/FeatureListProvider.ts
+++ b/src/subscription/FeatureListProvider.ts
@@ -28,18 +28,18 @@ export class FeatureListProvider {
 
 	private countFeatures(categories: FeatureCategory[]): void {
 		const featureCounts = new Map<string, { max: number }>()
-		categories.forEach((category) => {
+		for (const category of categories) {
 			var count = featureCounts.get(category.title)
 			const numberOfFeatures = category.features.length
 			if (count == null || numberOfFeatures > count.max) {
 				featureCounts.set(category.title, { max: numberOfFeatures })
 			}
-		})
-		categories.forEach((category) => {
+		}
+		for (const category of categories) {
 			category.featureCount = getFromMap(featureCounts, category.title, () => {
 				return { max: 0 }
 			})
-		})
+		}
 	}
 
 	static async getInitializedInstance(): Promise<FeatureListProvider> {

--- a/src/subscription/SubscriptionViewer.ts
+++ b/src/subscription/SubscriptionViewer.ts
@@ -104,7 +104,9 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 
 		this._giftCards = new Map()
 		loadGiftCards(assertNotNull(locator.logins.getUserController().user.customer)).then((giftCards) => {
-			giftCards.forEach((giftCard) => this._giftCards.set(elementIdPart(giftCard._id), giftCard))
+			for (const giftCard of giftCards) {
+				this._giftCards.set(elementIdPart(giftCard._id), giftCard)
+			}
 		})
 		this._giftCardsExpanded = stream<boolean>(false)
 

--- a/test/tests/api/common/utils/PlainTextSearchTest.ts
+++ b/test/tests/api/common/utils/PlainTextSearchTest.ts
@@ -80,9 +80,9 @@ o.spec("PlainTextSearchTest", function () {
 			const searchResult = _search(query, _searchEntries, attributeNames, false)
 
 			o(searchResult[0].matchedWords.length).equals(3)
-			searchResult[0].matchedWords.forEach((match) => {
+			for (const match of searchResult[0].matchedWords) {
 				o(query.includes(match)).equals(true)
-			})
+			}
 		})
 		o("check if partialWordMatches count is correct", function () {
 			const query = ["their", "something", "tes", "randomness"]

--- a/test/tests/api/worker/crypto/CompatibilityTest.ts
+++ b/test/tests/api/worker/crypto/CompatibilityTest.ts
@@ -38,7 +38,7 @@ o.spec("crypto compatibility", function () {
 		random.generateRandomData = originalRandom
 	})
 	o("rsa encryption", () => {
-		testData.rsaEncryptionTests.forEach((td) => {
+		for (const td of testData.rsaEncryptionTests) {
 			random.generateRandomData = (number) => hexToUint8Array(td.seed)
 
 			let publicKey = hexToPublicKey(td.publicKey)
@@ -47,10 +47,10 @@ o.spec("crypto compatibility", function () {
 			let privateKey = hexToPrivateKey(td.privateKey)
 			let data = rsaDecrypt(privateKey, encryptedData)
 			o(uint8ArrayToHex(data)).equals(td.input)
-		})
+		}
 	})
 	o("aes 256", function () {
-		testData.aes256Tests.forEach((td) => {
+		for (const td of testData.aes256Tests) {
 			let key = uint8ArrayToBitArray(hexToUint8Array(td.hexKey))
 			// encrypt data
 			let encryptedBytes = aes256Encrypt(key, base64ToUint8Array(td.plainTextBase64), base64ToUint8Array(td.ivBase64), true)
@@ -69,7 +69,7 @@ o.spec("crypto compatibility", function () {
 			o(uint8ArrayToBase64(encryptedKey256)).equals(td.encryptedKey256)
 			const decryptedKey256 = aes256DecryptKey(key, encryptedKey256)
 			o(uint8ArrayToHex(bitArrayToUint8Array(decryptedKey256))).equals(td.keyToEncrypt256)
-		})
+		}
 	})
 
 	/*
@@ -113,42 +113,42 @@ o.spec("crypto compatibility", function () {
 	})
 
 	o("aes 128", function () {
-		testData.aes128Tests.forEach((td) => {
+		for (const td of testData.aes128Tests) {
 			let key = uint8ArrayToBitArray(hexToUint8Array(td.hexKey))
 			let encryptedBytes = aes128Encrypt(key, base64ToUint8Array(td.plainTextBase64), base64ToUint8Array(td.ivBase64), true, false)
 			o(uint8ArrayToBase64(encryptedBytes)).equals(td.cipherTextBase64)
 			let decryptedBytes = uint8ArrayToBase64(aes128Decrypt(key, encryptedBytes))
 			o(decryptedBytes).equals(td.plainTextBase64)
-		})
+		}
 	})
 	o("aes 128 mac", function () {
-		testData.aes128MacTests.forEach((td) => {
+		for (const td of testData.aes128MacTests) {
 			let key = uint8ArrayToBitArray(hexToUint8Array(td.hexKey))
 			let encryptedBytes = aes128Encrypt(key, base64ToUint8Array(td.plainTextBase64), base64ToUint8Array(td.ivBase64), true, true)
 			o(uint8ArrayToBase64(encryptedBytes)).equals(td.cipherTextBase64)
 			let decryptedBytes = uint8ArrayToBase64(aes128Decrypt(key, encryptedBytes))
 			o(decryptedBytes).equals(td.plainTextBase64)
-		})
+		}
 	})
 	o("unicodeEncoding", function () {
-		testData.encodingTests.forEach((td) => {
+		for (const td of testData.encodingTests) {
 			let encoded = stringToUtf8Uint8Array(td.string)
 			o(uint8ArrayToBase64(encoded)).equals(neverNull(td.encodedString))
 			let decoded = utf8Uint8ArrayToString(encoded)
 			o(decoded).equals(td.string)
-		})
+		}
 	})
 	o("bcrypt 128", function () {
-		testData.bcrypt128Tests.forEach((td) => {
+		for (const td of testData.bcrypt128Tests) {
 			let key = generateKeyFromPassphraseBcrypt(td.password, hexToUint8Array(td.saltHex), KeyLength.b128)
 			o(uint8ArrayToHex(bitArrayToUint8Array(key))).equals(td.keyHex)
-		})
+		}
 	})
 	o("bcrypt 256", function () {
-		testData.bcrypt256Tests.forEach((td) => {
+		for (const td of testData.bcrypt256Tests) {
 			let key = generateKeyFromPassphraseBcrypt(td.password, hexToUint8Array(td.saltHex), KeyLength.b256)
 			o(uint8ArrayToHex(bitArrayToUint8Array(key))).equals(td.keyHex)
-		})
+		}
 	})
 	o("argon2id", async function () {
 		let argon2: WebAssembly.Exports
@@ -176,10 +176,10 @@ o.spec("crypto compatibility", function () {
 		}
 	})
 	o("compression", function () {
-		testData.compressionTests.forEach((td) => {
+		for (const td of testData.compressionTests) {
 			o(utf8Uint8ArrayToString(uncompress(base64ToUint8Array(td.compressedBase64TextJava)))).equals(td.uncompressedText)
 			o(utf8Uint8ArrayToString(uncompress(base64ToUint8Array(td.compressedBase64TextJavaScript)))).equals(td.uncompressedText)
-		})
+		}
 	})
 	/**
 	 * Creates the Javascript compatibility test data for compression. See CompatibilityTest.writeCompressionTestData() in Java for

--- a/test/tests/api/worker/crypto/CryptoFacadeTest.ts
+++ b/test/tests/api/worker/crypto/CryptoFacadeTest.ts
@@ -20,7 +20,6 @@ import {
 	createBirthday,
 	createContact,
 	createContactAddress,
-	createFile,
 	FileTypeRef,
 	Mail,
 	MailAddressTypeRef,
@@ -77,7 +76,7 @@ import { UserFacade } from "../../../../../src/api/worker/facades/UserFacade.js"
 import { SessionKeyNotFoundError } from "../../../../../src/api/common/error/SessionKeyNotFoundError.js"
 import { OwnerEncSessionKeysUpdateQueue } from "../../../../../src/api/worker/crypto/OwnerEncSessionKeysUpdateQueue.js"
 
-const { anything, captor } = matchers
+const { captor } = matchers
 
 const rsa = new RsaWeb()
 const rsaEncrypt = rsa.encrypt
@@ -842,7 +841,7 @@ o.spec("crypto facade", function () {
 				verify(ownerEncSessionKeysUpdateQueue.updateInstanceSessionKeys(updatedInstanceSessionKeysCaptor.capture()))
 				const updatedInstanceSessionKeys = updatedInstanceSessionKeysCaptor.value
 				o(updatedInstanceSessionKeys.length).equals(testData.bucketKey.bucketEncSessionKeys.length)
-				testData.bucketKey.bucketEncSessionKeys.forEach((isk) => {
+				for (const isk of testData.bucketKey.bucketEncSessionKeys) {
 					isk.symEncSessionKey = encryptKey(testData.mailGroupKey, decryptKey(testData.bk, isk.symEncSessionKey))
 					o(
 						updatedInstanceSessionKeys.some(
@@ -854,7 +853,7 @@ o.spec("crypto facade", function () {
 								arrayEquals(updatedKey.symEncSessionKey, isk.symEncSessionKey),
 						),
 					).equals(true)
-				})
+				}
 			},
 		)
 	})

--- a/test/tests/api/worker/rest/EntityRestClientMock.ts
+++ b/test/tests/api/worker/rest/EntityRestClientMock.ts
@@ -43,21 +43,21 @@ export class EntityRestClientMock extends EntityRestClient {
 	}
 
 	addElementInstances(...instances: Array<ElementEntity>) {
-		instances.forEach((instance) => (this._entities[instance._id] = instance))
+		for (const instance of instances) this._entities[instance._id] = instance
 	}
 
 	addListInstances(...instances: Array<ListElementEntity>) {
-		instances.forEach((instance) => {
+		for (const instance of instances) {
 			if (!this._listEntities[getListId(instance)]) this._listEntities[getListId(instance)] = {}
 			this._listEntities[getListId(instance)][getElementId(instance)] = instance
-		})
+		}
 	}
 
 	addBlobInstances(...instances: Array<BlobElementEntity>) {
-		instances.forEach((instance) => {
+		for (const instance of instances) {
 			if (!this._blobEntities[getListId(instance)]) this._blobEntities[getListId(instance)] = {}
 			this._blobEntities[getListId(instance)][getElementId(instance)] = instance
-		})
+		}
 	}
 
 	setElementException(id: Id, error: Error) {
@@ -174,7 +174,7 @@ export class EntityRestClientMock extends EntityRestClient {
 		return resolveTypeReference(instance._type).then((typeModel) => {
 			_verifyType(typeModel)
 
-			var ids = getIds(instance, typeModel)
+			const ids = getIds(instance, typeModel)
 
 			this._handleDelete(ids.id, ids.listId)
 		})

--- a/test/tests/api/worker/search/MailIndexerTest.ts
+++ b/test/tests/api/worker/search/MailIndexerTest.ts
@@ -589,7 +589,7 @@ o.spec("MailIndexer test", () => {
 	})
 
 	function _checkMailsInIndexUpdate(db: Db, indexUpdate: IndexUpdate, ...includedMails: Array<Mail>) {
-		includedMails.forEach((mail, index) => {
+		for (const [index, mail] of includedMails.entries()) {
 			let encInstanceId = encryptIndexKeyBase64(db.key, getElementId(mail), fixedIv)
 
 			if (indexUpdate.create.encInstanceIdToElementData.get(encInstanceId) == null) {
@@ -597,7 +597,7 @@ o.spec("MailIndexer test", () => {
 			}
 
 			o(indexUpdate.create.encInstanceIdToElementData.get(encInstanceId) != null).equals(true)
-		})
+		}
 	}
 
 	o.spec("processEntityEvents", function () {

--- a/test/tests/api/worker/search/SearchFacadeTest.ts
+++ b/test/tests/api/worker/search/SearchFacadeTest.ts
@@ -71,7 +71,7 @@ o.spec("SearchFacade test", () => {
 
 	function createDbContent(transaction: DbStubTransaction, dbData: KeyToIndexEntriesWithType[], fullIds: IdTuple[]) {
 		let counter = 0
-		dbData.forEach((keyToIndexEntries, index) => {
+		for (const [index, keyToIndexEntries] of dbData.entries()) {
 			keyToIndexEntries.indexEntries.sort((a, b) => compareOldestFirst(a.id, b.id))
 			const indexEntriesByType = groupBy(keyToIndexEntries.indexEntries, (e) => e.typeInfo)
 			const metaDataRow: SearchIndexMetaDataRow = {
@@ -79,9 +79,9 @@ o.spec("SearchFacade test", () => {
 				word: keyToIndexEntries.indexKey,
 				rows: [],
 			}
-			indexEntriesByType.forEach((entries, typeInfo) => {
+			for (const [typeInfo, entries] of indexEntriesByType.entries()) {
 				const chunks = splitInChunks(2, entries)
-				chunks.forEach((chunk) => {
+				for (const chunk of chunks) {
 					counter++
 					metaDataRow.rows.push({
 						app: typeInfo.appId,
@@ -94,17 +94,16 @@ o.spec("SearchFacade test", () => {
 						chunk.map((entry) => encryptSearchIndexEntry(dbKey, entry, encryptIndexKeyUint8Array(dbKey, entry.id, fixedIv))),
 					)
 					transaction.put(SearchIndexOS, counter, encSearchIndexRow)
-				})
-			})
+				}
+			}
 			transaction.put(SearchIndexMetaDataOS, null, encryptMetaData(dbKey, metaDataRow))
-			fullIds.forEach((id) => {
+			for (const id of fullIds) {
 				let encId = encryptIndexKeyBase64(dbKey, elementIdPart(id), fixedIv)
 				const elementDataEntry: ElementDataDbRow = [listIdPart(id), new Uint8Array(0), ""] // rows not needed for search
 
 				transaction.put(ElementDataOS, encId, elementDataEntry)
-			})
-			return Promise.resolve()
-		})
+			}
+		}
 	}
 
 	let createKeyToIndexEntries = (word: string, entries: SearchIndexEntryWithType[]): KeyToIndexEntriesWithType => {

--- a/test/tests/api/worker/search/SearchIndexEncodingTest.ts
+++ b/test/tests/api/worker/search/SearchIndexEncodingTest.ts
@@ -11,9 +11,10 @@ import {
 } from "../../../../../src/api/worker/search/SearchIndexEncoding.js"
 import { spy as makeSpy } from "@tutao/tutanota-test-utils"
 import { concat } from "@tutao/tutanota-utils"
+
 o.spec("SearchIndexEncoding test", function () {
 	o("numberOfBytes", function () {
-		;[
+		const cases = [
 			[0, 0],
 			[128, 1],
 			[255, 1],
@@ -23,7 +24,10 @@ o.spec("SearchIndexEncoding test", function () {
 			[512, 2],
 			[Math.pow(2, 16) - 1, 2],
 			[Math.pow(2, 16), 3], // 65536
-		].forEach(([num, res]) => o(numberOfBytes(num)).equals(res)(`${num} should require ${res}`))
+		]
+		for (const [num, res] of cases) {
+			o(numberOfBytes(num)).equals(res)(`${num} should require ${res}`)
+		}
 	})
 	o("calculateNeededSpaceSingleArray", function () {
 		o(calculateNeededSpace([new Uint8Array(32)])).equals(1 + 32)

--- a/test/tests/calendar/CalendarUtilsTest.ts
+++ b/test/tests/calendar/CalendarUtilsTest.ts
@@ -57,11 +57,11 @@ o.spec("calendar utils tests", function () {
 	function iso(strings: TemplateStringsArray, ...dates: number[]) {
 		let result = ""
 
-		dates.forEach((d, i) => {
+		for (const [i, d] of dates.entries()) {
 			const s = strings[i]
 			result += s
 			result += `(${d}) ${DateTime.fromMillis(d).toISO({ format: "extended", includeOffset: true })}`
-		})
+		}
 		result += lastThrow(strings)
 		return result
 	}

--- a/test/tests/contacts/VCardExporterTest.ts
+++ b/test/tests/contacts/VCardExporterTest.ts
@@ -489,37 +489,37 @@ export function createFilledContact(
 	c.lastName = lastName
 
 	if (emailAddresses) {
-		emailAddresses.forEach((m) => {
+		for (const m of emailAddresses) {
 			let a = createContactMailAddress()
 			a.address = m
 			a.type = ContactAddressType.WORK
 			a.customTypeName = ""
 			c.mailAddresses.push(a)
-		})
+		}
 	}
 
 	if (phoneNumbers) {
-		phoneNumbers.forEach((m) => {
+		for (const m of phoneNumbers) {
 			let a = createContactPhoneNumber()
 			a.number = m
 			a.type = ContactAddressType.WORK
 			a.customTypeName = ""
 			c.phoneNumbers.push(a)
-		})
+		}
 	}
 
 	if (addresses) {
-		addresses.forEach((m) => {
+		for (const m of addresses) {
 			let a = createContactAddress()
 			a.address = m
 			a.type = ContactAddressType.WORK
 			a.customTypeName = ""
 			c.addresses.push(a)
-		})
+		}
 	}
 
 	if (socialIds) {
-		socialIds.forEach((m) => {
+		for (const m of socialIds) {
 			let a = createContactSocialId()
 			if (typeof m === "string") {
 				a.socialId = m
@@ -530,7 +530,7 @@ export function createFilledContact(
 			}
 			a.customTypeName = ""
 			c.socialIds.push(a)
-		})
+		}
 	}
 
 	c.title = title

--- a/test/tests/desktop/DesktopContextMenuTest.ts
+++ b/test/tests/desktop/DesktopContextMenuTest.ts
@@ -56,7 +56,11 @@ o.spec("DesktopContextMenu Test", () => {
 			misspelledWord: "",
 		}
 		contextMenu.open(contextMenuParams as ContextMenuParams)
-		downcast(electronMock.MenuItem).mockedInstances.forEach((i) => i.click && i.click(undefined, undefined))
-		downcast(electronMock.MenuItem).mockedInstances.forEach((i) => i.click && i.click(undefined, "nowebcontents"))
+		for (const i of downcast(electronMock.MenuItem).mockedInstances) {
+			i.click?.(undefined, undefined)
+		}
+		for (const i of downcast(electronMock.MenuItem).mockedInstances) {
+			i.click?.(undefined, "nowebcontents")
+		}
 	})
 })

--- a/test/tests/desktop/ElectronUpdaterTest.ts
+++ b/test/tests/desktop/ElectronUpdaterTest.ts
@@ -111,9 +111,9 @@ o.spec("ElectronUpdater Test", function () {
 			}),
 			emit: function (ev: string, args: any) {
 				const entries = this.callbacks[ev]
-				entries.forEach((entry) => {
+				for (const entry of entries) {
 					setTimeout(() => entry.fn(args), 1)
-				})
+				}
 				this.callbacks[ev] = entries.filter((entry) => !entry.once)
 			},
 			checkForUpdates: spy(function () {

--- a/test/tests/desktop/PathUtilsTest.ts
+++ b/test/tests/desktop/PathUtilsTest.ts
@@ -142,21 +142,14 @@ o.spec("PathUtils", function () {
 			})
 		}
 
-		EXECUTABLE_EXTENSIONS.map((extension) => `someFile.${extension}`).forEach(testDoesLookExecutable)
-
-		EXECUTABLE_EXTENSIONS.map((extension) => `C:\\a\\b\\someFile.${extension}`).forEach(testDoesLookExecutable)
-
-		EXECUTABLE_EXTENSIONS.map((extension) => `C:\\a\\b\\.${extension}`).forEach(testDoesLookExecutable)
-
-		EXECUTABLE_EXTENSIONS.map((extension) => `/a/b/someFile.${extension}`).forEach(testDoesLookExecutable)
-
-		EXECUTABLE_EXTENSIONS.map((extension) => `/a/b/.${extension}`).forEach(testDoesLookExecutable)
-
-		EXECUTABLE_EXTENSIONS.map((extension) => `file:///a/b/someFile.${extension}`).forEach(testDoesLookExecutable)
-
-		EXECUTABLE_EXTENSIONS.map((extension) => `file:///a/b/.${extension}`).forEach(testDoesLookExecutable)
-
-		EXECUTABLE_EXTENSIONS.map((extension) => `.${extension}`).forEach(testDoesLookExecutable)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`someFile.${extension}`)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`C:\\a\\b\\someFile.${extension}`)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`C:\\a\\b\\.${extension}`)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`/a/b/someFile.${extension}`)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`/a/b/.${extension}`)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`file:///a/b/someFile.${extension}`)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`file:///a/b/.${extension}`)
+		for (const extension of EXECUTABLE_EXTENSIONS) testDoesLookExecutable(`.${extension}`)
 
 		o("should not detect non executable extensions as looking executable", function () {
 			o(looksExecutable("picture.jpg")).equals(false)

--- a/test/tests/desktop/net/ProtocolProxyTest.ts
+++ b/test/tests/desktop/net/ProtocolProxyTest.ts
@@ -153,6 +153,8 @@ o.spec("ProtocolProxy", function () {
 
 function headersToObject(headers: Headers): Record<string, OutgoingHttpHeader> {
 	const returnObject: Record<string, OutgoingHttpHeader> = {}
+	// headers should be iterable but maybe not in our configuration for some reason
+	// eslint-disable-next-line unicorn/no-array-for-each
 	headers.forEach((value: OutgoingHttpHeader, key: string) => {
 		returnObject[key] = value
 	})

--- a/test/tests/mail/MailUtilsSignatureTest.ts
+++ b/test/tests/mail/MailUtilsSignatureTest.ts
@@ -33,9 +33,9 @@ o.spec("MailUtilsSignatureTest", function () {
 		)
 	})
 	o.after(function () {
-		mockedAttributes.forEach(function (mockedAttribute) {
+		for (const mockedAttribute of mockedAttributes) {
 			unmockAttribute(mockedAttribute)
-		})
+		}
 	})
 	o("append - no signature", function () {
 		const properties = downcast({

--- a/test/tests/misc/HtmlSanitizerTest.ts
+++ b/test/tests/misc/HtmlSanitizerTest.ts
@@ -31,14 +31,14 @@ o.spec(
 					expected: "<img>",
 				},
 			]
-			tests.forEach((test) => {
+			for (const test of tests) {
 				// attacks should not be possible even if we load external content
 				o(
 					htmlSanitizer.sanitizeHTML(test.html, {
 						blockExternalContent: false,
 					}).html,
 				).equals(test.expected)
-			})
+			}
 		})
 		o("blockquotes", function () {
 			//var sanitizer = DOMPurify.sanitize("");

--- a/test/tests/misc/LanguageViewModelTest.ts
+++ b/test/tests/misc/LanguageViewModelTest.ts
@@ -2,6 +2,7 @@ import o from "@tutao/otest"
 import { getSubstitutedLanguageCode, getAvailableLanguageCode, lang } from "../../../src/misc/LanguageViewModel.js"
 // @ts-ignore[untyped-import]
 import en from "../../../src/translations/en.js"
+
 o.spec("LanguageViewModelTests", function () {
 	o(
 		"en is default language",
@@ -12,7 +13,7 @@ o.spec("LanguageViewModelTests", function () {
 		}),
 	)
 	o("getAvailableLanguage", function () {
-		;[
+		const cases = [
 			["en", "en"],
 			["zh_CN", "zh"],
 			["zh_Hant", "zh_hant"],
@@ -26,7 +27,8 @@ o.spec("LanguageViewModelTests", function () {
 			["pt_br", "pt_br"],
 			["fi", "fi"],
 			["fa", "fa_ir"],
-		].forEach(([k, r]) => o(getAvailableLanguageCode(k)).equals(r))
+		]
+		for (const [k, r] of cases) o(getAvailableLanguageCode(k)).equals(r)
 	})
 	o("_getSubstitutedLanguageCode", function () {
 		const cases: [string, string | null][] = [

--- a/test/tests/misc/OutOfOfficeNotificationTest.ts
+++ b/test/tests/misc/OutOfOfficeNotificationTest.ts
@@ -4,6 +4,7 @@ import { mockAttribute, unmockAttribute } from "@tutao/tutanota-test-utils"
 import { getDayShifted, getStartOfDay, getStartOfNextDay } from "@tutao/tutanota-utils"
 import { lang } from "../../../src/misc/LanguageViewModel.js"
 import { formatActivateState, isNotificationCurrentlyActive } from "../../../src/misc/OutOfOfficeNotificationUtils.js"
+
 o.spec("OutOfOfficeNotificationTest", function () {
 	const mockedAttributes: any = []
 	o.before(function () {
@@ -20,9 +21,9 @@ o.spec("OutOfOfficeNotificationTest", function () {
 		)
 	})
 	o.after(function () {
-		mockedAttributes.forEach(function (mockedAttribute) {
+		for (const mockedAttribute of mockedAttributes) {
 			unmockAttribute(mockedAttribute)
-		})
+		}
 	})
 	o("Active state formatting", function () {
 		lang._setLanguageTag("en")

--- a/test/tests/nodemocker.ts
+++ b/test/tests/nodemocker.ts
@@ -37,9 +37,12 @@ export function spyify<T>(obj: T): T {
 		case "function":
 			const fSpy = spy(obj as any)
 
-			Object.keys(anyObj) // classes are functions
-				.filter((k) => !["args", "callCount", "spy"].includes(k))
-				.forEach((k) => (fSpy[k] = spyify(anyObj[k])))
+			// classes are functions
+			for (const k of Object.keys(anyObj)) {
+				if (!["args", "callCount", "spy"].includes(k)) {
+					fSpy[k] = spyify(anyObj[k])
+				}
+			}
 
 			return downcast<T>(fSpy)
 		case "object":
@@ -86,7 +89,7 @@ export type Mocked<T> = Class<T> & {
 function classify(template: { prototype: {}; statics: {} }): Mocked<any> {
 	const cls = function () {
 		cls.mockedInstances.push(this)
-		Object.keys(template.prototype).forEach((p) => {
+		for (const p of Object.keys(template.prototype)) {
 			if ("function" === typeof template.prototype[p]) {
 				this[p] = spy(template.prototype[p]) // don't use spyify, we don't want these to be spyCached
 			} else if ("object" === typeof template.prototype[p]) {
@@ -102,7 +105,7 @@ function classify(template: { prototype: {}; statics: {} }): Mocked<any> {
 			} else {
 				this[p] = template.prototype[p]
 			}
-		})
+		}
 
 		if (typeof template.prototype["constructor"] === "function") {
 			template.prototype["constructor"].apply(this, arguments)
@@ -110,7 +113,9 @@ function classify(template: { prototype: {}; statics: {} }): Mocked<any> {
 	}
 
 	if (template.statics) {
-		Object.keys(template.statics).forEach((s) => (cls[s] = template.statics[s]))
+		for (const s of Object.keys(template.statics)) {
+			cls[s] = template.statics[s]
+		}
 	}
 
 	cls.mockedInstances = []


### PR DESCRIPTION
Please review carefully, eslint was suggesting incorrect fixes in some cases (when it couldn't figure out that `.forEach` was called on a `Map`). I went over all cases one-by-one but it wouldn't hurt to check them again.

## Test Notes
* [ ] try to add a `.foreach()` and check that the linter catches it
* [ ] Save calendar event with alarms, see that alarms show up correctly
* [ ] Check that calendar events are laid out correctly
* [ ] Delete an event, see that events are updated correctly
* [ ] Check importing .ics files into calendar
* [ ] Save mail draft with attachments, remove some of them, see that the draft is saved correctly
* [ ] Smoke test search index for mails, contacts, contact suggestions
* [ ] Smoke test merging contacts
* [ ] Smoke test exporting contacts
* [ ] [desktop] Check Ctrl+F/Ctri+P shortcuts
* [ ] [desktop] Smoke test context menu
* [ ] [desktop] Change zoom factor
* [ ] [desktop] Check that alarms still work
* [ ] Check changing theme
* [ ] Check that editor highlights monospace button on monospace region
* [ ] Test mail editor formatting shortcuts
* [ ] Smoke test knowledge base
* [ ] Check that inline images are displayed
* [ ] Remove inline image from mail editor, see that attachment is also removed
* [ ] See that mail editor updates recipient name when the contact name changes
* [ ] Check that unread mail counters still work
* [ ] Check that total attachment size is correctly displayed in mail viewer
* [ ] Check adding a u2f key
* [ ] Check that external content is still blocked in mail viewer
* [ ] Check that window close listeners (e.g. mail editor) still work
* [ ] Check that DNS record checker for custom domains still works
* [ ] Try to add a template with existing tag
* [ ] Check that user viewer shows the admin status correctly
* [ ] Smoke test whitelabel theme