### PR TITLE
[desktop] Make ProtocolProxy return network errors

### DIFF
--- a/src/api/worker/facades/LoginFacade.ts
+++ b/src/api/worker/facades/LoginFacade.ts
@@ -325,7 +325,8 @@ export class LoginFacade {
 			}
 		} catch (e) {
 			if (e instanceof ConnectionError && retryOnNetworkError < 10) {
-				// connection error can occur on ios when switching between apps, just retry in this case.
+				// Connection error can occur on ios when switching between apps or just as a timeout (our request timeout is shorter than the overall
+				// auth flow timeout). Just retry in this case.
 				return this.waitUntilSecondFactorApproved(accessToken, sessionId, retryOnNetworkError + 1)
 			}
 			throw e

--- a/src/desktop/net/ProtocolProxy.ts
+++ b/src/desktop/net/ProtocolProxy.ts
@@ -71,7 +71,7 @@ function interceptProtocol(protocol: string, session: Session, fetchImpl: typeof
 				log.debug(TAG, e)
 				log.debug(TAG, JSON.stringify(errorToObj(e)))
 				log.debug(TAG, `failed after ${Date.now() - startTime}ms`)
-				return new Response(null, { status: ServiceUnavailableError.CODE })
+				return Response.error()
 			}
 		}
 	})


### PR DESCRIPTION
After switching to a new API we started returning 503 for network errors which is treated in a special way by the app.

Using response.error() is closer to how the app would behave without a protocol handler.

close #5866
close #5868