### PR TITLE
fix wrong protocol comparison

### DIFF
--- a/src/misc/HtmlSanitizer.ts
+++ b/src/misc/HtmlSanitizer.ts
@@ -390,7 +390,7 @@ export class HtmlSanitizer {
 function isAllowedLink(link: string): boolean {
 	try {
 		// We create URL without explicit base (second argument). It is an error for relative links
-		return new URL(link).protocol !== "file"
+		return new URL(link).protocol !== "file:"
 	} catch (e) {
 		return false
 	}


### PR DESCRIPTION
the check is useless because URL.protocol includes the colon.

We have other safeguards against unsafe links in the native parts of our apps and obviously the browsers, so it's not a serious issue.

thanks to @Sjord