### PR TITLE
Remove argon2 target; merge into tutanota target

### DIFF
--- a/app-ios/argon2/phc-winner-argon2
+++ b/app-ios/argon2/phc-winner-argon2
@@ -1,1 +1,0 @@
-../../libs/phc-winner-argon2

--- a/app-ios/fastlane/Fastfile
+++ b/app-ios/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :ios do
 	desc "Push a new release to AppStore"
 	lane :release do |options|
 		match(
-			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension", "de.tutao.argon2"],
+			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension"],
 			type: "appstore",
 			verbose: false,
 			readonly: true,
@@ -49,7 +49,7 @@ platform :ios do
 	desc "Build a new release for ad-hoc"
 	lane :adhoc do |options|
 		match(
-			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension", "de.tutao.argon2"],
+			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension"],
 			type: "adhoc",
 			verbose: false,
 			readonly: true,
@@ -71,7 +71,7 @@ platform :ios do
 	desc "Build against test system"
 	lane :adhoctest do
 		match(
-			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension", "de.tutao.argon2"],
+			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension"],
 			type: "adhoc",
 			verbose: false,
 			readonly: true,
@@ -104,7 +104,7 @@ platform :ios do
  	desc "Renew adhoc cert"
  	lane :renewadhoccert do
 		match(
-			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension", "de.tutao.argon2"],
+			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension"],
 			type: "adhoc",
 			verbose: true,
 			readonly: false,
@@ -118,7 +118,7 @@ platform :ios do
 	desc "Renew appstore cert"
 	lane :renewappstorecert do
 		match(
-			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension", "de.tutao.argon2"],
+			app_identifier: ["de.tutao.tutanota", "de.tutao.tutanota.TutanotaShareExtension"],
 			type: "appstore",
 			verbose: true,
 			readonly: false,

--- a/app-ios/tutanota.xcodeproj/project.pbxproj
+++ b/app-ios/tutanota.xcodeproj/project.pbxproj
@@ -62,6 +62,20 @@
 		3D4F1BFB26EBADE500E87BF5 /* TUTBigNum.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D4F1BF926EBADE500E87BF5 /* TUTBigNum.m */; };
 		3D63A0E3233D009E00D05259 /* TUTLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D63A0E2233D009E00D05259 /* TUTLog.m */; };
 		3D63A0E5233D0C1400D05259 /* TUTLogTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D63A0E4233D0C1400D05259 /* TUTLogTest.m */; };
+		3D648B202AB98BEA00893C8D /* argon2.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B0F2AB98BEA00893C8D /* argon2.h */; };
+		3D648B212AB98BEA00893C8D /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D648B112AB98BEA00893C8D /* thread.c */; };
+		3D648B222AB98BEA00893C8D /* core.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B122AB98BEA00893C8D /* core.h */; };
+		3D648B232AB98BEA00893C8D /* blamka-round-ref.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B142AB98BEA00893C8D /* blamka-round-ref.h */; };
+		3D648B242AB98BEA00893C8D /* blamka-round-opt.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B152AB98BEA00893C8D /* blamka-round-opt.h */; };
+		3D648B252AB98BEA00893C8D /* blake2.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B162AB98BEA00893C8D /* blake2.h */; };
+		3D648B262AB98BEA00893C8D /* blake2b.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D648B172AB98BEA00893C8D /* blake2b.c */; };
+		3D648B272AB98BEA00893C8D /* blake2-impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B182AB98BEA00893C8D /* blake2-impl.h */; };
+		3D648B282AB98BEA00893C8D /* ref.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D648B192AB98BEA00893C8D /* ref.c */; };
+		3D648B292AB98BEA00893C8D /* encoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B1A2AB98BEA00893C8D /* encoding.h */; };
+		3D648B2A2AB98BEA00893C8D /* core.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D648B1B2AB98BEA00893C8D /* core.c */; };
+		3D648B2B2AB98BEA00893C8D /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = 3D648B1C2AB98BEA00893C8D /* thread.h */; };
+		3D648B2C2AB98BEA00893C8D /* argon2.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D648B1D2AB98BEA00893C8D /* argon2.c */; };
+		3D648B2D2AB98BEA00893C8D /* encoding.c in Sources */ = {isa = PBXBuildFile; fileRef = 3D648B1E2AB98BEA00893C8D /* encoding.c */; };
 		3D652B5820F8DC1600DF9962 /* build in Resources */ = {isa = PBXBuildFile; fileRef = 3D652B5720F8DC1500DF9962 /* build */; };
 		3D6A0AEA212C1701001CD791 /* CompatibilityTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D6A0AE9212C1701001CD791 /* CompatibilityTest.m */; settings = {COMPILER_FLAGS = "-Itutanota/include"; }; };
 		3D73DA312731953E008E7A8A /* RemoteProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D73DA302731953E008E7A8A /* RemoteProtocol.swift */; };
@@ -205,22 +219,6 @@
 		3DD4EA3B2726F41200D58207 /* DictionaryCoding in Frameworks */ = {isa = PBXBuildFile; productRef = 3DD4EA3A2726F41200D58207 /* DictionaryCoding */; };
 		3DDB5E6F28FDA59100E1E4BE /* libcrypto.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DDB5E6E28FDA59100E1E4BE /* libcrypto.xcframework */; };
 		3DDE413B28F4665700837BE6 /* SqlCipherDb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DDE413A28F4665700837BE6 /* SqlCipherDb.swift */; };
-		3DE1144B2AAF1C0E000D75B2 /* argon2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DE114452AAF1C0D000D75B2 /* argon2.framework */; };
-		3DE1144C2AAF1C0E000D75B2 /* argon2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3DE114452AAF1C0D000D75B2 /* argon2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		3DE114642AAF1D09000D75B2 /* argon2.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE114542AAF1D09000D75B2 /* argon2.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3DE114652AAF1D09000D75B2 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = 3DE114562AAF1D09000D75B2 /* thread.c */; };
-		3DE114662AAF1D09000D75B2 /* core.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE114572AAF1D09000D75B2 /* core.h */; };
-		3DE114672AAF1D0A000D75B2 /* blamka-round-ref.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE114592AAF1D09000D75B2 /* blamka-round-ref.h */; };
-		3DE114682AAF1D0A000D75B2 /* blamka-round-opt.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE1145A2AAF1D09000D75B2 /* blamka-round-opt.h */; };
-		3DE114692AAF1D0A000D75B2 /* blake2.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE1145B2AAF1D09000D75B2 /* blake2.h */; };
-		3DE1146A2AAF1D0A000D75B2 /* blake2b.c in Sources */ = {isa = PBXBuildFile; fileRef = 3DE1145C2AAF1D09000D75B2 /* blake2b.c */; };
-		3DE1146B2AAF1D0A000D75B2 /* blake2-impl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE1145D2AAF1D09000D75B2 /* blake2-impl.h */; };
-		3DE1146C2AAF1D0A000D75B2 /* ref.c in Sources */ = {isa = PBXBuildFile; fileRef = 3DE1145E2AAF1D09000D75B2 /* ref.c */; };
-		3DE1146E2AAF1D0A000D75B2 /* encoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE114602AAF1D09000D75B2 /* encoding.h */; };
-		3DE1146F2AAF1D0A000D75B2 /* core.c in Sources */ = {isa = PBXBuildFile; fileRef = 3DE114612AAF1D09000D75B2 /* core.c */; };
-		3DE114702AAF1D0A000D75B2 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DE114622AAF1D09000D75B2 /* thread.h */; };
-		3DE114712AAF1D0A000D75B2 /* argon2.c in Sources */ = {isa = PBXBuildFile; fileRef = 3DE114632AAF1D09000D75B2 /* argon2.c */; };
-		3DE114732AAF1D58000D75B2 /* encoding.c in Sources */ = {isa = PBXBuildFile; fileRef = 3DE114722AAF1D58000D75B2 /* encoding.c */; };
 		3DE1E44526666F0A0018C9DE /* UIColor+utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE1E44426666F0A0018C9DE /* UIColor+utils.swift */; };
 		3DE46D2B2848EBDA00DC9D43 /* IosFileFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE46D2A2848EBDA00DC9D43 /* IosFileFacade.swift */; };
 		3DE46D2E2849E33000DC9D43 /* IosThemeFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE46D2D2849E33000DC9D43 /* IosThemeFacade.swift */; };
@@ -239,13 +237,6 @@
 			remoteGlobalIDString = 3DD4A08220F8C6240086EB36;
 			remoteInfo = tutanota;
 		};
-		3DE114492AAF1C0E000D75B2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 3DD4A07B20F8C6240086EB36 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3DE114442AAF1C0D000D75B2;
-			remoteInfo = argon2;
-		};
 		3DEF18F82924E1F1009C4B55 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 3DD4A07B20F8C6240086EB36 /* Project object */;
@@ -262,7 +253,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3DE1144C2AAF1C0E000D75B2 /* argon2.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -334,6 +324,20 @@
 		3D63A0DD233CF7C900D05259 /* TUTLog.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TUTLog.h; sourceTree = "<group>"; };
 		3D63A0E2233D009E00D05259 /* TUTLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TUTLog.m; sourceTree = "<group>"; };
 		3D63A0E4233D0C1400D05259 /* TUTLogTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TUTLogTest.m; sourceTree = "<group>"; };
+		3D648B0F2AB98BEA00893C8D /* argon2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = argon2.h; sourceTree = "<group>"; };
+		3D648B112AB98BEA00893C8D /* thread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread.c; sourceTree = "<group>"; };
+		3D648B122AB98BEA00893C8D /* core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = core.h; sourceTree = "<group>"; };
+		3D648B142AB98BEA00893C8D /* blamka-round-ref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "blamka-round-ref.h"; sourceTree = "<group>"; };
+		3D648B152AB98BEA00893C8D /* blamka-round-opt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "blamka-round-opt.h"; sourceTree = "<group>"; };
+		3D648B162AB98BEA00893C8D /* blake2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blake2.h; sourceTree = "<group>"; };
+		3D648B172AB98BEA00893C8D /* blake2b.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2b.c; sourceTree = "<group>"; };
+		3D648B182AB98BEA00893C8D /* blake2-impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "blake2-impl.h"; sourceTree = "<group>"; };
+		3D648B192AB98BEA00893C8D /* ref.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ref.c; sourceTree = "<group>"; };
+		3D648B1A2AB98BEA00893C8D /* encoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encoding.h; sourceTree = "<group>"; };
+		3D648B1B2AB98BEA00893C8D /* core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = core.c; sourceTree = "<group>"; };
+		3D648B1C2AB98BEA00893C8D /* thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread.h; sourceTree = "<group>"; };
+		3D648B1D2AB98BEA00893C8D /* argon2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = argon2.c; sourceTree = "<group>"; };
+		3D648B1E2AB98BEA00893C8D /* encoding.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = encoding.c; sourceTree = "<group>"; };
 		3D652B5720F8DC1500DF9962 /* build */ = {isa = PBXFileReference; lastKnownFileType = folder; name = build; path = ../../build; sourceTree = "<group>"; };
 		3D6A0AE9212C1701001CD791 /* CompatibilityTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CompatibilityTest.m; sourceTree = "<group>"; };
 		3D73DA302731953E008E7A8A /* RemoteProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteProtocol.swift; sourceTree = "<group>"; };
@@ -485,22 +489,6 @@
 		3DD4A0A120F8C6260086EB36 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3DDB5E6E28FDA59100E1E4BE /* libcrypto.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = libcrypto.xcframework; sourceTree = "<group>"; };
 		3DDE413A28F4665700837BE6 /* SqlCipherDb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SqlCipherDb.swift; sourceTree = "<group>"; };
-		3DE114452AAF1C0D000D75B2 /* argon2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = argon2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3DE114542AAF1D09000D75B2 /* argon2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = argon2.h; sourceTree = "<group>"; };
-		3DE114562AAF1D09000D75B2 /* thread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = thread.c; sourceTree = "<group>"; };
-		3DE114572AAF1D09000D75B2 /* core.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = core.h; sourceTree = "<group>"; };
-		3DE114592AAF1D09000D75B2 /* blamka-round-ref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "blamka-round-ref.h"; sourceTree = "<group>"; };
-		3DE1145A2AAF1D09000D75B2 /* blamka-round-opt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "blamka-round-opt.h"; sourceTree = "<group>"; };
-		3DE1145B2AAF1D09000D75B2 /* blake2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = blake2.h; sourceTree = "<group>"; };
-		3DE1145C2AAF1D09000D75B2 /* blake2b.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = blake2b.c; sourceTree = "<group>"; };
-		3DE1145D2AAF1D09000D75B2 /* blake2-impl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "blake2-impl.h"; sourceTree = "<group>"; };
-		3DE1145E2AAF1D09000D75B2 /* ref.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ref.c; sourceTree = "<group>"; };
-		3DE1145F2AAF1D09000D75B2 /* run.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = run.c; sourceTree = "<group>"; };
-		3DE114602AAF1D09000D75B2 /* encoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = encoding.h; sourceTree = "<group>"; };
-		3DE114612AAF1D09000D75B2 /* core.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = core.c; sourceTree = "<group>"; };
-		3DE114622AAF1D09000D75B2 /* thread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = thread.h; sourceTree = "<group>"; };
-		3DE114632AAF1D09000D75B2 /* argon2.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = argon2.c; sourceTree = "<group>"; };
-		3DE114722AAF1D58000D75B2 /* encoding.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = encoding.c; sourceTree = "<group>"; };
 		3DE1E44426666F0A0018C9DE /* UIColor+utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+utils.swift"; sourceTree = "<group>"; };
 		3DE46D2A2848EBDA00DC9D43 /* IosFileFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosFileFacade.swift; sourceTree = "<group>"; };
 		3DE46D2D2849E33000DC9D43 /* IosThemeFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosThemeFacade.swift; sourceTree = "<group>"; };
@@ -523,7 +511,6 @@
 			files = (
 				3D36BCC2274E4A6100428878 /* CryptoTokenKit.framework in Frameworks */,
 				3DD4EA3B2726F41200D58207 /* DictionaryCoding in Frameworks */,
-				3DE1144B2AAF1C0E000D75B2 /* argon2.framework in Frameworks */,
 				3D4E3C9E28EC5B31001FA9D1 /* Security.framework in Frameworks */,
 				3D3B5169293797DC00C1B7DA /* Atomics in Frameworks */,
 				3DDB5E6F28FDA59100E1E4BE /* libcrypto.xcframework in Frameworks */,
@@ -532,13 +519,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3DD4A09820F8C6260086EB36 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3DE114422AAF1C0D000D75B2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -591,6 +571,51 @@
 				3D4A426629B6453700B10451 /* AlarmScheduler.swift */,
 			);
 			path = Alarms;
+			sourceTree = "<group>";
+		};
+		3D648B0C2AB98BEA00893C8D /* phc-winner-argon2 */ = {
+			isa = PBXGroup;
+			children = (
+				3D648B0E2AB98BEA00893C8D /* include */,
+				3D648B102AB98BEA00893C8D /* src */,
+			);
+			path = "phc-winner-argon2";
+			sourceTree = "<group>";
+		};
+		3D648B0E2AB98BEA00893C8D /* include */ = {
+			isa = PBXGroup;
+			children = (
+				3D648B0F2AB98BEA00893C8D /* argon2.h */,
+			);
+			path = include;
+			sourceTree = "<group>";
+		};
+		3D648B102AB98BEA00893C8D /* src */ = {
+			isa = PBXGroup;
+			children = (
+				3D648B112AB98BEA00893C8D /* thread.c */,
+				3D648B122AB98BEA00893C8D /* core.h */,
+				3D648B132AB98BEA00893C8D /* blake2 */,
+				3D648B192AB98BEA00893C8D /* ref.c */,
+				3D648B1A2AB98BEA00893C8D /* encoding.h */,
+				3D648B1B2AB98BEA00893C8D /* core.c */,
+				3D648B1C2AB98BEA00893C8D /* thread.h */,
+				3D648B1D2AB98BEA00893C8D /* argon2.c */,
+				3D648B1E2AB98BEA00893C8D /* encoding.c */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		3D648B132AB98BEA00893C8D /* blake2 */ = {
+			isa = PBXGroup;
+			children = (
+				3D648B142AB98BEA00893C8D /* blamka-round-ref.h */,
+				3D648B152AB98BEA00893C8D /* blamka-round-opt.h */,
+				3D648B162AB98BEA00893C8D /* blake2.h */,
+				3D648B172AB98BEA00893C8D /* blake2b.c */,
+				3D648B182AB98BEA00893C8D /* blake2-impl.h */,
+			);
+			path = blake2;
 			sourceTree = "<group>";
 		};
 		3D6C6D0522B7707B00289576 /* Keychain */ = {
@@ -653,6 +678,7 @@
 				3D891F032105B12F0031E528 /* TUTAes128Facade.m */,
 				3D891F1D2105BB200031E528 /* rsa_oaep_sha256.h */,
 				3D891EFD2105B12E0031E528 /* rsa_oaep_sha256.c */,
+				3D648B0C2AB98BEA00893C8D /* phc-winner-argon2 */,
 				3DF7FA592AB2EE3B00DB08D1 /* Argon2.swift */,
 				3D9B12A22721926E002B46A1 /* ValueEncryption.swift */,
 				3D84F5722722F35600858A58 /* IosNativeCryptoFacade.swift */,
@@ -1284,7 +1310,6 @@
 			children = (
 				3DD4A08520F8C6240086EB36 /* tutanota */,
 				3DD4A09E20F8C6260086EB36 /* tutanotaTests */,
-				3DE114462AAF1C0E000D75B2 /* argon2 */,
 				3DEF18F12924E1F1009C4B55 /* TutanotaShareExtension */,
 				3DD4A08420F8C6240086EB36 /* Products */,
 				3D891EEC2105A5590031E528 /* Frameworks */,
@@ -1299,7 +1324,6 @@
 				3DD4A08320F8C6240086EB36 /* tutanota.app */,
 				3DD4A09B20F8C6260086EB36 /* tutanotaTests.xctest */,
 				3DEF18F02924E1F1009C4B55 /* TutanotaShareExtension.appex */,
-				3DE114452AAF1C0D000D75B2 /* argon2.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1410,60 +1434,6 @@
 			path = Offline;
 			sourceTree = "<group>";
 		};
-		3DE114462AAF1C0E000D75B2 /* argon2 */ = {
-			isa = PBXGroup;
-			children = (
-				3DE114522AAF1D09000D75B2 /* phc-winner-argon2 */,
-			);
-			path = argon2;
-			sourceTree = "<group>";
-		};
-		3DE114522AAF1D09000D75B2 /* phc-winner-argon2 */ = {
-			isa = PBXGroup;
-			children = (
-				3DE114532AAF1D09000D75B2 /* include */,
-				3DE114552AAF1D09000D75B2 /* src */,
-			);
-			path = "phc-winner-argon2";
-			sourceTree = "<group>";
-		};
-		3DE114532AAF1D09000D75B2 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				3DE114542AAF1D09000D75B2 /* argon2.h */,
-			);
-			path = include;
-			sourceTree = "<group>";
-		};
-		3DE114552AAF1D09000D75B2 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				3DE114562AAF1D09000D75B2 /* thread.c */,
-				3DE114572AAF1D09000D75B2 /* core.h */,
-				3DE114582AAF1D09000D75B2 /* blake2 */,
-				3DE1145E2AAF1D09000D75B2 /* ref.c */,
-				3DE1145F2AAF1D09000D75B2 /* run.c */,
-				3DE114602AAF1D09000D75B2 /* encoding.h */,
-				3DE114612AAF1D09000D75B2 /* core.c */,
-				3DE114622AAF1D09000D75B2 /* thread.h */,
-				3DE114632AAF1D09000D75B2 /* argon2.c */,
-				3DE114722AAF1D58000D75B2 /* encoding.c */,
-			);
-			path = src;
-			sourceTree = "<group>";
-		};
-		3DE114582AAF1D09000D75B2 /* blake2 */ = {
-			isa = PBXGroup;
-			children = (
-				3DE114592AAF1D09000D75B2 /* blamka-round-ref.h */,
-				3DE1145A2AAF1D09000D75B2 /* blamka-round-opt.h */,
-				3DE1145B2AAF1D09000D75B2 /* blake2.h */,
-				3DE1145C2AAF1D09000D75B2 /* blake2b.c */,
-				3DE1145D2AAF1D09000D75B2 /* blake2-impl.h */,
-			);
-			path = blake2;
-			sourceTree = "<group>";
-		};
 		3DEF18F12924E1F1009C4B55 /* TutanotaShareExtension */ = {
 			isa = PBXGroup;
 			children = (
@@ -1481,24 +1451,17 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D648B222AB98BEA00893C8D /* core.h in Headers */,
+				3D648B292AB98BEA00893C8D /* encoding.h in Headers */,
+				3D648B242AB98BEA00893C8D /* blamka-round-opt.h in Headers */,
 				3D4E3CAA28EC6787001FA9D1 /* sqlite3.h in Headers */,
 				3D9B12B32721A1E2002B46A1 /* TUTErrorFactory.h in Headers */,
 				3DCE7AAB27200E0A0085E40D /* WebviewHacks.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3DE114402AAF1C0D000D75B2 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3DE114642AAF1D09000D75B2 /* argon2.h in Headers */,
-				3DE114692AAF1D0A000D75B2 /* blake2.h in Headers */,
-				3DE114682AAF1D0A000D75B2 /* blamka-round-opt.h in Headers */,
-				3DE1146E2AAF1D0A000D75B2 /* encoding.h in Headers */,
-				3DE114662AAF1D09000D75B2 /* core.h in Headers */,
-				3DE114672AAF1D0A000D75B2 /* blamka-round-ref.h in Headers */,
-				3DE114702AAF1D0A000D75B2 /* thread.h in Headers */,
-				3DE1146B2AAF1D0A000D75B2 /* blake2-impl.h in Headers */,
+				3D648B202AB98BEA00893C8D /* argon2.h in Headers */,
+				3D648B232AB98BEA00893C8D /* blamka-round-ref.h in Headers */,
+				3D648B2B2AB98BEA00893C8D /* thread.h in Headers */,
+				3D648B252AB98BEA00893C8D /* blake2.h in Headers */,
+				3D648B272AB98BEA00893C8D /* blake2-impl.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1520,7 +1483,6 @@
 			);
 			dependencies = (
 				3DEF18F92924E1F1009C4B55 /* PBXTargetDependency */,
-				3DE1144A2AAF1C0E000D75B2 /* PBXTargetDependency */,
 			);
 			name = tutanota;
 			packageProductDependencies = (
@@ -1548,24 +1510,6 @@
 			productName = tutanotaTests;
 			productReference = 3DD4A09B20F8C6260086EB36 /* tutanotaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		3DE114442AAF1C0D000D75B2 /* argon2 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 3DE1144D2AAF1C0E000D75B2 /* Build configuration list for PBXNativeTarget "argon2" */;
-			buildPhases = (
-				3DE114402AAF1C0D000D75B2 /* Headers */,
-				3DE114412AAF1C0D000D75B2 /* Sources */,
-				3DE114422AAF1C0D000D75B2 /* Frameworks */,
-				3DE114432AAF1C0D000D75B2 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = argon2;
-			productName = argon2;
-			productReference = 3DE114452AAF1C0D000D75B2 /* argon2.framework */;
-			productType = "com.apple.product-type.framework";
 		};
 		3DEF18EF2924E1F1009C4B55 /* TutanotaShareExtension */ = {
 			isa = PBXNativeTarget;
@@ -1610,9 +1554,6 @@
 						CreatedOnToolsVersion = 9.4.1;
 						LastSwiftMigration = 1250;
 						TestTargetID = 3DD4A08220F8C6240086EB36;
-					};
-					3DE114442AAF1C0D000D75B2 = {
-						CreatedOnToolsVersion = 14.3.1;
 					};
 					3DEF18EF2924E1F1009C4B55 = {
 						CreatedOnToolsVersion = 13.4.1;
@@ -1722,7 +1663,6 @@
 				3DD4A08220F8C6240086EB36 /* tutanota */,
 				3DD4A09A20F8C6260086EB36 /* tutanotaTests */,
 				3DEF18EF2924E1F1009C4B55 /* TutanotaShareExtension */,
-				3DE114442AAF1C0D000D75B2 /* argon2 */,
 			);
 		};
 /* End PBXProject section */
@@ -1810,13 +1750,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3DE114432AAF1C0D000D75B2 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		3DEF18EE2924E1F1009C4B55 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1864,6 +1797,7 @@
 				3DC5DEC728576621007364FF /* NativeInterface.swift in Sources */,
 				3D220202293F752D00366FD2 /* WebauthnKeyDescriptor.swift in Sources */,
 				3DCE7AAC27200E0A0085E40D /* WebviewHacks.m in Sources */,
+				3D648B282AB98BEA00893C8D /* ref.c in Sources */,
 				3DCE7AA22719D04B0085E40D /* UserPreferenceFacade.swift in Sources */,
 				3D0EB1F626F489AD002E5102 /* KeychainManager.swift in Sources */,
 				3DBA56D22850AAA6004416BE /* ErrorInfo.swift in Sources */,
@@ -1890,6 +1824,7 @@
 				3D3AFAE4285B0C350077F302 /* IntegrationInfo.swift in Sources */,
 				3DBA56D42850AAA6004416BE /* UploadTaskResponse.swift in Sources */,
 				3DBA56CC2850AAA6004416BE /* ThemeFacadeReceiveDispatcher.swift in Sources */,
+				3D648B2A2AB98BEA00893C8D /* core.c in Sources */,
 				3DC299FA267358AF00E1E79F /* ThemeManager.swift in Sources */,
 				3D3AFAE8285B0DB60077F302 /* IosMobileSystemFacade.swift in Sources */,
 				3D9B129727216D60002B46A1 /* ContactsSource.swift in Sources */,
@@ -1900,6 +1835,7 @@
 				3D97821A2739600700DB639C /* URLSession+Sync.swift in Sources */,
 				3DC5DEDB2858D6A9007364FF /* RsaKeyPair.swift in Sources */,
 				3D3AFAF2285CB2CF0077F302 /* IosCommonSystemFacade.swift in Sources */,
+				3D648B262AB98BEA00893C8D /* blake2b.c in Sources */,
 				3D84F57C27231F1F00858A58 /* Serialization.swift in Sources */,
 				3D2DB91B2733F43B00BCEF4C /* IosNativeCredentialsFacade.swift in Sources */,
 				3DE7B3442135855F003415BE /* TUTSubKeys.m in Sources */,
@@ -1912,6 +1848,7 @@
 				3D73DA3427319A91008E7A8A /* Operation.swift in Sources */,
 				3DC5DED82858CB58007364FF /* NativeCryptoFacadeReceiveDispatcher.swift in Sources */,
 				3DE46D2B2848EBDA00DC9D43 /* IosFileFacade.swift in Sources */,
+				3D648B212AB98BEA00893C8D /* thread.c in Sources */,
 				3D4A426729B6453700B10451 /* AlarmScheduler.swift in Sources */,
 				3DBA56D52850AAA6004416BE /* NativeKey.swift in Sources */,
 				3D4A426329B63C0E00B10451 /* AlarmCryptor.swift in Sources */,
@@ -1937,6 +1874,8 @@
 				3D2201FF293F752D00366FD2 /* WebAuthnRegistrationChallenge.swift in Sources */,
 				3D84F5732722F35600858A58 /* IosNativeCryptoFacade.swift in Sources */,
 				3DBA56C82850AAA6004416BE /* MobileFacadeSendDispatcher.swift in Sources */,
+				3D648B2C2AB98BEA00893C8D /* argon2.c in Sources */,
+				3D648B2D2AB98BEA00893C8D /* encoding.c in Sources */,
 				3DC5DED92858CB58007364FF /* RsaPublicKey.swift in Sources */,
 				3D0EB1F926F49E36002E5102 /* AppDelegate.swift in Sources */,
 				3D3AFAE3285B0C350077F302 /* MobileSystemfacade.swift in Sources */,
@@ -1957,19 +1896,6 @@
 				3DAA23A9267A208200219051 /* UIColorExtensionsTest.swift in Sources */,
 				3DF7FA5E2AB2FBE700DB08D1 /* CompatibilityTestSwift.swift in Sources */,
 				3D84F58527268EDE00858A58 /* AlarmModelTest.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3DE114412AAF1C0D000D75B2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3DE1146F2AAF1D0A000D75B2 /* core.c in Sources */,
-				3DE1146C2AAF1D0A000D75B2 /* ref.c in Sources */,
-				3DE114732AAF1D58000D75B2 /* encoding.c in Sources */,
-				3DE114712AAF1D0A000D75B2 /* argon2.c in Sources */,
-				3DE114652AAF1D09000D75B2 /* thread.c in Sources */,
-				3DE1146A2AAF1D0A000D75B2 /* blake2b.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1996,11 +1922,6 @@
 			isa = PBXTargetDependency;
 			target = 3DD4A08220F8C6240086EB36 /* tutanota */;
 			targetProxy = 3DD4A09C20F8C6260086EB36 /* PBXContainerItemProxy */;
-		};
-		3DE1144A2AAF1C0E000D75B2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 3DE114442AAF1C0D000D75B2 /* argon2 */;
-			targetProxy = 3DE114492AAF1C0E000D75B2 /* PBXContainerItemProxy */;
 		};
 		3DEF18F92924E1F1009C4B55 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2784,103 +2705,6 @@
 			};
 			name = Release;
 		};
-		3DE1144E2AAF1C0E000D75B2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = JKCH89Z3M9;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Tutao GmbH. All rights reserved.";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.0;
-				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
-				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
-				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tutao.argon2;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		3DE1144F2AAF1C0E000D75B2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
-				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = JKCH89Z3M9;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_MODULE_VERIFIER = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 Tutao GmbH. All rights reserved.";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = (
-					"@executable_path/../Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 13.3;
-				MARKETING_VERSION = 1.0;
-				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
-				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++20";
-				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = de.tutao.argon2;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AdHoc de.tutao.argon2";
-				SDKROOT = auto;
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 		3DEF18FC2924E1F1009C4B55 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2976,15 +2800,6 @@
 			buildConfigurations = (
 				3DD4A0A820F8C6260086EB36 /* Debug */,
 				3DD4A0A920F8C6260086EB36 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		3DE1144D2AAF1C0E000D75B2 /* Build configuration list for PBXNativeTarget "argon2" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3DE1144E2AAF1C0E000D75B2 /* Debug */,
-				3DE1144F2AAF1C0E000D75B2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/app-ios/tutanota.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/app-ios/tutanota.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/app-ios/tutanota/Info.plist
+++ b/app-ios/tutanota/Info.plist
@@ -58,7 +58,7 @@
 	<key>NSRemindersUsageDescription</key>
 	<string>Shows notification when new email arrives.</string>
 	<key>TutanotaApplicationPath</key>
-	<string>build/dist/</string>
+	<string>build/</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>ionicons.ttf</string>

--- a/app-ios/tutanota/Sources/Crypto/phc-winner-argon2
+++ b/app-ios/tutanota/Sources/Crypto/phc-winner-argon2
@@ -1,0 +1,1 @@
+../../../../libs/phc-winner-argon2


### PR DESCRIPTION
Turns out that it's very annoying to create shared libraries as a separate target, as while it works great locally, there are issues with building releases with Jenkins (as seen with the past three builds.

Let's just not do that.