### PR TITLE
Add argon2 to the bridging header

### DIFF
--- a/app-ios/tutanota/Sources/Crypto/Argon2.swift
+++ b/app-ios/tutanota/Sources/Crypto/Argon2.swift
@@ -1,5 +1,4 @@
 import Foundation
-import argon2
 
 /// Generate a hash using Argon2id with the given parameters
 ///

--- a/app-ios/tutanota/Sources/tutanota-Bridging-Header.h
+++ b/app-ios/tutanota/Sources/tutanota-Bridging-Header.h
@@ -10,3 +10,4 @@
 #import "Crypto/TUTAes128Facade.h"
 #import "Crypto/TUTCrypto.h"
 #include "Offline/sqlite3.h"
+#import "argon2.h"


### PR DESCRIPTION
Seems we can't just do 'import argon2' anymore