### PR TITLE
[iOS] Fix ValueEncryption converting back to base64 before parsing

### DIFF
--- a/app-ios/tutanota/Sources/Crypto/ValueEncryption.swift
+++ b/app-ios/tutanota/Sources/Crypto/ValueEncryption.swift
@@ -20,7 +20,7 @@ extension SimpleStringDecodable {
   static func aesDecrypt(base64: Base64, key: Key) throws -> Self {
     let decoded = TUTEncodingConverter.base64(toBytes: base64)
     let decrypted = try aesDecryptData(decoded, withKey: key)
-    let decValue = TUTEncodingConverter.bytes(toBase64: decrypted)
+    let decValue = TUTEncodingConverter.bytes(toString: decrypted)
     if let value = Self.init(string: decValue) {
       return value
     } else {


### PR DESCRIPTION
It seems there was a misunderstanding of how the decrypt base64 function worked.

Fixes #5928 