### PR TITLE
fix missing object store causing uncaught error reports

### DIFF
--- a/src/api/worker/facades/lazy/ConfigurationDatabase.ts
+++ b/src/api/worker/facades/lazy/ConfigurationDatabase.ts
@@ -5,6 +5,7 @@ import { ExternalImageRule } from "../../../common/TutanotaConstants.js"
 import { aes256RandomKey, aesDecrypt, aesEncrypt, decryptKey, encryptKey, IV_BYTE_LENGTH, random } from "@tutao/tutanota-crypto"
 import { UserFacade } from "../UserFacade.js"
 import { Metadata, ObjectStoreName } from "../../search/IndexTables.js"
+import { DbError } from "../../../common/error/DbError.js"
 
 const VERSION: number = 2
 const DB_KEY_PREFIX: string = "ConfigStorage"
@@ -52,7 +53,7 @@ export class ConfigurationDatabase {
 		const { db, metaData } = await this.db.getAsync()
 		if (!db.indexingSupported) return
 		const encryptedAddress = await encryptItem(address, metaData.key, metaData.iv)
-		return this._addAddressToImageList(encryptedAddress, rule)
+		return addAddressToImageList(db, encryptedAddress, rule)
 	}
 
 	async getExternalImageRule(address: string): Promise<ExternalImageRule> {
@@ -68,21 +69,12 @@ export class ConfigurationDatabase {
 				rule = entry.rule
 			} else {
 				// No rule set from earlier version means Allow
-				await this._addAddressToImageList(encryptedAddress, ExternalImageRule.Allow)
+				await addAddressToImageList(db, encryptedAddress, ExternalImageRule.Allow)
 				rule = ExternalImageRule.Allow
 			}
 		}
 
 		return rule
-	}
-
-	async _addAddressToImageList(encryptedAddress: Uint8Array, rule: ExternalImageRule): Promise<void> {
-		const { db } = await this.db.getAsync()
-		const transaction = await db.createTransaction(false, [ExternalImageListOS])
-		return transaction.put(ExternalImageListOS, null, {
-			address: encryptedAddress,
-			rule: rule,
-		})
 	}
 
 	async loadConfigDb(user: User, userGroupKey: Aes128Key): Promise<ConfigDb> {
@@ -97,11 +89,10 @@ export class ConfigurationDatabase {
 			const metaData = (await loadEncryptionMetadata(dbFacade, id, userGroupKey)) || (await initializeDb(dbFacade, id, userGroupKey))
 
 			if (event.oldVersion === 1) {
-				// migrate to aes256 with mac
+				// migrate from plain, mac-and-static-iv aes256 to aes256 with mac
 				const transaction = await dbFacade.createTransaction(true, [ExternalImageListOS])
 				const entries = await transaction.getAll(ExternalImageListOS)
-				const key = assertNotNull(metaData?.key)
-				const iv = assertNotNull(metaData?.iv)
+				const { key, iv } = metaData
 				for (const entry of entries) {
 					const address = await decryptLegacyItem(new Uint8Array(downcast(entry.key)), key, iv)
 					await this.addExternalImageRule(address, entry.value.rule)
@@ -154,5 +145,21 @@ async function initializeDb(db: DbFacade, id: string, userGroupKey: Aes128Key): 
 	return {
 		key,
 		iv,
+	}
+}
+
+async function addAddressToImageList(db: DbFacade, encryptedAddress: Uint8Array, rule: ExternalImageRule): Promise<void> {
+	try {
+		const transaction = await db.createTransaction(false, [ExternalImageListOS])
+		await transaction.put(ExternalImageListOS, null, {
+			address: encryptedAddress,
+			rule: rule,
+		})
+	} catch (e) {
+		if (e instanceof DbError) {
+			console.error("failed to add address to image list:", e.message)
+			return
+		}
+		throw e
 	}
 }


### PR DESCRIPTION
our indexedDb implementation is not very clear and the original error points to some timing or error handling problem in the initialization or migration sequence.
this patch stops these errors from becoming user-visible by ignoring them.
if the indexDB is available after all, the user can still add the rule later, if it is not, indexing will likely be disabled at some later point.

#5915