### PR TITLE
Fix handling corrupted credentials key

### DIFF
--- a/packages/tutanota-crypto/lib/misc/CryptoError.ts
+++ b/packages/tutanota-crypto/lib/misc/CryptoError.ts
@@ -1,6 +1,9 @@
 // TODO reconcile with CryptoError in tutanota-3
+//    currently will get deserialized to the CryptoError from tutanota-3
 export class CryptoError extends Error {
 	constructor(message: string, error?: Error) {
 		super(error ? message + "> " + (error.stack ? error.stack : error.message) : message)
+		// This is needed to correctly deserialize the error.
+		this.name = "CryptoError"
 	}
 }

--- a/src/api/common/utils/Utils.ts
+++ b/src/api/common/utils/Utils.ts
@@ -52,7 +52,6 @@ import { WebauthnError } from "../error/WebauthnError"
 import { SuspensionError } from "../error/SuspensionError.js"
 import { LoginIncompleteError } from "../error/LoginIncompleteError.js"
 import { OfflineDbClosedError } from "../error/OfflineDbClosedError.js"
-import Stream from "mithril/stream"
 
 export function getWhitelabelDomain(customerInfo: CustomerInfo, domainName?: string): DomainInfo | null {
 	return customerInfo.domainInfos.find((info) => info.whitelabelConfig != null && (domainName == null || info.domain === domainName)) ?? null


### PR DESCRIPTION
We did not expect encryption errors from fetching the credentials key before because we didn't check HMAC in those cases. Now that we do check it more consistently the errors show up sooner and must be handled properly.

fix #5916