### PR TITLE
Fix error on loading CustomerInfo after upgrade

### DIFF
--- a/src/misc/SubscriptionDialogs.ts
+++ b/src/misc/SubscriptionDialogs.ts
@@ -109,12 +109,12 @@ export async function showPlanUpgradeRequiredDialog(acceptedPlans: AvailablePlan
 	}
 }
 
-export async function showUpgradeWizardOrSwitchSubscriptionDialog(userController: UserController): Promise<PlanType> {
+export async function showUpgradeWizardOrSwitchSubscriptionDialog(userController: UserController): Promise<void> {
 	if (userController.isFreeAccount()) {
 		const { showUpgradeWizard } = await import("../subscription/UpgradeSubscriptionWizard")
-		return showUpgradeWizard(locator.logins)
+		await showUpgradeWizard(locator.logins)
 	} else {
-		return showSwitchPlanDialog(userController, NewPaidPlans)
+		await showSwitchPlanDialog(userController, NewPaidPlans)
 	}
 }
 

--- a/src/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/subscription/UpgradeSubscriptionWizard.ts
@@ -66,7 +66,7 @@ export type UpgradeSubscriptionData = {
 	msg: TranslationText | null
 }
 
-export async function showUpgradeWizard(logins: LoginController, acceptedPlans: AvailablePlanType[] = NewPaidPlans, msg?: TranslationText): Promise<PlanType> {
+export async function showUpgradeWizard(logins: LoginController, acceptedPlans: AvailablePlanType[] = NewPaidPlans, msg?: TranslationText): Promise<void> {
 	const [customer, accountingInfo] = await Promise.all([logins.getUserController().loadCustomer(), logins.getUserController().loadAccountingInfo()])
 	const priceDataProvider = await PriceAndConfigProvider.getInitializedInstance(null, locator.serviceExecutor, null)
 
@@ -109,11 +109,10 @@ export async function showUpgradeWizard(logins: LoginController, acceptedPlans: 
 		wizardPageWrapper(InvoiceAndPaymentDataPage, new InvoiceAndPaymentDataPageAttrs(upgradeData)),
 		wizardPageWrapper(UpgradeConfirmSubscriptionPage, new InvoiceAndPaymentDataPageAttrs(upgradeData)),
 	]
-	const deferred = defer<PlanType>()
+	const deferred = defer<void>()
 
 	const wizardBuilder = createWizardDialog(upgradeData, wizardPages, async () => {
-		const customerInfo = await locator.logins.getUserController().loadCustomerInfo()
-		deferred.resolve(customerInfo.plan as PlanType)
+		deferred.resolve()
 	})
 	wizardBuilder.dialog.show()
 	return deferred.promise


### PR DESCRIPTION
CustomerInfo is moved between lists on upgrade/downgrade and we might try to load it at the old location.

It seems like it was not necessary to load CustomerInfo anyway.

fix #5949