### PR TITLE
Drop support for browsers that do not have WebAssembly

### DIFF
--- a/src/login/PostLoginActions.ts
+++ b/src/login/PostLoginActions.ts
@@ -125,7 +125,6 @@ export class PostLoginActions implements PostLoginAction {
 			await locator.mailModel.init()
 			const calendarModel = await locator.calendarModel()
 			await calendarModel.init()
-			await this.checkWebAssemblyEnabled()
 			await this.remindActiveOutOfOfficeNotification()
 		}
 
@@ -161,30 +160,6 @@ export class PostLoginActions implements PostLoginAction {
 	private deactivateOutOfOfficeNotification(notification: OutOfOfficeNotification): Promise<void> {
 		notification.enabled = false
 		return this.entityClient.update(notification)
-	}
-
-	private async checkWebAssemblyEnabled() {
-		const closeButton: Partial<ButtonAttrs> = {
-			label: "close_alt",
-		}
-		if (!client.webassembly()) {
-			if (isIOSApp() || isAndroidApp()) {
-				// It's OK. We are not using WebAssembly on iOS/Android.
-				return
-			} else {
-				const notificationMessage = {
-					view: () => [m(".pb", lang.get("webAssemblyNotSupported1_msg")), m("", lang.get("webAssemblyNotSupported2_msg"))],
-				}
-				const buttons: ButtonAttrs[] = [
-					{
-						label: "download_action",
-						click: () => window.open(InfoLink.Download, "_blank"),
-						type: ButtonType.Primary,
-					},
-				]
-				notificationOverlay.show(notificationMessage, closeButton, buttons)
-			}
-		}
 	}
 
 	private remindActiveOutOfOfficeNotification(): Promise<void> {

--- a/src/misc/ClientDetector.ts
+++ b/src/misc/ClientDetector.ts
@@ -1,4 +1,4 @@
-import { assertMainOrNodeBoot, Mode } from "../api/common/Env"
+import { assertMainOrNodeBoot, isApp, Mode } from "../api/common/Env"
 import { BrowserData, BrowserType, DeviceType } from "./ClientConstants"
 
 assertMainOrNodeBoot()
@@ -118,7 +118,7 @@ export class ClientDetector {
 	 */
 	isSupported(): boolean {
 		this.syntaxChecks()
-		return this.isSupportedBrowserVersion() && this.testBuiltins() && this.websockets() && this.testCss()
+		return this.isSupportedBrowserVersion() && this.testBuiltins() && this.websockets() && this.testCss() && (isApp() || this.webassembly())
 	}
 
 	isMobileDevice(): boolean {


### PR DESCRIPTION
We no longer wish to support web browsers that have WebAssembly disabled as we need to use C libraries for some things now.

tutadb#1630