### PR TITLE
fix swiping an email from archive back to inbox

### DIFF
--- a/src/mail/view/MailListView.ts
+++ b/src/mail/view/MailListView.ts
@@ -404,9 +404,11 @@ export class MailListView implements Component<MailListViewAttrs> {
 		} else {
 			const folders = await locator.mailModel.getMailboxFolders(listElement)
 			if (folders) {
+				//Check if the user is in the trash/spam folder or if it's in Inbox or Archive
+				//to determinate the target folder
 				const targetMailFolder = this.showingSpamOrTrash
 					? this.getRecoverFolder(listElement, folders)
-					: assertNotNull(folders.getSystemFolderByType(MailFolderType.ARCHIVE))
+					: assertNotNull(folders.getSystemFolderByType(this.targetInbox() ? MailFolderType.INBOX : MailFolderType.ARCHIVE))
 				const wereMoved = await moveMails({
 					mailModel: locator.mailModel,
 					mails: [listElement],


### PR DESCRIPTION
When the user swipe an email from archive to return it to inbox the app is considering that the user is inside the inbox folder when getting destination folder, consequently the email isn't moved as the source and target folder are the same

This commit fixes that, checking if the user is inside the inbox folder or inside the archive, then determinate the target folder based on it

fix #5449