### PR TITLE
fix file attachment bubble out of screen

### DIFF
--- a/src/gui/AttachmentBubble.ts
+++ b/src/gui/AttachmentBubble.ts
@@ -205,7 +205,7 @@ export class AttachmentDetailsPopup implements ModalComponent {
 		//Verify if the attachment bubble is going to overflow the screen
 		//if yes, invert the side of the margin and discount the bubble width
 		if (targetRect.left + targetWidth > window.innerWidth) {
-			domPanel.style.right = px(targetRect.right - targetWidth)
+			domPanel.style.right = px(24)
 		} else {
 			domPanel.style.left = px(targetRect.left)
 		}

--- a/src/gui/AttachmentBubble.ts
+++ b/src/gui/AttachmentBubble.ts
@@ -201,7 +201,14 @@ export class AttachmentDetailsPopup implements ModalComponent {
 		domPanel.style.height = px(initialHeight)
 		// add half the difference between .button height of 44px and 30px for pixel-perfect positioning
 		domPanel.style.top = px(targetRect.top + 7)
-		domPanel.style.left = px(targetRect.left)
+
+		//Verify if the attachment bubble is going to overflow the screen
+		//if yes, invert the side of the margin and discount the bubble width
+		if (targetRect.left + targetWidth > window.innerWidth) {
+			domPanel.style.right = px(targetRect.right - targetWidth)
+		} else {
+			domPanel.style.left = px(targetRect.left)
+		}
 
 		const mutations = [opacity(0, 1, true), height(initialHeight, targetHeight)]
 		if (targetRect.width !== targetWidth) {


### PR DESCRIPTION
When the email has to attachments on mobile and the two attachments are placed side by side in the email view, when opens the action bubble for the right one the bubble overflow to the right clipping part of its content.

This commit verifies if the bubble will overflow the screen and inverts the side of it, instead to open to the right, it will open to the left side of screen.

fix #5919