### PR TITLE
fix multiple emails are selected when using long press

### DIFF
--- a/src/contacts/view/ContactListRecipientView.ts
+++ b/src/contacts/view/ContactListRecipientView.ts
@@ -20,6 +20,7 @@ import {
 } from "../../gui/SelectableRowContainer.js"
 import { px, size } from "../../gui/size.js"
 import { shiftByForCheckbox, translateXHide, translateXShow } from "./ContactRow.js"
+import { styles } from "../../gui/styles.js"
 
 assertMainOrNode()
 
@@ -57,7 +58,7 @@ export class ContactListRecipientView implements Component<ContactListViewAttrs>
 							focusDetailsViewer()
 						},
 						onSingleTogglingMultiselection: (item: ContactListEntry) => {
-							listModel.onSingleInclusiveSelection(item)
+							listModel.onSingleInclusiveSelection(item, styles.isSingleColumnLayout())
 						},
 						onRangeSelectionTowards: (item: ContactListEntry) => {
 							listModel.selectRangeTowards(item)

--- a/src/contacts/view/ContactListView.ts
+++ b/src/contacts/view/ContactListView.ts
@@ -3,12 +3,13 @@ import type { Contact } from "../../api/entities/tutanota/TypeRefs.js"
 import { size } from "../../gui/size"
 import { ListColumnWrapper } from "../../gui/ListColumnWrapper"
 import { assertMainOrNode } from "../../api/common/Env"
-import { MultiselectMode, List, ListAttrs, RenderConfig, ViewHolder } from "../../gui/base/List.js"
+import { List, ListAttrs, MultiselectMode, RenderConfig, ViewHolder } from "../../gui/base/List.js"
 import { ContactRow } from "./ContactRow.js"
 import { ContactViewModel } from "./ContactViewModel.js"
 import ColumnEmptyMessageBox from "../../gui/base/ColumnEmptyMessageBox.js"
 import { theme } from "../../gui/theme.js"
 import { BootIcons } from "../../gui/base/icons/BootIcons.js"
+import { styles } from "../../gui/styles.js"
 
 assertMainOrNode()
 
@@ -46,7 +47,7 @@ export class ContactListView implements ClassComponent<ContactListViewAttrs> {
 							onSingleSelection()
 						},
 						onSingleTogglingMultiselection: (item: Contact) => {
-							contactViewModel.listModel.onSingleInclusiveSelection(item)
+							contactViewModel.listModel.onSingleInclusiveSelection(item, styles.isSingleColumnLayout())
 						},
 						onRangeSelectionTowards: (item: Contact) => {
 							contactViewModel.listModel.selectRangeTowards(item)

--- a/src/mail/view/MailListView.ts
+++ b/src/mail/view/MailListView.ts
@@ -356,7 +356,7 @@ export class MailListView implements Component<MailListViewAttrs> {
 								vnode.attrs.onSingleSelection(item)
 							},
 							onSingleTogglingMultiselection: (item: Mail) => {
-								listModel.onSingleInclusiveSelection(item)
+								listModel.onSingleInclusiveSelection(item, styles.isSingleColumnLayout())
 							},
 							onRangeSelectionTowards: (item: Mail) => {
 								listModel.selectRangeTowards(item)

--- a/src/misc/ListModel.ts
+++ b/src/misc/ListModel.ts
@@ -328,8 +328,17 @@ export class ListModel<ElementType extends ListElement> {
 	}
 
 	/** An element was added to the selection. If multiselect was not on, add previous single selection and newly added selected item to the selection. */
-	onSingleInclusiveSelection(item: ElementType): void {
+	onSingleInclusiveSelection(item: ElementType, clearSelectionOnMultiSelectStart?: boolean): void {
+		// If it isn't in MultiSelect, we discard all previous items
+		// and start a new set of selected items in MultiSelect mode
+		// we do it only if the user is on singleColumnMode, because
+		// there are different expected behaviors there
+		if (!this.state.inMultiselect && clearSelectionOnMultiSelectStart) {
+			this.selectNone()
+		}
+
 		const selectedItems = new Set(this.state.selectedItems)
+
 		if (this.state.inMultiselect && selectedItems.has(item)) {
 			selectedItems.delete(item)
 		} else {

--- a/src/search/view/SearchListView.ts
+++ b/src/search/view/SearchListView.ts
@@ -13,6 +13,7 @@ import { BootIcons } from "../../gui/base/icons/BootIcons.js"
 import { lang } from "../../misc/LanguageViewModel.js"
 import { theme } from "../../gui/theme.js"
 import { VirtualRow } from "../../gui/base/ListUtils.js"
+import { styles } from "../../gui/styles.js"
 
 assertMainOrNode()
 
@@ -64,7 +65,7 @@ export class SearchListView implements Component<SearchListViewAttrs> {
 							attrs.onSingleSelection(item)
 						},
 						onSingleTogglingMultiselection: (item: SearchResultListEntry) => {
-							attrs.listModel.onSingleInclusiveSelection(item)
+							attrs.listModel.onSingleInclusiveSelection(item, styles.isSingleColumnLayout())
 						},
 						onRangeSelectionTowards: (item: SearchResultListEntry) => {
 							attrs.listModel.selectRangeTowards(item)

--- a/test/tests/misc/ListModelTest.ts
+++ b/test/tests/misc/ListModelTest.ts
@@ -669,6 +669,17 @@ o.spec("ListModel", function () {
 				o(listModel.state.activeIndex).equals(2)
 			})
 
+			o(
+				"when not in multiselect it will not select both previous single selection and the newly selected item if in one column layout",
+				async function () {
+					await setItems(items)
+					listModel.onSingleSelection(itemA)
+					listModel.onSingleInclusiveSelection(itemC, true)
+					o(getSortedSelection()).deepEquals([itemC])
+					o(listModel.state.inMultiselect).equals(true)
+				},
+			)
+
 			o("when in multiselect it will add newly selected item to the selection", async function () {
 				await setItems(items)
 				listModel.onSingleInclusiveSelection(itemA)


### PR DESCRIPTION
When the user is on mobile or more specific on a viewport that uses the single column layout and visualises an email, when back to mail list and long press to select another different email, the first one keeps selected.

This commit changes the behavior of the emails lists and contacts lists, discarding the previous selected email if in single column layout. On bigger viewports that uses two or more columns, the behavior stays the same.

fix #5696