### PR TITLE
fix wrong push notification urls

### DIFF
--- a/test/tests/testInNode.ts
+++ b/test/tests/testInNode.ts
@@ -51,12 +51,15 @@ globalThis.performance = {
 	measure: noOp,
 }
 const crypto = await import("node:crypto")
-globalThis.crypto = {
-	getRandomValues: function (bytes) {
-		let randomBytes = crypto.randomBytes(bytes.length)
-		bytes.set(randomBytes)
+Object.defineProperty(globalThis, "crypto", {
+	value: {
+		getRandomValues: function (bytes) {
+			let randomBytes = crypto.randomBytes(bytes.length)
+			bytes.set(randomBytes)
+		},
 	},
-}
+})
+
 globalThis.XMLHttpRequest = (await import("xhr2")).default
 process.on("unhandledRejection", function (e) {
 	console.log("Uncaught (in promise) " + e.stack)


### PR DESCRIPTION
we moved from plain strings to actual URLs in the build process which added slashes at the end of the result. the client still used plain strings to construct the notification URLs and had duplicated slashes because of that

fix #6010