### PR TITLE
Fix processing calendar event updates when MailDetails is enabled

### DIFF
--- a/src/api/worker/rest/EntityRestClient.ts
+++ b/src/api/worker/rest/EntityRestClient.ts
@@ -148,12 +148,7 @@ export class EntityRestClient implements EntityRestInterface {
 
 		const sessionKey = ownerKey
 			? this._crypto.resolveSessionKeyWithOwnerKey(migratedEntity, ownerKey)
-			: await this._crypto.resolveSessionKey(typeModel, migratedEntity).catch(
-					ofClass(SessionKeyNotFoundError, (e) => {
-						console.log("could not resolve session key", e)
-						return null // will result in _errors being set on the instance
-					}),
-			  )
+			: await this._crypto.resolveSessionKey(typeModel, migratedEntity)
 		const instance = await this.instanceMapper.decryptAndMapToInstance<T>(typeModel, migratedEntity, sessionKey)
 		return this._crypto.applyMigrationsForInstance(instance)
 	}

--- a/test/tests/api/worker/rest/EntityRestClientMock.ts
+++ b/test/tests/api/worker/rest/EntityRestClientMock.ts
@@ -99,7 +99,7 @@ export class EntityRestClientMock extends EntityRestClient {
 		}
 	}
 
-	async load<T extends SomeEntity>(typeRef: TypeRef<T>, id: T["_id"], queryParameters: Dict | null | undefined, extraHeaders?: Dict): Promise<T> {
+	async load<T extends SomeEntity>(typeRef: TypeRef<T>, id: T["_id"], queryParameters?: Dict | null | undefined, extraHeaders?: Dict): Promise<T> {
 		if (id instanceof Array && id.length === 2) {
 			// list element request
 			const listId = id[0]


### PR DESCRIPTION
0cf654d06 changed how we handle missing session key when decrypting instances which is handled like a programming error now. This broke the logic for the CalendarModel where we have a temporary solution for not having a proper key: we are supposed to always pass the key provider for instances that are encrypted together with Mail but in this case we don't have a reference to mail yet so we can't do that.

We removed the handling for the missing session key because it shouldn't result in silent errors on the client and this way we can actually handle it when we need it like in the case above with calendar updates.

fix #6021