### PR TITLE
don't use string concatenation in RestClient.ts to build urls

### DIFF
--- a/src/api/worker/rest/RestClient.ts
+++ b/src/api/worker/rest/RestClient.ts
@@ -74,7 +74,8 @@ export class RestClient {
 				}
 
 				const origin = options.baseUrl ?? getApiBaseUrl(this.domainConfig)
-				const resourceURL = new URL(origin + path)
+				const resourceURL = new URL(origin)
+				resourceURL.pathname = path
 				const url = addParamsToUrl(resourceURL, queryParams)
 				const xhr = new XMLHttpRequest()
 				xhr.open(method, url.toString())


### PR DESCRIPTION
concatenation this is prone to failure because of missing/duplicated slashes. we're building a URL anyway, so we might as well use the dedicated setter for path.