### PR TITLE
Fix uncaught programming error, check for contact list id

### DIFF
--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -340,7 +340,7 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 		return this.contactViewModel.listModel.getSelectedAsArray()
 	}
 
-	private async getContactListId() {
+	private async getContactListId(): Promise<Id | null> {
 		if (this.inContactListView()) {
 			return assertNotNull(await this.contactListViewModel.getContactListId())
 		} else {
@@ -349,8 +349,10 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 	}
 
 	async createNewContact() {
-		let listId = await this.getContactListId()
-		new ContactEditor(locator.entityClient, null, listId).show()
+		const listId = await this.getContactListId()
+		if (listId) {
+			new ContactEditor(locator.entityClient, null, listId).show()
+		}
 	}
 
 	private editSelectedContact() {
@@ -395,8 +397,10 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 						contactEdit: (c: Contact) => this.editContact(c),
 						contactDelete: deleteContacts,
 						contactCreate: async (c: Contact) => {
-							let listId = await this.getContactListId()
-							this.editContact(c, listId)
+							const listId = await this.getContactListId()
+							if (listId) {
+								this.editContact(c, listId)
+							}
 						},
 						onWriteMail: writeMail,
 						selectNone: () => this.contactListViewModel.listModel?.selectNone(),

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -39,7 +39,7 @@ import { ContactTypeRef } from "../../api/entities/tutanota/TypeRefs.js"
 import type { InlineImages } from "../view/MailViewer"
 import { FileOpenError } from "../../api/common/error/FileOpenError"
 import type { lazy } from "@tutao/tutanota-utils"
-import { cleanMatch, downcast, isNotNull, noOp, ofClass, typedValues } from "@tutao/tutanota-utils"
+import { assertNotNull, cleanMatch, downcast, isNotNull, noOp, ofClass, typedValues } from "@tutao/tutanota-utils"
 import { isCustomizationEnabledForCustomer } from "../../api/common/utils/Utils"
 import { createInlineImage, replaceCidsWithInlineImages, replaceInlineImagesWithCids } from "../view/MailGuiUtils"
 import { client } from "../../misc/ClientDetector"
@@ -732,7 +732,8 @@ export class MailEditor implements Component<MailEditorAttrs> {
 						contactModel.getContactListId().then((contactListId) => {
 							const newContact = createNewContact(locator.logins.getUserController().user, recipient.address, recipient.name)
 							import("../../contacts/ContactEditor").then(({ ContactEditor }) => {
-								new ContactEditor(entity, newContact, contactListId ?? undefined, createdContactReceiver).show()
+								// external users don't see edit buttons
+								new ContactEditor(entity, newContact, assertNotNull(contactListId), createdContactReceiver).show()
 							})
 						})
 					},

--- a/src/mail/view/MailViewer.ts
+++ b/src/mail/view/MailViewer.ts
@@ -583,7 +583,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 							this.viewModel.contactModel.getContactListId().then((contactListId) => {
 								import("../../contacts/ContactEditor").then(({ ContactEditor }) => {
 									const contact = createNewContact(locator.logins.getUserController().user, mailAddress.address, mailAddress.name)
-									new ContactEditor(this.viewModel.entityClient, contact, contactListId ?? undefined).show()
+									new ContactEditor(this.viewModel.entityClient, contact, assertNotNull(contactListId)).show()
 								})
 							})
 						},

--- a/src/search/view/SearchView.ts
+++ b/src/search/view/SearchView.ts
@@ -15,7 +15,7 @@ import { getFreeSearchStartDate, SEARCH_MAIL_FIELDS } from "../model/SearchUtils
 import { Dialog } from "../../gui/base/Dialog"
 import { locator } from "../../api/main/MainLocator"
 import { getIndentedFolderNameForDropdown } from "../../mail/model/MailUtils"
-import { getFirstOrThrow, isSameDay, isSameTypeRef, isSameTypeRefNullable, lazyMemoized, noOp, ofClass, TypeRef } from "@tutao/tutanota-utils"
+import { assertNotNull, getFirstOrThrow, isSameDay, isSameTypeRef, isSameTypeRefNullable, lazyMemoized, noOp, ofClass, TypeRef } from "@tutao/tutanota-utils"
 import { formatDateWithMonth, formatDateWithTimeIfNotEven } from "../../misc/Formatter"
 import { Icons } from "../../gui/base/icons/Icons"
 import { AppHeaderAttrs, Header } from "../../gui/Header.js"
@@ -515,7 +515,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 				? m(IconButton, {
 						click: () => {
 							locator.contactModel.getContactListId().then((contactListId) => {
-								new ContactEditor(locator.entityClient, null, contactListId ?? undefined).show()
+								new ContactEditor(locator.entityClient, null, assertNotNull(contactListId)).show()
 							})
 						},
 						title: "newContact_action",
@@ -609,7 +609,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 						.catch(ofClass(PermissionError, noOp))
 				} else if (type && isSameTypeRef(type, ContactTypeRef)) {
 					locator.contactModel.getContactListId().then((contactListId) => {
-						new ContactEditor(locator.entityClient, null, contactListId ?? undefined).show()
+						new ContactEditor(locator.entityClient, null, assertNotNull(contactListId)).show()
 					})
 				}
 			},
@@ -678,7 +678,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 				type: ButtonType.FolderColumnHeader,
 				click: () => {
 					locator.contactModel.getContactListId().then((contactListId) => {
-						new ContactEditor(locator.entityClient, null, contactListId ?? undefined).show()
+						new ContactEditor(locator.entityClient, null, assertNotNull(contactListId)).show()
 					})
 				},
 				label: "newContact_action",


### PR DESCRIPTION
It seems like it happens when users trigger the contact editor too early, probably because their security key is sending keyboard input.

Co-authored-by: ivk <ivk@tutao.de>

fix #5959