### PR TITLE
Update Alarm Permission on Android

### DIFF
--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,10 @@
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+	<uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
+	<uses-permission
+			android:name="android.permission.SCHEDULE_EXACT_ALARM"
+			android:maxSdkVersion="32"/>
 
 	<!-- We have to enable cleartext (non-HTTPS) traffic because of the external email content
 	which might still be served or HTTP. The only alternative is to proxy all of it. -->


### PR DESCRIPTION
Starting on API 33, Google stopped granting the SCHEDULE_EXACT_ALARM automatically when installing the app, making necessary to ask for user's permission before scheduling alarms.

This commit limits the SCHEDULE_EXACT_ALARM permission to API 32 and introduces the USE_EXACT_ALARM permission that is granted when installing the app.

fix #6045