### PR TITLE
Show progress bar when exporting emails

### DIFF
--- a/src/gui/dialogs/ProgressDialog.ts
+++ b/src/gui/dialogs/ProgressDialog.ts
@@ -10,6 +10,7 @@ import Stream from "mithril/stream"
 import { TabIndex } from "../../api/common/TutanotaConstants"
 import type { lazy } from "@tutao/tutanota-utils"
 import { delay } from "@tutao/tutanota-utils"
+import { DialogHeaderBar, DialogHeaderBarAttrs } from "../base/DialogHeaderBar.js"
 
 assertMainOrNode()
 
@@ -17,6 +18,8 @@ export async function showProgressDialog<T>(
 	messageIdOrMessageFunction: TranslationKey | lazy<string>,
 	action: Promise<T>,
 	progressStream?: Stream<number>,
+	isCancelable?: boolean,
+	headerBarAttrs?: DialogHeaderBarAttrs,
 ): Promise<T> {
 	if (progressStream != null) {
 		progressStream.map(() => {
@@ -26,24 +29,27 @@ export async function showProgressDialog<T>(
 
 	const progressDialog = new Dialog(DialogType.Progress, {
 		view: () =>
-			m(
-				".hide-outline",
-				{
-					// We make this element focusable so that the screen reader announces the dialog
-					tabindex: TabIndex.Default,
+			m("", [
+				isCancelable && headerBarAttrs ? m(".dialog-header.mb-l.mt-negative-l.mr-negative-l.ml-negative-l", m(DialogHeaderBar, headerBarAttrs)) : null,
+				m(
+					".hide-outline",
+					{
+						// We make this element focusable so that the screen reader announces the dialog
+						tabindex: TabIndex.Default,
 
-					oncreate(vnode) {
-						// We need to delay so that the eelement is attached to the parent
-						setTimeout(() => {
-							;(vnode.dom as HTMLElement).focus()
-						}, 10)
+						oncreate(vnode) {
+							// We need to delay so that the eelement is attached to the parent
+							setTimeout(() => {
+								;(vnode.dom as HTMLElement).focus()
+							}, 10)
+						},
 					},
-				},
-				[
-					m(".flex-center", progressStream ? m(CompletenessIndicator, { percentageCompleted: progressStream() }) : progressIcon()),
-					m("p#dialog-title", lang.getMaybeLazy(messageIdOrMessageFunction)),
-				],
-			),
+					[
+						m(".flex-center", progressStream ? m(CompletenessIndicator, { percentageCompleted: progressStream() }) : progressIcon()),
+						m("p#dialog-title", lang.getMaybeLazy(messageIdOrMessageFunction)),
+					],
+				),
+			]),
 	}).setCloseHandler(() => {
 		// do not close progress on onClose event
 	})

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -496,6 +496,9 @@ styles.registerStyle("main", () => {
 		".mr-negative-s": {
 			"margin-right": px(-size.hpad_button),
 		},
+		".mr-negative-l": {
+			"margin-right": px(-size.hpad_large),
+		},
 		".ml-negative-s": {
 			"margin-left": px(-size.hpad_button),
 		},

--- a/src/mail/export/Exporter.ts
+++ b/src/mail/export/Exporter.ts
@@ -19,6 +19,7 @@ import type { EntityClient } from "../../api/common/EntityClient"
 import { locator } from "../../api/main/MainLocator"
 import { FileController, zipDataFiles } from "../../file/FileController"
 import { MailFacade } from "../../api/worker/facades/lazy/MailFacade.js"
+import { OperationId } from "../../api/main/OperationProgressTracker.js"
 // .msg export is handled in DesktopFileExport because it uses APIs that can't be loaded web side
 export type MailExportMode = "msg" | "eml"
 
@@ -58,19 +59,41 @@ export function generateExportFileName(subject: string, sentOn: Date, mode: Mail
  * @returns {Promise<void>} resolved after the fileController
  * was instructed to open the new zip File containing the exported files
  */
-export function exportMails(mails: Array<Mail>, mailFacade: MailFacade, entityClient: EntityClient, fileController: FileController): Promise<void> {
-	const downloadPromise = promiseMap(mails, (mail) =>
-		import("../../misc/HtmlSanitizer").then(({ htmlSanitizer }) => makeMailBundle(mail, mailFacade, entityClient, fileController, htmlSanitizer)),
-	)
-	return Promise.all([getMailExportMode(), downloadPromise]).then(([mode, bundles]) => {
-		promiseMap(bundles, (bundle) => generateMailFile(bundle, generateExportFileName(bundle.subject, new Date(bundle.receivedOn), mode), mode)).then(
-			(files) => {
-				const zipName = `${sortableTimestamp()}-${mode}-mail-export.zip`
-				const maybeZipPromise = files.length === 1 ? Promise.resolve(files[0]) : zipDataFiles(files, zipName)
-				maybeZipPromise.then((outputFile) => fileController.saveDataFile(outputFile))
-			},
-		)
+export async function exportMails(
+	mails: Array<Mail>,
+	mailFacade: MailFacade,
+	entityClient: EntityClient,
+	fileController: FileController,
+	operationId?: OperationId,
+): Promise<void> {
+	// Considering that the effort for generating the bundle is higher
+	// than generating the files, we need to consider it twice, so the
+	// total effort would be (mailsToBundle * 2) + filesToGenerate
+	const totalMails = mails.length * 3
+	let doneMails = 0
+
+	const updateProgress = operationId !== undefined ? () => locator.operationProgressTracker.onProgress(operationId, (++doneMails / totalMails) * 100) : noOp
+
+	const downloadPromise = promiseMap(mails, async (mail) => {
+		const { htmlSanitizer } = await import("../../misc/HtmlSanitizer")
+		const bundle = await makeMailBundle(mail, mailFacade, entityClient, fileController, htmlSanitizer)
+		updateProgress()
+		updateProgress()
+		return bundle
 	})
+
+	const [mode, bundles] = await Promise.all([getMailExportMode(), downloadPromise])
+	const dataFiles: DataFile[] = []
+	for (const bundle of bundles) {
+		const mailFile = await generateMailFile(bundle, generateExportFileName(bundle.subject, new Date(bundle.receivedOn), mode), mode)
+		dataFiles.push(mailFile)
+		updateProgress()
+	}
+
+	const zipName = `${sortableTimestamp()}-${mode}-mail-export.zip`
+	const outputFile = await (dataFiles.length === 1 ? dataFiles[0] : zipDataFiles(dataFiles, zipName))
+
+	return fileController.saveDataFile(outputFile)
 }
 
 export function mailToEmlFile(mail: MailBundle, fileName: string): DataFile {

--- a/src/mail/export/Exporter.ts
+++ b/src/mail/export/Exporter.ts
@@ -20,6 +20,7 @@ import { locator } from "../../api/main/MainLocator"
 import { FileController, zipDataFiles } from "../../file/FileController"
 import { MailFacade } from "../../api/worker/facades/lazy/MailFacade.js"
 import { OperationId } from "../../api/main/OperationProgressTracker.js"
+import { CancelledError } from "../../api/common/error/CancelledError.js"
 // .msg export is handled in DesktopFileExport because it uses APIs that can't be loaded web side
 export type MailExportMode = "msg" | "eml"
 
@@ -67,55 +68,58 @@ export async function exportMails(
 	operationId?: OperationId,
 	signal?: AbortSignal,
 ): Promise<void> {
-	// Considering that the effort for generating the bundle is higher
-	// than generating the files, we need to consider it twice, so the
-	// total effort would be (mailsToBundle * 2) + filesToGenerate
-	const totalMails = mails.length * 3
-	let doneMails = 0
-	let cancel = false
+	let cancelled = false
 
 	const onAbort = () => {
-		cancel = true
+		cancelled = true
 	}
 
-	//We use once here to let the AbortController remove the
-	//listener after dispatch the abort function
-	signal?.addEventListener("abort", onAbort, { once: true })
+	try {
+		// Considering that the effort for generating the bundle is higher
+		// than generating the files, we need to consider it twice, so the
+		// total effort would be (mailsToBundle * 2) + filesToGenerate
+		const totalMails = mails.length * 3
+		let doneMails = 0
 
-	const updateProgress = operationId !== undefined ? () => locator.operationProgressTracker.onProgress(operationId, (++doneMails / totalMails) * 100) : noOp
+		signal?.addEventListener("abort", onAbort)
+		const updateProgress =
+			operationId !== undefined ? () => locator.operationProgressTracker.onProgress(operationId, (++doneMails / totalMails) * 100) : noOp
 
-	//The only way to skip a Promise is throwing an error.
-	//this throws just the error name to be handled by the try/catch statement.
+		//The only way to skip a Promise is throwing an error.
+		//this throws just a CancelledError to be handled by the try/catch statement.
 
-	//This function must be called in each iteration across all promises since
-	//throwing it inside the onAbort function doesn't interrupt the pending promises.
-	const checkAbortSignal = () => {
-		if (cancel) throw { name: "AbortSignal" }
+		//This function must be called in each iteration across all promises since
+		//throwing it inside the onAbort function doesn't interrupt the pending promises.
+		const checkAbortSignal = () => {
+			if (cancelled) throw new CancelledError("export cancelled")
+		}
+
+		const downloadPromise = promiseMap(mails, async (mail) => {
+			checkAbortSignal()
+			const { htmlSanitizer } = await import("../../misc/HtmlSanitizer")
+			const bundle = await makeMailBundle(mail, mailFacade, entityClient, fileController, htmlSanitizer)
+			updateProgress()
+			updateProgress()
+			return bundle
+		})
+
+		const [mode, bundles] = await Promise.all([getMailExportMode(), downloadPromise])
+		const dataFiles: DataFile[] = []
+		for (const bundle of bundles) {
+			checkAbortSignal()
+			const mailFile = await generateMailFile(bundle, generateExportFileName(bundle.subject, new Date(bundle.receivedOn), mode), mode)
+			dataFiles.push(mailFile)
+			updateProgress()
+		}
+
+		const zipName = `${sortableTimestamp()}-${mode}-mail-export.zip`
+		const outputFile = await (dataFiles.length === 1 ? dataFiles[0] : zipDataFiles(dataFiles, zipName))
+		return fileController.saveDataFile(outputFile)
+	} catch (e) {
+		if (e.name !== "CancelledError") throw e
+	} finally {
+		signal?.removeEventListener("abort", onAbort)
 	}
-
-	const downloadPromise = promiseMap(mails, async (mail) => {
-		checkAbortSignal()
-		const { htmlSanitizer } = await import("../../misc/HtmlSanitizer")
-		const bundle = await makeMailBundle(mail, mailFacade, entityClient, fileController, htmlSanitizer)
-		updateProgress()
-		updateProgress()
-		return bundle
-	})
-
-	const [mode, bundles] = await Promise.all([getMailExportMode(), downloadPromise])
-	const dataFiles: DataFile[] = []
-	for (const bundle of bundles) {
-		checkAbortSignal()
-		const mailFile = await generateMailFile(bundle, generateExportFileName(bundle.subject, new Date(bundle.receivedOn), mode), mode)
-		dataFiles.push(mailFile)
-		updateProgress()
-	}
-
-	const zipName = `${sortableTimestamp()}-${mode}-mail-export.zip`
-	const outputFile = await (dataFiles.length === 1 ? dataFiles[0] : zipDataFiles(dataFiles, zipName))
-
-	signal?.removeEventListener("abort", onAbort)
-	return fileController.saveDataFile(outputFile)
 }
 
 export function mailToEmlFile(mail: MailBundle, fileName: string): DataFile {

--- a/src/mail/view/MailViewerToolbar.ts
+++ b/src/mail/view/MailViewerToolbar.ts
@@ -158,9 +158,7 @@ export class MailViewerActions implements Component<MailViewerToolbarAttrs> {
 						operation.progress,
 						true,
 						headerBarAttrs,
-					).catch((e) => {
-						if (e.name !== "AbortSignal") throw e
-					}),
+					),
 				icon: Icons.Export,
 			})
 		}


### PR DESCRIPTION
When exporting mails no progress is informed to the user, just a blocking dialog asking to wait.

Now it show a progress bar and informs the user how many emails have been prepared and how many emails are going to be exported.

Co-Authors: @ganthern @rezbyte 

close #5546