### PR TITLE
Rollback Android Alarm permission

### DIFF
--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -10,10 +10,7 @@
 	<uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
-	<uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
-	<uses-permission
-			android:name="android.permission.SCHEDULE_EXACT_ALARM"
-			android:maxSdkVersion="32"/>
+	<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
 
 	<!-- We have to enable cleartext (non-HTTPS) traffic because of the external email content
 	which might still be served or HTTP. The only alternative is to proxy all of it. -->


### PR DESCRIPTION
As Google will probably take a deeper look at this permission request, we decided to postpone it to the next release.

#6059
#6045