### PR TITLE
Prevent having outdated client during credential migration

### DIFF
--- a/buildSrc/buildWebapp.js
+++ b/buildSrc/buildWebapp.js
@@ -172,7 +172,10 @@ async function bundleServiceWorker(bundles, version, minify) {
 				banner() {
 					return `function filesToCache() { return ${JSON.stringify(filesToCache)} }
 					function version() { return "${version}" }
-					function customDomainCacheExclusions() { return ${JSON.stringify(customDomainFileExclusions)} }`
+					function customDomainCacheExclusions() { return ${JSON.stringify(customDomainFileExclusions)} }
+					function shouldTakeOverImmediately() {
+						return self.location.hostname.endsWith(".tutanota.com") && Date.now() > new Date("2023-11-07T13:00:00.000Z").getTime()
+					}`
 				},
 			},
 		],

--- a/src/login/LoginViewModel.ts
+++ b/src/login/LoginViewModel.ts
@@ -442,9 +442,11 @@ export class LoginViewModel implements ILoginViewModel {
 	}
 }
 
-/** to give people time to visit the old domain and refresh to a web app that knows about the
- * /migrate route without them being prompted to migrate right away, we have a time delay on
- * the start of the migration. */
+// To give people time to visit the old domain and refresh to a web app that knows about the
+// /migrate route without them being prompted to migrate right away, we have a time delay on
+// the start of the migration.
+//
+// This date is also referenced from service worker build to decide on immediate takeover
 export const ACTIVATED_MIGRATION = () => (Const.CURRENT_DATE?.getTime() ?? Date.now()) > new Date("2023-11-07T13:00:00.000Z").getTime()
 
 /** are we on *.tutanota.com?


### PR DESCRIPTION
We implemented immediate takeover for the old domain so that the users who initiate credential migration won't be stuck with the client which doesn't support it.

close #6074