### PR TITLE
Fix handling errors when fetching feature list

### DIFF
--- a/src/subscription/FeatureListProvider.ts
+++ b/src/subscription/FeatureListProvider.ts
@@ -15,14 +15,14 @@ export class FeatureListProvider {
 	private async init(): Promise<void> {
 		if ("undefined" === typeof fetch) return
 		const listResourceUrl = `${this.domainConfig.websiteBaseUrl}/resources/data/features.json`
-		this.featureList = await resolveOrNull(
-			() => fetch(listResourceUrl).then((r) => r.json()),
-			(e) => console.log("failed to fetch feature list:", e),
-		).then((featureList) => {
+		try {
+			const featureList = await fetch(listResourceUrl).then((r) => r.json())
 			this.countFeatures([...featureList.Free.categories, ...featureList.Revolutionary.categories, ...featureList.Legend.categories])
 			this.countFeatures([...featureList.Essential.categories, ...featureList.Advanced.categories, ...featureList.Unlimited.categories])
-			return featureList
-		})
+			this.featureList = featureList
+		} catch (e) {
+			console.warn(`failed to fetch feature list from  ${listResourceUrl}`, e)
+		}
 	}
 
 	private countFeatures(categories: FeatureCategory[]): void {
@@ -71,28 +71,9 @@ export type WebsitePlanPrices = Pick<
 	"additionalUserPriceMonthly" | "contactFormPriceMonthly" | "firstYearDiscount" | "monthlyPrice" | "monthlyReferencePrice"
 >
 
-async function resolveOrNull<T>(fn: () => Promise<T>, handler: (a: Error) => void): Promise<T | null> {
-	try {
-		return await fn()
-	} catch (e) {
-		handler(e)
-		return null
-	}
-}
-
 export type SelectedSubscriptionOptions = {
 	businessUse: Stream<boolean>
 	paymentInterval: Stream<PaymentInterval>
-}
-
-export type SubscriptionConfig = {
-	nbrOfAliases: number
-	orderNbrOfAliases: number
-	storageGb: number
-	orderStorageGb: number
-	sharing: boolean
-	business: boolean
-	whitelabel: boolean
 }
 
 /**


### PR DESCRIPTION
Previously it would fail on any error because .catch() block didn't return anything. It was possible because the type inference was failing for the helper function.

close tutadb#1661

## Test notes
- [ ] Trying to sign up does not result in error
- [ ] Trying to do an action that results in asking for an upgrade does not result in error