### PR TITLE
change plans to use grid and separate the price from the details

### DIFF
--- a/buildSrc/LaunchHtml.js
+++ b/buildSrc/LaunchHtml.js
@@ -76,7 +76,6 @@ function csp(env) {
 				" script-src 'self' 'wasm-unsafe-eval';" +
 				" worker-src 'self';" +
 				" frame-src 'none';" +
-				" frame-ancestors 'none';" +
 				" font-src 'self';" +
 				" img-src http: blob: data: *;" +
 				" style-src 'unsafe-inline';" +
@@ -96,7 +95,7 @@ function csp(env) {
 			" media-src * data: blob: 'unsafe-inline';" +
 			" style-src * 'unsafe-inline';" +
 			" frame-src *;" +
-			` connect-src 'self' 'unsafe-inline' ${getCspUrls(env)} https://tuta.com;`
+			` connect-src *;`
 
 		return `<meta http-equiv="Content-Security-Policy" content="${cspContent}">`
 	}

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -1677,6 +1677,47 @@ styles.registerStyle("main", () => {
 			width: "100%",
 			padding: px(10),
 		},
+		".plans-grid": {
+			display: "grid",
+			"grid-template-columns": "1fr",
+			"grid-auto-flow": "column",
+			"grid-template-rows": "auto 1fr",
+		},
+		"@media (max-width: 992px)": {
+			".plans-grid": {
+				"grid-template-rows": "auto 1fr auto 1fr",
+			},
+			".plans-grid > div:nth-child(3), .plans-grid > div:nth-child(4)": {
+				order: 1,
+			},
+			".plans-grid > div:nth-child(5), .plans-grid > div:nth-child(6)": {
+				"grid-column": "1 / 3",
+				"justify-self": "center",
+			},
+			".plans-grid > div:nth-child(5)": {
+				"grid-row-start": 3,
+			},
+			".plans-grid > div:nth-child(6)": {
+				"grid-row-start": 4,
+			},
+		},
+		"@media (max-width: 600px)": {
+			".plans-grid": {
+				"grid-template-rows": "auto min-content auto min-content auto min-content",
+			},
+			".plans-grid > div:nth-child(3), .plans-grid > div:nth-child(4)": {
+				order: "unset",
+			},
+			".plans-grid > div:nth-child(5), .plans-grid > div:nth-child(6)": {
+				"grid-column": "unset",
+			},
+			".plans-grid > div:nth-child(5)": {
+				"grid-row-start": "unset",
+			},
+			".plans-grid > div:nth-child(6)": {
+				"grid-row-start": "unset",
+			},
+		},
 		".buyOptionBox.active": {
 			border: `1px solid ${theme.content_accent}`,
 		},

--- a/src/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/subscription/UpgradeSubscriptionWizard.ts
@@ -132,8 +132,8 @@ export async function loadSignupWizard(
 
 	const priceDataProvider = await PriceAndConfigProvider.getInitializedInstance(registrationDataId, locator.serviceExecutor, referralCode)
 	const prices = priceDataProvider.getRawPricingData()
-	const dc = locator.domainConfigProvider().getCurrentDomainConfig()
-	const featureListProvider = await FeatureListProvider.getInitializedInstance(dc)
+	const domainConfig = locator.domainConfigProvider().getCurrentDomainConfig()
+	const featureListProvider = await FeatureListProvider.getInitializedInstance(domainConfig)
 
 	const signupData: UpgradeSubscriptionData = {
 		options: {

--- a/src/subscription/giftcards/PurchaseGiftCardDialog.ts
+++ b/src/subscription/giftcards/PurchaseGiftCardDialog.ts
@@ -14,8 +14,6 @@ import { UserError } from "../../api/main/UserError"
 import { Keys, PaymentMethodType, PlanType } from "../../api/common/TutanotaConstants"
 import { lang } from "../../misc/LanguageViewModel"
 import { BadGatewayError, PreconditionFailedError } from "../../api/common/error/RestError"
-import { Icons } from "../../gui/base/icons/Icons"
-import { Icon } from "../../gui/base/Icon"
 import { GiftCardMessageEditorField } from "./GiftCardMessageEditorField"
 import { client } from "../../misc/ClientDetector"
 import { count, filterInt, noOp, ofClass } from "@tutao/tutanota-utils"
@@ -24,7 +22,9 @@ import { formatPrice, PaymentInterval, PriceAndConfigProvider } from "../PriceUt
 import { GiftCardService } from "../../api/entities/sys/Services"
 import { UpgradePriceType } from "../FeatureListProvider"
 import { TranslationKeyType } from "../../misc/TranslationKey.js"
-import { px } from "../../gui/size.js"
+import { px } from "../../gui/size"
+import { Icon } from "../../gui/base/Icon"
+import { Icons } from "../../gui/base/icons/Icons"
 
 class PurchaseGiftCardModel {
 	message = lang.get("defaultGiftCardMessage_msg")
@@ -123,6 +123,7 @@ class GiftCardPurchaseView implements Component<GiftCardPurchaseViewAttrs> {
 				},
 				model.availablePackages.map((option, index) => {
 					const value = parseFloat(option.value)
+
 					return m(BuyOptionBox, {
 						heading: m(
 							".flex-center",
@@ -144,13 +145,11 @@ class GiftCardPurchaseView implements Component<GiftCardPurchaseViewAttrs> {
 						},
 						price: formatPrice(value, true),
 						helpLabel: () => this.getGiftCardHelpText(model.revolutionaryPrice, value),
-						categories: [],
 						width: 230,
 						height: 250,
 						paymentInterval: null,
 						highlighted: model.selectedPackage === index,
 						showReferenceDiscount: false,
-						renderCategoryTitle: false,
 						mobile: false,
 						bonusMonths: 0,
 					})


### PR DESCRIPTION
This commit separated the price from the details, now they're built separately and now the pick a plan screen uses grid to build the columns and rows, giving more flexibility to the box-size according to the amount of text

fix #6087