### PR TITLE
Fix pressing enter bypassing the `confirmFreeSubscription` dialog

### DIFF
--- a/src/subscription/UpgradeSubscriptionPage.ts
+++ b/src/subscription/UpgradeSubscriptionPage.ts
@@ -207,7 +207,7 @@ function confirmFreeSubscription(): Promise<boolean> {
 			dialog.close()
 			setTimeout(() => resolve(confirmed), DefaultAnimationTime)
 		}
-
+		const isFormValid = stream.lift((_oneAccountValue, _privateUseValue) => _oneAccountValue && _privateUseValue, oneAccountValue, privateUseValue)
 		dialog = new Dialog(DialogType.Alert, {
 			view: () => [
 				// m(".h2.pb", lang.get("confirmFreeAccount_label")),
@@ -233,9 +233,7 @@ function confirmFreeSubscription(): Promise<boolean> {
 					m(Button, {
 						label: "ok_action",
 						click: () => {
-							if (oneAccountValue() && privateUseValue()) {
-								closeAction(true)
-							}
+							if (isFormValid()) closeAction(true)
 						},
 						type: ButtonType.Primary,
 					}),
@@ -252,7 +250,9 @@ function confirmFreeSubscription(): Promise<boolean> {
 			.addShortcut({
 				key: Keys.RETURN,
 				shift: false,
-				exec: () => closeAction(true),
+				exec: () => {
+					if (isFormValid()) closeAction(true)
+				},
 				help: "ok_action",
 			})
 			.show()

--- a/src/subscription/UpgradeSubscriptionPage.ts
+++ b/src/subscription/UpgradeSubscriptionPage.ts
@@ -207,7 +207,7 @@ function confirmFreeSubscription(): Promise<boolean> {
 			dialog.close()
 			setTimeout(() => resolve(confirmed), DefaultAnimationTime)
 		}
-		const isFormValid = stream.lift((_oneAccountValue, _privateUseValue) => _oneAccountValue && _privateUseValue, oneAccountValue, privateUseValue)
+		const isFormValid = () => oneAccountValue() && privateUseValue()
 		dialog = new Dialog(DialogType.Alert, {
 			view: () => [
 				// m(".h2.pb", lang.get("confirmFreeAccount_label")),


### PR DESCRIPTION
Stops users from bypassing the business & age check boxes when signing up for a free account.

Closes #5169.