### PR TITLE
fix link-tt z-index too low

### DIFF
--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -61,7 +61,7 @@ styles.registerStyle("main", () => {
 			? {
 					opacity: 1,
 					transition: "opacity .1s linear",
-					"z-index": 100,
+					"z-index": 9999,
 			  }
 			: {},
 		"*:not(input):not(textarea)": isAdminClient()


### PR DESCRIPTION
increased the z-index of link tooltips
to a bigger number. The link tooltip should be
probably above everything else when displayed.

fix #6124