### PR TITLE
Fix checkbox not indicating if disabled

### DIFF
--- a/src/gui/base/Checkbox.ts
+++ b/src/gui/base/Checkbox.ts
@@ -37,7 +37,7 @@ export class Checkbox implements Component<CheckboxAttrs> {
 			},
 			[
 				m(
-					`.wrapper.flex.items-center${a.disabled ? ".disabled" : undefined}`,
+					`.wrapper.flex.items-center${a.disabled ? ".disabled" : ""}`,
 					{
 						oncreate: (vnode) => {
 							if (!a.disabled) addFlash(vnode.dom)

--- a/src/gui/base/Checkbox.ts
+++ b/src/gui/base/Checkbox.ts
@@ -37,9 +37,8 @@ export class Checkbox implements Component<CheckboxAttrs> {
 			},
 			[
 				m(
-					".wrapper.flex.items-center",
+					`.wrapper.flex.items-center${a.disabled ? ".disabled" : undefined}`,
 					{
-						style: { opacity: a.disabled ? 0.2 : 1 },
 						oncreate: (vnode) => {
 							if (!a.disabled) addFlash(vnode.dom)
 						},

--- a/src/gui/base/Checkbox.ts
+++ b/src/gui/base/Checkbox.ts
@@ -27,7 +27,7 @@ export class Checkbox implements Component<CheckboxAttrs> {
 		const a = vnode.attrs
 		const helpLabel = a.helpLabel ? m("small.block.content-fg", lang.getMaybeLazy(a.helpLabel)) : []
 		return m(
-			".click.pt",
+			`${a.disabled ? ".click-disabled" : ".click"}.pt`,
 			{
 				onclick: (e: MouseEvent) => {
 					if (e.target !== this._domInput) {
@@ -39,8 +39,13 @@ export class Checkbox implements Component<CheckboxAttrs> {
 				m(
 					".wrapper.flex.items-center",
 					{
-						oncreate: (vnode) => addFlash(vnode.dom),
-						onremove: (vnode) => removeFlash(vnode.dom),
+						style: { opacity: a.disabled ? 0.2 : 1 },
+						oncreate: (vnode) => {
+							if (!a.disabled) addFlash(vnode.dom)
+						},
+						onremove: (vnode) => {
+							if (!a.disabled) removeFlash(vnode.dom)
+						},
 					},
 					[
 						// the real checkbox is transparent and only used to allow keyboard focusing and selection
@@ -58,9 +63,11 @@ export class Checkbox implements Component<CheckboxAttrs> {
 							style: {
 								opacity: 0,
 								position: "absolute",
-								cursor: "pointer",
+								cursor: a.disabled ? "default" : "pointer",
 								z_index: -1,
 							},
+							disabled: a.disabled,
+							"aria-disabled": String(a.disabled),
 						}),
 						m(Icon, {
 							icon: a.checked ? BootIcons.CheckboxSelected : BootIcons.Checkbox,

--- a/src/gui/base/Checkbox.ts
+++ b/src/gui/base/Checkbox.ts
@@ -79,7 +79,7 @@ export class Checkbox implements Component<CheckboxAttrs> {
 							{
 								class: this.focused ? "content-accent-fg" : "content-fg",
 								onclick: (e: MouseEvent) => {
-									// if the label contains a link, then stop the event so that the checkbox doesnt get toggled upon clicking
+									// if the label contains a link, then stop the event so that the checkbox doesn't get toggled upon clicking
 									// we still allow it to be checked if they click on the non-link part of the label
 									if (e.target instanceof HTMLElement && e.target.tagName.toUpperCase() === "A") {
 										e.stopPropagation()

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -1172,6 +1172,9 @@ styles.registerStyle("main", () => {
 			background: stateBgActive,
 			"transition-duration": ".3s",
 		},
+		".disabled": {
+			opacity: "0.3",
+		},
 		".translucent": {
 			opacity: "0.4",
 		},


### PR DESCRIPTION
Greys out the checkbox by reducing its opacity & setting the cursor to default. Also included is a small typo fix.

Closes #3133.