### PR TITLE
Fix MAPI does not attach files unless already logged in

### DIFF
--- a/src/login/PostLoginActions.ts
+++ b/src/login/PostLoginActions.ts
@@ -97,7 +97,7 @@ export class PostLoginActions implements PostLoginAction {
 			hourCycle: getHourCycle(this.logins.getUserController().userSettingsGroupRoot),
 		})
 
-		if (isApp() || isDesktop()) {
+		if (isApp()) {
 			// don't wait for it, just invoke
 			locator.fileApp.clearFileData().catch((e) => console.log("Failed to clean file data", e))
 		}


### PR DESCRIPTION
When the user is with the desktop app closed and try to send a file through email the Tuta client doesn't attach the file to the email.

This commit removes the temp folder cleanup at the startup when running the desktop app, since we might have multiple instances running and using the temp folder.

fix #5850