### PR TITLE
Fix back press on the mail view closing the app on Android

### DIFF
--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -376,6 +376,17 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 		return this.viewSlider
 	}
 
+	handleBackButton(): boolean {
+		if (this.viewSlider.focusedColumn === this.mailColumn) {
+			this.viewSlider.focus(this.listColumn)
+			return true
+		} else if (this.viewSlider.focusedColumn === this.listColumn) {
+			this.mailViewModel.listModel?.selectNone()
+			return true
+		}
+		return false
+	}
+
 	private renderHeaderRightView(): Children {
 		return isNewMailActionAvailable()
 			? [


### PR DESCRIPTION
This PR fixes back events on Android closing the app when on the mail list by handling the event on the `MailView`.

Closes #5560.