### PR TITLE
Fix folder name tooltip on mail viewer header overflowing the screen

### DIFF
--- a/src/gui/base/Icon.ts
+++ b/src/gui/base/Icon.ts
@@ -28,7 +28,7 @@ import("./icons/Icons.js").then((IconsModule) => {
 })
 
 export class Icon implements Component<IconAttrs> {
-	private root?: HTMLElement
+	private root: HTMLElement | null = null
 	private tooltip?: HTMLElement
 
 	oncreate(vnode: VnodeDOM<IconAttrs>): any {

--- a/src/gui/base/Icon.ts
+++ b/src/gui/base/Icon.ts
@@ -1,9 +1,10 @@
-import m, { Children, Component, Vnode } from "mithril"
+import m, { Children, Component, Vnode, VnodeDOM } from "mithril"
 import { theme } from "../theme"
 import type { lazy } from "@tutao/tutanota-utils"
 import { assertMainOrNode } from "../../api/common/Env"
 import { BootIcons, BootIconsSvg } from "./icons/BootIcons"
 import { Icons } from "./icons/Icons"
+import { px } from "../size.js"
 
 assertMainOrNode()
 
@@ -27,6 +28,12 @@ import("./icons/Icons.js").then((IconsModule) => {
 })
 
 export class Icon implements Component<IconAttrs> {
+	private root?: HTMLElement
+
+	oncreate(vnode: VnodeDOM<IconAttrs>): any {
+		this.root = vnode.dom as HTMLElement
+	}
+
 	view(vnode: Vnode<IconAttrs>): Children {
 		// @ts-ignore
 		const icon = BootIconsSvg[vnode.attrs.icon] ?? IconsSvg[vnode.attrs.icon]
@@ -40,8 +47,28 @@ export class Icon implements Component<IconAttrs> {
 				style: this.getStyle(vnode.attrs.style ?? null),
 			},
 			m.trust(icon),
-			vnode.attrs.hoverText ? m("span.tooltiptext.no-wrap", vnode.attrs.hoverText) : null,
+			vnode.attrs.hoverText &&
+				m(
+					"span.tooltiptext.no-wrap",
+					{
+						oncreate: (vnode) => {
+							const tooltip = vnode.dom as HTMLElement
+							if (this.root && tooltip) this.moveElementIfOffscreen(this.root, tooltip)
+						},
+					},
+					vnode.attrs.hoverText,
+				),
 		) // icon is typed, so we may not embed untrusted data
+	}
+
+	private moveElementIfOffscreen(root: HTMLElement, tooltip: HTMLElement): void {
+		const tooltipRect = tooltip.getBoundingClientRect()
+		// Get the width of the area in pixels that the tooltip penetrates the viewport
+		const distanceOver = tooltipRect.x + tooltipRect.width - window.innerWidth
+		if (distanceOver > 0) {
+			const parentRect = root.getBoundingClientRect()
+			tooltip.style.left = px(-distanceOver - parentRect.width)
+		}
 	}
 
 	getStyle(style: Record<string, any> | null): {

--- a/src/gui/base/Icon.ts
+++ b/src/gui/base/Icon.ts
@@ -29,6 +29,7 @@ import("./icons/Icons.js").then((IconsModule) => {
 
 export class Icon implements Component<IconAttrs> {
 	private root?: HTMLElement
+	private tooltip?: HTMLElement
 
 	oncreate(vnode: VnodeDOM<IconAttrs>): any {
 		this.root = vnode.dom as HTMLElement
@@ -45,6 +46,9 @@ export class Icon implements Component<IconAttrs> {
 				"aria-hidden": "true",
 				class: this.getClass(vnode.attrs),
 				style: this.getStyle(vnode.attrs.style ?? null),
+				onmouseenter: () => {
+					if (this.root && this.tooltip) this.moveElementIfOffscreen(this.root, this.tooltip)
+				},
 			},
 			m.trust(icon),
 			vnode.attrs.hoverText &&
@@ -52,8 +56,7 @@ export class Icon implements Component<IconAttrs> {
 					"span.tooltiptext.no-wrap",
 					{
 						oncreate: (vnode) => {
-							const tooltip = vnode.dom as HTMLElement
-							if (this.root && tooltip) this.moveElementIfOffscreen(this.root, tooltip)
+							this.tooltip = vnode.dom as HTMLElement
 						},
 					},
 					vnode.attrs.hoverText,


### PR DESCRIPTION
Stops tooltips from overflowing if they exceed the bounds of the viewport by shifting them left.

Closes #6162.