### PR TITLE
fix that text is not deselectable

### DIFF
--- a/src/gui/PinchZoom.ts
+++ b/src/gui/PinchZoom.ts
@@ -499,6 +499,7 @@ export class PinchZoom {
 					Math.abs(touch.clientY - this.currentTouchStart.y) < this.SAME_POSITION_RADIUS
 				) {
 					// at this point we are sure that there is no second tap for a double tap
+					window.getSelection()?.empty() // deselect any selected text
 					singleClickAction(event, target)
 				}
 			}, this.DOUBLE_TAP_TIME_MS)

--- a/src/gui/nav/ViewSlider.ts
+++ b/src/gui/nav/ViewSlider.ts
@@ -389,6 +389,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 
 	focusPreviousColumn(): Promise<unknown> {
 		if (this.isFocusPreviousPossible()) {
+			window.getSelection()?.empty() // try to deselect text
 			return this.focus(assertNotNull(this.getPreviousColumn(), "previous column was null!"))
 		} else {
 			return Promise.resolve()


### PR DESCRIPTION
text is deselected when the viewslider
focuses the previous column
and if a double tap in the mailviewer
is aborted due to timeout

fix #2873