### PR TITLE
fix that too many divs are being printed

### DIFF
--- a/src/gui/DesktopToolbars.ts
+++ b/src/gui/DesktopToolbars.ts
@@ -28,7 +28,7 @@ export const DesktopViewerToolbar = pureComponent((__, children) => {
 	//
 	// see comment for .scrollbar-gutter-stable-or-fallback
 	return m(
-		".scrollbar-gutter-stable-or-fallback.overflow-y-hidden",
+		".scrollbar-gutter-stable-or-fallback.overflow-y-hidden.noprint",
 		{
 			class: responsiveCardHMargin(),
 			style: {

--- a/src/mail/view/ConversationViewer.ts
+++ b/src/mail/view/ConversationViewer.ts
@@ -94,7 +94,7 @@ export class ConversationViewer implements Component<ConversationViewerAttrs> {
 		// We reduce space by 100 for the header of the viewer and a bit more
 		const height =
 			document.body.offsetHeight - (styles.isUsingBottomNavigation() ? size.navbar_height_mobile + size.bottom_nav_bar : size.navbar_height) - 300
-		return m(".mt-l", {
+		return m(".mt-l.noprint", {
 			style: {
 				height: px(height),
 			},


### PR DESCRIPTION
Divs that should not be printed need
the noprint css class assigned.
Printing the desktop toolbar results in
a small grey vertical line. And printing
the footer results in an extra empty page.

fix #6119
fix #6120