### PR TITLE
Fix sender and recipient names in mail view being unselectable

### DIFF
--- a/src/mail/view/MailViewerHeader.ts
+++ b/src/mail/view/MailViewerHeader.ts
@@ -57,7 +57,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 		const dateTime = formatDateWithWeekday(viewModel.mail.receivedDate) + " • " + formatTime(viewModel.mail.receivedDate)
 		const dateTimeFull = formatDateWithWeekdayAndYear(viewModel.mail.receivedDate) + " • " + formatTime(viewModel.mail.receivedDate)
 
-		return m(".header", [
+		return m(".header.selectable", [
 			this.renderSubjectActionsLine(attrs),
 			this.renderFolderText(viewModel),
 			this.renderAddressesAndDate(viewModel, attrs, dateTime, dateTimeFull),


### PR DESCRIPTION
This allows you to select everything inside the mail viewer header & thus copy the sender and recipient names.

Closes #5748.