### PR TITLE
Fix the day name being wrong when exporting an email as a `.eml`

### DIFF
--- a/src/mail/export/Exporter.ts
+++ b/src/mail/export/Exporter.ts
@@ -219,7 +219,7 @@ function escapeSpecialCharacters(name: string): string {
 }
 
 export function _formatSmtpDateTime(date: Date): string {
-	const dayNames = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+	const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
 	const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 	return (
 		dayNames[date.getUTCDay()] +


### PR DESCRIPTION
This fixes the day name being always the day in the date field in exported eml files. 
Closes #5282.