### PR TITLE
Fix updating deleted event show error

### DIFF
--- a/src/calendar/date/eventeditor/CalendarEventModel.ts
+++ b/src/calendar/date/eventeditor/CalendarEventModel.ts
@@ -80,7 +80,7 @@ import {
 import { arrayEqualsWithPredicate, assertNonNull, assertNotNull, getFirstOrThrow, identity, lazy, Require } from "@tutao/tutanota-utils"
 import { cleanMailAddress } from "../../../api/common/utils/CommonCalendarUtils.js"
 import { CalendarInfo, CalendarModel } from "../../model/CalendarModel.js"
-import { PayloadTooLargeError } from "../../../api/common/error/RestError.js"
+import { NotFoundError, PayloadTooLargeError } from "../../../api/common/error/RestError.js"
 import { CalendarNotificationSender } from "../CalendarNotificationSender.js"
 import { SendMailModel } from "../../../mail/editor/SendMailModel.js"
 import { UserError } from "../../../api/main/UserError.js"
@@ -357,6 +357,8 @@ export class CalendarEventModel {
 		} catch (e) {
 			if (e instanceof PayloadTooLargeError) {
 				throw new UserError("requestTooLarge_msg")
+			} else if (e instanceof NotFoundError) {
+				return EventSaveResult.NotFound
 			} else {
 				throw e
 			}
@@ -566,6 +568,7 @@ function cleanupInitialValuesForEditing(initialValues: Partial<CalendarEvent>): 
 export const enum EventSaveResult {
 	Saved,
 	Failed,
+	NotFound,
 }
 
 /** generic function that asynchronously returns whatever type the caller passed in, but not necessarily the same promise. */

--- a/src/calendar/view/eventeditor/CalendarEventEditDialog.ts
+++ b/src/calendar/view/eventeditor/CalendarEventEditDialog.ts
@@ -181,9 +181,12 @@ export async function showExistingCalendarEventEditDialog(
 
 		try {
 			const result = await model.apply()
-			if (result === EventSaveResult.Saved) {
+			if (result === EventSaveResult.Saved || result === EventSaveResult.NotFound) {
 				finished = true
 				finish()
+
+				// Inform the user that the event was deleted, avoiding misunderstanding that the event was saved
+				if (EventSaveResult.NotFound) Dialog.message("eventNoLongerExists_msg")
 			}
 		} catch (e) {
 			if (e instanceof UserError) {

--- a/src/misc/TranslationKey.ts
+++ b/src/misc/TranslationKey.ts
@@ -1584,3 +1584,4 @@ export type TranslationKeyType =
 	| "yourMessage_label"
 	| "you_label"
 	| "emptyString_msg"
+	| "eventNoLongerExists_msg"

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1602,6 +1602,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "DEINE ORDNER",
 		"yourMessage_label": "Deine Nachricht",
-		"you_label": "Du"
+		"you_label": "Du",
+		"eventNoLongerExists_msg": "Das angeforderte Ereignis existiert nicht mehr"
 	}
 }

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -1602,6 +1602,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "Ihre ORDNER",
 		"yourMessage_label": "Ihre Nachricht",
-		"you_label": "Sie"
+		"you_label": "Sie",
+		"eventNoLongerExists_msg": "Das angeforderte Ereignis existiert nicht mehr"
 	}
 }

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1598,6 +1598,7 @@ export default {
 		"yourCalendars_label": "Your calendars",
 		"yourFolders_action": "YOUR FOLDERS",
 		"yourMessage_label": "Your message",
-		"you_label": "You"
+		"you_label": "You",
+		"eventNoLongerExists_msg": "The requested event no longer exists"
 	}
 }


### PR DESCRIPTION
When the user tries to update an event that was deleted, they receive just an error.

Now, the app handles the NotFoundError and shows a message to the user informing that the event doesn't exist anymore.

fix #3388