### PR TITLE
Fix DEL shortcut doesn't work in web app

### DIFF
--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -437,6 +437,18 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 				help: "deleteContacts_action",
 			},
 			{
+				key: Keys.BACKSPACE,
+				exec: () => {
+					if (this.inContactListView()) {
+						this.contactListViewModel.deleteSelectedEntries()
+					} else {
+						this.deleteSelectedContacts()
+					}
+					return true
+				},
+				help: "deleteContacts_action",
+			},
+			{
 				key: Keys.N,
 				exec: () => {
 					this.createNewContact()

--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -407,6 +407,13 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				help: "deleteEmails_action",
 			},
 			{
+				key: Keys.BACKSPACE,
+				exec: () => {
+					this.mailViewModel.listModel && this.deleteMails(this.mailViewModel.listModel.getSelectedAsArray())
+				},
+				help: "deleteEmails_action",
+			},
+			{
 				key: Keys.A,
 				exec: () => {
 					this.mailViewModel.listModel && archiveMails(this.mailViewModel.listModel.getSelectedAsArray())

--- a/src/search/view/SearchView.ts
+++ b/src/search/view/SearchView.ts
@@ -622,6 +622,11 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 			help: "delete_action",
 		},
 		{
+			key: Keys.BACKSPACE,
+			exec: () => this.deleteSelected(),
+			help: "delete_action",
+		},
+		{
 			key: Keys.A,
 			exec: () => this.archiveSelected(),
 			help: "archive_action",


### PR DESCRIPTION
In keyboards that doesn't have the del key, sometimes the Backspace key is named as DEL. eg Some Apple Keyboards

This adds Backspace as a new shortcut to delete emails/contacts, the behavior is the same from the DEL button.

closes #4563