### PR TITLE
fix event not found message even with existing events

### DIFF
--- a/src/calendar/view/eventeditor/CalendarEventEditDialog.ts
+++ b/src/calendar/view/eventeditor/CalendarEventEditDialog.ts
@@ -186,7 +186,7 @@ export async function showExistingCalendarEventEditDialog(
 				finish()
 
 				// Inform the user that the event was deleted, avoiding misunderstanding that the event was saved
-				if (EventSaveResult.NotFound) Dialog.message("eventNoLongerExists_msg")
+				if (result === EventSaveResult.NotFound) Dialog.message("eventNoLongerExists_msg")
 			}
 		} catch (e) {
 			if (e instanceof UserError) {

--- a/src/login/LoginViewModel.ts
+++ b/src/login/LoginViewModel.ts
@@ -410,8 +410,8 @@ export class LoginViewModel implements ILoginViewModel {
 					if (e instanceof KeyPermanentlyInvalidatedError) {
 						await this.credentialsProvider.clearCredentials(e)
 						await this._updateCachedCredentials()
-					} else if (e instanceof DeviceStorageUnavailableError) {
-						console.warn("device storage unavailable, cannot save credentials:", e)
+					} else if (e instanceof DeviceStorageUnavailableError || e instanceof CancelledError) {
+						console.warn("will proceed with ephemeral credentials because device storage is unavailable:", e)
 					} else {
 						throw e
 					}


### PR DESCRIPTION
The if statement to show the error message was just checking for EventSaveResult.NotFound === true, what is always true. Changed to result === EventSaveResult.NotFound.

fix #6207