### PR TITLE
catch CancelledError during credentials store

### DIFF
--- a/src/login/LoginViewModel.ts
+++ b/src/login/LoginViewModel.ts
@@ -410,8 +410,8 @@ export class LoginViewModel implements ILoginViewModel {
 					if (e instanceof KeyPermanentlyInvalidatedError) {
 						await this.credentialsProvider.clearCredentials(e)
 						await this._updateCachedCredentials()
-					} else if (e instanceof DeviceStorageUnavailableError) {
-						console.warn("device storage unavailable, cannot save credentials:", e)
+					} else if (e instanceof DeviceStorageUnavailableError || e instanceof CancelledError) {
+						console.warn("will proceed with ephemeral credentials because device storage is unavailable:", e)
 					} else {
 						throw e
 					}


### PR DESCRIPTION
we will proceed with the login as normal, just without persisting the credentials.

this is similar to how we would handle denied keychain access, for example.

#3853
close #6213