### PR TITLE
Fix Icon tooltip position when its text changes

### DIFF
--- a/src/gui/base/Icon.ts
+++ b/src/gui/base/Icon.ts
@@ -65,6 +65,7 @@ export class Icon implements Component<IconAttrs> {
 	}
 
 	private moveElementIfOffscreen(root: HTMLElement, tooltip: HTMLElement): void {
+		tooltip.style.removeProperty("left")
 		const tooltipRect = tooltip.getBoundingClientRect()
 		// Get the width of the area in pixels that the tooltip penetrates the viewport
 		const distanceOver = tooltipRect.x + tooltipRect.width - window.innerWidth


### PR DESCRIPTION
Fixes the folder name tooltip in the conversation view over or underflowing when the folder name is changed.

Closes #6228.