### PR TITLE
fix text is deleted after closing email template popup

### DIFF
--- a/src/api/worker/search/MailIndexer.ts
+++ b/src/api/worker/search/MailIndexer.ts
@@ -285,10 +285,7 @@ export class MailIndexer {
 	async extendIndexIfNeeded(user: User, newOldestTimestamp: number): Promise<void> {
 		if (this.currentIndexTimestamp > FULL_INDEXED_TIMESTAMP && this.currentIndexTimestamp > newOldestTimestamp) {
 			this.mailboxIndexingPromise = this.mailboxIndexingPromise
-				.then(
-					async () => await this.indexMailboxes(user, newOldestTimestamp),
-					async () => await this.indexMailboxes(user, newOldestTimestamp),
-				)
+				.then(async () => await this.indexMailboxes(user, newOldestTimestamp))
 				.catch(
 					ofClass(CancelledError, (e) => {
 						console.log("extend mail index has been cancelled", e)

--- a/src/api/worker/search/MailIndexer.ts
+++ b/src/api/worker/search/MailIndexer.ts
@@ -285,7 +285,7 @@ export class MailIndexer {
 	async extendIndexIfNeeded(user: User, newOldestTimestamp: number): Promise<void> {
 		if (this.currentIndexTimestamp > FULL_INDEXED_TIMESTAMP && this.currentIndexTimestamp > newOldestTimestamp) {
 			this.mailboxIndexingPromise = this.mailboxIndexingPromise
-				.then(async () => await this.indexMailboxes(user, newOldestTimestamp))
+				.then(() => this.indexMailboxes(user, newOldestTimestamp))
 				.catch(
 					ofClass(CancelledError, (e) => {
 						console.log("extend mail index has been cancelled", e)

--- a/src/desktop/DesktopMain.ts
+++ b/src/desktop/DesktopMain.ts
@@ -199,6 +199,16 @@ async function createComponents(): Promise<Components> {
 	})
 	const webDialogController = new WebDialogController()
 
+	// Insert or remove the icon when the 'run in background' setting is changed
+	conf.on(DesktopConfigKey.runAsTrayApp, async (value: boolean) => {
+		if (value) {
+			await tray.create()
+			await tray.update(notifier)
+		} else {
+			tray.destroy()
+		}
+	})
+
 	tray.setWindowManager(wm)
 	const sse = new DesktopSseClient(app, conf, notifier, wm, desktopAlarmScheduler, desktopNet, desktopCrypto, alarmStorage, lang)
 	// It should be ok to await this, all we are waiting for is dynamic imports

--- a/src/desktop/DesktopMain.ts
+++ b/src/desktop/DesktopMain.ts
@@ -18,7 +18,7 @@ import { DesktopTray } from "./tray/DesktopTray"
 import { log } from "./DesktopLog"
 import { UpdaterWrapper } from "./UpdaterWrapper"
 import { ElectronNotificationFactory } from "./NotificatonFactory"
-import { buildSecretStorage } from "./sse/SecretStorage"
+import { buildSecretStorage, preselectGnomeLibsecret } from "./sse/SecretStorage"
 import fs from "node:fs"
 import { DesktopIntegrator, getDesktopIntegratorForPlatform } from "./integration/DesktopIntegrator"
 import net from "node:net"
@@ -60,7 +60,6 @@ import { DefaultDateProvider } from "../calendar/date/CalendarUtils.js"
 import { OfflineDbRefCounter } from "./db/OfflineDbRefCounter.js"
 import { WorkerSqlCipher } from "./db/WorkerSqlCipher.js"
 import { TempFs } from "./files/TempFs.js"
-import { WASMArgon2idFacade } from "../api/worker/facades/Argon2idFacade.js"
 
 /**
  * Should be injected during build time.
@@ -136,6 +135,7 @@ if (opts.registerAsMailHandler && opts.unregisterAsMailHandler) {
 async function createComponents(): Promise<Components> {
 	const en = (await import("../translations/en.js")).default
 	lang.init(en)
+	preselectGnomeLibsecret(electron)
 	const secretStorage = await buildSecretStorage(electron, fs, path)
 	const keyStoreFacade = new DesktopKeyStoreFacade(secretStorage, desktopCrypto)
 	const configMigrator = new DesktopConfigMigrator(desktopCrypto, keyStoreFacade, electron)

--- a/src/desktop/tray/DesktopTray.ts
+++ b/src/desktop/tray/DesktopTray.ts
@@ -36,21 +36,29 @@ export class DesktopTray {
 	constructor(config: DesktopConfig) {
 		this._conf = config
 		this.getAppIcon()
-		app.on("will-quit", (e: Event) => {
-			if (this._tray) {
-				this._tray.destroy()
-
-				this._tray = null
-			}
-		})
+		app.on("will-quit", this.destroy)
 			.whenReady()
 			.then(async () => {
-				if (!this._wm) log.warn("Tray: No WM set before 'ready'!")
-				const runAsTrayApp = await this._conf.getVar(DesktopConfigKey.runAsTrayApp)
-				if (runAsTrayApp) {
-					this._tray = platformTray.getTray(this._wm, await this.getAppIcon())
-				}
+				// Need this wrapper so that `create()` will be called
+				await this.create()
 			})
+	}
+
+	async create() {
+		if (!this._wm) log.warn("Tray: No WM set before 'ready'!")
+		const runAsTrayApp = await this._conf.getVar(DesktopConfigKey.runAsTrayApp)
+		console.log("Create tray:" + runAsTrayApp)
+		if (runAsTrayApp) {
+			this._tray = platformTray.getTray(this._wm, await this.getAppIcon())
+		}
+	}
+
+	destroy() {
+		if (this._tray) {
+			this._tray.destroy()
+			console.log("Tray destroyed")
+			this._tray = null
+		}
 	}
 
 	async update(notifier: DesktopNotifier): Promise<void> {

--- a/src/desktop/tray/DesktopTray.ts
+++ b/src/desktop/tray/DesktopTray.ts
@@ -46,7 +46,10 @@ export class DesktopTray {
 			.whenReady()
 			.then(async () => {
 				if (!this._wm) log.warn("Tray: No WM set before 'ready'!")
-				this._tray = platformTray.getTray(this._wm, await this.getAppIcon())
+				const runAsTrayApp = await this._conf.getVar(DesktopConfigKey.runAsTrayApp)
+				if (runAsTrayApp) {
+					this._tray = platformTray.getTray(this._wm, await this.getAppIcon())
+				}
 			})
 	}
 

--- a/src/mail/model/InboxRuleHandler.ts
+++ b/src/mail/model/InboxRuleHandler.ts
@@ -167,7 +167,7 @@ async function checkInboxRule(mailFacade: MailFacade, entityClient: EntityClient
 				inboxRule,
 			)
 		} else if (ruleType === InboxRuleType.RECIPIENT_BCC_EQUALS) {
-			const bccRecipients = !isLegacyMail(mail) ? (await mailFacade.loadMailDetailsBlob(mail)).recipients.ccRecipients : mail.bccRecipients
+			const bccRecipients = !isLegacyMail(mail) ? (await mailFacade.loadMailDetailsBlob(mail)).recipients.bccRecipients : mail.bccRecipients
 			return _checkEmailAddresses(
 				bccRecipients.map((m) => m.address),
 				inboxRule,

--- a/src/mail/view/MailRow.ts
+++ b/src/mail/view/MailRow.ts
@@ -224,7 +224,7 @@ export class MailRow implements VirtualRow<Mail> {
 									classes: ".small.mr-s",
 									oncreate: (vnode) => (this.teamLabelDom = vnode.dom as HTMLElement),
 								},
-								"Tutanota Team",
+								"Tuta Team",
 							),
 							m(".text-ellipsis", {
 								oncreate: (vnode) => (this.senderDom = vnode.dom as HTMLElement),

--- a/src/mail/view/MailRow.ts
+++ b/src/mail/view/MailRow.ts
@@ -20,6 +20,7 @@ import {
 import { px, size } from "../../gui/size.js"
 import { NBSP, noOp } from "@tutao/tutanota-utils"
 import { VirtualRow } from "../../gui/base/ListUtils.js"
+import { companyTeamLabel } from "../../misc/ClientConstants.js"
 
 const iconMap: Record<MailFolderType, string> = {
 	[MailFolderType.CUSTOM]: FontIcons.Folder,
@@ -224,7 +225,7 @@ export class MailRow implements VirtualRow<Mail> {
 									classes: ".small.mr-s",
 									oncreate: (vnode) => (this.teamLabelDom = vnode.dom as HTMLElement),
 								},
-								"Tuta Team",
+								companyTeamLabel,
 							),
 							m(".text-ellipsis", {
 								oncreate: (vnode) => (this.senderDom = vnode.dom as HTMLElement),

--- a/src/mail/view/MailViewerHeader.ts
+++ b/src/mail/view/MailViewerHeader.ts
@@ -566,7 +566,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 					{
 						classes: ".mr-s",
 					},
-					"Tutanota Team",
+					"Tuta Team",
 			  )
 			: null
 	}

--- a/src/mail/view/MailViewerHeader.ts
+++ b/src/mail/view/MailViewerHeader.ts
@@ -27,6 +27,7 @@ import { liveDataAttrs } from "../../gui/AriaUtils.js"
 import { isKeyPressed } from "../../misc/KeyManager.js"
 import { AttachmentBubble } from "../../gui/AttachmentBubble.js"
 import { responsiveCardHMargin, responsiveCardHPadding } from "../../gui/cards.js"
+import { companyTeamLabel } from "../../misc/ClientConstants.js"
 
 export interface MailAddressAndName {
 	name: string
@@ -566,7 +567,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 					{
 						classes: ".mr-s",
 					},
-					"Tuta Team",
+					companyTeamLabel,
 			  )
 			: null
 	}

--- a/src/mail/view/MailViewerHeader.ts
+++ b/src/mail/view/MailViewerHeader.ts
@@ -590,7 +590,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 	}
 
 	private renderHardAuthenticationFailWarning(viewModel: MailViewerViewModel): Children | null {
-		if (!viewModel.isWarningDismissed() && viewModel.mail.authStatus === MailAuthenticationStatus.HARD_FAIL) {
+		if (!viewModel.isWarningDismissed() && viewModel.checkMailAuthenticationStatus(MailAuthenticationStatus.HARD_FAIL)) {
 			return m(InfoBanner, {
 				message: "mailAuthFailed_msg",
 				icon: Icons.Warning,
@@ -607,7 +607,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 	}
 
 	private renderSoftAuthenticationFailWarning(viewModel: MailViewerViewModel): Children | null {
-		if (!viewModel.isWarningDismissed() && viewModel.mail.authStatus === MailAuthenticationStatus.SOFT_FAIL) {
+		if (!viewModel.isWarningDismissed() && viewModel.checkMailAuthenticationStatus(MailAuthenticationStatus.SOFT_FAIL)) {
 			return m(InfoBanner, {
 				message: () =>
 					viewModel.mail.differentEnvelopeSender
@@ -641,7 +641,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 		}
 		const alwaysOrNeverAllowButtons = attrs.viewModel.canPersistBlockingStatus()
 			? [
-					attrs.viewModel.isMailAuthenticated()
+					attrs.viewModel.checkMailAuthenticationStatus(MailAuthenticationStatus.AUTHENTICATED)
 						? {
 								label: "allowExternalContentSender_action" as const,
 								click: () => attrs.viewModel.setContentBlockingStatus(ContentBlockingStatus.AlwaysShow),

--- a/src/mail/view/MailViewerUtils.ts
+++ b/src/mail/view/MailViewerUtils.ts
@@ -142,6 +142,30 @@ export function mailViewerMoreActions(viewModel: MailViewerViewModel, showReadBu
 		}
 	}
 
+	if (viewModel.canPersistBlockingStatus() && viewModel.isShowingExternalContent()) {
+		moreButtons.push({
+			label: "disallowExternalContent_action",
+			click: () => viewModel.setContentBlockingStatus(ContentBlockingStatus.Block),
+			icon: Icons.Picture,
+		})
+	}
+
+	if (viewModel.canPersistBlockingStatus() && viewModel.isBlockingExternalImages()) {
+		moreButtons.push({
+			label: "showImages_action",
+			click: () => viewModel.setContentBlockingStatus(ContentBlockingStatus.Show),
+			icon: Icons.Picture,
+		})
+	}
+
+	if (viewModel.isListUnsubscribe()) {
+		moreButtons.push({
+			label: "unsubscribe_action",
+			click: () => unsubscribe(viewModel),
+			icon: Icons.Cancel,
+		})
+	}
+
 	if (!client.isMobileDevice() && viewModel.canExport()) {
 		moreButtons.push({
 			label: "export_action",
@@ -155,14 +179,6 @@ export function mailViewerMoreActions(viewModel: MailViewerViewModel, showReadBu
 			label: "print_action",
 			click: () => window.print(),
 			icon: Icons.Print,
-		})
-	}
-
-	if (viewModel.isListUnsubscribe()) {
-		moreButtons.push({
-			label: "unsubscribe_action",
-			click: () => unsubscribe(viewModel),
-			icon: Icons.Cancel,
 		})
 	}
 
@@ -182,21 +198,8 @@ export function mailViewerMoreActions(viewModel: MailViewerViewModel, showReadBu
 		})
 	}
 
-	if (viewModel.canPersistBlockingStatus() && viewModel.isShowingExternalContent()) {
-		moreButtons.push({
-			label: "disallowExternalContent_action",
-			click: () => viewModel.setContentBlockingStatus(ContentBlockingStatus.Block),
-			icon: Icons.Picture,
-		})
-	}
-
-	if (viewModel.canPersistBlockingStatus() && viewModel.isBlockingExternalImages()) {
-		moreButtons.push({
-			label: "showImages_action",
-			click: () => viewModel.setContentBlockingStatus(ContentBlockingStatus.Show),
-			icon: Icons.Picture,
-		})
-	}
+	// adding more optional buttons? put them above the report action so the new button
+	// is not sometimes where the report action usually sits.
 
 	return moreButtons
 }

--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -386,13 +386,13 @@ export class MailViewerViewModel {
 		this.mail.phishingStatus = status
 	}
 
-	isMailAuthenticated() {
+	checkMailAuthenticationStatus(status: MailAuthenticationStatus) {
 		// all legacy mail should have authStatus set, non-legacy mail can have it set to null. then the wrapper should have
 		// the value. if the wrapper is not loaded yet, this returns false.
 		if (this.mail.authStatus != null) {
-			return this.mail.authStatus === MailAuthenticationStatus.AUTHENTICATED
+			return this.mail.authStatus === status
 		} else if (this.mailWrapper?.isLegacy() === false) {
-			return this.mailWrapper.getDetails().authStatus === MailAuthenticationStatus.AUTHENTICATED
+			return this.mailWrapper.getDetails().authStatus === status
 		} else {
 			// mailWrapper not loaded yet or it's a legacy mail without authStatus
 			return false
@@ -620,7 +620,7 @@ export class MailViewerViewModel {
 			return ExternalImageRule.None
 		})
 		const isAllowedAndAuthenticatedExternalSender =
-			externalImageRule === ExternalImageRule.Allow && mail.authStatus === MailAuthenticationStatus.AUTHENTICATED
+			externalImageRule === ExternalImageRule.Allow && this.checkMailAuthenticationStatus(MailAuthenticationStatus.AUTHENTICATED)
 		// We should not try to sanitize body while we still animate because it's a heavy operation.
 		await delayBodyRenderingUntil
 		this.renderIsDelayed = false

--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -387,11 +387,16 @@ export class MailViewerViewModel {
 	}
 
 	isMailAuthenticated() {
-		return this.mail.authStatus === MailAuthenticationStatus.AUTHENTICATED
-	}
-
-	setAuthenticationStatus(status: MailAuthenticationStatus) {
-		this.mail.authStatus = status
+		// all legacy mail should have authStatus set, non-legacy mail can have it set to null. then the wrapper should have
+		// the value. if the wrapper is not loaded yet, this returns false.
+		if (this.mail.authStatus != null) {
+			return this.mail.authStatus === MailAuthenticationStatus.AUTHENTICATED
+		} else if (this.mailWrapper?.isLegacy() === false) {
+			return this.mailWrapper.getDetails().authStatus === MailAuthenticationStatus.AUTHENTICATED
+		} else {
+			// mailWrapper not loaded yet or it's a legacy mail without authStatus
+			return false
+		}
 	}
 
 	canCreateSpamRule(): boolean {

--- a/src/misc/ClientConstants.ts
+++ b/src/misc/ClientConstants.ts
@@ -36,3 +36,5 @@ export type BrowserData = {
 	needsExplicitIDBIds: boolean
 	indexedDbSupported: boolean
 }
+
+export const companyTeamLabel = "Tuta Team"

--- a/src/search/SearchBarOverlay.ts
+++ b/src/search/SearchBarOverlay.ts
@@ -195,7 +195,7 @@ export class SearchBarOverlay implements Component<SearchBarOverlayAttrs> {
 								{
 									classes: ".small.mr-s",
 								},
-								"Tutanota Team",
+								"Tuta Team",
 						  )
 						: null,
 					m("small.text-ellipsis", getSenderOrRecipientHeading(mail, true)),

--- a/src/search/SearchBarOverlay.ts
+++ b/src/search/SearchBarOverlay.ts
@@ -21,6 +21,7 @@ import { getContactListName } from "../contacts/model/ContactUtils"
 import { getMailFolderIcon } from "../mail/view/MailGuiUtils"
 import { locator } from "../api/main/MainLocator"
 import { IndexingErrorReason } from "../api/worker/search/SearchTypes"
+import { companyTeamLabel } from "../misc/ClientConstants.js"
 
 type SearchBarOverlayAttrs = {
 	state: SearchBarState
@@ -195,7 +196,7 @@ export class SearchBarOverlay implements Component<SearchBarOverlayAttrs> {
 								{
 									classes: ".small.mr-s",
 								},
-								"Tuta Team",
+								companyTeamLabel,
 						  )
 						: null,
 					m("small.text-ellipsis", getSenderOrRecipientHeading(mail, true)),

--- a/src/search/view/SearchViewModel.ts
+++ b/src/search/view/SearchViewModel.ts
@@ -276,12 +276,11 @@ export class SearchViewModel {
 		const startDate = this.startDate
 
 		if (startDate && startDate.getTime() < this.search.indexState().currentMailIndexTimestamp) {
-			confirmCallback().then((confirmed) => {
+			confirmCallback().then(async (confirmed) => {
 				if (confirmed) {
-					this.indexerFacade.extendMailIndex(startDate.getTime()).then(() => {
-						this.updateSearchUrl()
-						this.updateUi()
-					})
+					await this.indexerFacade.extendMailIndex(startDate.getTime())
+					this.updateSearchUrl()
+					this.updateUi()
 				}
 			})
 		} else {

--- a/src/settings/SelectMailAddressForm.ts
+++ b/src/settings/SelectMailAddressForm.ts
@@ -51,7 +51,7 @@ export class SelectMailAddressForm implements Component<SelectMailAddressFormAtt
 	}
 
 	onupdate(vnode: Vnode<SelectMailAddressFormAttrs>) {
-		if (this.lastAttrs.selectedDomain !== vnode.attrs.selectedDomain) {
+		if (this.lastAttrs.selectedDomain.domain !== vnode.attrs.selectedDomain.domain) {
 			this.verifyMailAddress(vnode.attrs)
 		}
 		this.lastAttrs = vnode.attrs

--- a/src/templates/view/TemplatePopup.ts
+++ b/src/templates/view/TemplatePopup.ts
@@ -59,7 +59,7 @@ export function showTemplatePopupInEditor(templateModel: TemplatePopupModel, edi
 		rect = new DomRectReadOnlyPolyfilled(editorRect.left, cursorRect.bottom, popUpWidth, cursorRect.height)
 	}
 
-	const popup = new TemplatePopup(templateModel, rect, onSelect, initialSearchString)
+	const popup = new TemplatePopup(templateModel, rect, onSelect, initialSearchString, () => editor.focus())
 	templateModel.search(initialSearchString)
 	popup.show()
 }
@@ -77,7 +77,13 @@ export class TemplatePopup implements ModalComponent {
 	private _inputDom: HTMLElement | null = null
 	private _debounceFilter: (_: string) => void
 
-	constructor(templateModel: TemplatePopupModel, rect: PosRect, onSelect: (arg0: string) => void, initialSearchString: string) {
+	constructor(
+		templateModel: TemplatePopupModel,
+		rect: PosRect,
+		onSelect: (arg0: string) => void,
+		initialSearchString: string,
+		private readonly restoreEditorFocus?: () => void,
+	) {
 		this._rect = rect
 		this._onSelect = onSelect
 		this._initialWindowWidth = window.innerWidth
@@ -93,7 +99,7 @@ export class TemplatePopup implements ModalComponent {
 				key: Keys.ESC,
 				enabled: () => true,
 				exec: () => {
-					this._onSelect("")
+					this.restoreEditorFocus?.()
 
 					this._close()
 
@@ -434,8 +440,7 @@ export class TemplatePopup implements ModalComponent {
 	}
 
 	backgroundClick(e: MouseEvent): void {
-		this._onSelect("")
-
+		this.restoreEditorFocus?.()
 		this._close()
 	}
 


### PR DESCRIPTION
When the user opens the template popup while writing an email and close the popup without selecting a template, the selected text is replaced by an empty string.

This commit verifies if the text isn't empty before changing it, so we prevent the text replacement by nothing and also keep the behavior of focusing the editor after closing the popup.

fix #3263