### PR TITLE
fix that external images in draft editor are displayed without consent

### DIFF
--- a/src/calendar/view/eventeditor/CalendarEventEditDialog.ts
+++ b/src/calendar/view/eventeditor/CalendarEventEditDialog.ts
@@ -186,7 +186,7 @@ export async function showExistingCalendarEventEditDialog(
 				finish()
 
 				// Inform the user that the event was deleted, avoiding misunderstanding that the event was saved
-				if (EventSaveResult.NotFound) Dialog.message("eventNoLongerExists_msg")
+				if (result === EventSaveResult.NotFound) Dialog.message("eventNoLongerExists_msg")
 			}
 		} catch (e) {
 			if (e instanceof UserError) {

--- a/src/gui/base/Checkbox.ts
+++ b/src/gui/base/Checkbox.ts
@@ -17,7 +17,6 @@ export type CheckboxAttrs = {
 export class Checkbox implements Component<CheckboxAttrs> {
 	private focused: boolean
 	private _domInput: HTMLElement | null = null
-	private _domIcon: HTMLElement | null = null
 
 	constructor() {
 		this.focused = false
@@ -39,6 +38,9 @@ export class Checkbox implements Component<CheckboxAttrs> {
 				m(
 					`.wrapper.flex.items-center${a.disabled ? ".disabled" : ""}`,
 					{
+						role: "checkbox",
+						"aria-checked": String(a.checked),
+						"aria-disabled": String(a.disabled),
 						oncreate: (vnode) => {
 							if (!a.disabled) addFlash(vnode.dom)
 						},
@@ -49,15 +51,14 @@ export class Checkbox implements Component<CheckboxAttrs> {
 					[
 						m(Icon, {
 							icon: a.checked ? BootIcons.CheckboxSelected : BootIcons.Checkbox,
-							class: this.focused ? "svg-content-accent-fg" : "svg-content-fg",
-							oncreate: (vnode) => (this._domIcon = vnode.dom as HTMLElement),
+							class: "abs",
 						}),
 						m(
-							"label.pl",
+							"label",
 							{
 								class: this.focused ? "content-accent-fg" : "content-fg",
 								onclick: (e: MouseEvent) => {
-									// if the label contains a link, then stop the event so that the checkbox doesnt get toggled upon clicking
+									// if the label contains a link, then stop the event so that the checkbox doesn't get toggled upon clicking
 									// we still allow it to be checked if they click on the non-link part of the label
 									if (e.target instanceof HTMLElement && e.target.tagName.toUpperCase() === "A") {
 										e.stopPropagation()
@@ -71,19 +72,17 @@ export class Checkbox implements Component<CheckboxAttrs> {
 								checked: a.checked,
 								onfocus: () => (this.focused = true),
 								onblur: () => (this.focused = false),
-								onremove: (e) => {
+								onremove: () => {
 									// workaround for chrome error on login with return shortcut "Error: Failed to execute 'removeChild' on 'Node': The node to be removed is no longer a child of this node. Perhaps it was moved in a 'blur' event handler?"
 									// TODO test if still needed with mithril 1.1.1
 									if (this._domInput) this._domInput.onblur = null
 								},
 								style: {
 									opacity: 0,
-									position: "absolute",
 									cursor: a.disabled ? "default" : "pointer",
 									z_index: -1,
 								},
 								disabled: a.disabled,
-								"aria-disabled": String(a.disabled),
 							}),
 							a.label(),
 						),

--- a/src/login/LoginViewModel.ts
+++ b/src/login/LoginViewModel.ts
@@ -410,8 +410,8 @@ export class LoginViewModel implements ILoginViewModel {
 					if (e instanceof KeyPermanentlyInvalidatedError) {
 						await this.credentialsProvider.clearCredentials(e)
 						await this._updateCachedCredentials()
-					} else if (e instanceof DeviceStorageUnavailableError) {
-						console.warn("device storage unavailable, cannot save credentials:", e)
+					} else if (e instanceof DeviceStorageUnavailableError || e instanceof CancelledError) {
+						console.warn("will proceed with ephemeral credentials because device storage is unavailable:", e)
 					} else {
 						throw e
 					}

--- a/src/mail/view/MailFolderRow.ts
+++ b/src/mail/view/MailFolderRow.ts
@@ -118,23 +118,12 @@ export class MailFolderRow implements Component<MailFolderRowAttrs> {
 				m(NavButton, {
 					...button,
 					onfocus: onHover,
-					onblur: () => {
-						// The setTimout is so that there is some time to tab to the rightButton
-						// otherwise it disappears immediately and is unreachable on keyboard
-						setTimeout(() => {
-							this.hovered = false
-						}, 5)
-					},
 					onkeydown: handleBackwardsTab,
 				}),
 				// show the edit button in either edit mode or on hover (excluding hover on mobile)
 				rightButton && (editMode || (!client.isMobileDevice() && this.hovered))
 					? m(IconButton, {
 							...rightButton,
-							onblur: () => {
-								this.rightButtonClicked = false
-								m.redraw()
-							},
 							click: (event, dom) => {
 								// Don't ask me why, but you need to set this to true twice
 								// to have hovering off the folder row work correctly on web

--- a/src/mail/view/MailViewerViewModel.ts
+++ b/src/mail/view/MailViewerViewModel.ts
@@ -420,7 +420,11 @@ export class MailViewerViewModel {
 	}
 
 	isBlockingExternalImages(): boolean {
-		return this.contentBlockingStatus === ContentBlockingStatus.Block || this.contentBlockingStatus === ContentBlockingStatus.AlwaysBlock
+		return (
+			this.contentBlockingStatus === ContentBlockingStatus.Block ||
+			this.contentBlockingStatus === ContentBlockingStatus.AlwaysBlock ||
+			this.contentBlockingStatus === ContentBlockingStatus.NoExternalContent
+		)
 	}
 
 	getDifferentEnvelopeSender(): string | null {


### PR DESCRIPTION
making `isBlockingExternalImages` the default by also adding `this.contentBlockingStatus === ContentBlockingStatus.NoExternalContent` makes sure images are not displayed unless
after explicitly giving permission.

also see the discussion in https://github.com/tutao/tutanota/issues/6227#issuecomment-1834081434

fix #6227