### PR TITLE
only invoke indexMailboxes once when extending or creating search index

### DIFF
--- a/src/api/worker/search/MailIndexer.ts
+++ b/src/api/worker/search/MailIndexer.ts
@@ -285,10 +285,7 @@ export class MailIndexer {
 	async extendIndexIfNeeded(user: User, newOldestTimestamp: number): Promise<void> {
 		if (this.currentIndexTimestamp > FULL_INDEXED_TIMESTAMP && this.currentIndexTimestamp > newOldestTimestamp) {
 			this.mailboxIndexingPromise = this.mailboxIndexingPromise
-				.then(
-					async () => await this.indexMailboxes(user, newOldestTimestamp),
-					async () => await this.indexMailboxes(user, newOldestTimestamp),
-				)
+				.then(async () => await this.indexMailboxes(user, newOldestTimestamp))
 				.catch(
 					ofClass(CancelledError, (e) => {
 						console.log("extend mail index has been cancelled", e)

--- a/src/api/worker/search/MailIndexer.ts
+++ b/src/api/worker/search/MailIndexer.ts
@@ -285,7 +285,7 @@ export class MailIndexer {
 	async extendIndexIfNeeded(user: User, newOldestTimestamp: number): Promise<void> {
 		if (this.currentIndexTimestamp > FULL_INDEXED_TIMESTAMP && this.currentIndexTimestamp > newOldestTimestamp) {
 			this.mailboxIndexingPromise = this.mailboxIndexingPromise
-				.then(async () => await this.indexMailboxes(user, newOldestTimestamp))
+				.then(() => this.indexMailboxes(user, newOldestTimestamp))
 				.catch(
 					ofClass(CancelledError, (e) => {
 						console.log("extend mail index has been cancelled", e)

--- a/src/search/view/SearchViewModel.ts
+++ b/src/search/view/SearchViewModel.ts
@@ -276,12 +276,11 @@ export class SearchViewModel {
 		const startDate = this.startDate
 
 		if (startDate && startDate.getTime() < this.search.indexState().currentMailIndexTimestamp) {
-			confirmCallback().then((confirmed) => {
+			confirmCallback().then(async (confirmed) => {
 				if (confirmed) {
-					this.indexerFacade.extendMailIndex(startDate.getTime()).then(() => {
-						this.updateSearchUrl()
-						this.updateUi()
-					})
+					await this.indexerFacade.extendMailIndex(startDate.getTime())
+					this.updateSearchUrl()
+					this.updateUi()
 				}
 			})
 		} else {


### PR DESCRIPTION
fixes #6278

This fix only removes the duplicate invocation of indexMailboxes which already improves the performance for my case by factor 10.


Timings for initial indexing:
30 days, 74 mails, **7224 ms**
```
IndexerCore.ts:941 {"indexingTime":65.10000000335276,"storageTime":2390.100000000559,"preparingTime":4834.699999997392,"mailcount":74,"storedBytes":760928,"encryptionTime":449.8999999957159,"writeRequests":5148,"largestColumn":295,"words":5012,"indexedBytes":682158,"downloadingTime":4319.699999998324} total time:  7224.799999997951
```

Next 30 days:
30 days, 61 mails, **6554 ms**
```
IndexerCore.ts:941 {"indexingTime":58.20000000298023,"storageTime":1879.2999999998137,"preparingTime":4674.89999999851,"mailcount":61,"storedBytes":649648,"encryptionTime":391.39999999664724,"writeRequests":4285,"largestColumn":413,"words":1989,"indexedBytes":663768,"downloadingTime":4225.299999998882} total time:  6554.199999998324
```