### PR TITLE
Fix back navigation in Calendar working incorrectly for day/week view

### DIFF
--- a/src/api/worker/WorkerLocator.ts
+++ b/src/api/worker/WorkerLocator.ts
@@ -302,6 +302,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 			locator.instanceMapper,
 			locator.crypto,
 			locator.blobAccessToken,
+			assertNotNull(cache),
 		)
 	})
 	locator.mail = lazyMemoized(async () => {

--- a/src/calendar/view/CalendarView.ts
+++ b/src/calendar/view/CalendarView.ts
@@ -513,20 +513,6 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 		)
 	}
 
-	handleBackButton(): boolean {
-		const route = m.route.get()
-
-		if (route.startsWith("/calendar/day")) {
-			m.route.set(route.replace("day", "month"))
-			return true
-		} else if (route.startsWith("/calendar/week")) {
-			m.route.set(route.replace("week", "month"))
-			return true
-		} else {
-			return false
-		}
-	}
-
 	_onPressedAddCalendar() {
 		if (locator.logins.getUserController().getCalendarMemberships().length === 0) {
 			this._showCreateCalendarDialog()
@@ -739,7 +725,6 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			".main-view",
 			m(this.viewSlider, {
 				header: m(Header, {
-					handleBackPress: () => this.handleBackButton(),
 					...attrs.header,
 				}),
 				bottomNav: m(BottomNav),

--- a/test/tests/api/worker/facades/BlobFacadeTest.ts
+++ b/test/tests/api/worker/facades/BlobFacadeTest.ts
@@ -31,6 +31,7 @@ import { BlobAccessTokenFacade, BlobReferencingInstance } from "../../../../../s
 import { DateProvider } from "../../../../../src/api/common/DateProvider.js"
 import { elementIdPart, listIdPart } from "../../../../../src/api/common/utils/EntityUtils.js"
 import { createTestEntity } from "../../../TestUtils.js"
+import { DefaultEntityRestCache } from "../../../../../src/api/worker/rest/DefaultEntityRestCache.js"
 
 const { anything, captor } = matchers
 
@@ -81,6 +82,7 @@ o.spec("BlobFacade test", function () {
 			instanceMapperMock,
 			cryptoFacadeMock,
 			blobAccessTokenFacade,
+			object<DefaultEntityRestCache>(),
 		)
 	})
 


### PR DESCRIPTION
When the user is on day/week view and press the android back key it is redirected to month view, even if it never visited it.

This commit removes the handleBackPress from Calendar header, as it doesn't have to deal with it anymore since we want the same behavior as we have for month view.

fix #6280