### PR TITLE
Fix back swipe doesn't return to mail tab after multi-selecting contacts

### DIFF
--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -793,7 +793,12 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 		if (this.viewSlider.focusedColumn === this.detailsColumn) {
 			this.viewSlider.focus(this.listColumn)
 			return true
-		} else if (this.showingListView()) {
+		} else if (
+			this.showingListView() &&
+			!this.contactViewModel.listModel.isSelectionEmpty() &&
+			!(this.contactListViewModel.listModel && this.contactListViewModel.listModel?.isSelectionEmpty())
+		) {
+			// Just empty the list if the selection isn't empty
 			this.contactViewModel.listModel.selectNone()
 			this.contactListViewModel.listModel?.selectNone()
 

--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -795,10 +795,11 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 			return true
 		} else if (
 			this.showingListView() &&
-			!this.contactViewModel.listModel.isSelectionEmpty() &&
-			!(this.contactListViewModel.listModel && this.contactListViewModel.listModel?.isSelectionEmpty())
+			(this.contactViewModel.listModel.state.inMultiselect ||
+				(this.contactListViewModel.listModel && this.contactListViewModel.listModel?.state.inMultiselect))
 		) {
-			// Just empty the list if the selection isn't empty
+			// Just try to empty the list of selected items the user is on
+			// multiselect mode
 			this.contactViewModel.listModel.selectNone()
 			this.contactListViewModel.listModel?.selectNone()
 

--- a/src/misc/ListModel.ts
+++ b/src/misc/ListModel.ts
@@ -542,6 +542,10 @@ export class ListModel<ElementType extends ListElement> {
 		return this.state.items.length === 0 && this.state.loadingStatus === ListLoadingState.Done
 	}
 
+	isSelectionEmpty(): boolean {
+		return this.state.selectedItems.size === 0
+	}
+
 	stopLoading() {
 		if (this.state.loadingStatus === ListLoadingState.Loading) {
 			// We can't really cancel ongoing requests but we can prevent more requests from happening

--- a/src/misc/ListModel.ts
+++ b/src/misc/ListModel.ts
@@ -542,10 +542,6 @@ export class ListModel<ElementType extends ListElement> {
 		return this.state.items.length === 0 && this.state.loadingStatus === ListLoadingState.Done
 	}
 
-	isSelectionEmpty(): boolean {
-		return this.state.selectedItems.size === 0
-	}
-
 	stopLoading() {
 		if (this.state.loadingStatus === ListLoadingState.Loading) {
 			// We can't really cancel ongoing requests but we can prevent more requests from happening


### PR DESCRIPTION
When the user multi-select any quantity of contacts at the ContactView and after swiping/pressing back two times it doesn't return to MailList view.

This commit makes sure to just handle the back actions and clear the selection if there's any contact selected, otherwise do the default app handling for back swipe/press.

fix #6181