### PR TITLE
Fix edit/more button is not clickable for push identifiers

### DIFF
--- a/src/calendar/view/CalendarView.ts
+++ b/src/calendar/view/CalendarView.ts
@@ -404,13 +404,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 	}
 
 	async _createNewEventDialog(date: Date | null = null): Promise<void> {
-		let dateToUse: Date
-		if (date != null) {
-			dateToUse = date
-		} else {
-			// in agenda view, we always show today as the current date, so new event should be created today instead of the (invisibly) selected date in the model.
-			dateToUse = this.currentViewType === CalendarViewType.AGENDA ? getStartOfDay(new Date()) : this.viewModel.selectedDate()
-		}
+		const dateToUse = date ?? this.viewModel.selectedDate()
 
 		// Disallow creation of events when there is no existing calendar
 		let calendarInfos = this.viewModel.getCalendarInfosCreateIfNeeded()

--- a/src/gui/base/Icon.ts
+++ b/src/gui/base/Icon.ts
@@ -46,8 +46,14 @@ export class Icon implements Component<IconAttrs> {
 				"aria-hidden": "true",
 				class: this.getClass(vnode.attrs),
 				style: this.getStyle(vnode.attrs.style ?? null),
-				onmouseenter: () => {
-					if (this.root && this.tooltip) this.moveElementIfOffscreen(this.root, this.tooltip)
+				// mithril lets us mute the normal redraw that occurs after
+				// event callbacks, but TS doesn't know
+				onmouseenter: (e: MouseEvent & { redraw: boolean }) => {
+					if (this.root && this.tooltip) {
+						this.moveElementIfOffscreen(this.root, this.tooltip)
+					} else {
+						e.redraw = false
+					}
 				},
 			},
 			m.trust(icon),


### PR DESCRIPTION
Fix edit/more button is not clickable for push identifiers

The problem is related to the property onmouseenter added to the icon.
onmouseenter is triggered every time that the mouse moves inside the
container, because it was redrawn and the mouse is already on it.
It was triggering the tooltip and redrawing the component repeatedly.

fix #6293