### PR TITLE
[deps] Update electron to latest stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#991676c3b0c53ecb08380b2799cf7b8fda6c9f16",
 				"cborg": "4.0.5",
 				"dompurify": "3.0.6",
-				"electron": "26.6.2",
+				"electron": "28.0.0",
 				"electron-updater": "6.1.7",
 				"jszip": "3.10.1",
 				"keytar": "git+https://github.com/tutao/node-keytar#5ca97465e584eb11f120f63529598d551d3a0d49",
@@ -4649,9 +4649,9 @@
 			}
 		},
 		"node_modules/electron": {
-			"version": "26.6.2",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-26.6.2.tgz",
-			"integrity": "sha512-OWxzVtCJwN9en34bnLupw2dTRsDTBzQZyz0Wx0zjeJ2wgUVlpqavtVDpt50aaJpJR/5GcHH/apIa3uvGWz/ABQ==",
+			"version": "28.0.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-28.0.0.tgz",
+			"integrity": "sha512-eDhnCFBvG0PGFVEpNIEdBvyuGUBsFdlokd+CtuCe2ER3P+17qxaRfWRxMmksCOKgDHb5Wif5UxqOkZSlA4snlw==",
 			"hasInstallScript": true,
 			"dependencies": {
 				"@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#991676c3b0c53ecb08380b2799cf7b8fda6c9f16",
 		"cborg": "4.0.5",
 		"dompurify": "3.0.6",
-		"electron": "26.6.2",
+		"electron": "28.0.0",
 		"electron-updater": "6.1.7",
 		"jszip": "3.10.1",
 		"keytar": "git+https://github.com/tutao/node-keytar#5ca97465e584eb11f120f63529598d551d3a0d49",


### PR DESCRIPTION
This as to stay on top of things, but the main motivation being the ongoing flatpak packaging work.

That work is primarily focused on the Flatpak sandbox + Electron integration.

Build runs fine, and a quick sanity check per `artifacts/desktop/linux-unpacked/tutanota-desktop` everything looks and behaves as expected.

release notes: https://releases.electronjs.org/release/v28.0.0