### PR TITLE
fix incomplete string escape during calendar export

### DIFF
--- a/packages/tutanota-utils/lib/StringUtils.ts
+++ b/packages/tutanota-utils/lib/StringUtils.ts
@@ -42,9 +42,11 @@ export function capitalizeFirstLetter(str: string): string {
 export function endsWith(string: string, substring: string): boolean {
 	return string.endsWith(substring)
 }
+
 export function lazyStringValue(valueOrLazy: string | lazy<string>): string {
 	return typeof valueOrLazy === "function" ? valueOrLazy() : valueOrLazy
 }
+
 export function repeat(value: string, length: number): string {
 	let result = ""
 
@@ -54,6 +56,7 @@ export function repeat(value: string, length: number): string {
 
 	return result
 }
+
 export function cleanMatch(s1: string, s2: string): boolean {
 	return s1.toLowerCase().trim() === s2.toLowerCase().trim()
 }
@@ -89,6 +92,7 @@ export function toLowerCase(str: string): string {
 export function localeCompare(a: string, b: string): number {
 	return a.localeCompare(b)
 }
+
 export function byteLength(str: string | null | undefined): number {
 	if (str == null) return 0
 	// returns the byte length of an utf8 string
@@ -111,6 +115,10 @@ export function byteLength(str: string | null | undefined): number {
  * replace all instances of substr in str with replacement
  */
 export function replaceAll(str: string, substr: string, replacement: string): string {
+	if (typeof String.prototype.replaceAll === "function") {
+		// available from ES2021
+		return str.replaceAll(substr, replacement)
+	}
 	const regex = escapedStringRegExp(substr, "g")
 	return str.replace(regex, replacement)
 }

--- a/src/api/worker/WorkerLocator.ts
+++ b/src/api/worker/WorkerLocator.ts
@@ -302,6 +302,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 			locator.instanceMapper,
 			locator.crypto,
 			locator.blobAccessToken,
+			assertNotNull(cache),
 		)
 	})
 	locator.mail = lazyMemoized(async () => {

--- a/src/calendar/export/CalendarExporter.ts
+++ b/src/calendar/export/CalendarExporter.ts
@@ -1,6 +1,6 @@
 import type { CalendarAttendeeStatus, CalendarMethod } from "../../api/common/TutanotaConstants"
 import { assertEnumValue, EndType, RepeatPeriod, SECOND_MS } from "../../api/common/TutanotaConstants"
-import { assertNotNull, downcast, incrementDate, mapAndFilterNull, neverNull, pad, stringToUtf8Uint8Array } from "@tutao/tutanota-utils"
+import { assertNotNull, downcast, incrementDate, mapAndFilterNull, neverNull, pad, replaceAll, stringToUtf8Uint8Array } from "@tutao/tutanota-utils"
 import { calendarAttendeeStatusToParstat, iCalReplacements, repeatPeriodToIcalFrequency } from "./CalendarParser"
 import { getAllDayDateLocal, isAllDayEvent } from "../../api/common/utils/CommonCalendarUtils"
 import { AlarmIntervalUnit, generateUid, getTimeZone, parseAlarmInterval } from "../date/CalendarUtils"
@@ -237,7 +237,7 @@ function quotedString(input: string): string {
 function serializeIcalText(value: string): string {
 	let text = value
 	for (const rawEscape in iCalReplacements) {
-		text = text?.replace(rawEscape, iCalReplacements[rawEscape as keyof typeof iCalReplacements])
+		text = replaceAll(text, rawEscape, iCalReplacements[rawEscape as keyof typeof iCalReplacements])
 	}
 	return text
 }

--- a/src/calendar/export/CalendarParser.ts
+++ b/src/calendar/export/CalendarParser.ts
@@ -111,11 +111,15 @@ const parsePropertyParameters = combineParsers(
 	makeSeparatedByParser(/*separator*/ makeCharacterParser(";"), /*value*/ propertyParametersKeyValueParser),
 )
 
+// make sure the slashes are _always_ replaced first
+// unless you're using an actual parser for this.
+// otherwise we get fun stuff like ";\" -> "\;\" -> "\\;\\"
+// instead of ";\" -> ";\\" -> "\;\\"
 export const iCalReplacements = {
-	";": "\\;",
 	"\\": "\\\\",
-	"\n": "\\n",
+	";": "\\;",
 	",": "\\,",
+	"\n": "\\n",
 }
 
 const revICalReplacements = reverse(iCalReplacements)

--- a/src/calendar/view/CalendarView.ts
+++ b/src/calendar/view/CalendarView.ts
@@ -513,20 +513,6 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 		)
 	}
 
-	handleBackButton(): boolean {
-		const route = m.route.get()
-
-		if (route.startsWith("/calendar/day")) {
-			m.route.set(route.replace("day", "month"))
-			return true
-		} else if (route.startsWith("/calendar/week")) {
-			m.route.set(route.replace("week", "month"))
-			return true
-		} else {
-			return false
-		}
-	}
-
 	_onPressedAddCalendar() {
 		if (locator.logins.getUserController().getCalendarMemberships().length === 0) {
 			this._showCreateCalendarDialog()
@@ -739,7 +725,6 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			".main-view",
 			m(this.viewSlider, {
 				header: m(Header, {
-					handleBackPress: () => this.handleBackButton(),
 					...attrs.header,
 				}),
 				bottomNav: m(BottomNav),

--- a/src/misc/parsing/ParserCombinator.ts
+++ b/src/misc/parsing/ParserCombinator.ts
@@ -32,7 +32,7 @@ export function makeCharacterParser(character: string): Parser<string> {
 
 		const sliceStart = Math.max(iterator.position - 10, 0)
 		const sliceEnd = Math.min(iterator.position + 10, iterator.iteratee.length - 1)
-		throw new ParserError(`expected character ${character} got ${value} near ${iterator.iteratee.slice(sliceStart, sliceEnd)}`)
+		throw new ParserError(`expected character "${character}" got "${value}" near ${iterator.iteratee.slice(sliceStart, sliceEnd)}`)
 	}
 }
 
@@ -47,7 +47,7 @@ export function makeNotCharacterParser(character: string): Parser<string> {
 
 		const sliceStart = Math.max(iterator.position - 10, 0)
 		const sliceEnd = Math.min(iterator.position + 10, iterator.iteratee.length - 1)
-		throw new ParserError(`expected character ${character} got ${value} near ${iterator.iteratee.slice(sliceStart, sliceEnd)}`)
+		throw new ParserError(`expected character "${character}" got "${value}" near ${iterator.iteratee.slice(sliceStart, sliceEnd)}`)
 	}
 }
 

--- a/test/tests/api/worker/facades/BlobFacadeTest.ts
+++ b/test/tests/api/worker/facades/BlobFacadeTest.ts
@@ -31,6 +31,7 @@ import { BlobAccessTokenFacade, BlobReferencingInstance } from "../../../../../s
 import { DateProvider } from "../../../../../src/api/common/DateProvider.js"
 import { elementIdPart, listIdPart } from "../../../../../src/api/common/utils/EntityUtils.js"
 import { createTestEntity } from "../../../TestUtils.js"
+import { DefaultEntityRestCache } from "../../../../../src/api/worker/rest/DefaultEntityRestCache.js"
 
 const { anything, captor } = matchers
 
@@ -81,6 +82,7 @@ o.spec("BlobFacade test", function () {
 			instanceMapperMock,
 			cryptoFacadeMock,
 			blobAccessTokenFacade,
+			object<DefaultEntityRestCache>(),
 		)
 	})
 

--- a/test/tests/calendar/CalendarImporterTest.ts
+++ b/test/tests/calendar/CalendarImporterTest.ts
@@ -253,7 +253,6 @@ o.spec("CalendarImporterTest", function () {
 				"END:VEVENT",
 			])
 		})
-
 		o("with repeat rule (never ends)", function () {
 			o(
 				serializeEvent(
@@ -304,7 +303,6 @@ o.spec("CalendarImporterTest", function () {
 				"END:VEVENT",
 			])
 		})
-
 		o("with repeat rule (ends after occurrences)", function () {
 			o(
 				serializeEvent(
@@ -1091,6 +1089,39 @@ o.spec("CalendarImporterTest", function () {
 						},
 					],
 				},
+			)
+		})
+		o("import and re-export descriptions exported from outlook", async function () {
+			const text = `BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:REPLY
+BEGIN:VEVENT
+DTSTART:20221026T210000Z
+DTEND:20221026T220000Z
+DTSTAMP:20221018T202558Z
+UID:040000008200E00074C5B7101A82E00800000000B073543805E3D801000000000000000010000000EA368AA63E095848BAEEE25C239F56C6
+SEQUENCE:0
+SUMMARY:App Feedback Session
+DESCRIPTION:\\n________________________________________________________________________________\\nMicrosoft Teams meeting\\nJoin on your computer\\, mobile app or room device\\nUnited States\\, Minneapolis\\nPhone Conference ID: 000 000 000
+LOCATION:Microsoft Teams Meeting
+ORGANIZER;EMAIL=Mary.Doe@example.com:mailto:Mary.Doe@example.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE;CN="Dack";EMAIL=dack@example.com:mailto:dack@example.com
+END:VEVENT
+END:VCALENDAR`
+
+			const parsed = parseCalendarStringData(text, zone)
+			const serialized = [
+				"BEGIN:VCALENDAR",
+				`VERSION:2.0`,
+				`CALSCALE:GREGORIAN`,
+				`METHOD:REPLY`,
+				...serializeEvent(parsed.contents[0].event, [], new Date(), zone),
+				"END:VCALENDAR",
+			].join("\n")
+			const parsedAgain = parseCalendarStringData(serialized, zone)
+			o(parsedAgain.contents[0].event.description).equals(
+				"\n________________________________________________________________________________\nMicrosoft Teams meeting\nJoin on your computer, mobile app or room device\nUnited States, Minneapolis\nPhone Conference ID: 000 000 000",
 			)
 		})
 		o("roundtrip export -> import", async function () {


### PR DESCRIPTION
* str.replace(pat, rep) only replaces the first instance if pat is a string
* our str.replaceAll method of escaping the control chars is order-dependent. slashes must be done first to prevent double-escaping.

fix #4685
fix f8dd6c9cacf1ad3f5a31baf2629e25c0e4c7b2f0

## Test notes
re-test 
https://github.com/tutao/tutanota/issues/4685
https://github.com/tutao/tutanota/issues/3507
https://github.com/tutao/tutanota/issues/2164