### PR TITLE
Set app category to "Social" in Android manifest

### DIFF
--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -36,7 +36,8 @@
 			android:resizeableActivity="true"
 			android:usesCleartextTraffic="true"
 			android:exported="true"
-			android:dataExtractionRules="@xml/data_extraction_rules">
+			android:dataExtractionRules="@xml/data_extraction_rules"
+			android:appCategory="social">
 		<!-- we do not want to restart activity for most of the things. uiMode changes with dark mode. -->
 		<activity
 				android:name=".MainActivity"


### PR DESCRIPTION
This will help system processes & other apps on Android devices correctly categorize the Tuta Mail app.

Close #4119.