### PR TITLE
Declare methods with Keep to avoid them being optimized out

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/AndroidNativeCryptoFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/AndroidNativeCryptoFacade.kt
@@ -2,6 +2,7 @@ package de.tutao.tutanota
 
 import android.content.Context
 import android.net.Uri
+import androidx.annotation.Keep
 import androidx.annotation.VisibleForTesting
 import de.tutao.tutanota.ipc.*
 import org.apache.commons.io.IOUtils
@@ -433,6 +434,7 @@ private class SubKeys(
 )
 
 
+@Keep
 class CryptoError : Exception {
 	constructor(message: String) : super(message)
 	constructor(cause: Throwable) : super(cause)

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberEncapsulation.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberEncapsulation.kt
@@ -3,12 +3,14 @@
 
 package de.tutao.tutanota.ipc
 
-import kotlinx.serialization.*
-import kotlinx.serialization.json.*
+import androidx.annotation.Keep
+import kotlinx.serialization.Serializable
 
 
 @Serializable
+@Keep
 data class KyberEncapsulation(
-	val ciphertext: DataWrapper,
-	val sharedSecret: DataWrapper,
+		val ciphertext: DataWrapper,
+		val sharedSecret: DataWrapper,
 )
+

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberKeyPair.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberKeyPair.kt
@@ -3,11 +3,13 @@
 
 package de.tutao.tutanota.ipc
 
+import androidx.annotation.Keep
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 
 
 @Serializable
+@Keep
 data class KyberKeyPair(
 	val publicKey: KyberPublicKey,
 	val privateKey: KyberPrivateKey,

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberPrivateKey.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberPrivateKey.kt
@@ -3,11 +3,13 @@
 
 package de.tutao.tutanota.ipc
 
+import androidx.annotation.Keep
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 
 
 @Serializable
+@Keep
 data class KyberPrivateKey(
 	val raw: DataWrapper,
 )

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberPublicKey.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/KyberPublicKey.kt
@@ -3,11 +3,13 @@
 
 package de.tutao.tutanota.ipc
 
+import androidx.annotation.Keep
 import kotlinx.serialization.*
 import kotlinx.serialization.json.*
 
 
 @Serializable
+@Keep
 data class KyberPublicKey(
 	val raw: DataWrapper,
 )


### PR DESCRIPTION
The compiler removes unused functions, but it does not know that they are to be accessed with JNI, so we must annotate these classes/methods with Keep to prevent them from being optimized out.

tutadb#1736