### PR TITLE
Fix mails disappear from search view when moved

### DIFF
--- a/src/misc/ListModel.ts
+++ b/src/misc/ListModel.ts
@@ -1,4 +1,4 @@
-import { getElementId, isSameId, ListElement } from "../api/common/utils/EntityUtils.js"
+import { elementIdPart, getElementId, isSameId, ListElement } from "../api/common/utils/EntityUtils.js"
 import { ListLoadingState, ListState } from "../gui/base/List.js"
 
 import { OperationType } from "../api/common/TutanotaConstants.js"
@@ -238,8 +238,11 @@ export class ListModel<ElementType extends ListElement> {
 		// We cannot use binary search here because the sort order of items can change based on the entity update and we need to find the position of the
 		// old entity by id in order to remove it.
 
+		// Since every element id is unique and there's no scenario where the same item appears twice but in different lists, we can safely sort just
+		// by the element id, ignoring the list id
+
 		// update unfiltered list: find the position, take out the old item and put the updated one
-		const positionToUpdateUnfiltered = this.rawState.unfilteredItems.findIndex((item) => isSameId(item._id, entity._id))
+		const positionToUpdateUnfiltered = this.rawState.unfilteredItems.findIndex((item) => isSameId(elementIdPart(item._id), elementIdPart(entity._id)))
 		const unfilteredItems = this.rawState.unfilteredItems.slice()
 		if (positionToUpdateUnfiltered >= 0) {
 			unfilteredItems.splice(positionToUpdateUnfiltered, 1, entity)
@@ -247,7 +250,7 @@ export class ListModel<ElementType extends ListElement> {
 		}
 
 		// update filtered list & selected items
-		const positionToUpdateFiltered = this.rawState.filteredItems.findIndex((item) => isSameId(item._id, entity._id))
+		const positionToUpdateFiltered = this.rawState.filteredItems.findIndex((item) => isSameId(elementIdPart(item._id), elementIdPart(entity._id)))
 		const filteredItems = this.rawState.filteredItems.slice()
 		const selectedItems = new Set(this.rawState.selectedItems)
 		if (positionToUpdateFiltered >= 0) {
@@ -259,8 +262,8 @@ export class ListModel<ElementType extends ListElement> {
 		}
 
 		// keep active element up-to-date
-		const activeElementUpdated = this.rawState.activeElement != null && isSameId(this.rawState.activeElement._id, entity._id)
-		const newActiveElement = activeElementUpdated ? this.rawState.activeElement : this.rawState.activeElement
+		const activeElementUpdated = this.rawState.activeElement != null && isSameId(elementIdPart(this.rawState.activeElement._id), elementIdPart(entity._id))
+		const newActiveElement = this.rawState.activeElement
 
 		if (positionToUpdateUnfiltered !== -1 || positionToUpdateFiltered !== -1 || activeElementUpdated) {
 			this.updateState({ unfilteredItems, filteredItems, selectedItems, activeElement: newActiveElement })


### PR DESCRIPTION
When the user search for emails and another client do some update that
affects the current results, the affected emails where gone from the
list and the search needs to be done again.

This happens due the fact that the **MOVE** operation consists on the
combination of the DELETE and CREATE operations. So, when the client
receives the DELETE action, the email is removed from the list but not 
re-added when the CREATE action is received.

This commit handles the MOVE operation by checking if it really is a
MOVE operation (the updates contain a CREATE and DELETE for same id) and
then handle to update the current states to match the new listId.

fix #1732