### PR TITLE
Fix creating a template list causes SessionKeyNotFoundError

### DIFF
--- a/src/api/worker/facades/lazy/GroupManagementFacade.ts
+++ b/src/api/worker/facades/lazy/GroupManagementFacade.ts
@@ -128,15 +128,17 @@ export class GroupManagementFacade {
 		return { user, group }
 	}
 
-	createTemplateGroup(name: string): Promise<Id> {
-		return this.generateUserAreaGroupData(name).then((groupData) => {
-			const serviceData = createUserAreaGroupPostData({
-				groupData: groupData,
-			})
-			return this.serviceExecutor
-				.post(TemplateGroupService, serviceData, { sessionKey: aes256RandomKey() }) // we expect a session key to be defined as the entity is marked encrypted
-				.then((returnValue) => returnValue.group)
+	async createTemplateGroup(name: string): Promise<Id> {
+		const groupData = await this.generateUserAreaGroupData(name)
+		const serviceData = createUserAreaGroupPostData({
+			groupData,
 		})
+
+		const postGroupData = await this.serviceExecutor.post(TemplateGroupService, serviceData, { sessionKey: aes256RandomKey() }) // we expect a session key to be defined as the entity is marked encrypted
+
+		await this.reloadUser()
+
+		return postGroupData.group
 	}
 
 	async createContactListGroup(name: string): Promise<Group> {

--- a/src/templates/TemplateGroupUtils.ts
+++ b/src/templates/TemplateGroupUtils.ts
@@ -15,11 +15,14 @@ export async function createInitialTemplateListIfAllowed(): Promise<TemplateGrou
 	const customer = await userController.loadCustomer()
 	const { getAvailablePlansWithTemplates } = await import("../subscription/SubscriptionUtils.js")
 	let allowed = (await userController.getPlanConfig()).templates || isCustomizationEnabledForCustomer(customer, FeatureType.BusinessFeatureEnabled)
-	if (!allowed && userController.isGlobalAdmin()) {
-		allowed = await showPlanUpgradeRequiredDialog(await getAvailablePlansWithTemplates())
-	} else {
-		Dialog.message(() => lang.get("contactAdmin_msg"))
+	if (!allowed) {
+		if (userController.isGlobalAdmin()) {
+			allowed = await showPlanUpgradeRequiredDialog(await getAvailablePlansWithTemplates())
+		} else {
+			Dialog.message(() => lang.get("contactAdmin_msg"))
+		}
 	}
+
 	if (allowed) {
 		const groupId = await locator.groupManagementFacade.createTemplateGroup("")
 		return locator.entityClient.load<TemplateGroupRoot>(TemplateGroupRootTypeRef, groupId)


### PR DESCRIPTION
Seems that the problem have already been fixed, but this commit implements the changes suggested in the issue.

Also, fixes a bug that the contactAdmin_msg was displayed even when the user was the global admin or user was allowed to create a template. This wasn't preventing real allowed users from creating templates.

close #6205