### PR TITLE
Make the error message when trying to edit a read only event more accurate

### DIFF
--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -185,7 +185,7 @@ export default {
 		"cancel_action": "Abbrechen",
 		"cannotEditEvent_msg": "Du kannst nur Teile dieses Ereignisses bearbeiten.",
 		"cannotEditFullEvent_msg": "Du kannst nur Teile dieses Termins bearbeiten, weil es nicht in deinem Kalender erstellt wurde.",
-		"cannotEditNotOrganizer_msg": "Du kannst nur Teile dieses Termins bearbeiten, da du nicht der Organisator bist.",
+		"cannotEditNotOrganizer_msg": "Du kannst diesen Termin nicht bearbeiten, da du nicht der Organisator bist.",
 		"cannotEditSingleInstance_msg": "Du kannst nur Teile dieses Termins bearbeiten, weil er Teil einer Serie ist.",
 		"canNotOpenFileOnDevice_msg": "Diese Datei kann auf diesem Gerät nicht geöffnet werden.",
 		"captchaDisplay_label": "Captcha",

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -185,7 +185,7 @@ export default {
 		"cancel_action": "Abbrechen",
 		"cannotEditEvent_msg": "Sie können nur Teile dieses Termins bearbeiten.",
 		"cannotEditFullEvent_msg": "Sie können nur Teile dieses Termins bearbeiten, weil es nicht in Ihrem Kalender erstellt wurde.",
-		"cannotEditNotOrganizer_msg": "Sie können nur Teile dieses Termins bearbeiten, da Sie nicht der Organisator sind.",
+		"cannotEditNotOrganizer_msg": "Sie können diesen Termin nicht bearbeiten, da Sie nicht der Organisator sind.",
 		"cannotEditSingleInstance_msg": "Sie können nur Teile dieses Termins bearbeiten, weil er Teil einer Serie ist.",
 		"canNotOpenFileOnDevice_msg": "Diese Datei kann auf diesem Gerät nicht geöffnet werden.",
 		"captchaDisplay_label": "Captcha",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -181,7 +181,7 @@ export default {
 		"cancel_action": "Cancel",
 		"cannotEditEvent_msg": "You can only edit parts of this event.",
 		"cannotEditFullEvent_msg": "You can only edit parts of this event because it was not created in your calendar.",
-		"cannotEditNotOrganizer_msg": "You can only edit parts of this event because you are not its organizer.",
+		"cannotEditNotOrganizer_msg": "You cannot edit this event because you are not its organizer.",
 		"cannotEditSingleInstance_msg": "You can only edit parts of this event because it is part of an event series.",
 		"canNotOpenFileOnDevice_msg": "This file can not be opened on this device.",
 		"captchaDisplay_label": "Captcha",


### PR DESCRIPTION
Both the people reviewing the previous PR (#6357) & I forgot that events the user is not the organizer of cannot be edited at all. This should correct the message. 
- [ ] Can someone with strong (preferably native) German abilities check my translations are correct?

Fixes the issue in [this comment.](https://github.com/tutao/tutanota/issues/5816#issuecomment-1891901013)