### PR TITLE
Fix circle agenda view

### DIFF
--- a/src/calendar/view/CalendarAgendaView.ts
+++ b/src/calendar/view/CalendarAgendaView.ts
@@ -220,7 +220,7 @@ export class CalendarAgendaView implements Component<CalendarAgendaViewAttrs> {
 		let eventsNodes: Child[] = []
 		for (const [eventIndex, event] of events.entries()) {
 			if (eventToShowTimeIndicator === eventIndex && isSameDay(new Date(), event.startTime)) {
-				eventsNodes.push(m(".mt-xs.mb-xs", { key: "timeIndicator" }, m(CalendarTimeIndicator, {})))
+				eventsNodes.push(m(".mt-xs.mb-xs", { key: "timeIndicator" }, m(CalendarTimeIndicator, { circleLeftTangent: true })))
 			}
 			if (currentTime && event.startTime < currentTime) {
 				newScrollPosition += agendaItemHeight + agendaGap

--- a/src/calendar/view/CalendarTimeIndicator.ts
+++ b/src/calendar/view/CalendarTimeIndicator.ts
@@ -1,26 +1,30 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { px, size } from "../../gui/size.js"
 
-export type CalendarTimeIndicatorAttrs = {}
+export type CalendarTimeIndicatorAttrs = {
+	/** Make the circle tangent to the left side of the line rather than intersecting it */
+	circleLeftTangent?: boolean
+}
 
 /**
  * Indicator used for indicating the current time relative to the current date in the calendar view.
  */
 export class CalendarTimeIndicator implements Component<CalendarTimeIndicatorAttrs> {
 	view({ attrs }: Vnode<CalendarTimeIndicatorAttrs>): Children {
+		const iconRadius = size.icon_size_small / 2
+		const leftOffset = attrs.circleLeftTangent ? 0 : -iconRadius
 		return m(
-			".accent-bg.rel",
+			".accent-bg",
 			{
 				"aria-hidden": "true",
 				style: {
 					height: px(size.calendar_day_event_padding),
 				},
 			},
-			m(`.circle.icon-small.accent-bg.abs`, {
+			m(`.circle.icon-small.accent-bg`, {
 				"aria-hidden": "true",
 				style: {
-					top: "-5px",
-					left: "-6.5px",
+					translate: `${px(leftOffset)} ${px(-5)}`,
 				},
 			}),
 		)

--- a/src/calendar/view/CalendarView.ts
+++ b/src/calendar/view/CalendarView.ts
@@ -292,8 +292,6 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			{
 				minWidth: size.second_col_min_width + size.third_col_min_width,
 				maxWidth: size.third_col_max_width,
-				// We need to allow time indicator in Agenda view to overflow
-				overflowXVisible: true,
 			},
 		)
 		this.viewSlider = new ViewSlider([this.sidebarColumn, this.contentColumn])

--- a/src/gui/base/ViewColumn.ts
+++ b/src/gui/base/ViewColumn.ts
@@ -22,7 +22,6 @@ export class ViewColumn implements Component<Attrs> {
 	readonly maxWidth: number
 	private readonly headerCenter: lazy<string>
 	private readonly ariaLabel: lazy<string>
-	private readonly overflowXVisible: boolean
 	width: number
 	offset: number // offset to the left
 
@@ -42,7 +41,6 @@ export class ViewColumn implements Component<Attrs> {
 	 * @param maxWidth The maximum allowed width for the view column.
 	 * @param headerCenter The title of the view column.
 	 * @param ariaLabel The label of the view column to be read by screen readers. Defaults to headerCenter if not specified.
-	 * @param overflowXVisible Enable contents to spill over horizontally from the column.
 	 */
 	constructor(
 		component: Component,
@@ -54,20 +52,17 @@ export class ViewColumn implements Component<Attrs> {
 			// provide separately. We should always require aria description instead.
 			headerCenter,
 			ariaLabel = () => this.getTitle(),
-			overflowXVisible = false,
 		}: {
 			minWidth: number
 			maxWidth: number
 			headerCenter?: lazy<string>
 			ariaLabel?: lazy<string>
-			overflowXVisible?: boolean
 		},
 	) {
 		this.component = component
 		this.columnType = columnType
 		this.minWidth = minWidth
 		this.maxWidth = maxWidth
-		this.overflowXVisible = overflowXVisible
 
 		this.headerCenter = headerCenter || (() => "")
 
@@ -87,7 +82,6 @@ export class ViewColumn implements Component<Attrs> {
 			".view-column.fill-absolute",
 			{
 				...landmark,
-				class: this.overflowXVisible ? "" : ".overflow-x-hidden",
 				"aria-hidden": this.isVisible || this.isInForeground ? "false" : "true",
 				oncreate: (vnode) => {
 					this.domColumn = vnode.dom as HTMLElement


### PR DESCRIPTION
Add an option in time indicator's attributes to make the circle not clip to the left, so it can be visible in certain views where overflow-x is not possible.

RE: https://github.com/tutao/tutanota/issues/6284#issuecomment-1893823223