### PR TITLE
Fix calendar search

### DIFF
--- a/packages/tutanota-utils/lib/DateUtils.ts
+++ b/packages/tutanota-utils/lib/DateUtils.ts
@@ -5,6 +5,8 @@
  */
 export const DAY_IN_MILLIS = 1000 * 60 * 60 * 24
 
+export const YEAR_IN_MILLIS = DAY_IN_MILLIS * 365
+
 /**
  * dates from before 1970 have negative timestamps and are currently considered edge cases
  */

--- a/src/api/worker/search/SearchFacade.ts
+++ b/src/api/worker/search/SearchFacade.ts
@@ -1,7 +1,6 @@
 import { MailTypeRef } from "../../entities/tutanota/TypeRefs.js"
 import { DbTransaction } from "./DbFacade"
 import { resolveTypeReference } from "../../common/EntityFunctions"
-import { tokenize } from "@tutao/tutanota-utils"
 import type { PromiseMapFn } from "@tutao/tutanota-utils"
 import {
 	arrayHash,
@@ -15,6 +14,7 @@ import {
 	neverNull,
 	promiseMap,
 	promiseMapCompat,
+	tokenize,
 	TypeRef,
 	uint8ArrayToBase64,
 } from "@tutao/tutanota-utils"

--- a/src/calendar/date/CalendarEventsRepository.ts
+++ b/src/calendar/date/CalendarEventsRepository.ts
@@ -63,10 +63,10 @@ export class CalendarEventsRepository {
 		return this.daysToEvents
 	}
 
-	async loadMonthsIfNeeded(daysInMonths: Array<Date>, progressMonitor: IProgressMonitor, cancel?: Stream<boolean>): Promise<void> {
+	async loadMonthsIfNeeded(daysInMonths: Array<Date>, progressMonitor: IProgressMonitor, canceled: Stream<boolean>): Promise<void> {
 		const promiseForThisLoadRequest = this.pendingLoadRequest.then(async () => {
 			for (const dayInMonth of daysInMonths) {
-				if (cancel && cancel()) return
+				if (canceled()) return
 
 				const month = getMonthRange(dayInMonth, this.zone)
 

--- a/src/calendar/view/CalendarViewModel.ts
+++ b/src/calendar/view/CalendarViewModel.ts
@@ -416,7 +416,7 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 	}
 
 	loadMonthsIfNeeded(daysInMonths: Array<Date>, progressMonitor: IProgressMonitor): Promise<void> {
-		return this.eventsRepository.loadMonthsIfNeeded(daysInMonths, progressMonitor)
+		return this.eventsRepository.loadMonthsIfNeeded(daysInMonths, progressMonitor, stream(false))
 	}
 
 	private doRedraw() {

--- a/src/misc/ListModel.ts
+++ b/src/misc/ListModel.ts
@@ -139,6 +139,8 @@ export class ListModel<ElementType extends ListElement> {
 	}
 
 	updateLoadingStatus(status: ListLoadingState) {
+		if (this.rawState.loadingStatus === status) return
+
 		this.updateState({ loadingStatus: status })
 	}
 

--- a/src/search/model/SearchUtils.ts
+++ b/src/search/model/SearchUtils.ts
@@ -288,6 +288,7 @@ export function decodeCalendarSearchKey(searchKey: string): { id: Id; start: num
 }
 
 export function encodeCalendarSearchKey(event: CalendarEvent): string {
+	console.trace("Who is trying to encode?")
 	const eventStartTime = event.startTime.getTime()
 	return base64ToBase64Url(stringToBase64(JSON.stringify({ start: eventStartTime, id: getElementId(event) })))
 }

--- a/src/search/model/SearchUtils.ts
+++ b/src/search/model/SearchUtils.ts
@@ -288,7 +288,6 @@ export function decodeCalendarSearchKey(searchKey: string): { id: Id; start: num
 }
 
 export function encodeCalendarSearchKey(event: CalendarEvent): string {
-	console.trace("Who is trying to encode?")
 	const eventStartTime = event.startTime.getTime()
 	return base64ToBase64Url(stringToBase64(JSON.stringify({ start: eventStartTime, id: getElementId(event) })))
 }


### PR DESCRIPTION
[fix search view missing some updates to the search URL](https://github.com/tutao/tutanota/commit/9a4184716546837ae81248ebb9404efca9c2cec8)

the list that is recreated when the URL changes also calls
updateSearchUrl which then overrides later state changes from the search
bar. re-ordering some operations that happen when clearing the search
bar or routing from quicksearch fixes that.

also cancel the current search when leaving the search view or changing
the search bar content.