### PR TITLE
Fix The object can not be cloned on iOS

### DIFF
--- a/src/calendar/date/CalendarEventsRepository.ts
+++ b/src/calendar/date/CalendarEventsRepository.ts
@@ -16,7 +16,7 @@ import { getListId, isSameId } from "../../api/common/utils/EntityUtils.js"
 import { DateTime } from "luxon"
 import { CalendarFacade } from "../../api/worker/facades/lazy/CalendarFacade.js"
 import { EntityClient } from "../../api/common/EntityClient.js"
-import { findAllAndRemove, freezeMap } from "@tutao/tutanota-utils"
+import { findAllAndRemove } from "@tutao/tutanota-utils"
 import { OperationType } from "../../api/common/TutanotaConstants.js"
 import { NotAuthorizedError, NotFoundError } from "../../api/common/error/RestError.js"
 import { EventController } from "../../api/main/EventController.js"
@@ -120,7 +120,10 @@ export class CalendarEventsRepository {
 	}
 
 	private replaceEvents(newMap: DaysToEvents): void {
-		this.daysToEvents(freezeMap(newMap))
+		// We rely on typescript ReadonlyMap type because freezing
+		// this map throws "The object can not be cloned" on iOS
+		// when the source of newMap is updateEventMap
+		this.daysToEvents(newMap)
 	}
 
 	private cloneEvents(): Map<number, Array<CalendarEvent>> {


### PR DESCRIPTION
This solves the error "The Object can not be cloned" that has being thrown on iOS while opening the calendar.

Seems to be related to freezeMap and updateEventMap functions. Need further investigations.

### How to Reproduce
Without this patch:
- [ ] Open the app with the latest master
- [ ] Open the calendar
- [ ] Get the error message