### PR TITLE
Fix being unable to disable mail search index in apps

### DIFF
--- a/src/api/worker/offline/OfflineStorage.ts
+++ b/src/api/worker/offline/OfflineStorage.ts
@@ -160,7 +160,7 @@ export class OfflineStorage implements CacheStorage, ExposedCacheStorage {
 			}
 		}
 		// if nothing is written here, it means it's a new database
-		return (await this.getLastUpdateTime()) == null
+		return (await this.getLastUpdateTime()).type === "never"
 	}
 
 	private async recreateDbFile(userId: string, databaseKey: Uint8Array): Promise<void> {

--- a/src/settings/MailSettingsViewer.ts
+++ b/src/settings/MailSettingsViewer.ts
@@ -269,7 +269,7 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 						}),
 					)
 				} else {
-					showProgressDialog("pleaseWait_msg", locator.indexerFacade.disableMailIndexing("Disabled by user"))
+					showProgressDialog("pleaseWait_msg", locator.indexerFacade.disableMailIndexing())
 				}
 			},
 			dropdownWidth: 250,

--- a/test/tests/api/worker/search/IndexerTest.ts
+++ b/test/tests/api/worker/search/IndexerTest.ts
@@ -1228,7 +1228,7 @@ o.spec("Indexer test", () => {
 			verify(indexer._contact.indexFullContactList(contactList))
 		})
 
-		o("When init() is called with a fresh db and contacts will not be indexed, they will be downloaded", async function () {
+		o("When init() is called with a fresh db and contacts have not been indexed, they will be downloaded", async function () {
 			when(indexer._contact.getIndexTimestamp(contactList)).thenResolve(FULL_INDEXED_TIMESTAMP)
 			const cacheInfo: CacheInfo = {
 				isPersistent: true,
@@ -1240,7 +1240,6 @@ o.spec("Indexer test", () => {
 
 			await indexer.init({ user, userGroupKey, cacheInfo })
 			verify(indexer._entity.loadAll(ContactTypeRef, contactList.contacts))
-			verify(indexer._mail.enableMailIndexing(matchers.anything()))
 		})
 
 		o("When init() is called with a fresh db and contacts are not yet indexed, they will be indexed and not downloaded", async function () {
@@ -1269,7 +1268,6 @@ o.spec("Indexer test", () => {
 			when(indexer._mail.enableMailIndexing(matchers.anything())).thenResolve(undefined)
 
 			await indexer.init({ user, userGroupKey, cacheInfo })
-			verify(indexer._mail.enableMailIndexing(matchers.anything()), { times: 0 })
 		})
 	})
 })


### PR DESCRIPTION
There are multiple bugs that all caused this.

1. There was a loop where Indexer.disableMailIndexing() would call init() which would re-initialize mail indexing again. We moved enabling mail indexing out of init() as it was mixing up responsibilities.  We could make init() return whether it is a new database but instead  we rely on isNewOfflineDb which should work the same way.
2. OfflineStorage.init() was not checking for the last update correctly which made all the places that check for isNewOfflineDb work incorrectly.
3. MailSettingsViewer was still passing a reason string in place of a user id which made it impossible to disable search index. We've removed the parameter as it is redundant and inconsistent.

fix #6412