### PR TITLE
Migrate to Argon2id on login

### DIFF
--- a/src/api/common/TutanotaConstants.ts
+++ b/src/api/common/TutanotaConstants.ts
@@ -264,6 +264,7 @@ type ConstType = {
 	WEBAUTHN_RP_ID: string
 	U2f_APPID_SUFFIX: string
 	U2F_LEGACY_APPID: string
+	EXECUTE_KDF_MIGRATION: boolean
 }
 
 export const Const: ConstType = {
@@ -284,6 +285,8 @@ export const Const: ConstType = {
 	// we'll still get the contents
 	// because it will be redirected to tuta.com after new domain deploy.
 	U2F_LEGACY_APPID: "https://tutanota.com/u2f-appid.json",
+	// Controls actual execution of the KDF migration
+	EXECUTE_KDF_MIGRATION: false,
 } as const
 
 export const TUTANOTA_MAIL_ADDRESS_DOMAINS: ReadonlyArray<string> = Object.freeze([

--- a/src/api/entities/sys/ModelInfo.ts
+++ b/src/api/entities/sys/ModelInfo.ts
@@ -1,5 +1,5 @@
 const modelInfo = {
-	version: 94,
+	version: 95,
 	compatibleSince: 94,
 }
 		

--- a/src/api/entities/sys/Services.ts
+++ b/src/api/entities/sys/Services.ts
@@ -6,6 +6,7 @@ import {AutoLoginDataDeleteTypeRef} from "./TypeRefs.js"
 import {BrandingDomainGetReturnTypeRef} from "./TypeRefs.js"
 import {BrandingDomainDataTypeRef} from "./TypeRefs.js"
 import {BrandingDomainDeleteDataTypeRef} from "./TypeRefs.js"
+import {ChangeKdfPostInTypeRef} from "./TypeRefs.js"
 import {ChangePasswordDataTypeRef} from "./TypeRefs.js"
 import {CloseSessionServicePostTypeRef} from "./TypeRefs.js"
 import {CreateCustomerServerPropertiesDataTypeRef} from "./TypeRefs.js"
@@ -114,6 +115,15 @@ export const BrandingDomainService = Object.freeze({
 	post: {data: BrandingDomainDataTypeRef, return: null},
 	put: {data: BrandingDomainDataTypeRef, return: null},
 	delete: {data: BrandingDomainDeleteDataTypeRef, return: null},
+} as const)
+
+export const ChangeKdfService = Object.freeze({
+	app: "sys",
+	name: "ChangeKdfService",
+	get: null,
+	post: {data: ChangeKdfPostInTypeRef, return: null},
+	put: null,
+	delete: null,
 } as const)
 
 export const ChangePasswordService = Object.freeze({

--- a/src/api/entities/sys/TypeModels.js
+++ b/src/api/entities/sys/TypeModels.js
@@ -200,7 +200,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AdministratedGroup": {
         "name": "AdministratedGroup",
@@ -280,7 +280,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AdministratedGroupsRef": {
         "name": "AdministratedGroupsRef",
@@ -314,7 +314,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AlarmInfo": {
         "name": "AlarmInfo",
@@ -366,7 +366,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AlarmNotification": {
         "name": "AlarmNotification",
@@ -466,7 +466,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AlarmServicePost": {
         "name": "AlarmServicePost",
@@ -500,7 +500,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ArchiveRef": {
         "name": "ArchiveRef",
@@ -532,7 +532,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ArchiveType": {
         "name": "ArchiveType",
@@ -586,7 +586,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AuditLogEntry": {
         "name": "AuditLogEntry",
@@ -711,7 +711,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AuditLogRef": {
         "name": "AuditLogRef",
@@ -745,7 +745,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AuthenticatedDevice": {
         "name": "AuthenticatedDevice",
@@ -795,7 +795,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Authentication": {
         "name": "Authentication",
@@ -856,7 +856,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AutoLoginDataDelete": {
         "name": "AutoLoginDataDelete",
@@ -888,7 +888,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AutoLoginDataGet": {
         "name": "AutoLoginDataGet",
@@ -931,7 +931,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AutoLoginDataReturn": {
         "name": "AutoLoginDataReturn",
@@ -963,7 +963,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "AutoLoginPostReturn": {
         "name": "AutoLoginPostReturn",
@@ -995,7 +995,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Blob": {
         "name": "Blob",
@@ -1045,7 +1045,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BlobReferenceTokenWrapper": {
         "name": "BlobReferenceTokenWrapper",
@@ -1077,7 +1077,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Booking": {
         "name": "Booking",
@@ -1201,7 +1201,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BookingItem": {
         "name": "BookingItem",
@@ -1287,7 +1287,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BookingsRef": {
         "name": "BookingsRef",
@@ -1321,7 +1321,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BootstrapFeature": {
         "name": "BootstrapFeature",
@@ -1353,7 +1353,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Braintree3ds2Request": {
         "name": "Braintree3ds2Request",
@@ -1403,7 +1403,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Braintree3ds2Response": {
         "name": "Braintree3ds2Response",
@@ -1444,7 +1444,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BrandingDomainData": {
         "name": "BrandingDomainData",
@@ -1512,7 +1512,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BrandingDomainDeleteData": {
         "name": "BrandingDomainDeleteData",
@@ -1544,7 +1544,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BrandingDomainGetReturn": {
         "name": "BrandingDomainGetReturn",
@@ -1578,7 +1578,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Bucket": {
         "name": "Bucket",
@@ -1612,7 +1612,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BucketKey": {
         "name": "BucketKey",
@@ -1683,7 +1683,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "BucketPermission": {
         "name": "BucketPermission",
@@ -1798,7 +1798,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CalendarEventRef": {
         "name": "CalendarEventRef",
@@ -1839,7 +1839,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CertificateInfo": {
         "name": "CertificateInfo",
@@ -1900,7 +1900,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Challenge": {
         "name": "Challenge",
@@ -1953,7 +1953,75 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
+    },
+    "ChangeKdfPostIn": {
+        "name": "ChangeKdfPostIn",
+        "since": 95,
+        "type": "DATA_TRANSFER_TYPE",
+        "id": 2198,
+        "rootId": "A3N5cwAIlg",
+        "versioned": false,
+        "encrypted": false,
+        "values": {
+            "_format": {
+                "final": false,
+                "name": "_format",
+                "id": 2199,
+                "since": 95,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "kdfVersion": {
+                "final": false,
+                "name": "kdfVersion",
+                "id": 2204,
+                "since": 95,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "oldVerifier": {
+                "final": false,
+                "name": "oldVerifier",
+                "id": 2203,
+                "since": 95,
+                "type": "Bytes",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "pwEncUserGroupKey": {
+                "final": false,
+                "name": "pwEncUserGroupKey",
+                "id": 2202,
+                "since": 95,
+                "type": "Bytes",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "salt": {
+                "final": false,
+                "name": "salt",
+                "id": 2201,
+                "since": 95,
+                "type": "Bytes",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "verifier": {
+                "final": false,
+                "name": "verifier",
+                "id": 2200,
+                "since": 95,
+                "type": "Bytes",
+                "cardinality": "One",
+                "encrypted": false
+            }
+        },
+        "associations": {},
+        "app": "sys",
+        "version": "95"
     },
     "ChangePasswordData": {
         "name": "ChangePasswordData",
@@ -2039,7 +2107,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Chat": {
         "name": "Chat",
@@ -2089,7 +2157,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CloseSessionServicePost": {
         "name": "CloseSessionServicePost",
@@ -2132,7 +2200,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CreateCustomerServerPropertiesData": {
         "name": "CreateCustomerServerPropertiesData",
@@ -2164,7 +2232,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CreateCustomerServerPropertiesReturn": {
         "name": "CreateCustomerServerPropertiesReturn",
@@ -2198,7 +2266,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CreateGroupData": {
         "name": "CreateGroupData",
@@ -2293,7 +2361,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CreateGroupListData": {
         "name": "CreateGroupListData",
@@ -2345,7 +2413,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CreateSessionData": {
         "name": "CreateSessionData",
@@ -2433,7 +2501,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CreateSessionReturn": {
         "name": "CreateSessionReturn",
@@ -2486,7 +2554,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CreditCard": {
         "name": "CreditCard",
@@ -2554,7 +2622,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomDomainCheckGetIn": {
         "name": "CustomDomainCheckGetIn",
@@ -2597,7 +2665,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomDomainCheckGetOut": {
         "name": "CustomDomainCheckGetOut",
@@ -2660,7 +2728,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomDomainData": {
         "name": "CustomDomainData",
@@ -2703,7 +2771,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomDomainReturn": {
         "name": "CustomDomainReturn",
@@ -2746,7 +2814,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Customer": {
         "name": "Customer",
@@ -3012,7 +3080,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerAccountTerminationPostIn": {
         "name": "CustomerAccountTerminationPostIn",
@@ -3044,7 +3112,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerAccountTerminationPostOut": {
         "name": "CustomerAccountTerminationPostOut",
@@ -3078,7 +3146,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerAccountTerminationRequest": {
         "name": "CustomerAccountTerminationRequest",
@@ -3157,7 +3225,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerData": {
         "name": "CustomerData",
@@ -3329,7 +3397,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerInfo": {
         "name": "CustomerInfo",
@@ -3642,7 +3710,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerProperties": {
         "name": "CustomerProperties",
@@ -3750,7 +3818,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerReturn": {
         "name": "CustomerReturn",
@@ -3794,7 +3862,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "CustomerServerProperties": {
         "name": "CustomerServerProperties",
@@ -3911,7 +3979,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DateWrapper": {
         "name": "DateWrapper",
@@ -3943,7 +4011,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DebitServicePutData": {
         "name": "DebitServicePutData",
@@ -3977,7 +4045,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DeleteCustomerData": {
         "name": "DeleteCustomerData",
@@ -4047,7 +4115,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DnsRecord": {
         "name": "DnsRecord",
@@ -4097,7 +4165,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DomainInfo": {
         "name": "DomainInfo",
@@ -4159,7 +4227,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DomainMailAddressAvailabilityData": {
         "name": "DomainMailAddressAvailabilityData",
@@ -4191,7 +4259,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DomainMailAddressAvailabilityReturn": {
         "name": "DomainMailAddressAvailabilityReturn",
@@ -4223,7 +4291,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "DomainsRef": {
         "name": "DomainsRef",
@@ -4257,7 +4325,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "EmailSenderListElement": {
         "name": "EmailSenderListElement",
@@ -4316,7 +4384,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "EntityEventBatch": {
         "name": "EntityEventBatch",
@@ -4377,7 +4445,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "EntityUpdate": {
         "name": "EntityUpdate",
@@ -4445,7 +4513,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Exception": {
         "name": "Exception",
@@ -4486,7 +4554,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ExternalPropertiesReturn": {
         "name": "ExternalPropertiesReturn",
@@ -4548,7 +4616,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ExternalUserReference": {
         "name": "ExternalUserReference",
@@ -4619,7 +4687,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Feature": {
         "name": "Feature",
@@ -4651,7 +4719,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "File": {
         "name": "File",
@@ -4701,7 +4769,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GeneratedIdWrapper": {
         "name": "GeneratedIdWrapper",
@@ -4733,7 +4801,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCard": {
         "name": "GiftCard",
@@ -4837,7 +4905,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardCreateData": {
         "name": "GiftCardCreateData",
@@ -4896,7 +4964,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardCreateReturn": {
         "name": "GiftCardCreateReturn",
@@ -4930,7 +4998,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardDeleteData": {
         "name": "GiftCardDeleteData",
@@ -4964,7 +5032,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardGetReturn": {
         "name": "GiftCardGetReturn",
@@ -5016,7 +5084,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardOption": {
         "name": "GiftCardOption",
@@ -5048,7 +5116,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardRedeemData": {
         "name": "GiftCardRedeemData",
@@ -5100,7 +5168,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardRedeemGetReturn": {
         "name": "GiftCardRedeemGetReturn",
@@ -5152,7 +5220,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GiftCardsRef": {
         "name": "GiftCardsRef",
@@ -5186,7 +5254,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Group": {
         "name": "Group",
@@ -5373,7 +5441,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GroupInfo": {
         "name": "GroupInfo",
@@ -5517,7 +5585,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GroupMember": {
         "name": "GroupMember",
@@ -5607,7 +5675,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GroupMembership": {
         "name": "GroupMembership",
@@ -5697,7 +5765,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "GroupRoot": {
         "name": "GroupRoot",
@@ -5778,7 +5846,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "InstanceSessionKey": {
         "name": "InstanceSessionKey",
@@ -5848,7 +5916,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Invoice": {
         "name": "Invoice",
@@ -6055,7 +6123,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "InvoiceDataGetIn": {
         "name": "InvoiceDataGetIn",
@@ -6087,7 +6155,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "InvoiceDataGetOut": {
         "name": "InvoiceDataGetOut",
@@ -6229,7 +6297,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "InvoiceDataItem": {
         "name": "InvoiceDataItem",
@@ -6306,7 +6374,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "InvoiceInfo": {
         "name": "InvoiceInfo",
@@ -6485,7 +6553,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "InvoiceItem": {
         "name": "InvoiceItem",
@@ -6571,7 +6639,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "KeyPair": {
         "name": "KeyPair",
@@ -6657,7 +6725,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "LocationServiceGetReturn": {
         "name": "LocationServiceGetReturn",
@@ -6689,7 +6757,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Login": {
         "name": "Login",
@@ -6748,7 +6816,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MailAddressAlias": {
         "name": "MailAddressAlias",
@@ -6789,7 +6857,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MailAddressAliasGetIn": {
         "name": "MailAddressAliasGetIn",
@@ -6823,7 +6891,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MailAddressAliasServiceData": {
         "name": "MailAddressAliasServiceData",
@@ -6866,7 +6934,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MailAddressAliasServiceDataDelete": {
         "name": "MailAddressAliasServiceDataDelete",
@@ -6918,7 +6986,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MailAddressAliasServiceReturn": {
         "name": "MailAddressAliasServiceReturn",
@@ -6977,7 +7045,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MailAddressAvailability": {
         "name": "MailAddressAvailability",
@@ -7018,7 +7086,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MailAddressToGroup": {
         "name": "MailAddressToGroup",
@@ -7079,7 +7147,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MembershipAddData": {
         "name": "MembershipAddData",
@@ -7132,7 +7200,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MembershipRemoveData": {
         "name": "MembershipRemoveData",
@@ -7176,7 +7244,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MissedNotification": {
         "name": "MissedNotification",
@@ -7283,7 +7351,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MultipleMailAddressAvailabilityData": {
         "name": "MultipleMailAddressAvailabilityData",
@@ -7317,7 +7385,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "MultipleMailAddressAvailabilityReturn": {
         "name": "MultipleMailAddressAvailabilityReturn",
@@ -7351,7 +7419,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "NotificationInfo": {
         "name": "NotificationInfo",
@@ -7401,7 +7469,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "NotificationMailTemplate": {
         "name": "NotificationMailTemplate",
@@ -7451,7 +7519,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "NotificationSessionKey": {
         "name": "NotificationSessionKey",
@@ -7494,7 +7562,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "OrderProcessingAgreement": {
         "name": "OrderProcessingAgreement",
@@ -7601,7 +7669,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "OtpChallenge": {
         "name": "OtpChallenge",
@@ -7635,7 +7703,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PaymentDataServiceGetData": {
         "name": "PaymentDataServiceGetData",
@@ -7667,7 +7735,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PaymentDataServiceGetReturn": {
         "name": "PaymentDataServiceGetReturn",
@@ -7699,7 +7767,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PaymentDataServicePostData": {
         "name": "PaymentDataServicePostData",
@@ -7733,7 +7801,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PaymentDataServicePutData": {
         "name": "PaymentDataServicePutData",
@@ -7848,7 +7916,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PaymentDataServicePutReturn": {
         "name": "PaymentDataServicePutReturn",
@@ -7891,7 +7959,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PaymentErrorInfo": {
         "name": "PaymentErrorInfo",
@@ -7941,7 +8009,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PdfInvoiceServiceData": {
         "name": "PdfInvoiceServiceData",
@@ -7984,7 +8052,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PdfInvoiceServiceReturn": {
         "name": "PdfInvoiceServiceReturn",
@@ -8043,7 +8111,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Permission": {
         "name": "Permission",
@@ -8177,7 +8245,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PhoneNumber": {
         "name": "PhoneNumber",
@@ -8209,7 +8277,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PlanConfiguration": {
         "name": "PlanConfiguration",
@@ -8322,7 +8390,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PlanPrices": {
         "name": "PlanPrices",
@@ -8464,7 +8532,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PlanServiceGetOut": {
         "name": "PlanServiceGetOut",
@@ -8498,7 +8566,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PremiumFeatureData": {
         "name": "PremiumFeatureData",
@@ -8539,7 +8607,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PremiumFeatureReturn": {
         "name": "PremiumFeatureReturn",
@@ -8571,7 +8639,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PriceData": {
         "name": "PriceData",
@@ -8632,7 +8700,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PriceItemData": {
         "name": "PriceItemData",
@@ -8691,7 +8759,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PriceRequestData": {
         "name": "PriceRequestData",
@@ -8768,7 +8836,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PriceServiceData": {
         "name": "PriceServiceData",
@@ -8811,7 +8879,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PriceServiceReturn": {
         "name": "PriceServiceReturn",
@@ -8883,7 +8951,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PublicKeyGetIn": {
         "name": "PublicKeyGetIn",
@@ -8915,7 +8983,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PublicKeyGetOut": {
         "name": "PublicKeyGetOut",
@@ -8974,7 +9042,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PublicKeyPutIn": {
         "name": "PublicKeyPutIn",
@@ -9026,7 +9094,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PushIdentifier": {
         "name": "PushIdentifier",
@@ -9166,7 +9234,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "PushIdentifierList": {
         "name": "PushIdentifierList",
@@ -9200,7 +9268,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ReceivedGroupInvitation": {
         "name": "ReceivedGroupInvitation",
@@ -9343,7 +9411,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RecoverCode": {
         "name": "RecoverCode",
@@ -9420,7 +9488,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ReferralCodeGetIn": {
         "name": "ReferralCodeGetIn",
@@ -9454,7 +9522,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ReferralCodePostIn": {
         "name": "ReferralCodePostIn",
@@ -9477,7 +9545,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ReferralCodePostOut": {
         "name": "ReferralCodePostOut",
@@ -9511,7 +9579,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RegistrationCaptchaServiceData": {
         "name": "RegistrationCaptchaServiceData",
@@ -9552,7 +9620,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RegistrationCaptchaServiceGetData": {
         "name": "RegistrationCaptchaServiceGetData",
@@ -9620,7 +9688,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RegistrationCaptchaServiceReturn": {
         "name": "RegistrationCaptchaServiceReturn",
@@ -9661,7 +9729,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RegistrationConfigReturn": {
         "name": "RegistrationConfigReturn",
@@ -9702,7 +9770,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RegistrationReturn": {
         "name": "RegistrationReturn",
@@ -9734,7 +9802,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RegistrationServiceData": {
         "name": "RegistrationServiceData",
@@ -9784,7 +9852,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RejectedSender": {
         "name": "RejectedSender",
@@ -9879,7 +9947,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RejectedSendersRef": {
         "name": "RejectedSendersRef",
@@ -9913,7 +9981,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RepeatRule": {
         "name": "RepeatRule",
@@ -9992,7 +10060,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ResetFactorsDeleteData": {
         "name": "ResetFactorsDeleteData",
@@ -10042,7 +10110,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "ResetPasswordData": {
         "name": "ResetPasswordData",
@@ -10112,7 +10180,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "RootInstance": {
         "name": "RootInstance",
@@ -10171,7 +10239,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SaltData": {
         "name": "SaltData",
@@ -10203,7 +10271,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SaltReturn": {
         "name": "SaltReturn",
@@ -10244,7 +10312,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SecondFactor": {
         "name": "SecondFactor",
@@ -10332,7 +10400,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SecondFactorAuthAllowedReturn": {
         "name": "SecondFactorAuthAllowedReturn",
@@ -10364,7 +10432,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SecondFactorAuthData": {
         "name": "SecondFactorAuthData",
@@ -10436,7 +10504,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SecondFactorAuthDeleteData": {
         "name": "SecondFactorAuthDeleteData",
@@ -10470,7 +10538,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SecondFactorAuthGetData": {
         "name": "SecondFactorAuthGetData",
@@ -10502,7 +10570,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SecondFactorAuthGetReturn": {
         "name": "SecondFactorAuthGetReturn",
@@ -10534,7 +10602,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SecondFactorAuthentication": {
         "name": "SecondFactorAuthentication",
@@ -10620,7 +10688,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SendRegistrationCodeData": {
         "name": "SendRegistrationCodeData",
@@ -10679,7 +10747,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SendRegistrationCodeReturn": {
         "name": "SendRegistrationCodeReturn",
@@ -10711,7 +10779,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SentGroupInvitation": {
         "name": "SentGroupInvitation",
@@ -10800,7 +10868,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Session": {
         "name": "Session",
@@ -10934,7 +11002,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SignOrderProcessingAgreementData": {
         "name": "SignOrderProcessingAgreementData",
@@ -10975,7 +11043,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SseConnectData": {
         "name": "SseConnectData",
@@ -11018,7 +11086,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "StringConfigValue": {
         "name": "StringConfigValue",
@@ -11059,7 +11127,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "StringWrapper": {
         "name": "StringWrapper",
@@ -11091,7 +11159,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SwitchAccountTypePostIn": {
         "name": "SwitchAccountTypePostIn",
@@ -11170,7 +11238,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "SystemKeysReturn": {
         "name": "SystemKeysReturn",
@@ -11277,7 +11345,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "TakeOverDeletedAddressData": {
         "name": "TakeOverDeletedAddressData",
@@ -11336,7 +11404,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "TypeInfo": {
         "name": "TypeInfo",
@@ -11377,7 +11445,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "U2fChallenge": {
         "name": "U2fChallenge",
@@ -11420,7 +11488,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "U2fKey": {
         "name": "U2fKey",
@@ -11472,7 +11540,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "U2fRegisteredDevice": {
         "name": "U2fRegisteredDevice",
@@ -11540,7 +11608,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "U2fResponseData": {
         "name": "U2fResponseData",
@@ -11590,7 +11658,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UpdateAdminshipData": {
         "name": "UpdateAdminshipData",
@@ -11643,7 +11711,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UpdatePermissionKeyData": {
         "name": "UpdatePermissionKeyData",
@@ -11705,7 +11773,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UpdateSessionKeysPostIn": {
         "name": "UpdateSessionKeysPostIn",
@@ -11739,7 +11807,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UpgradePriceServiceData": {
         "name": "UpgradePriceServiceData",
@@ -11791,7 +11859,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UpgradePriceServiceReturn": {
         "name": "UpgradePriceServiceReturn",
@@ -11962,7 +12030,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "User": {
         "name": "User",
@@ -12196,7 +12264,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserAlarmInfo": {
         "name": "UserAlarmInfo",
@@ -12266,7 +12334,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserAlarmInfoListType": {
         "name": "UserAlarmInfoListType",
@@ -12300,7 +12368,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserAreaGroups": {
         "name": "UserAreaGroups",
@@ -12334,7 +12402,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserAuthentication": {
         "name": "UserAuthentication",
@@ -12388,7 +12456,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserData": {
         "name": "UserData",
@@ -12476,7 +12544,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserDataDelete": {
         "name": "UserDataDelete",
@@ -12528,7 +12596,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserExternalAuthInfo": {
         "name": "UserExternalAuthInfo",
@@ -12598,7 +12666,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserGroupRoot": {
         "name": "UserGroupRoot",
@@ -12659,7 +12727,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "UserReturn": {
         "name": "UserReturn",
@@ -12703,7 +12771,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "VariableExternalAuthInfo": {
         "name": "VariableExternalAuthInfo",
@@ -12807,7 +12875,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "VerifyRegistrationCodeData": {
         "name": "VerifyRegistrationCodeData",
@@ -12848,7 +12916,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "Version": {
         "name": "Version",
@@ -12919,7 +12987,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "VersionData": {
         "name": "VersionData",
@@ -12978,7 +13046,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "VersionInfo": {
         "name": "VersionInfo",
@@ -13103,7 +13171,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "VersionReturn": {
         "name": "VersionReturn",
@@ -13137,7 +13205,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WebauthnResponseData": {
         "name": "WebauthnResponseData",
@@ -13196,7 +13264,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WebsocketCounterData": {
         "name": "WebsocketCounterData",
@@ -13239,7 +13307,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WebsocketCounterValue": {
         "name": "WebsocketCounterValue",
@@ -13280,7 +13348,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WebsocketEntityData": {
         "name": "WebsocketEntityData",
@@ -13332,7 +13400,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WebsocketLeaderStatus": {
         "name": "WebsocketLeaderStatus",
@@ -13364,7 +13432,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WhitelabelChild": {
         "name": "WhitelabelChild",
@@ -13470,7 +13538,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WhitelabelChildrenRef": {
         "name": "WhitelabelChildrenRef",
@@ -13504,7 +13572,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WhitelabelConfig": {
         "name": "WhitelabelConfig",
@@ -13639,7 +13707,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     },
     "WhitelabelParent": {
         "name": "WhitelabelParent",
@@ -13683,6 +13751,6 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "94"
+        "version": "95"
     }
 }

--- a/src/api/entities/sys/TypeRefs.ts
+++ b/src/api/entities/sys/TypeRefs.ts
@@ -515,6 +515,22 @@ export type Challenge = {
 	otp:  null | OtpChallenge;
 	u2f:  null | U2fChallenge;
 }
+export const ChangeKdfPostInTypeRef: TypeRef<ChangeKdfPostIn> = new TypeRef("sys", "ChangeKdfPostIn")
+
+export function createChangeKdfPostIn(values: StrippedEntity<ChangeKdfPostIn>): ChangeKdfPostIn {
+	return Object.assign(create(typeModels.ChangeKdfPostIn, ChangeKdfPostInTypeRef), values)
+}
+
+export type ChangeKdfPostIn = {
+	_type: TypeRef<ChangeKdfPostIn>;
+
+	_format: NumberString;
+	kdfVersion: NumberString;
+	oldVerifier: Uint8Array;
+	pwEncUserGroupKey: Uint8Array;
+	salt: Uint8Array;
+	verifier: Uint8Array;
+}
 export const ChangePasswordDataTypeRef: TypeRef<ChangePasswordData> = new TypeRef("sys", "ChangePasswordData")
 
 export function createChangePasswordData(values: StrippedEntity<ChangePasswordData>): ChangePasswordData {

--- a/src/api/main/MainLocator.ts
+++ b/src/api/main/MainLocator.ts
@@ -842,7 +842,7 @@ class MainLocator {
 	// For testing argon2 migration after login. The production server will reject this request.
 	// This can be removed when we enable the migration.
 	async changeToBycrypt(passphrase: string): Promise<unknown> {
-		var currentUser = this.logins.getUserController().user
+		const currentUser = this.logins.getUserController().user
 		return this.loginFacade.migrateKdfType(KdfType.Bcrypt, passphrase, currentUser)
 	}
 }

--- a/src/api/main/MainLocator.ts
+++ b/src/api/main/MainLocator.ts
@@ -10,7 +10,7 @@ import { LoginController } from "./LoginController"
 import type { ContactModel } from "../../contacts/model/ContactModel"
 import { EntityClient } from "../common/EntityClient"
 import type { CalendarInfo, CalendarModel } from "../../calendar/model/CalendarModel"
-import { defer, DeferredObject, lazy, lazyAsync, lazyMemoized, noOp } from "@tutao/tutanota-utils"
+import { assertNotNull, defer, DeferredObject, lazy, lazyAsync, lazyMemoized, noOp } from "@tutao/tutanota-utils"
 import { ProgressTracker } from "./ProgressTracker"
 import { MinimizedMailEditorViewModel } from "../../mail/model/MinimizedMailEditorViewModel"
 import { SchedulerImpl } from "../common/utils/Scheduler.js"
@@ -65,7 +65,7 @@ import { NewsModel } from "../../misc/news/NewsModel.js"
 import type { OwnMailAddressNameChanger } from "../../settings/mailaddress/OwnMailAddressNameChanger.js"
 import type { MailAddressNameChanger, MailAddressTableModel } from "../../settings/mailaddress/MailAddressTableModel.js"
 import type { AnotherUserMailAddressNameChanger } from "../../settings/mailaddress/AnotherUserMailAddressNameChanger.js"
-import type { GroupInfo } from "../entities/sys/TypeRefs.js"
+import { GroupInfo } from "../entities/sys/TypeRefs.js"
 import type { SendMailModel } from "../../mail/editor/SendMailModel.js"
 import type { CalendarEvent, Mail, MailboxProperties } from "../entities/tutanota/TypeRefs.js"
 import { CalendarEventAttendee } from "../entities/tutanota/TypeRefs.js"
@@ -83,7 +83,7 @@ import { OfflineIndicatorViewModel } from "../../gui/base/OfflineIndicatorViewMo
 import { AppHeaderAttrs, Header } from "../../gui/Header.js"
 import { CalendarViewModel } from "../../calendar/view/CalendarViewModel.js"
 import { ReceivedGroupInvitationsModel } from "../../sharing/model/ReceivedGroupInvitationsModel.js"
-import { Const, FeatureType, GroupType } from "../common/TutanotaConstants.js"
+import { asKdfType, Const, FeatureType, GroupType, KdfType } from "../common/TutanotaConstants.js"
 import type { ExternalLoginViewModel } from "../../login/ExternalLoginView.js"
 import type { ConversationViewModel, ConversationViewModelFactory } from "../../mail/view/ConversationViewModel.js"
 import type { AlarmScheduler } from "../../calendar/date/AlarmScheduler.js"
@@ -838,6 +838,13 @@ class MainLocator {
 
 		return this.nativeContactSyncManager
 	})
+
+	// For testing argon2 migration after login. The production server will reject this request.
+	// This can be removed when we enable the migration.
+	async changeToBycrypt(passphrase: string): Promise<unknown> {
+		var currentUser = this.logins.getUserController().user
+		return this.loginFacade.migrateKdfType(KdfType.Bcrypt, passphrase, currentUser)
+	}
 }
 
 export type IMainLocator = Readonly<MainLocator>

--- a/src/api/worker/WorkerLocator.ts
+++ b/src/api/worker/WorkerLocator.ts
@@ -258,6 +258,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 		locator.entropyFacade,
 		new DatabaseKeyFactory(locator.deviceEncryptionFacade),
 		argon2idFacade,
+		cache,
 	)
 
 	locator.search = lazyMemoized(async () => {

--- a/src/api/worker/WorkerLocator.ts
+++ b/src/api/worker/WorkerLocator.ts
@@ -182,6 +182,8 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 	locator.cache = cache ?? entityRestClient
 
 	locator.cachingEntityClient = new EntityClient(locator.cache)
+	const noncachingEntityClient = new EntityClient(entityRestClient)
+
 	locator.indexer = lazyMemoized(async () => {
 		const { Indexer } = await import("./search/Indexer.js")
 		return new Indexer(entityRestClient, mainInterface.infoMessageHandler, browserData, locator.cache as DefaultEntityRestCache, await locator.mail())
@@ -241,6 +243,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 
 	locator.deviceEncryptionFacade = new DeviceEncryptionFacade()
 	const { DatabaseKeyFactory } = await import("../../misc/credentials/DatabaseKeyFactory.js")
+
 	locator.login = new LoginFacade(
 		worker,
 		locator.restClient,
@@ -258,7 +261,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 		locator.entropyFacade,
 		new DatabaseKeyFactory(locator.deviceEncryptionFacade),
 		argon2idFacade,
-		cache,
+		noncachingEntityClient,
 	)
 
 	locator.search = lazyMemoized(async () => {
@@ -339,7 +342,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 			locator.user,
 			await locator.groupManagement(),
 			assertNotNull(cache),
-			new EntityClient(entityRestClient), // without cache
+			noncachingEntityClient, // without cache
 			nativePushFacade,
 			mainInterface.operationProgressTracker,
 			locator.instanceMapper,
@@ -355,7 +358,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 			locator.user,
 			await locator.groupManagement(),
 			locator.serviceExecutor,
-			new EntityClient(entityRestClient), // without cache
+			noncachingEntityClient, // without cache
 		)
 	})
 	const scheduler = new SchedulerImpl(dateProvider, self, self)

--- a/src/api/worker/facades/UserFacade.ts
+++ b/src/api/worker/facades/UserFacade.ts
@@ -1,9 +1,8 @@
 import { GroupType } from "../../common/TutanotaConstants"
-import { decryptKey } from "@tutao/tutanota-crypto"
+import { Aes128Key, decryptKey } from "@tutao/tutanota-crypto"
 import { assertNotNull, getFromMap } from "@tutao/tutanota-utils"
 import { ProgrammingError } from "../../common/error/ProgrammingError"
 import { createWebsocketLeaderStatus, GroupMembership, User, WebsocketLeaderStatus } from "../../entities/sys/TypeRefs"
-import { Aes128Key } from "@tutao/tutanota-crypto"
 import { LoginIncompleteError } from "../../common/error/LoginIncompleteError"
 
 export interface AuthDataProvider {

--- a/src/api/worker/facades/lazy/MailFacade.ts
+++ b/src/api/worker/facades/lazy/MailFacade.ts
@@ -659,22 +659,22 @@ export class MailFacade {
 			const isSharedMailboxSender = !isSameId(this.userFacade.getGroupId(GroupType.Mail), senderMailGroupId)
 
 			if (recipient.type === RecipientType.EXTERNAL) {
-				const password = this.getContactPassword(recipient.contact)
-				if (password == null || isSharedMailboxSender) {
+				const passphrase = this.getContactPassword(recipient.contact)
+				if (passphrase == null || isSharedMailboxSender) {
 					// no password given and prevent sending to secure externals from shared group
 					notFoundRecipients.push(recipient.address)
 					continue
 				}
 
 				const salt = generateRandomSalt()
-				const kdfVersion = DEFAULT_KDF_TYPE
-				const passwordKey = await this.loginFacade.deriveUserPassphraseKey(kdfVersion, password, salt)
+				const kdfType = DEFAULT_KDF_TYPE
+				const passwordKey = await this.loginFacade.deriveUserPassphraseKey({ kdfType, passphrase, salt })
 				const passwordVerifier = createAuthVerifier(passwordKey)
 				const externalGroupKeys = await this._getExternalGroupKey(recipient.address, passwordKey, passwordVerifier)
 				const data = createSecureExternalRecipientKeyData({
 					mailAddress: recipient.address,
 					symEncBucketKey: null, // legacy for old permission system, not used anymore
-					kdfVersion: kdfVersion,
+					kdfVersion: kdfType,
 					ownerEncBucketKey: encryptKey(externalGroupKeys.externalMailGroupKey, bucketKey),
 					passwordVerifier: passwordVerifier,
 					salt: salt,

--- a/src/api/worker/facades/lazy/MailFacade.ts
+++ b/src/api/worker/facades/lazy/MailFacade.ts
@@ -10,9 +10,9 @@ import {
 	ReportMailService,
 	SendDraftService,
 } from "../../../entities/tutanota/Services.js"
-import type { ConversationType } from "../../../common/TutanotaConstants.js"
 import {
 	ArchiveDataType,
+	ConversationType,
 	CounterType,
 	DEFAULT_KDF_TYPE,
 	GroupType,

--- a/src/login/recover/RecoverLoginDialog.ts
+++ b/src/login/recover/RecoverLoginDialog.ts
@@ -18,8 +18,6 @@ import { assertMainOrNode } from "../../api/common/Env"
 import { createDropdown, DropdownButtonAttrs } from "../../gui/base/Dropdown.js"
 import { IconButton, IconButtonAttrs } from "../../gui/base/IconButton.js"
 import { ButtonSize } from "../../gui/base/ButtonSize.js"
-import { SaltService } from "../../api/entities/sys/Services.js"
-import { createSaltData } from "../../api/entities/sys/TypeRefs.js"
 
 assertMainOrNode()
 export type ResetAction = "password" | "secondFactor"
@@ -109,8 +107,6 @@ export function show(mailAddress?: string | null, resetAction?: ResetAction): Di
 				if (errorMessageId) {
 					Dialog.message(errorMessageId)
 				} else {
-					const saltRequest = createSaltData({ mailAddress: cleanMailAddress })
-					const saltReturn = await locator.serviceExecutor.get(SaltService, saltRequest)
 					showProgressDialog(
 						"pleaseWait_msg",
 						locator.loginFacade.recoverLogin(cleanMailAddress, cleanRecoverCodeValue, passwordModel.getNewPassword(), client.getIdentifier()),

--- a/src/misc/credentials/CredentialsProvider.ts
+++ b/src/misc/credentials/CredentialsProvider.ts
@@ -131,7 +131,7 @@ export class CredentialsProvider {
 	 * Change the encrypted password for the stored credentials.
 	 */
 	async replacePassword(credentials: CredentialsInfo, encryptedPassword: string): Promise<void> {
-		const encryptedCredentials = await this.storage.loadByUserId(credentials.userId)
+		const encryptedCredentials = this.storage.loadByUserId(credentials.userId)
 		if (encryptedCredentials == null) {
 			throw new Error(`Trying to replace password for credentials but credentials are not persisted: ${credentials.userId}`)
 		}

--- a/src/settings/login/ChangePasswordDialogs.ts
+++ b/src/settings/login/ChangePasswordDialogs.ts
@@ -6,8 +6,8 @@ import { lang } from "../../misc/LanguageViewModel.js"
 import m from "mithril"
 import { NotAuthenticatedError } from "../../api/common/error/RestError.js"
 import { PasswordForm, PasswordModel } from "../PasswordForm.js"
-import { ofClass } from "@tutao/tutanota-utils"
-import { asKdfType } from "../../api/common/TutanotaConstants.js"
+import { assertNotNull, ofClass } from "@tutao/tutanota-utils"
+import { asKdfType, DEFAULT_KDF_TYPE } from "../../api/common/TutanotaConstants.js"
 
 /**
  *The admin does not have to enter the old password in addition to the new password (twice). The password strength is not enforced.
@@ -36,13 +36,6 @@ export async function showChangeUserPasswordAsAdminDialog(user: User) {
 	})
 }
 
-async function storeNewPassword(encryptedPassword: string) {
-	const storedCredentials = await locator.credentialsProvider.getCredentialsInfoByUserId(locator.logins.getUserController().userId)
-	if (storedCredentials != null) {
-		await locator.credentialsProvider.replacePassword(storedCredentials, encryptedPassword)
-	}
-}
-
 /**
  * The user must enter the old password in addition to the new password (twice). The password strength is enforced.
  */
@@ -55,14 +48,32 @@ export async function showChangeOwnPasswordDialog(allowCancel: boolean = true) {
 		if (error) {
 			Dialog.message(error)
 		} else {
-			const currentKdfType = asKdfType(locator.logins.getUserController().user.kdfVersion)
-			showProgressDialog("pleaseWait_msg", locator.loginFacade.changePassword(model.getOldPassword(), model.getNewPassword(), currentKdfType))
-				.then(({ encryptedPassword }) => {
+			var currentUser = locator.logins.getUserController().user
+			const currentKdfType = asKdfType(currentUser.kdfVersion)
+			const currentPasswordKeyData = {
+				kdfType: currentKdfType,
+				salt: assertNotNull(currentUser.salt),
+				passphrase: model.getOldPassword(),
+			}
+
+			const newPasswordKeyData = {
+				kdfType: DEFAULT_KDF_TYPE,
+				salt: await locator.loginFacade.generateRandomSalt(),
+				passphrase: model.getNewPassword(),
+			}
+
+			showProgressDialog("pleaseWait_msg", locator.loginFacade.changePassword(currentPasswordKeyData, newPasswordKeyData))
+				.then(async (encryptedPassword) => {
 					Dialog.message("pwChangeValid_msg")
 					dialog.close()
-
 					// do not wait for it or catch the errors, we do not want to confuse the user with the password change if anything goes wrong
-					storeNewPassword(encryptedPassword)
+
+					const credentialsProvider = locator.credentialsProvider
+					const storedCredentials = await credentialsProvider.getCredentialsInfoByUserId(currentUser._id)
+					if (storedCredentials != null) {
+						const password = assertNotNull(encryptedPassword, "encrypted password not provided")
+						await credentialsProvider.replacePassword(storedCredentials, password)
+					}
 				})
 				.catch(
 					ofClass(NotAuthenticatedError, (e) => {

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -34,7 +34,6 @@ import { EntropyFacade } from "../../../../../src/api/worker/facades/EntropyFaca
 import { DatabaseKeyFactory } from "../../../../../src/misc/credentials/DatabaseKeyFactory.js"
 import { Argon2idFacade } from "../../../../../src/api/worker/facades/Argon2idFacade.js"
 import { createTestEntity } from "../../../TestUtils.js"
-import { DefaultEntityRestCache } from "../../../../../src/api/worker/rest/DefaultEntityRestCache.js"
 
 const { anything, argThat } = matchers
 
@@ -574,7 +573,8 @@ o.spec("LoginFacadeTest", function () {
 			let user: User
 
 			o.beforeEach(async function () {
-				const userPassphraseKey = await facade.deriveUserPassphraseKey(KdfType.Bcrypt, passphrase, SALT)
+				const passphraseKeyData = { kdfType: KdfType.Bcrypt, passphrase, salt: SALT }
+				const userPassphraseKey = await facade.deriveUserPassphraseKey(passphraseKeyData)
 				user = await makeUser(userId, KdfType.Bcrypt, userPassphraseKey)
 				user.salt = SALT
 				usingOfflineStorage = true
@@ -724,7 +724,8 @@ o.spec("LoginFacadeTest", function () {
 					type: "internal",
 				} as Credentials
 
-				const userPassphraseKey = await facade.deriveUserPassphraseKey(KdfType.Bcrypt, passphrase, SALT)
+				const passphraseKeyData = { kdfType: KdfType.Bcrypt, passphrase, salt: SALT }
+				const userPassphraseKey = await facade.deriveUserPassphraseKey(passphraseKeyData)
 				user = await makeUser(userId, KdfType.Bcrypt, userPassphraseKey)
 				user.externalAuthInfo = createTestEntity(UserExternalAuthInfoTypeRef, {
 					latestSaltHash: sha256Hash(SALT),

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -97,7 +97,6 @@ o.spec("LoginFacadeTest", function () {
 	let blobAccessTokenFacade: BlobAccessTokenFacade
 	let databaseKeyFactoryMock: DatabaseKeyFactory
 	let argon2idFacade: Argon2idFacade
-	let entityRestCache: DefaultEntityRestCache
 
 	const timeRangeDays = 42
 
@@ -140,7 +139,6 @@ o.spec("LoginFacadeTest", function () {
 		databaseKeyFactoryMock = object()
 		argon2idFacade = object()
 		when(argon2idFacade.generateKeyFromPassphrase(anything(), anything())).thenResolve(PASSWORD_KEY)
-		entityRestCache = object<DefaultEntityRestCache>()
 
 		facade = new LoginFacade(
 			workerMock,
@@ -156,7 +154,7 @@ o.spec("LoginFacadeTest", function () {
 			entropyFacade,
 			databaseKeyFactoryMock,
 			argon2idFacade,
-			entityRestCache,
+			entityClientMock,
 		)
 
 		eventBusClientMock = instance(EventBusClient)


### PR DESCRIPTION
The current modern KDF is Argon2id, but the migration can be reused for future KDFs.

This includes
- when creating a new session
- when resuming a session

Also migrate locally stored credentials.

tutadb#1655