### PR TITLE
enforce updating _ownerEncSessionKey for Files if needed

### DIFF
--- a/src/api/common/EntityTypes.ts
+++ b/src/api/common/EntityTypes.ts
@@ -48,7 +48,6 @@ export interface Instance extends Entity {
 
 export interface Entity {
 	_type: TypeRef<this>
-	// _ownerEncSessionKey?: ?Uint8Array,
 }
 
 export interface ElementEntity extends Entity, Element {

--- a/src/api/main/MainLocator.ts
+++ b/src/api/main/MainLocator.ts
@@ -422,6 +422,7 @@ class MainLocator {
 				this.workerFacade,
 				this.search,
 				this.mailFacade,
+				this.cryptoFacade,
 			)
 	}
 

--- a/src/api/worker/WorkerLocator.ts
+++ b/src/api/worker/WorkerLocator.ts
@@ -204,6 +204,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 		locator.instanceMapper,
 		new OwnerEncSessionKeysUpdateQueue(locator.user, locator.serviceExecutor),
 		locator.pqFacade,
+		cache,
 	)
 
 	const loginListener: LoginListener = {

--- a/src/api/worker/facades/lazy/BlobFacade.ts
+++ b/src/api/worker/facades/lazy/BlobFacade.ts
@@ -1,16 +1,6 @@
 import { addParamsToUrl, isSuspensionResponse, RestClient } from "../../rest/RestClient.js"
 import { CryptoFacade, encryptBytes } from "../../crypto/CryptoFacade.js"
-import {
-	clear,
-	concat,
-	downcast,
-	isSameTypeRef,
-	neverNull,
-	promiseMap,
-	splitUint8ArrayInChunks,
-	uint8ArrayToBase64,
-	uint8ArrayToString,
-} from "@tutao/tutanota-utils"
+import { clear, concat, neverNull, promiseMap, splitUint8ArrayInChunks, uint8ArrayToBase64, uint8ArrayToString } from "@tutao/tutanota-utils"
 import { ArchiveDataType, MAX_BLOB_SIZE_BYTES } from "../../../common/TutanotaConstants.js"
 
 import { HttpMethod, MediaType, resolveTypeReference } from "../../../common/EntityFunctions.js"
@@ -30,10 +20,7 @@ import { BlobGetInTypeRef, BlobPostOut, BlobPostOutTypeRef, BlobServerAccessInfo
 import { AuthDataProvider } from "../UserFacade.js"
 import { doBlobRequestWithRetry, tryServers } from "../../rest/EntityRestClient.js"
 import { BlobAccessTokenFacade, BlobReferencingInstance } from "../BlobAccessTokenFacade.js"
-import { SessionKeyNotFoundError } from "../../../common/error/SessionKeyNotFoundError.js"
 import { DefaultEntityRestCache } from "../../rest/DefaultEntityRestCache.js"
-import { FileTypeRef } from "../../../entities/tutanota/TypeRefs.js"
-import { getElementId, getListId } from "../../../common/utils/EntityUtils.js"
 import { SomeEntity } from "../../../common/EntityTypes.js"
 
 assertWorkerOrNode()
@@ -186,25 +173,8 @@ export class BlobFacade {
 		}
 	}
 
-	/**
-	 * Resolves the session key and retries downloading the file instance in case we are out of sync.
-	 *
-	 * We assume that we are out of sync in case we retrieve a SessionKeyNotFoundError.
-	 */
 	private async resolveSessionKey(entity: SomeEntity): Promise<Aes128Key | Aes256Key> {
-		try {
-			return neverNull(await this.cryptoFacade.resolveSessionKeyForInstance(entity))
-		} catch (e) {
-			if (e instanceof SessionKeyNotFoundError && isSameTypeRef(FileTypeRef, entity._type) && this.entityRestCache) {
-				console.log("cache out of sync, trying to remove instance ", entity)
-				const file = downcast(entity)
-				await this.entityRestCache.deleteFromCacheIfExists(FileTypeRef, getListId(file), getElementId(file))
-				const updatedFile = await this.entityRestCache.load(FileTypeRef, file._id)
-				return neverNull(await this.cryptoFacade.resolveSessionKeyForInstance(updatedFile))
-			} else {
-				throw e
-			}
-		}
+		return neverNull(await this.cryptoFacade.resolveSessionKeyForInstance(entity))
 	}
 
 	private async encryptAndUploadChunk(

--- a/src/api/worker/search/IndexUtils.ts
+++ b/src/api/worker/search/IndexUtils.ts
@@ -132,7 +132,7 @@ const typeInfos = {
 	},
 }
 
-function getAttributeIds(model: TypeModel) {
+export function getAttributeIds(model: TypeModel) {
 	return Object.keys(model.values)
 		.map((name) => model.values[name].id)
 		.concat(Object.keys(model.associations).map((name) => model.associations[name].id))

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -285,7 +285,8 @@ export class MailEditor implements Component<MailEditorAttrs> {
 	}
 
 	private downloadInlineImage(model: SendMailModel, cid: string) {
-		const inlineAttachment = model.getAttachments().find((attachment) => attachment.cid === cid)
+		const tutanotaFiles = model.getAttachments().filter((attachment) => isTutanotaFile(attachment))
+		const inlineAttachment = tutanotaFiles.find((attachment) => attachment.cid === cid)
 
 		if (inlineAttachment && isTutanotaFile(inlineAttachment)) {
 			locator.fileController.open(inlineAttachment).catch(ofClass(FileOpenError, () => Dialog.message("canNotOpenFileOnDevice_msg")))

--- a/src/mail/export/Exporter.ts
+++ b/src/mail/export/Exporter.ts
@@ -21,6 +21,7 @@ import { FileController, zipDataFiles } from "../../file/FileController"
 import { MailFacade } from "../../api/worker/facades/lazy/MailFacade.js"
 import { OperationId } from "../../api/main/OperationProgressTracker.js"
 import { CancelledError } from "../../api/common/error/CancelledError.js"
+import { CryptoFacade } from "../../api/worker/crypto/CryptoFacade.js"
 // .msg export is handled in DesktopFileExport because it uses APIs that can't be loaded web side
 export type MailExportMode = "msg" | "eml"
 
@@ -65,6 +66,7 @@ export async function exportMails(
 	mailFacade: MailFacade,
 	entityClient: EntityClient,
 	fileController: FileController,
+	cryptoFacade: CryptoFacade,
 	operationId?: OperationId,
 	signal?: AbortSignal,
 ): Promise<{ failed: Mail[] }> {
@@ -99,7 +101,7 @@ export async function exportMails(
 			checkAbortSignal()
 			try {
 				const { htmlSanitizer } = await import("../../misc/HtmlSanitizer")
-				return await makeMailBundle(mail, mailFacade, entityClient, fileController, htmlSanitizer)
+				return await makeMailBundle(mail, mailFacade, entityClient, fileController, htmlSanitizer, cryptoFacade)
 			} catch (e) {
 				errorMails.push(mail)
 			} finally {

--- a/src/mail/view/MailListView.ts
+++ b/src/mail/view/MailListView.ts
@@ -270,7 +270,14 @@ export class MailListView implements Component<MailListViewAttrs> {
 				const key = mapKey(mail)
 				const downloadPromise = Promise.resolve().then(async () => {
 					const { htmlSanitizer } = await import("../../misc/HtmlSanitizer")
-					const bundle = await makeMailBundle(mail, locator.mailFacade, locator.entityClient, locator.fileController, htmlSanitizer)
+					const bundle = await makeMailBundle(
+						mail,
+						locator.mailFacade,
+						locator.entityClient,
+						locator.fileController,
+						htmlSanitizer,
+						locator.cryptoFacade,
+					)
 					progressMonitor.workDone(1)
 					const file = await generateMailFile(bundle, name, exportMode)
 					progressMonitor.workDone(1)

--- a/src/mail/view/MailViewerToolbar.ts
+++ b/src/mail/view/MailViewerToolbar.ts
@@ -3,7 +3,7 @@ import { MailModel } from "../model/MailModel.js"
 import { Mail } from "../../api/entities/tutanota/TypeRefs.js"
 import { IconButton } from "../../gui/base/IconButton.js"
 import { promptAndDeleteMails, showMoveMailsDropdown } from "./MailGuiUtils.js"
-import { assertNotNull, noOp, ofClass } from "@tutao/tutanota-utils"
+import { noOp, ofClass } from "@tutao/tutanota-utils"
 import { Icons } from "../../gui/base/icons/Icons.js"
 import { MailViewerViewModel } from "./MailViewerViewModel.js"
 import { UserError } from "../../api/main/UserError.js"
@@ -11,7 +11,7 @@ import { showUserError } from "../../misc/ErrorHandlerImpl.js"
 import { createDropdown, DropdownButtonAttrs } from "../../gui/base/Dropdown.js"
 import { editDraft, mailViewerMoreActions } from "./MailViewerUtils.js"
 import { ButtonType } from "../../gui/base/Button.js"
-import { isApp, Mode } from "../../api/common/Env.js"
+import { isApp } from "../../api/common/Env.js"
 import { locator } from "../../api/main/MainLocator.js"
 import { showProgressDialog } from "../../gui/dialogs/ProgressDialog.js"
 import { lang } from "../../misc/LanguageViewModel.js"
@@ -20,10 +20,6 @@ import { Dialog, DialogType } from "../../gui/base/Dialog.js"
 import { ColumnWidth, Table } from "../../gui/base/Table.js"
 import { ExpanderButton, ExpanderPanel } from "../../gui/base/Expander.js"
 import stream from "mithril/stream"
-import { loadMailDetails } from "../model/MailUtils.js"
-import { createErrorReportData, createReportErrorIn } from "../../api/entities/monitor/TypeRefs.js"
-import { ReportErrorService } from "../../api/entities/monitor/Services.js"
-import { ErrorReportClientType } from "../../misc/ClientConstants.js"
 import { exportMails } from "../export/Exporter.js"
 
 /*
@@ -158,7 +154,15 @@ export class MailViewerActions implements Component<MailViewerToolbarAttrs> {
 								"{current}": Math.round((operation.progress() / 100) * attrs.mails.length).toFixed(0),
 								"{total}": attrs.mails.length,
 							}),
-						exportMails(attrs.mails, locator.mailFacade, locator.entityClient, locator.fileController, operation.id, ac.signal)
+						exportMails(
+							attrs.mails,
+							locator.mailFacade,
+							locator.entityClient,
+							locator.fileController,
+							locator.cryptoFacade,
+							operation.id,
+							ac.signal,
+						)
 							.then((result) => this.handleExportEmailsResult(result.failed))
 							.finally(operation.done),
 						operation.progress,

--- a/test/tests/mail/view/MailViewerViewModelTest.ts
+++ b/test/tests/mail/view/MailViewerViewModelTest.ts
@@ -24,6 +24,7 @@ import { FileController } from "../../../../src/file/FileController.js"
 import { createTestEntity } from "../../TestUtils.js"
 import { MailState } from "../../../../src/api/common/TutanotaConstants.js"
 import { GroupInfoTypeRef } from "../../../../src/api/entities/sys/TypeRefs.js"
+import { CryptoFacade } from "../../../../src/api/worker/crypto/CryptoFacade.js"
 
 o.spec("MailViewerViewModel", function () {
 	let mail: Mail
@@ -41,6 +42,7 @@ o.spec("MailViewerViewModel", function () {
 	let mailFacade: MailFacade
 	let sendMailModel: SendMailModel
 	let sendMailModelFactory: (mailboxDetails: MailboxDetail) => Promise<SendMailModel> = () => Promise.resolve(sendMailModel)
+	let cryptoFacade: CryptoFacade
 
 	function makeViewModelWithHeaders(headers: string) {
 		entityClient = object()
@@ -54,6 +56,7 @@ o.spec("MailViewerViewModel", function () {
 		workerFacade = object()
 		searchModel = object()
 		mailFacade = object()
+		cryptoFacade = object()
 		mail = prepareMailWithHeaders(mailFacade, headers)
 
 		return new MailViewerViewModel(
@@ -70,6 +73,7 @@ o.spec("MailViewerViewModel", function () {
 			workerFacade,
 			searchModel,
 			mailFacade,
+			cryptoFacade,
 		)
 	}
 


### PR DESCRIPTION
https://github.com/tutao/tutanota/issues/6275

We assumed that _ownerEncSessionKey is written for a File
when we download it. This is not always the case as the
UpdateSessionKeysService might not have been invoked or
the invocation might have failed.