### PR TITLE
Fix addresses are not synchronized and sync permission

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/AndroidMobileSystemFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/AndroidMobileSystemFacade.kt
@@ -1,6 +1,5 @@
 package de.tutao.tutanota
 
-import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.Intent
@@ -18,7 +17,7 @@ import java.io.IOException
 class AndroidMobileSystemFacade(
 		private val contact: Contact,
 		private val fileFacade: AndroidFileFacade,
-		private val activity: Activity,
+		private val activity: MainActivity,
 ) : MobileSystemFacade {
 	override suspend fun findSuggestions(query: String): List<NativeContact> {
 		return contact.findSuggestions(query)
@@ -36,8 +35,13 @@ class AndroidMobileSystemFacade(
 			}
 		}
 	}
+
 	override suspend fun deleteContacts(userId: String, contactId: String?) {
 		return contact.deleteContacts(userId, contactId)
+	}
+
+	override suspend fun goToSettings(translationKey: String) {
+		return activity.goToSettings(translationKey)
 	}
 
 	override suspend fun syncContacts(userId: String, contacts: List<StructuredContact>) {

--- a/app-android/app/src/main/java/de/tutao/tutanota/AndroidMobileSystemFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/AndroidMobileSystemFacade.kt
@@ -1,10 +1,13 @@
 package de.tutao.tutanota
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
+import android.provider.Settings
 import android.util.Log
+import androidx.core.content.ContextCompat.startActivity
 import androidx.core.content.FileProvider
 import de.tutao.tutanota.ipc.MobileSystemFacade
 import de.tutao.tutanota.ipc.NativeContact
@@ -17,7 +20,7 @@ import java.io.IOException
 class AndroidMobileSystemFacade(
 		private val contact: Contact,
 		private val fileFacade: AndroidFileFacade,
-		private val activity: MainActivity,
+		private val activity: Activity,
 ) : MobileSystemFacade {
 	override suspend fun findSuggestions(query: String): List<NativeContact> {
 		return contact.findSuggestions(query)
@@ -40,8 +43,14 @@ class AndroidMobileSystemFacade(
 		return contact.deleteContacts(userId, contactId)
 	}
 
-	override suspend fun goToSettings(translationKey: String) {
-		return activity.goToSettings(translationKey)
+	override suspend fun goToSettings() {
+		withContext(Dispatchers.Main) {
+			val intent = Intent(
+					Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+					Uri.parse("package:${activity.packageName}")
+			)
+			startActivity(activity, intent, null)
+		}
 	}
 
 	override suspend fun syncContacts(userId: String, contacts: List<StructuredContact>) {

--- a/app-android/app/src/main/java/de/tutao/tutanota/Contact.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/Contact.kt
@@ -558,6 +558,14 @@ class Contact(private val activity: MainActivity) {
 			)
 		}
 
+		for (address in contact.addresses) {
+			ops.add(
+					insertAddressOperation(address)
+							.withValueBackReference(ContactsContract.Data.RAW_CONTACT_ID, index)
+							.build()
+			)
+		}
+
 		val result = resolver.applyBatch(ContactsContract.AUTHORITY, ops)
 		Log.d(TAG, "Save result: $result")
 	}

--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -453,17 +453,6 @@ class MainActivity : FragmentActivity() {
 		}
 	}
 
-	suspend fun goToSettings(translationKey: String) {
-		commonNativeFacade.showAlertDialog(translationKey)
-		withContext(Dispatchers.Main) {
-			val intent = Intent(
-					Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-					Uri.parse("package:$packageName")
-			)
-			startActivity(intent)
-		}
-	}
-
 	suspend fun askNotificationPermissionIfNeeded() {
 		// if API < 33 we should have the permission automatically
 		// check also enables us to use the POST_NOTIFICATIONS const

--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -453,6 +453,17 @@ class MainActivity : FragmentActivity() {
 		}
 	}
 
+	suspend fun goToSettings(translationKey: String) {
+		commonNativeFacade.showAlertDialog(translationKey)
+		withContext(Dispatchers.Main) {
+			val intent = Intent(
+					Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+					Uri.parse("package:$packageName")
+			)
+			startActivity(intent)
+		}
+	}
+
 	suspend fun askNotificationPermissionIfNeeded() {
 		// if API < 33 we should have the permission automatically
 		// check also enables us to use the POST_NOTIFICATIONS const

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacade.kt
@@ -41,7 +41,6 @@ interface MobileSystemFacade {
 	 * Redirect the user to Phone's Settings
 	 */
 	 suspend fun goToSettings(
-		translationKey: String,
 	): Unit
 	/**
 	 * Open URI in the OS.

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacade.kt
@@ -38,6 +38,12 @@ interface MobileSystemFacade {
 		contactId: String?,
 	): Unit
 	/**
+	 * Redirect the user to Phone's Settings
+	 */
+	 suspend fun goToSettings(
+		translationKey: String,
+	): Unit
+	/**
 	 * Open URI in the OS.
 	 */
 	 suspend fun openLink(

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacadeReceiveDispatcher.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacadeReceiveDispatcher.kt
@@ -48,6 +48,13 @@ class MobileSystemFacadeReceiveDispatcher(
 				)
 				return json.encodeToString(result)
 			}
+			"goToSettings" -> {
+				val translationKey: String = json.decodeFromString(arg[0])
+				val result: Unit = this.facade.goToSettings(
+					translationKey,
+				)
+				return json.encodeToString(result)
+			}
 			"openLink" -> {
 				val uri: String = json.decodeFromString(arg[0])
 				val result: Boolean = this.facade.openLink(

--- a/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacadeReceiveDispatcher.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/generated_ipc/MobileSystemFacadeReceiveDispatcher.kt
@@ -49,9 +49,7 @@ class MobileSystemFacadeReceiveDispatcher(
 				return json.encodeToString(result)
 			}
 			"goToSettings" -> {
-				val translationKey: String = json.decodeFromString(arg[0])
 				val result: Unit = this.facade.goToSettings(
-					translationKey,
 				)
 				return json.encodeToString(result)
 			}

--- a/app-ios/tutanota/Sources/Contacts/StructuredContactTypes.swift
+++ b/app-ios/tutanota/Sources/Contacts/StructuredContactTypes.swift
@@ -21,6 +21,7 @@ enum ContactPhoneNumberType: String {
   case mobile = "2"
   case fax = "3"
   case other = "4"
+  case custom = "5"
 
   func toCNLabel() -> String {
     switch self {

--- a/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacade.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacade.swift
@@ -38,7 +38,6 @@ public protocol MobileSystemFacade {
 	 * Redirect the user to Phone's Settings
 	 */
 	func goToSettings(
-		_ translationKey: String
 	) async throws -> Void
 	/**
 	 * Open URI in the OS.

--- a/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacade.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacade.swift
@@ -35,6 +35,12 @@ public protocol MobileSystemFacade {
 		_ contactId: String?
 	) async throws -> Void
 	/**
+	 * Redirect the user to Phone's Settings
+	 */
+	func goToSettings(
+		_ translationKey: String
+	) async throws -> Void
+	/**
 	 * Open URI in the OS.
 	 */
 	func openLink(

--- a/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacadeReceiveDispatcher.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacadeReceiveDispatcher.swift
@@ -41,9 +41,7 @@ public class MobileSystemFacadeReceiveDispatcher {
 			)
 			return "null"
 		case "goToSettings":
-			let translationKey = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
 			try await self.facade.goToSettings(
-				translationKey
 			)
 			return "null"
 		case "openLink":

--- a/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacadeReceiveDispatcher.swift
+++ b/app-ios/tutanota/Sources/GeneratedIpc/MobileSystemFacadeReceiveDispatcher.swift
@@ -40,6 +40,12 @@ public class MobileSystemFacadeReceiveDispatcher {
 				contactId
 			)
 			return "null"
+		case "goToSettings":
+			let translationKey = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
+			try await self.facade.goToSettings(
+				translationKey
+			)
+			return "null"
 		case "openLink":
 			let uri = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
 			let result = try await self.facade.openLink(

--- a/app-ios/tutanota/Sources/IosMobileSystemFacade.swift
+++ b/app-ios/tutanota/Sources/IosMobileSystemFacade.swift
@@ -1,12 +1,12 @@
 import Foundation
 import Contacts
 
+private let PERMISSION_ERROR_DOMAIN = "de.tutao.tutanota.PermissionError"
+
 class IosMobileSystemFacade: MobileSystemFacade {
   private let contactsSynchronization: ContactsSynchronization
   private let contactsSource: ContactsSource
   private let viewController: ViewController
-
-  let PERMISSION_ERROR_DOMAIN = "de.tutao.tutanota.PermissionError"
   
   init(contactsSource: ContactsSource, viewController: ViewController, contactsSynchronization: ContactsSynchronization) {
     self.contactsSource = contactsSource

--- a/ipc-schema/facades/MobileSystemFacade.json
+++ b/ipc-schema/facades/MobileSystemFacade.json
@@ -50,6 +50,15 @@
 			],
 			"ret": "void"
 		},
+		"goToSettings": {
+			"doc": "Redirect the user to Phone's Settings",
+			"arg": [
+				{
+					"translationKey": "string"
+				}
+			],
+			"ret": "void"
+		},
 		"openLink": {
 			"doc": "Open URI in the OS.",
 			"arg": [

--- a/ipc-schema/facades/MobileSystemFacade.json
+++ b/ipc-schema/facades/MobileSystemFacade.json
@@ -52,11 +52,7 @@
 		},
 		"goToSettings": {
 			"doc": "Redirect the user to Phone's Settings",
-			"arg": [
-				{
-					"translationKey": "string"
-				}
-			],
+			"arg": [],
 			"ret": "void"
 		},
 		"openLink": {

--- a/src/api/common/utils/ErrorUtils.ts
+++ b/src/api/common/utils/ErrorUtils.ts
@@ -150,6 +150,7 @@ const ErrorNameToType = {
 	"de.tutao.tutanota.CancelledError": CancelledError,
 	"de.tutao.tutanota.webauthn.WebauthnError": WebauthnError,
 	"de.tutao.tutanota.Webauthn": WebauthnError,
+	"de.tutao.tutanota.PermissionError": PermissionError,
 }
 
 export function isSecurityError(e: any): boolean {

--- a/src/contacts/model/NativeContactsSyncManager.ts
+++ b/src/contacts/model/NativeContactsSyncManager.ts
@@ -13,6 +13,7 @@ import { ContactModel } from "./ContactModel.js"
 import { DeviceConfig } from "../../misc/DeviceConfig.js"
 import { PermissionError } from "../../api/common/error/PermissionError.js"
 import { isApp } from "../../api/common/Env.js"
+import { Dialog } from "../../gui/base/Dialog.js"
 
 export class NativeContactsSyncManager {
 	constructor(
@@ -114,7 +115,7 @@ export class NativeContactsSyncManager {
 
 	showContactsPermissionDialog() {
 		if (!isApp()) return
-		this.mobileSystemFacade.goToSettings("allowContactReadWrite_msg")
+		Dialog.message("allowContactReadWrite_msg").then(() => this.mobileSystemFacade.goToSettings())
 	}
 
 	async clearContacts() {

--- a/src/misc/TranslationKey.ts
+++ b/src/misc/TranslationKey.ts
@@ -1608,3 +1608,4 @@ export type TranslationKeyType =
 	| "yourMessage_label"
 	| "you_label"
 	| "emptyString_msg"
+	| "allowContactReadWrite_msg"

--- a/src/native/common/generatedipc/MobileSystemFacade.ts
+++ b/src/native/common/generatedipc/MobileSystemFacade.ts
@@ -29,7 +29,7 @@ export interface MobileSystemFacade {
 	/**
 	 * Redirect the user to Phone's Settings
 	 */
-	goToSettings(translationKey: string): Promise<void>
+	goToSettings(): Promise<void>
 
 	/**
 	 * Open URI in the OS.

--- a/src/native/common/generatedipc/MobileSystemFacade.ts
+++ b/src/native/common/generatedipc/MobileSystemFacade.ts
@@ -27,6 +27,11 @@ export interface MobileSystemFacade {
 	deleteContacts(username: string, contactId: string | null): Promise<void>
 
 	/**
+	 * Redirect the user to Phone's Settings
+	 */
+	goToSettings(translationKey: string): Promise<void>
+
+	/**
 	 * Open URI in the OS.
 	 */
 	openLink(uri: string): Promise<boolean>

--- a/src/native/common/generatedipc/MobileSystemFacadeSendDispatcher.ts
+++ b/src/native/common/generatedipc/MobileSystemFacadeSendDispatcher.ts
@@ -19,6 +19,9 @@ export class MobileSystemFacadeSendDispatcher implements MobileSystemFacade {
 	async deleteContacts(...args: Parameters<MobileSystemFacade["deleteContacts"]>) {
 		return this.transport.invokeNative("ipc", ["MobileSystemFacade", "deleteContacts", ...args])
 	}
+	async goToSettings(...args: Parameters<MobileSystemFacade["goToSettings"]>) {
+		return this.transport.invokeNative("ipc", ["MobileSystemFacade", "goToSettings", ...args])
+	}
 	async openLink(...args: Parameters<MobileSystemFacade["openLink"]>) {
 		return this.transport.invokeNative("ipc", ["MobileSystemFacade", "openLink", ...args])
 	}

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1626,6 +1626,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "DEINE ORDNER",
 		"yourMessage_label": "Deine Nachricht",
-		"you_label": "Du"
+		"you_label": "Du",
+		"allowContactReadWrite_msg": "Um die Kontaktsynchronisierung zu aktivieren, benötigt Tuta Lese- und Schreibzugriff auf Ihre Kontakte. Du kannst dies jederzeit in den Systemeinstellungen ändern."
 	}
 }

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1627,6 +1627,6 @@ export default {
 		"yourFolders_action": "DEINE ORDNER",
 		"yourMessage_label": "Deine Nachricht",
 		"you_label": "Du",
-		"allowContactReadWrite_msg": "Um die Kontaktsynchronisierung zu aktivieren, benötigt Tuta Lese- und Schreibzugriff auf Ihre Kontakte. Du kannst dies jederzeit in den Systemeinstellungen ändern."
+		"allowContactReadWrite_msg": "Um Ihre Kontakte zu synchronisieren, benötigen wir die Berechtigung zum Lesen und Schreiben in Ihrem Kontaktbuch. Du kannst dies jederzeit in den Systemeinstellungen ändern."
 	}
 }

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -1626,6 +1626,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "Ihre ORDNER",
 		"yourMessage_label": "Ihre Nachricht",
-		"you_label": "Sie"
+		"you_label": "Sie",
+		"allowContactReadWrite_msg": "Um die Kontaktsynchronisierung zu aktivieren, benötigt Tuta Lese- und Schreibzugriff auf Ihre Kontakte. Sie können dies jederzeit in den Systemeinstellungen ändern."
 	}
 }

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -1627,6 +1627,6 @@ export default {
 		"yourFolders_action": "Ihre ORDNER",
 		"yourMessage_label": "Ihre Nachricht",
 		"you_label": "Sie",
-		"allowContactReadWrite_msg": "Um die Kontaktsynchronisierung zu aktivieren, benötigt Tuta Lese- und Schreibzugriff auf Ihre Kontakte. Sie können dies jederzeit in den Systemeinstellungen ändern."
+		"allowContactReadWrite_msg": "Um Ihre Kontakte zu synchronisieren, benötigen wir die Berechtigung zum Lesen und Schreiben in Ihrem Kontaktbuch. Sie können dies jederzeit in den Systemeinstellungen ändern."
 	}
 }

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1623,6 +1623,6 @@ export default {
 		"yourFolders_action": "YOUR FOLDERS",
 		"yourMessage_label": "Your message",
 		"you_label": "You",
-		"allowContactReadWrite_msg": "To enable Contacts Synchronization, Tuta needs access to read and write in your contacts. You can change this anytime in the system settings."
+		"allowContactReadWrite_msg": "In order to synchronize your contacts, we need the permission to read and write to your contacts book. You can change this anytime in the system settings."
 	}
 }

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1622,6 +1622,7 @@ export default {
 		"yourCalendars_label": "Your calendars",
 		"yourFolders_action": "YOUR FOLDERS",
 		"yourMessage_label": "Your message",
-		"you_label": "You"
+		"you_label": "You",
+		"allowContactReadWrite_msg": "To enable Contacts Synchronization, Tuta needs access to read and write in your contacts. You can change this anytime in the system settings."
 	}
 }


### PR DESCRIPTION
When the user tries to enable contact synchronization the app crashes without error message. The reason was a missing Phone type that was added now. 

Insert address when creating contacts on Android and doesn't enable change synchronization permission dropdown to enabled if no permission were granted. Also handle errors of missing contact permissions and displays a message about it.

fix #6494
fix #6500 
close #6492