### PR TITLE
Fix not removing mail results from search on move

### DIFF
--- a/src/api/common/utils/EntityUpdateUtils.ts
+++ b/src/api/common/utils/EntityUpdateUtils.ts
@@ -28,6 +28,6 @@ export function containsEventOfType(events: ReadonlyArray<EntityUpdateData>, typ
 	return events.some((event) => event.operation === type && event.instanceId === elementId)
 }
 
-export function getEventOfType(events: ReadonlyArray<EntityUpdate>, type: OperationType, elementId: Id): EntityUpdate | null {
+export function getEventOfType<T extends EntityUpdateData | EntityUpdate>(events: ReadonlyArray<T>, type: OperationType, elementId: Id): T | null {
 	return events.find((event) => event.operation === type && event.instanceId === elementId) ?? null
 }

--- a/src/search/view/SearchViewModel.ts
+++ b/src/search/view/SearchViewModel.ts
@@ -518,9 +518,12 @@ export class SearchViewModel {
 					(email) => update.instanceId === elementIdPart(email) && update.instanceListId !== listIdPart(email),
 				)
 				if (index >= 0) {
-					// We need to update the listId of the updated item, since it was moved to another folder.
-					const newIdTuple: IdTuple = [update.instanceListId, update.instanceId]
-					this._searchResult.results[index] = newIdTuple
+					const restrictionLength = this._searchResult.restriction.listIds.length
+					if ((restrictionLength > 0 && this._searchResult.restriction.listIds.includes(update.instanceListId)) || restrictionLength === 0) {
+						// We need to update the listId of the updated item, since it was moved to another folder.
+						const newIdTuple: IdTuple = [update.instanceListId, update.instanceId]
+						this._searchResult.results[index] = newIdTuple
+					}
 				}
 			}
 		} else if (isUpdateForTypeRef(CalendarEventTypeRef, update) && isSameTypeRef(lastType, CalendarEventTypeRef)) {
@@ -582,8 +585,15 @@ export class SearchViewModel {
 		if (isSameTypeRef(this.searchedType, MailTypeRef)) {
 			if (!newState.inMultiselect && newState.selectedItems.size === 1) {
 				const mail = this.getSelectedMails()[0]
-				if (!this.conversationViewModel || !isSameId(elementIdPart(this.conversationViewModel?.primaryMail._id), elementIdPart(mail._id))) {
+
+				if (!this.conversationViewModel) {
 					this.updateDisplayedConversation(mail)
+				} else if (this.conversationViewModel) {
+					const isSameElementId = isSameId(elementIdPart(this.conversationViewModel?.primaryMail._id), elementIdPart(mail._id))
+					const isSameListId = isSameId(listIdPart(this.conversationViewModel?.primaryMail._id), listIdPart(mail._id))
+					if (!isSameElementId || !isSameListId) {
+						this.updateDisplayedConversation(mail)
+					}
 				}
 			} else {
 				this.conversationViewModel = null


### PR DESCRIPTION
Previously we would skip the delete part of the moving mail when we try to simulate the update. This lead to issues where folder filter does not match the displayed email.

Now we check for valid destination when optimizing for move batches.

fix #6495