### PR TITLE
Swap ctrl/meta on macOS/iOS

### DIFF
--- a/src/api/common/Env.ts
+++ b/src/api/common/Env.ts
@@ -41,6 +41,13 @@ export function isIOSApp(): boolean {
 	return env.mode === Mode.App && env.platformId === "ios"
 }
 
+/**
+ * Return true if an Apple device; used for checking if CTRL or CMD/Meta should be used as the primary modifier
+ */
+export function isAppleDevice(): boolean {
+	return env.platformId === "darwin" || isIOSApp()
+}
+
 export function isAndroidApp(): boolean {
 	if (isApp() && env.platformId == null) {
 		throw new ProgrammingError("PlatformId is not set!")

--- a/src/calendar/gui/eventeditor-view/CalendarEventEditDialog.ts
+++ b/src/calendar/gui/eventeditor-view/CalendarEventEditDialog.ts
@@ -104,7 +104,7 @@ async function showCalendarEventEditDialog(model: CalendarEventModel, responseMa
 		})
 		.addShortcut({
 			key: Keys.S,
-			ctrl: true,
+			ctrlOrCmd: true,
 			exec: () => okAction(assertNotNull(headerDom, "headerDom was null")),
 			help: "save_action",
 		})

--- a/src/contacts/ContactEditor.ts
+++ b/src/contacts/ContactEditor.ts
@@ -563,7 +563,7 @@ export class ContactEditor {
 			})
 			.addShortcut({
 				key: Keys.S,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: () => {
 					// noinspection JSIgnoredPromiseFromCall
 					this.validateAndSave()

--- a/src/contacts/view/CalendarViewerActions.ts
+++ b/src/contacts/view/CalendarViewerActions.ts
@@ -72,7 +72,7 @@ export class CalendarViewerActions implements Component<CalendarViewToolbarAttrs
 		if (this.canExport(event)) {
 			this.shortcuts.push({
 				key: Keys.E,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: () => {
 					onExport(event)
 				},

--- a/src/contacts/view/ContactViewerActions.ts
+++ b/src/contacts/view/ContactViewerActions.ts
@@ -79,7 +79,7 @@ export class ContactViewerActions implements Component<ContactViewToolbarAttrs> 
 		if (this.canMerge(contacts)) {
 			this.shortcuts.push({
 				key: Keys.M,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: () => {
 					onMerge(contacts[0], contacts[1])
 				},
@@ -90,7 +90,7 @@ export class ContactViewerActions implements Component<ContactViewToolbarAttrs> 
 		if (this.canExport(contacts)) {
 			this.shortcuts.push({
 				key: Keys.E,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: () => {
 					onExport(contacts)
 				},

--- a/src/gui/base/ListUtils.ts
+++ b/src/gui/base/ListUtils.ts
@@ -82,7 +82,7 @@ export function listSelectionKeyboardShortcuts(multiselectMode: MultiselectMode,
 		},
 		{
 			key: Keys.A,
-			ctrl: true,
+			ctrlOrCmd: true,
 			shift: true,
 			exec: mapLazily(list, (list) => (list?.areAllSelected() ? list.selectNone() : list?.selectAll())),
 			help: "selectAllLoaded_action",

--- a/src/gui/base/TextField.ts
+++ b/src/gui/base/TextField.ts
@@ -5,7 +5,7 @@ import { theme } from "../theme"
 import type { TranslationKey } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import type { lazy } from "@tutao/tutanota-utils"
-import type { keyHandler } from "../../misc/KeyManager"
+import { keyboardEventToKeyPress, keyHandler } from "../../misc/KeyManager"
 import { TabIndex } from "../../api/common/TutanotaConstants"
 import { ClickHandler, getOperatingClasses } from "./GuiUtils"
 
@@ -256,11 +256,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 						onblur: (e: FocusEvent) => this.blur(e, a),
 						onkeydown: (e: KeyboardEvent) => {
 							// keydown is used to cancel certain keypresses of the user (mainly needed for the BubbleTextField)
-							let key = {
-								key: e.key,
-								ctrl: e.ctrlKey,
-								shift: e.shiftKey,
-							}
+							const key = keyboardEventToKeyPress(e)
 							return a.keyHandler != null ? a.keyHandler(key) : true
 						},
 						onupdate: () => {
@@ -314,11 +310,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 				onfocus: (e: FocusEvent) => this.focus(e, a),
 				onblur: (e: FocusEvent) => this.blur(e, a),
 				onkeydown: (e: KeyboardEvent) => {
-					let key = {
-						key: e.key,
-						ctrl: e.ctrlKey,
-						shift: e.shiftKey,
-					}
+					const key = keyboardEventToKeyPress(e)
 					return a.keyHandler != null ? a.keyHandler(key) : true
 				},
 				oninput: () => {

--- a/src/gui/dialogs/ShortcutDialog.ts
+++ b/src/gui/dialogs/ShortcutDialog.ts
@@ -6,10 +6,14 @@ import { TextField } from "../base/TextField.js"
 import type { Shortcut } from "../../misc/KeyManager"
 import { ButtonType } from "../base/Button.js"
 import { DialogHeaderBarAttrs } from "../base/DialogHeaderBar"
+import { isAppleDevice } from "../../api/common/Env.js"
 
 function makeShortcutName(shortcut: Shortcut): string {
+	const mainModifier = isAppleDevice() ? Keys.META.name : Keys.CTRL.name
+
 	return (
 		(shortcut.meta ? Keys.META.name + " + " : "") +
+		(shortcut.ctrlOrCmd ? mainModifier + " + " : "") +
 		(shortcut.ctrl ? Keys.CTRL.name + " + " : "") +
 		(shortcut.shift ? Keys.SHIFT.name + " + " : "") +
 		(shortcut.alt ? Keys.ALT.name + " + " : "") +

--- a/src/mail/editor/MailEditor.ts
+++ b/src/mail/editor/MailEditor.ts
@@ -250,25 +250,25 @@ export class MailEditor implements Component<MailEditorAttrs> {
 		const shortcuts: Shortcut[] = [
 			{
 				key: Keys.SPACE,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: () => this.openTemplates(),
 				help: "openTemplatePopup_msg",
 			}, // B (bold), I (italic), and U (underline) are handled by squire
 			{
 				key: Keys.B,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: noOp,
 				help: "formatTextBold_msg",
 			},
 			{
 				key: Keys.I,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: noOp,
 				help: "formatTextItalic_msg",
 			},
 			{
 				key: Keys.U,
-				ctrl: true,
+				ctrlOrCmd: true,
 				exec: noOp,
 				help: "formatTextUnderline_msg",
 			},
@@ -1004,7 +1004,7 @@ async function createMailEditorDialog(model: SendMailModel, blockExternalContent
 		},
 		{
 			key: Keys.S,
-			ctrl: true,
+			ctrlOrCmd: true,
 			exec: () => {
 				save().catch(ofClass(UserError, showUserError))
 			},
@@ -1012,7 +1012,7 @@ async function createMailEditorDialog(model: SendMailModel, blockExternalContent
 		},
 		{
 			key: Keys.S,
-			ctrl: true,
+			ctrlOrCmd: true,
 			shift: true,
 			exec: () => {
 				send()
@@ -1021,7 +1021,7 @@ async function createMailEditorDialog(model: SendMailModel, blockExternalContent
 		},
 		{
 			key: Keys.RETURN,
-			ctrl: true,
+			ctrlOrCmd: true,
 			exec: () => {
 				send()
 			},

--- a/src/misc/NavShortcuts.ts
+++ b/src/misc/NavShortcuts.ts
@@ -33,7 +33,7 @@ export function setupNavShortcuts() {
 		{
 			key: Keys.L,
 			shift: true,
-			ctrl: true,
+			ctrlOrCmd: true,
 			enabled: () => locator.logins.isUserLoggedIn(),
 			exec: (key) => m.route.set(LogoutUrl),
 			help: "switchAccount_action",

--- a/src/native/main/WebDesktopFacade.ts
+++ b/src/native/main/WebDesktopFacade.ts
@@ -74,7 +74,7 @@ export class WebDesktopFacade implements DesktopFacade {
 	async addShortcuts(shortcuts: Array<NativeShortcut>): Promise<void> {
 		const baseShortcut: Shortcut = {
 			exec: () => true,
-			ctrl: false,
+			ctrlOrCmd: false,
 			alt: false,
 			meta: false,
 			help: "emptyString_msg",

--- a/src/settings/EditOutOfOfficeNotificationDialog.ts
+++ b/src/settings/EditOutOfOfficeNotificationDialog.ts
@@ -84,7 +84,7 @@ export function showEditOutOfOfficeNotificationDialog(outOfOfficeNotification: O
 		})
 		.addShortcut({
 			key: Keys.S,
-			ctrl: true,
+			ctrlOrCmd: true,
 			exec: saveOutOfOfficeNotification,
 			help: "save_action",
 		})

--- a/src/templates/view/TemplateSearchBar.ts
+++ b/src/templates/view/TemplateSearchBar.ts
@@ -2,7 +2,7 @@ import m, { Children, ClassComponent, Component, Vnode } from "mithril"
 import type { TranslationKey } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { inputLineHeight, px } from "../../gui/size"
-import type { keyHandler } from "../../misc/KeyManager"
+import { keyboardEventToKeyPress, keyHandler } from "../../misc/KeyManager"
 import { theme } from "../../gui/theme"
 import type { lazy } from "@tutao/tutanota-utils"
 import Stream from "mithril/stream"
@@ -40,11 +40,7 @@ export class TemplateSearchBar implements ClassComponent<TemplateSearchBarAttrs>
 				this.domInput.focus()
 			},
 			onkeydown: (e: KeyboardEvent) => {
-				let key = {
-					key: e.key,
-					ctrl: e.ctrlKey,
-					shift: e.shiftKey,
-				}
+				const key = keyboardEventToKeyPress(e)
 				return a.keyHandler != null ? a.keyHandler(key) : true
 			},
 			oninput: () => {


### PR DESCRIPTION
Apple devices have this swapped, so we need to register it swapped. For example, CTRL-S on Linux is equivalent to CMD-S on macOS (for saving a draft).

Also fix KeyManager's private fields, since those have not been properly marked as private, yet.

Fixes #6503