### PR TITLE
Fix dragging all-day events

### DIFF
--- a/src/calendar/view/CalendarView.ts
+++ b/src/calendar/view/CalendarView.ts
@@ -209,7 +209,6 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 									},
 									selectedDate: this.viewModel.selectedDate(),
 									onDateSelected: (date) => {
-										this.viewModel.selectedDate(date)
 										this.setUrl(CalendarViewType.DAY, date)
 									},
 									groupColors,

--- a/src/calendar/view/CalendarViewModel.ts
+++ b/src/calendar/view/CalendarViewModel.ts
@@ -220,6 +220,10 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 		}
 	}
 
+	onDragCancel() {
+		this._draggedEvent = null
+	}
+
 	get temporaryEvents(): Array<CalendarEvent> {
 		return this._transientEvents.concat(this._draggedEvent ? [this._draggedEvent.eventClone] : [])
 	}

--- a/src/calendar/view/EventDragHandler.ts
+++ b/src/calendar/view/EventDragHandler.ts
@@ -22,6 +22,7 @@ export interface EventDragHandlerCallbacks {
 	readonly onDragStart: (calendarEvent: CalendarEvent, timeToMoveBy: number) => void
 	readonly onDragUpdate: (timeToMoveBy: number) => void
 	readonly onDragEnd: (timeToMoveBy: number, mode: CalendarOperation | null) => Promise<void>
+	readonly onDragCancel: () => void
 }
 
 /**
@@ -178,10 +179,15 @@ export class EventDragHandler {
 	}
 
 	cancelDrag() {
+		this._draggingArea.classList.remove("cursor-grabbing")
+		this._eventDragCallbacks.onDragCancel()
+
 		this._data = null
 		this._isDragging = false
 		this._hasChanged = true
 		this._lastDiffBetweenDates = null
+
+		m.redraw()
 	}
 }
 

--- a/src/calendar/view/MultiDayCalendarView.ts
+++ b/src/calendar/view/MultiDayCalendarView.ts
@@ -211,7 +211,7 @@ export class MultiDayCalendarView implements Component<MultiDayCalendarViewAttrs
 				onmouseleave: (mouseEvent: EventRedraw<MouseEvent>) => {
 					mouseEvent.redraw = false
 
-					this.endDrag(mouseEvent)
+					this.cancelDrag()
 				},
 			},
 			[
@@ -526,8 +526,11 @@ export class MultiDayCalendarView implements Component<MultiDayCalendarViewAttrs
 								},
 								key: event._id[0] + event._id[1] + event.startTime.getTime(),
 								onmousedown: () => {
-									this.isHeaderEventBeingDragged = true
-									this.startEventDrag(event)
+									// Only allow dragging all-day events on the desktop layout, since the header supports it
+									if (styles.isDesktopLayout()) {
+										this.isHeaderEventBeingDragged = true
+										this.startEventDrag(event)
+									}
 								},
 							},
 							this.renderLongEventBubble(
@@ -651,5 +654,9 @@ export class MultiDayCalendarView implements Component<MultiDayCalendarViewAttrs
 		if (this.dateUnderMouse) {
 			this.eventDragHandler.endDrag(this.dateUnderMouse, pos).catch(ofClass(UserError, showUserError))
 		}
+	}
+
+	private cancelDrag() {
+		this.eventDragHandler.cancelDrag()
 	}
 }

--- a/test/tests/calendar/EventDragHandlerTest.ts
+++ b/test/tests/calendar/EventDragHandlerTest.ts
@@ -1,12 +1,11 @@
 import o from "@tutao/otest"
-import { EventDragHandler } from "../../../src/calendar/view/EventDragHandler.js"
-import { defer, downcast } from "@tutao/tutanota-utils"
+import { EventDragHandler, EventDragHandlerCallbacks } from "../../../src/calendar/view/EventDragHandler.js"
+import { DAY_IN_MILLIS, defer, downcast } from "@tutao/tutanota-utils"
 import type { DraggedEvent } from "../../../src/calendar/view/CalendarViewModel.js"
 import { makeEvent } from "./CalendarTestUtils.js"
 import { getAllDayDateUTCFromZone, getStartOfDayWithZone, getStartOfNextDayWithZone } from "../../../src/calendar/date/CalendarUtils.js"
 import { isAllDayEvent } from "../../../src/api/common/utils/CommonCalendarUtils.js"
 import { DateTime } from "luxon"
-import { DAY_IN_MILLIS } from "@tutao/tutanota-utils"
 import { spy } from "@tutao/tutanota-test-utils"
 
 const INIT_MOUSE_POS = {
@@ -30,13 +29,14 @@ o.spec("Event Drag Handler", function () {
 				remove: () => {},
 			},
 		})
-		let callbackMock
-		let handler
+		let callbackMock: EventDragHandlerCallbacks
+		let handler: EventDragHandler
 		o.beforeEach(() => {
 			callbackMock = downcast({
 				onDragStart: spy((draggedEvent: DraggedEvent, diff: number) => {}),
 				onDragUpdate: spy((diff: number) => {}),
 				onDragEnd: spy((diff: number) => Promise.resolve()),
+				onDragCancel: spy(() => {}),
 			})
 			handler = new EventDragHandler(body, callbackMock)
 		})
@@ -55,7 +55,7 @@ o.spec("Event Drag Handler", function () {
 			handler.handleDrag(new Date(2021, 8, 21), DRAG_MOUSE_POS)
 			o(callbackMock.onDragStart.callCount).equals(1)
 			// end drag callback is called with diff set to 0 so no startTime change
-			await handler.endDrag(new Date(2021, 8, 22))
+			await handler.endDrag(new Date(2021, 8, 22), DRAG_MOUSE_POS)
 			o(callbackMock.onDragEnd.callCount).equals(1)
 			o(callbackMock.onDragEnd.args[0]).equals(0)
 			o(handler.isDragging).equals(false)
@@ -69,8 +69,18 @@ o.spec("Event Drag Handler", function () {
 			o(callbackMock.onDragStart.callCount).equals(0)
 			o(handler.isDragging).equals(false)
 			// Drop but didn't move any more
-			await handler.endDrag(new Date(2021, 8, 21))
+			await handler.endDrag(new Date(2021, 8, 21), DRAG_MOUSE_POS)
 			o(callbackMock.onDragEnd.callCount).equals(0)
+			o(handler.isDragging).equals(false)
+		})
+		o("Cancel drag", async function () {
+			const event = makeEvent("event", new Date(2021, 8, 22), new Date(2021, 8, 23))
+			handler.prepareDrag(event, new Date(2021, 8, 22), INIT_MOUSE_POS, true)
+			handler.handleDrag(new Date(2021, 8, 24), DRAG_MOUSE_POS)
+			o(handler.isDragging).equals(true)
+			handler.cancelDrag()
+			o(callbackMock.onDragEnd.callCount).equals(0)
+			o(callbackMock.onDragCancel.callCount).equals(1)
 			o(handler.isDragging).equals(false)
 		})
 		o("A good drag and drop run", async function () {
@@ -92,8 +102,9 @@ o.spec("Event Drag Handler", function () {
 			o(updateTimeToMoveBy).equals(3 * DAY_IN_MILLIS)
 			// drag end
 			const deferredCallbackComplete = defer()
+			// @ts-ignore
 			callbackMock.onDragEnd = spy(() => deferredCallbackComplete.promise)
-			const endDragPromise = handler.endDrag(dragDate)
+			const endDragPromise = handler.endDrag(dragDate, DRAG_MOUSE_POS)
 			o(callbackMock.onDragEnd.callCount).equals(1)
 			const [endTimeToMoveBy] = callbackMock.onDragEnd.args
 			o(endTimeToMoveBy).equals(3 * DAY_IN_MILLIS)
@@ -126,7 +137,7 @@ o.spec("Event Drag Handler", function () {
 			handler.prepareDrag(shortEvent, originalStartDate, INIT_MOUSE_POS, false)
 			handler.handleDrag(newStartDate, DRAG_MOUSE_POS)
 			o(callbackMock.onDragStart.callCount).equals(1)
-			await handler.endDrag(newStartDate)
+			await handler.endDrag(newStartDate, DRAG_MOUSE_POS)
 			const oneDayPlusOneHour = 25 * 60 * 60 * 1000
 			o(callbackMock.onDragEnd.callCount).equals(1)
 			o(callbackMock.onDragEnd.args[0]).equals(oneDayPlusOneHour) //we want the event to start at the exact same time ignoring changing the clocks
@@ -164,7 +175,7 @@ o.spec("Event Drag Handler", function () {
 			handler.prepareDrag(alldayEvent, originalStartDate, INIT_MOUSE_POS, true)
 			handler.handleDrag(newStartDate, DRAG_MOUSE_POS)
 			o(callbackMock.onDragStart.callCount).equals(1)
-			await handler.endDrag(newStartDate)
+			await handler.endDrag(newStartDate, DRAG_MOUSE_POS)
 			const oneDay = 24 * 60 * 60 * 1000
 			o(callbackMock.onDragEnd.callCount).equals(1)
 			o(callbackMock.onDragEnd.args[0]).equals(oneDay) //we want the event to start at the beginning of the day taking changing the clocks into account


### PR DESCRIPTION
Moving the cursor outside of the calendar view cancels the drag event.

Also do not allow dragging all-day events in the mobile view, as this does not work properly with the mobile header.

Fixes #6513