### PR TITLE
Import vCard from Attachment and from Native

### DIFF
--- a/src/contacts/ContactImporter.ts
+++ b/src/contacts/ContactImporter.ts
@@ -101,7 +101,7 @@ function showContactImportDialog(contacts: Contact[], okAction: (dialog: Dialog)
 			),
 			/** variable-size child container that may be scrollable. */
 			m(
-				".dialog-max-height.plr-l.pb.text-break.scroll.nav-bg",
+				".dialog-max-height.plr-l.pb.text-break.nav-bg",
 				m(
 					".plr-l",
 					m(
@@ -110,7 +110,7 @@ function showContactImportDialog(contacts: Contact[], okAction: (dialog: Dialog)
 							".flex.col.rel",
 							{
 								style: {
-									height: px(size.list_row_height * contacts.length),
+									height: "80vh",
 								},
 							},
 							m(List, {


### PR DESCRIPTION
When user receives a vCard as attachment an import option is displayed inside the attachment bubble, allowing the user to preview and import the users contained inside that vCard.

The app handles both vCard mime types, text/vcard and text/x-vcard

close [#6469](https://github.com/tutao/tutanota/issues/6469)