### PR TITLE
[desktop] Fix not closing offline DB before deleting it

### DIFF
--- a/src/desktop/DesktopMain.ts
+++ b/src/desktop/DesktopMain.ts
@@ -172,9 +172,8 @@ async function createComponents(): Promise<Components> {
 			try {
 				await db.openDb(userId, key)
 			} catch (e) {
-				log.warn("failed to open db for", userId, e)
 				if (!retry) throw e
-				log.debug("retrying")
+				log.debug("retrying to create db", userId)
 				await this.delete(userId)
 				return this.create(userId, key, false)
 			}


### PR DESCRIPTION
Previously when the database initialization failed (e.g. due to mismatching key) we would not close it but would try to simply delete it. Windows was disallowing it due to the file lock and the app would get stuck with a database that is not opened nor can be deleted.

Now we make sure to close the database if initialization fails. Additionally, we proceed with closing the database if vacuuming fails during the normal database closing so it doesn't prevent us from closing the database. This is not needed to fix the issue at hand but hopefully improves the reliability

fix #5063