### PR TITLE
Fix PayPal logo size

### DIFF
--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -1682,6 +1682,10 @@ styles.registerStyle("main", () => {
 			"border-top-right-radius": px(size.border_radius),
 			"border-right": `1px solid ${stateBgHover}`,
 		},
+		".payment-logo": {
+			// that's the size of the SVG and it seems to be a good size
+			width: "124px",
+		},
 		// contact
 		".wrapping-row": {
 			display: "flex",

--- a/src/subscription/PaymentMethodInput.ts
+++ b/src/subscription/PaymentMethodInput.ts
@@ -237,7 +237,7 @@ class PaypalInput {
 				},
 				m(BaseButton, {
 					label: "PayPal",
-					icon: m(".payment-logo", m.trust(PayPalLogo)),
+					icon: m(".payment-logo.flex", m.trust(PayPalLogo)),
 					class: "border border-radius bg-white button-height plr",
 					onclick: () => {
 						this.__paymentPaypalTest?.getStage(1).complete()


### PR DESCRIPTION
After converting PayPal icon to svg we failed to add explicit size for it so it had no size.

fix #6559