### PR TITLE
Fallback to blue if an invalid color is passed

### DIFF
--- a/src/calendar/gui/CalendarGuiUtils.ts
+++ b/src/calendar/gui/CalendarGuiUtils.ts
@@ -61,7 +61,7 @@ import { CalendarEventTimes, cleanMailAddress, isAllDayEvent } from "../../api/c
 import { CalendarEvent, UserSettingsGroupRoot } from "../../api/entities/tutanota/TypeRefs.js"
 import { ProgrammingError } from "../../api/common/error/ProgrammingError.js"
 import { size } from "../../gui/size.js"
-import { isColorLight } from "../../gui/base/Color.js"
+import { isColorLight, isValidColorCode } from "../../gui/base/Color.js"
 import { GroupColors } from "../view/CalendarView.js"
 import { CalendarInfo } from "../model/CalendarModel.js"
 import { User } from "../../api/entities/sys/TypeRefs.js"
@@ -729,8 +729,11 @@ export const iconForAttendeeStatus: Record<CalendarAttendeeStatus, AllIcons> = O
 	[CalendarAttendeeStatus.ADDED]: Icons.CircleEmpty,
 })
 export const getGroupColors = memoized((userSettingsGroupRoot: UserSettingsGroupRoot) => {
-	return userSettingsGroupRoot.groupSettings.reduce((acc, gc) => {
-		acc.set(gc.group, gc.color)
+	return userSettingsGroupRoot.groupSettings.reduce((acc, { group, color }) => {
+		if (!isValidColorCode(color)) {
+			color = defaultCalendarColor
+		}
+		acc.set(group, color)
 		return acc
 	}, new Map())
 })

--- a/src/gui/base/Color.ts
+++ b/src/gui/base/Color.ts
@@ -5,6 +5,16 @@ assertMainOrNodeBoot()
 // 3 or 6 digit hex color codes
 export const VALID_HEX_CODE_FORMAT: RegExp = new RegExp("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
 
+/**
+ * Returns true if the color code is a valid hex color code.
+ *
+ * The format can be #RGB or #RRGGBB, and it is not case-sensitive, but the digits must be hexadecimal,
+ * with 1 or 2 digits per color channel, and the code must be prefixed with an octothorpe character (`#`).
+ */
+export function isValidColorCode(colorCode: string): boolean {
+	return VALID_HEX_CODE_FORMAT.test(colorCode)
+}
+
 export function isColorLight(c: string): boolean {
 	const { r, g, b } = hexToRgb(c)
 	// Counting the perceptive luminance
@@ -18,7 +28,7 @@ export function hexToRgb(colorCode: string): {
 	g: number
 	b: number
 } {
-	assert(VALID_HEX_CODE_FORMAT.test(colorCode), "Invalid color code: " + colorCode)
+	assert(isValidColorCode(colorCode), "Invalid color code: " + colorCode)
 	let hexWithoutHash = colorCode.slice(1)
 
 	if (hexWithoutHash.length === 3) {

--- a/test/tests/gui/ColorTest.ts
+++ b/test/tests/gui/ColorTest.ts
@@ -1,5 +1,5 @@
 import o from "@tutao/otest"
-import { hexToRgb, isColorLight, rgbToHex } from "../../../src/gui/base/Color.js"
+import { hexToRgb, isColorLight, isValidColorCode, rgbToHex } from "../../../src/gui/base/Color.js"
 o.spec("color", function () {
 	o("hexToRGB 6digit", function () {
 		o(hexToRgb("#b73a9a")).deepEquals({
@@ -14,6 +14,16 @@ o.spec("color", function () {
 			g: 187,
 			b: 204,
 		})
+	})
+	o("isValidColorCode", function () {
+		o(isValidColorCode("#abc")).equals(true)
+		o(isValidColorCode("#ABC")).equals(true)
+		o(isValidColorCode("#aBc")).equals(true)
+		o(isValidColorCode("#aabbcc")).equals(true)
+		o(isValidColorCode("#AABBCC")).equals(true)
+		o(isValidColorCode("#aAbBcC")).equals(true)
+		o(isValidColorCode("AABBCC")).equals(false)
+		o(isValidColorCode("#ABCDEG")).equals(false)
 	})
 	o("rgbToHex", function () {
 		o(


### PR DESCRIPTION
It doesn't make sense to error here and make the entire app unusable, so we just fallback to a blue color.

Fixes #6515