### PR TITLE
Don't show incorrect mail address info on legacy plans

### DIFF
--- a/src/misc/TranslationKey.ts
+++ b/src/misc/TranslationKey.ts
@@ -1625,3 +1625,4 @@ export type TranslationKeyType =
 	| "yourMessage_label"
 	| "you_label"
 	| "emptyString_msg"
+	| "mailAddressInfoLegacy_msg"

--- a/src/settings/mailaddress/AddAliasDialog.ts
+++ b/src/settings/mailaddress/AddAliasDialog.ts
@@ -1,6 +1,6 @@
 import { lang, TranslationKey } from "../../misc/LanguageViewModel.js"
 import { Dialog } from "../../gui/base/Dialog.js"
-import { PlanType, TUTANOTA_MAIL_ADDRESS_DOMAINS } from "../../api/common/TutanotaConstants.js"
+import { NewPaidPlans, TUTANOTA_MAIL_ADDRESS_DOMAINS } from "../../api/common/TutanotaConstants.js"
 import m from "mithril"
 import { SelectMailAddressForm } from "../SelectMailAddressForm.js"
 import { ExpanderPanel } from "../../gui/base/Expander.js"
@@ -59,13 +59,7 @@ export function showAddAliasDialog(model: MailAddressTableModel, isNewPaidPlan: 
 									Dialog.confirm(() => `${lang.get("paidEmailDomainLegacy_msg")}\n${lang.get("changePaidPlan_msg")}`).then(
 										async (confirmed) => {
 											if (confirmed) {
-												isNewPaidPlan = await showPlanUpgradeRequiredDialog([
-													PlanType.Revolutionary,
-													PlanType.Legend,
-													PlanType.Essential,
-													PlanType.Advanced,
-													PlanType.Unlimited,
-												])
+												isNewPaidPlan = await showPlanUpgradeRequiredDialog(NewPaidPlans)
 											}
 										},
 									)

--- a/src/settings/mailaddress/MailAddressTable.ts
+++ b/src/settings/mailaddress/MailAddressTable.ts
@@ -17,7 +17,6 @@ import { AddressInfo, AddressStatus, MailAddressTableModel } from "./MailAddress
 import { showAddAliasDialog } from "./AddAliasDialog.js"
 import { locator } from "../../api/main/MainLocator.js"
 import { UpgradeRequiredError } from "../../api/main/UpgradeRequiredError.js"
-import { PlanType } from "../../api/common/TutanotaConstants.js"
 
 assertMainOrNode()
 
@@ -78,7 +77,7 @@ export class MailAddressTable implements Component<MailAddressTableAttrs> {
 								"{totalAmount}": model.aliasCount.totalAliases,
 							}),
 						),
-						m(".small.mt-s", lang.get("mailAddressInfo_msg")),
+						m(".small.mt-s", lang.get(model.aliasLimitIncludesCustomDomains() ? "mailAddressInfoLegacy_msg" : "mailAddressInfo_msg")),
 				  ]
 				: null,
 		]

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1643,6 +1643,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "DEINE ORDNER",
 		"yourMessage_label": "Deine Nachricht",
-		"you_label": "Du"
+		"you_label": "Du",
+		"mailAddressInfoLegacy_msg": "Deaktivierte E-Mail-Adressen können einer anderen Mailbox innerhalb deines Kontos zugewiesen werden."
 	}
 }

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -1643,6 +1643,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "Ihre ORDNER",
 		"yourMessage_label": "Ihre Nachricht",
-		"you_label": "Sie"
+		"you_label": "Sie",
+		"mailAddressInfoLegacy_msg": "Deaktivierte E-Mail-Adressen können einer anderen Mailbox innerhalb Ihres Kontos zugewiesen werden."
 	}
 }

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1639,6 +1639,7 @@ export default {
 		"yourCalendars_label": "Your calendars",
 		"yourFolders_action": "YOUR FOLDERS",
 		"yourMessage_label": "Your message",
-		"you_label": "You"
+		"you_label": "You",
+		"mailAddressInfoLegacy_msg": "Disabled email addresses can be reassigned to another user or mailbox within your account."
 	}
 }


### PR DESCRIPTION
It is not true that legacy plans can have unlimited custom domains. Make it not display anything here to prevent confusion.

Fixes #6540 