### PR TITLE
Make the email signature preview not disabled if Default is picked

### DIFF
--- a/src/settings/EditSignatureDialog.ts
+++ b/src/settings/EditSignatureDialog.ts
@@ -52,7 +52,8 @@ export function show(props: TutanotaProperties) {
 
 							selectedType = type
 							editor.setValue(getSignature(type, defaultSignature, currentCustomSignature))
-							editor.setEnabled(type === EmailSignatureType.EMAIL_SIGNATURE_TYPE_CUSTOM)
+							editor.setEnabled(type !== EmailSignatureType.EMAIL_SIGNATURE_TYPE_NONE)
+							editor.setReadOnly(type !== EmailSignatureType.EMAIL_SIGNATURE_TYPE_CUSTOM)
 						},
 					}),
 					m(editor),


### PR DESCRIPTION
It should still be read-only, but it shouldn't be disabled.

Fixes #6619