### PR TITLE
Reset selection in contact list view when deleting selected contents

### DIFF
--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -800,7 +800,7 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 	}
 
 	private deleteSelectedContacts(): Promise<void> {
-		return deleteContacts(this.getSelectedContacts())
+		return deleteContacts(this.getSelectedContacts(), () => this.contactViewModel.listModel.selectNone())
 	}
 
 	getViewSlider(): ViewSlider | null {


### PR DESCRIPTION
Call selectNone on the list model to clear the selection after deleting a selection of contacts.

Fixes #6623