### PR TITLE
Fix wrong label on new event button tooltip

### DIFF
--- a/src/calendar/view/CalendarMobileHeader.ts
+++ b/src/calendar/view/CalendarMobileHeader.ts
@@ -64,7 +64,7 @@ export class CalendarMobileHeader implements Component<CalendarMobileHeaderAttrs
 				this.renderViewSelector(attrs),
 				m(IconButton, {
 					icon: Icons.Add,
-					title: "createEvent_label",
+					title: "newEvent_action",
 					click: attrs.onCreateEvent,
 				}),
 			],


### PR DESCRIPTION
This should be newEvent_action; createEvent_label is used as a placeholder for when the event name is empty in the edit event dialog.

Fixes #6626