### PR TITLE
Fix client-side captcha verification; fix SignupFormTest

### DIFF
--- a/src/subscription/Captcha.ts
+++ b/src/subscription/Captcha.ts
@@ -17,12 +17,18 @@ import { uint8ArrayToBase64 } from "@tutao/tutanota-utils"
  * @returns {string} HH:MM if parsed, null otherwise
  */
 export function parseCaptchaInput(captchaInput: string): string | null {
-	if (captchaInput.match(/^[0-2]?[0-9]:[0-5]?[05]$/)) {
+	if (captchaInput.match(/^[0-2]?[0-9]:[0-5]?[0-9]$/)) {
 		let [h, m] = captchaInput
 			.trim()
 			.split(":")
 			.map((t) => Number(t))
-		return [h % 12, m % 60].map((a) => String(a).padStart(2, "0")).join(":")
+
+		// regex correctly matches 0-59 minutes, but matches hours 0-29, so we need to make sure hours is 0-24
+		if (h > 24) {
+			return null
+		}
+
+		return [h % 12, m].map((a) => String(a).padStart(2, "0")).join(":")
 	} else {
 		return null
 	}
@@ -91,20 +97,28 @@ function showCaptchaDialog(challenge: Uint8Array, token: string): Promise<string
 		const okAction = () => {
 			let parsedInput = parseCaptchaInput(captchaInput)
 
-			if (parsedInput) {
-				dialog.close()
-
-				locator.serviceExecutor
-					.post(RegistrationCaptchaService, createRegistrationCaptchaServiceData({ token, response: parsedInput }))
-					.then(() => {
-						resolve(token)
-					})
-					.catch((e) => {
-						reject(e)
-					})
-			} else {
+			// User entered an incorrectly formatted time
+			if (parsedInput == null) {
 				Dialog.message("captchaEnter_msg")
+				return
 			}
+
+			// The user entered a correctly formatted time, but not one that our captcha will ever give out (i.e. not *0 or *5)
+			const minuteOnesPlace = parsedInput[parsedInput.length - 1]
+			if (minuteOnesPlace !== "0" && minuteOnesPlace !== "5") {
+				Dialog.message("createAccountInvalidCaptcha_msg")
+				return
+			}
+
+			dialog.close()
+			locator.serviceExecutor
+				.post(RegistrationCaptchaService, createRegistrationCaptchaServiceData({ token, response: parsedInput }))
+				.then(() => {
+					resolve(token)
+				})
+				.catch((e) => {
+					reject(e)
+				})
 		}
 
 		let actionBarAttrs: DialogHeaderBarAttrs = {

--- a/test/tests/Suite.ts
+++ b/test/tests/Suite.ts
@@ -121,6 +121,7 @@ import "./api/worker/pdf/DeflaterTest.js"
 import "./api/worker/pdf/PdfWriterTest.js"
 import "./api/worker/pdf/PdfObjectTest.js"
 import "./api/worker/invoicegen/PdfInvoiceGeneratorTest.js"
+import "./subscription/SignupFormTest.js"
 import "./api/worker/facades/ContactFacadeTest.js"
 
 import * as td from "testdouble"

--- a/test/tests/subscription/SignupFormTest.ts
+++ b/test/tests/subscription/SignupFormTest.ts
@@ -1,22 +1,31 @@
-// Note: This file is not included yet because importing SingupForm breaks test and also because test does not work
 import o from "@tutao/otest"
 import { parseCaptchaInput } from "../../../src/subscription/Captcha.js"
+
 o.spec("CaptchaInputParse", function () {
-	o("Hour", function () {
+	o("invalid input", function () {
 		o(parseCaptchaInput("nonsense")).equals(null)
 		o(parseCaptchaInput("2:")).equals(null)
 		o(parseCaptchaInput(":::")).equals(null)
 		o(parseCaptchaInput("")).equals(null)
 		o(parseCaptchaInput("25:01")).equals(null)
 		o(parseCaptchaInput("08:84")).equals(null)
+		o(parseCaptchaInput("08:60")).equals(null)
+	})
+	o("single digit hour or minute", function () {
 		o(parseCaptchaInput("1:1")).equals("01:01")
 		o(parseCaptchaInput("13:1")).equals("01:01")
-		o(parseCaptchaInput("13:01")).equals("01:01")
 		o(parseCaptchaInput("01:1")).equals("01:01")
 		o(parseCaptchaInput("1:01")).equals("01:01")
+		o(parseCaptchaInput("2:00")).equals("02:00")
+	})
+	o("hour 0", function () {
 		o(parseCaptchaInput("24:00")).equals("00:00")
 		o(parseCaptchaInput("12:00")).equals("00:00")
+		o(parseCaptchaInput("00:00")).equals("00:00")
 		o(parseCaptchaInput("24:14")).equals("00:14")
-		o(parseCaptchaInput("2:00")).equals("02:00")
+	})
+	o("24 hour and 12 hour match", function () {
+		o(parseCaptchaInput("13:01")).equals("01:01")
+		o(parseCaptchaInput("01:01")).equals("01:01")
 	})
 })


### PR DESCRIPTION
Fix Captcha matching hours 25-29 and allows it to match times that will never be correct (but can be checked locally).

Add missing SignupFormTest to the test suite.

Fixes #6316