### PR TITLE
Events are removed immediately when deleting single or changing rules

### DIFF
--- a/src/calendar/date/CalendarUtils.ts
+++ b/src/calendar/date/CalendarUtils.ts
@@ -465,8 +465,6 @@ export function addDaysForRecurringEvent(
 		if (isExcludedDate(startTime, exclusions)) {
 			const eventsOnExcludedDay = daysToEvents.get(getStartOfDayWithZone(startTime, timeZone).getTime())
 			if (!eventsOnExcludedDay) continue
-			const eventOnThisDay = { _id: event._id, startTime }
-			findAndRemove(eventsOnExcludedDay, (e) => isSameEventInstance(e, eventOnThisDay))
 		} else {
 			const eventClone = clone(event)
 			if (allDay) {

--- a/test/tests/calendar/CalendarUtilsTest.ts
+++ b/test/tests/calendar/CalendarUtilsTest.ts
@@ -928,17 +928,6 @@ o.spec("calendar utils tests", function () {
 		o.beforeEach(function () {
 			eventsForDays = new Map()
 		})
-		o("excluding an instance of a recurring event correctly removes it from the map when addDays is called again", function () {
-			const event = createEvent(getDateInZone("2023-07-20T12:00"), getDateInZone("2023-07-20T13:00"))
-			event.repeatRule = createRepeatRuleWithValues(RepeatPeriod.DAILY, 1, zone)
-			event.repeatRule.endType = EndType.Count
-			event.repeatRule.endValue = "2"
-			addDaysForRecurringEvent(eventsForDays, event, getMonthRange(getDateInZone("2023-07-01"), zone), zone)
-			o(countDaysWithEvents(eventsForDays)).equals(2)
-			event.repeatRule.excludedDates = [createTestEntity(DateWrapperTypeRef, { date: getDateInZone("2023-07-21T12:00") })]
-			addDaysForRecurringEvent(eventsForDays, event, getMonthRange(getDateInZone("2023-07-01"), zone), zone)
-			o(countDaysWithEvents(eventsForDays)).equals(1)
-		})
 		o("recurring event - short with time ", function () {
 			// event that goes on for 2 hours and repeats weekly
 			const event = createEvent(getDateInZone("2019-05-02T10:00"), getDateInZone("2019-05-02T12:00"))


### PR DESCRIPTION
Took out some code that was no longer useful. Long events are now always

taken out when updated, the new event will automatically be filled in.

close #6491
close #6444