### PR TITLE
Fix SearchBar returning no results even with not enabled index

### DIFF
--- a/src/search/SearchBar.ts
+++ b/src/search/SearchBar.ts
@@ -392,6 +392,11 @@ export class SearchBar implements Component<SearchBarAttrs> {
 				})
 				.finally(() => (this.confirmDialogShown = false))
 		} else {
+			// Skip the search if the user is trying to bypass the search dialog
+			if (!locator.search.indexState().mailIndexEnabled && isSameTypeRef(restriction.type, MailTypeRef)) {
+				return
+			}
+
 			if (!locator.search.isNewSearch(query, restriction) && oldQuery === query) {
 				const result = locator.search.result()
 


### PR DESCRIPTION
The users were able to trigger an empty search result even without accepting to enable the search index. Now, even if the user tries to bypass the dialog, the SearchBar will not return any result

fix #2689