### PR TITLE
Fix the all day events in the calendar being misaligned on desktop

### DIFF
--- a/src/calendar/view/MultiDayCalendarView.ts
+++ b/src/calendar/view/MultiDayCalendarView.ts
@@ -357,7 +357,8 @@ export class MultiDayCalendarView implements Component<MultiDayCalendarViewAttrs
 
 	private renderHeaderDesktop(attrs: MultiDayCalendarViewAttrs, thisPageEvents: EventsOnDays, mainPageEvents: EventsOnDays): Children {
 		const { daysInPeriod, onDateSelected, onEventClicked, groupColors, temporaryEvents } = attrs
-		return m(".calendar-long-events-header.flex-fixed.content-bg.pt-s", [
+		// `scrollbar-gutter-stable-or-fallback` is needed because the scroll bar brings the calendar body out of line with the header
+		return m(".calendar-long-events-header.flex-fixed.content-bg.pt-s.scrollbar-gutter-stable-or-fallback", [
 			m(".calendar-hour-margin", [this.renderDayNamesRow(thisPageEvents.days, onDateSelected)]),
 			m(".content-bg", [
 				m(


### PR DESCRIPTION
The ideal solution in my eyes is to rewrite the calendar header so that the header and body for the day are in one column flex. Using flex is better than constantly calculating the sizes of elements ourselves both in code simplicity and performance.

Until then, this quick workaround seems to do the trick.

Closes #6521.