### PR TITLE
Add keyboard controls to the date picker

### DIFF
--- a/src/calendar/gui/eventeditor-view/RepeatRuleEditor.ts
+++ b/src/calendar/gui/eventeditor-view/RepeatRuleEditor.ts
@@ -26,7 +26,13 @@ export class RepeatRuleEditor implements Component<RepeatRuleEditorAttrs> {
 			renderTwoColumnsIfFits(
 				[
 					m(".flex-grow.pr-s", this.renderRepeatPeriod(attrs)),
-					m(".flex-grow.pl-s" + (model.repeatPeriod != null ? "" : ".hidden"), this.renderRepeatInterval(attrs)),
+					m(
+						".flex-grow.pl-s" + (model.repeatPeriod != null ? "" : ".hidden"),
+						this.renderRepeatInterval({
+							...attrs,
+							disabled: model.repeatPeriod == null ? true : attrs.disabled,
+						}),
+					),
 				],
 				this.renderEndCondition(attrs),
 			),

--- a/src/calendar/gui/pickers/DatePicker.ts
+++ b/src/calendar/gui/pickers/DatePicker.ts
@@ -305,7 +305,7 @@ export class VisualDatePicker implements Component<VisualDatePickerAttrs> {
 	private renderDay({ date, day, isPaddingDay }: CalendarDay, index: number, attrs: VisualDatePickerAttrs): Children {
 		const isSelectedDay = isSameDayOfDate(date, attrs.selectedDate)
 		const size = this.getElementWidth(attrs)
-		const selector = isSelectedDay ? ".circle.accent-bg" : ""
+		const selector = isSelectedDay && !isPaddingDay ? ".circle.accent-bg" : ""
 		return m(
 			".rel.flex.items-center.justify-center",
 			{

--- a/src/calendar/gui/pickers/DatePicker.ts
+++ b/src/calendar/gui/pickers/DatePicker.ts
@@ -1,5 +1,4 @@
 import m, { Children, Component, Vnode } from "mithril"
-import { Icons } from "../../../gui/base/icons/Icons.js"
 import { client } from "../../../misc/ClientDetector.js"
 import { formatDate, formatDateWithWeekdayAndYear, formatMonthWithFullYear } from "../../../misc/Formatter.js"
 import type { TranslationText } from "../../../misc/LanguageViewModel.js"
@@ -11,12 +10,13 @@ import { getStartOfDay, isSameDayOfDate } from "@tutao/tutanota-utils"
 import { DateTime } from "luxon"
 import { getAllDayDateLocal } from "../../../api/common/utils/CommonCalendarUtils.js"
 import { TextField } from "../../../gui/base/TextField.js"
-import { Keys } from "../../../api/common/TutanotaConstants.js"
 import type { CalendarDay } from "../../date/CalendarUtils.js"
 import { parseDate } from "../../../misc/DateParser.js"
-import { isKeyPressed } from "../../../misc/KeyManager.js"
 import renderSwitchMonthArrowIcon from "../../../gui/base/buttons/ArrowButton.js"
 import { getCalendarMonth } from "../CalendarGuiUtils.js"
+import { isKeyPressed, keyboardEventToKeyPress, keyHandler, KeyPress, useKeyHandler } from "../../../misc/KeyManager.js"
+import { Keys, TabIndex } from "../../../api/common/TutanotaConstants.js"
+import { AriaPopupType } from "../../../gui/AriaUtils.js"
 
 export interface DatePickerAttrs {
 	date: Date
@@ -43,7 +43,7 @@ export class DatePicker implements Component<DatePickerAttrs> {
 	private inputText: string = ""
 	private showingDropdown: boolean = false
 	private domInput: HTMLElement | null = null
-	private documentClickListener: ((e: MouseEvent) => unknown) | null = null
+	private documentInteractionListener: ((e: MouseEvent) => unknown) | null = null
 	private textFieldHasFocus: boolean = false
 
 	constructor({ attrs }: Vnode<DatePickerAttrs>) {
@@ -89,26 +89,41 @@ export class DatePicker implements Component<DatePickerAttrs> {
 				label,
 				helpLabel: () => this.renderHelpLabel(date, nullSelectionText ?? null),
 				disabled,
+				hasPopup: AriaPopupType.Dialog,
 				oninput: (text) => this.handleInput(text, onDateSelected),
-				onfocus: () => {
-					this.showingDropdown = true
+				onfocus: (_, input) => {
+					if (!disabled) {
+						this.showingDropdown = true
+					}
 					this.textFieldHasFocus = true
+				},
+				onDomInputCreated: (input) => {
+					if (this.domInput == null) {
+						this.domInput = input
+					}
 				},
 				onblur: () => {
 					this.textFieldHasFocus = false
 				},
-				oncreate: (vnode) => {
-					this.domInput = vnode.dom as HTMLElement
-				},
 				keyHandler: (key) => {
-					if (isKeyPressed(key.key, Keys.TAB)) {
-						this.showingDropdown = false
+					if (isKeyPressed(key.key, Keys.DOWN)) {
+						if (!disabled && !key.shift && !key.ctrl && !key.meta) {
+							this.showingDropdown = true
+						}
 					}
-
-					return true
+					return this.handleEscapePress(key)
 				},
 			}),
 		)
+	}
+
+	private handleEscapePress(key: KeyPress) {
+		if (isKeyPressed(key.key, Keys.ESC) && this.showingDropdown) {
+			this.domInput?.focus()
+			this.showingDropdown = false
+			return false
+		}
+		return true
 	}
 
 	private renderHelpLabel(date: Date | null, nullSelectionText: TranslationText | null): Children {
@@ -121,15 +136,16 @@ export class DatePicker implements Component<DatePickerAttrs> {
 		}
 	}
 
-	private renderDropdown({ date, onDateSelected, startOfTheWeekOffset, rightAlignDropdown }: DatePickerAttrs): Children {
+	private renderDropdown({ date, onDateSelected, startOfTheWeekOffset, rightAlignDropdown, label }: DatePickerAttrs): Children {
 		return m(
 			".fixed.content-bg.z3.menu-shadow.plr.pb-s",
 			{
+				"aria-modal": "true",
+				"aria-label": lang.getMaybeLazy(label),
 				style: {
 					width: "280px",
 					right: rightAlignDropdown ? "0" : null,
 				},
-				onblur: () => (this.showingDropdown = false),
 				oncreate: (vnode) => {
 					const listener = (e: MouseEvent) => {
 						if (!vnode.dom.contains(e.target as HTMLElement)) {
@@ -138,12 +154,14 @@ export class DatePicker implements Component<DatePickerAttrs> {
 						}
 					}
 
-					this.documentClickListener = listener
+					this.documentInteractionListener = listener
 					document.addEventListener("click", listener, true)
+					document.addEventListener("focus", listener, true)
 				},
 				onremove: (vnode) => {
-					if (this.documentClickListener) {
-						document.removeEventListener("click", this.documentClickListener, true)
+					if (this.documentInteractionListener) {
+						document.removeEventListener("click", this.documentInteractionListener, true)
+						document.removeEventListener("focus", this.documentInteractionListener, true)
 					}
 				},
 			},
@@ -153,10 +171,12 @@ export class DatePicker implements Component<DatePickerAttrs> {
 					this.handleSelectedDate(newDate, onDateSelected)
 
 					if (dayClick) {
-						// Do not close dropdown on changing a month
+						// Do not close the dropdown when changing the month
+						this.domInput?.focus()
 						this.showingDropdown = false
 					}
 				},
+				keyHandler: (key: KeyPress) => this.handleEscapePress(key),
 				wide: false,
 				startOfTheWeekOffset: startOfTheWeekOffset,
 			}),
@@ -210,6 +230,7 @@ export class DatePicker implements Component<DatePickerAttrs> {
 type VisualDatePickerAttrs = {
 	selectedDate: Date | null
 	onDateSelected?: (date: Date, dayClick: boolean) => unknown
+	keyHandler?: keyHandler
 	wide: boolean
 	startOfTheWeekOffset: number
 }
@@ -234,20 +255,26 @@ export class VisualDatePicker implements Component<VisualDatePickerAttrs> {
 
 		let date = new Date(this.displayingDate)
 		let { weeks, weekdays } = getCalendarMonth(this.displayingDate, vnode.attrs.startOfTheWeekOffset, true)
-		return m(".flex.flex-column", [
-			this.renderPickerHeader(vnode, date),
-			m(".flex.flex-space-between", this.renderWeekDays(vnode.attrs.wide, weekdays)),
-			m(
-				".flex.flex-column.flex-space-around",
-				{
-					style: {
-						fontSize: px(14),
-						lineHeight: px(this.getElementWidth(vnode.attrs)),
+		return m(
+			".flex.flex-column",
+			{
+				onkeydown: (event: KeyboardEvent) => useKeyHandler(event, vnode.attrs.keyHandler),
+			},
+			[
+				this.renderPickerHeader(vnode, date),
+				m(".flex.flex-space-between", this.renderWeekDays(vnode.attrs.wide, weekdays)),
+				m(
+					".flex.flex-column.flex-space-around",
+					{
+						style: {
+							fontSize: px(14),
+							lineHeight: px(this.getElementWidth(vnode.attrs)),
+						},
 					},
-				},
-				weeks.map((w) => this.renderWeek(w, vnode.attrs)),
-			),
-		])
+					weeks.map((w) => this.renderWeek(w, vnode.attrs)),
+				),
+			],
+		)
 	}
 
 	private renderPickerHeader(vnode: Vnode<VisualDatePickerAttrs>, date: Date): Children {
@@ -275,22 +302,126 @@ export class VisualDatePicker implements Component<VisualDatePickerAttrs> {
 		this.displayingDate.setMonth(this.displayingDate.getMonth() + 1)
 	}
 
-	private renderDay({ date, day, isPaddingDay }: CalendarDay, attrs: VisualDatePickerAttrs): Children {
+	private renderDay({ date, day, isPaddingDay }: CalendarDay, index: number, attrs: VisualDatePickerAttrs): Children {
 		const isSelectedDay = isSameDayOfDate(date, attrs.selectedDate)
 		const size = this.getElementWidth(attrs)
 		const selector = isSelectedDay ? ".circle.accent-bg" : ""
 		return m(
-			".rel.click.flex.items-center.justify-center",
+			".rel.flex.items-center.justify-center",
 			{
 				style: {
 					height: px(size),
 					width: px(size),
 				},
+				class: isPaddingDay ? undefined : "click",
 				"aria-hidden": `${isPaddingDay}`,
 				"aria-label": date.toLocaleDateString(),
 				"aria-selected": `${isSelectedDay}`,
 				role: "option",
+				tabindex: isSelectedDay ? TabIndex.Default : TabIndex.Programmatic,
 				onclick: isPaddingDay ? undefined : () => attrs.onDateSelected?.(date, true),
+				onkeydown: (event: KeyboardEvent) => {
+					const key = keyboardEventToKeyPress(event)
+					const target = event.target as HTMLInputElement
+
+					if (isKeyPressed(key.key, Keys.LEFT)) {
+						let targetDay
+
+						if (target.previousElementSibling == null) {
+							// If the user presses left on the first day of the week, go to the last day of the previous week
+							targetDay = target.parentElement?.previousElementSibling?.children.item(6)
+						} else {
+							targetDay = target.previousElementSibling
+						}
+
+						if (!this.focusDayIfPossible(target, targetDay)) {
+							this.onPrevMonthSelected()
+							m.redraw.sync()
+							this.focusLastDay(target)
+						}
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.RIGHT)) {
+						let targetDay
+
+						if (target.nextElementSibling == null) {
+							targetDay = target.parentElement?.nextElementSibling?.children.item(0)
+						} else {
+							targetDay = target.nextElementSibling
+						}
+
+						if (!this.focusDayIfPossible(target, targetDay)) {
+							this.onNextMonthSelected()
+							m.redraw.sync()
+							this.focusFirstDay(target)
+						}
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.UP)) {
+						const dayAbove = target.parentElement?.previousElementSibling?.children.item(index)
+						if (!this.focusDayIfPossible(target, dayAbove)) {
+							// If the user presses up on the first week, go to the same day of the previous week
+							this.onPrevMonthSelected()
+							m.redraw.sync()
+							this.focusLastWeekDay(target, index)
+						}
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.DOWN)) {
+						const dayBelow = target.parentElement?.nextElementSibling?.children.item(index)
+						if (!this.focusDayIfPossible(target, dayBelow)) {
+							this.onNextMonthSelected()
+							m.redraw.sync()
+							this.focusFirstWeekDay(target, index)
+						}
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.HOME) && !isPaddingDay) {
+						this.focusFirstDay(target)
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.END) && !isPaddingDay) {
+						this.focusLastDay(target)
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.PAGE_UP) && !isPaddingDay) {
+						if (key.shift) {
+							this.displayingDate.setFullYear(this.displayingDate.getFullYear() - 1)
+						} else {
+							this.onPrevMonthSelected()
+						}
+						m.redraw.sync()
+						this.focusFirstDay(target)
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.PAGE_DOWN) && !isPaddingDay) {
+						if (key.shift) {
+							this.displayingDate.setFullYear(this.displayingDate.getFullYear() + 1)
+						} else {
+							this.onNextMonthSelected()
+						}
+						m.redraw.sync()
+						this.focusFirstDay(target)
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.RETURN) && !isPaddingDay) {
+						attrs.onDateSelected?.(date, true)
+						event.preventDefault()
+					}
+
+					if (isKeyPressed(key.key, Keys.SPACE) && !isPaddingDay) {
+						attrs.onDateSelected?.(date, false)
+						event.preventDefault()
+					}
+				},
 			},
 			[
 				m(".abs.z1" + selector, {
@@ -304,6 +435,93 @@ export class VisualDatePicker implements Component<VisualDatePickerAttrs> {
 		)
 	}
 
+	// Focuses on a day if it is not a padding day & returns whether it focused on the day
+	private focusDayIfPossible(previousElement: HTMLElement, dayElement: globalThis.Element | null | undefined): boolean {
+		const element = dayElement as HTMLInputElement | null | undefined
+		if (element != null && element.getAttribute("aria-hidden") === "false") {
+			element.focus()
+			// Put the currently focused element into the tab index so the next tab press follows the tab index
+			element.tabIndex = 0
+			previousElement.tabIndex = -1
+			return true
+		}
+		return false
+	}
+
+	// Focus the last day of the month in the calendar
+	private focusLastDay(target: HTMLInputElement) {
+		const weeks = target.parentElement?.parentElement?.children
+		if (weeks != null) {
+			for (let i = weeks.length - 1; i > 0; i--) {
+				const week = weeks.item(i)?.children
+				let isDateFound = false
+				if (week != null) {
+					for (let j = week.length - 1; j > 0; j--) {
+						const child = week.item(j)
+						if (this.focusDayIfPossible(target, child)) {
+							isDateFound = true
+							break
+						}
+					}
+				}
+				if (isDateFound) break
+			}
+		}
+	}
+
+	// Focus a day in the final week of the calendar
+	private focusLastWeekDay(target: HTMLInputElement, weekDay: number) {
+		const weeks = target.parentElement?.parentElement?.children
+		if (weeks != null) {
+			for (let i = weeks.length - 1; i > 0; i--) {
+				const week = weeks.item(i)?.children
+				if (week != null) {
+					const child = week.item(weekDay)
+					if (this.focusDayIfPossible(target, child)) {
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Focus the first day of the month in the calendar
+	private focusFirstDay(target: HTMLInputElement) {
+		const weeks = target.parentElement?.parentElement?.children
+		if (weeks != null) {
+			for (let i = 0; i < weeks.length - 1; i++) {
+				const week = weeks.item(i)?.children
+				let isDateFound = false
+				if (week != null) {
+					for (let j = 0; j < week.length - 1; j++) {
+						const child = week.item(j)
+						if (this.focusDayIfPossible(target, child)) {
+							isDateFound = true
+							break
+						}
+					}
+				}
+				if (isDateFound) break
+			}
+		}
+	}
+
+	// Focus a day in the first week of the calendar
+	private focusFirstWeekDay(target: HTMLInputElement, weekDay: number) {
+		const weeks = target.parentElement?.parentElement?.children
+		if (weeks != null) {
+			for (let i = 0; i < weeks.length - 1; i++) {
+				const week = weeks.item(i)?.children
+				if (week != null) {
+					const child = week.item(weekDay)
+					if (this.focusDayIfPossible(target, child)) {
+						break
+					}
+				}
+			}
+		}
+	}
+
 	private getElementWidth(attrs: VisualDatePickerAttrs): number {
 		return attrs.wide ? 40 : 24
 	}
@@ -311,7 +529,7 @@ export class VisualDatePicker implements Component<VisualDatePickerAttrs> {
 	private renderWeek(week: ReadonlyArray<CalendarDay>, attrs: VisualDatePickerAttrs): Children {
 		return m(
 			".flex.flex-space-between",
-			week.map((d) => this.renderDay(d, attrs)),
+			week.map((d, i) => this.renderDay(d, i, attrs)),
 		)
 	}
 

--- a/src/calendar/gui/pickers/TimePicker.ts
+++ b/src/calendar/gui/pickers/TimePicker.ts
@@ -15,16 +15,16 @@ export type TimePickerAttrs = {
 }
 
 export class TimePicker implements Component<TimePickerAttrs> {
-	private _values: ReadonlyArray<string>
-	private _focused: boolean
-	private _selectedIndex!: number
-	private _oldValue: string
-	private _value: string
-	private amPm: boolean
+	private values: ReadonlyArray<string>
+	private focused: boolean
+	private selectedIndex!: number
+	private oldValue: string
+	private value: string
+	private readonly amPm: boolean
 
 	constructor({ attrs }: Vnode<TimePickerAttrs>) {
-		this._focused = false
-		this._value = ""
+		this.focused = false
+		this.value = ""
 		this.amPm = attrs.timeFormat === TimeFormat.TWELVE_HOURS
 		const times: string[] = []
 
@@ -33,77 +33,77 @@ export class TimePicker implements Component<TimePickerAttrs> {
 				times.push(timeStringFromParts(hour, minute, this.amPm))
 			}
 		}
-		this._oldValue = attrs.time?.toString(false) ?? "--"
-		this._values = times
+		this.oldValue = attrs.time?.toString(false) ?? "--"
+		this.values = times
 	}
 
 	view({ attrs }: Vnode<TimePickerAttrs>): Children {
 		if (attrs.time) {
 			const timeAsString = attrs.time?.toString(this.amPm) ?? ""
-			this._selectedIndex = this._values.indexOf(timeAsString)
+			this.selectedIndex = this.values.indexOf(timeAsString)
 
-			if (!this._focused) {
-				this._value = timeAsString
+			if (!this.focused) {
+				this.value = timeAsString
 			}
 		}
 
 		if (client.isMobileDevice()) {
-			return this._renderNativeTimePicker(attrs)
+			return this.renderNativeTimePicker(attrs)
 		} else {
-			return this._renderCustomTimePicker(attrs)
+			return this.renderCustomTimePicker(attrs)
 		}
 	}
 
-	_renderNativeTimePicker(attrs: TimePickerAttrs): Children {
-		if (this._oldValue !== attrs.time?.toString(false)) {
-			this._onSelected(attrs)
+	private renderNativeTimePicker(attrs: TimePickerAttrs): Children {
+		if (this.oldValue !== attrs.time?.toString(false)) {
+			this.onSelected(attrs)
 		}
 
 		// input[type=time] wants time in 24h format, no matter what is actually displayed. Otherwise it will be empty.
 		const timeAsString = attrs.time?.toString(false) ?? ""
-		this._oldValue = timeAsString
+		this.oldValue = timeAsString
 
-		this._value = timeAsString
+		this.value = timeAsString
 
 		return m(TextField, {
 			label: "emptyString_msg",
-			value: this._value,
+			value: this.value,
 			type: TextFieldType.Time,
 			oninput: (value) => {
-				if (this._value === value) {
+				if (this.value === value) {
 					return
 				}
-				this._value = value
+				this.value = value
 				attrs.onTimeSelected(Time.parseFromString(value))
 			},
 			disabled: attrs.disabled,
 		})
 	}
 
-	_renderCustomTimePicker(attrs: TimePickerAttrs): Children {
-		return [this._renderInputField(attrs), this._focused ? this._renderTimeSelector(attrs) : null]
+	private renderCustomTimePicker(attrs: TimePickerAttrs): Children {
+		return [this.renderInputField(attrs), this.focused ? this.renderTimeSelector(attrs) : null]
 	}
 
-	_renderInputField(attrs: TimePickerAttrs): Children {
+	private renderInputField(attrs: TimePickerAttrs): Children {
 		return m(TextField, {
 			label: "emptyString_msg",
-			value: this._value,
-			oninput: (v) => (this._value = v),
+			value: this.value,
+			oninput: (v) => (this.value = v),
 			disabled: attrs.disabled,
 			onfocus: (dom, input) => {
-				this._focused = true
+				this.focused = true
 				input.select()
 			},
 			onblur: (e) => {
-				if (this._focused) {
-					this._onSelected(attrs)
+				if (this.focused) {
+					this.onSelected(attrs)
 				}
 
 				e.redraw = false
 			},
 			keyHandler: (key) => {
 				if (isKeyPressed(key.key, Keys.RETURN)) {
-					this._onSelected(attrs)
+					this.onSelected(attrs)
 					const active = document.activeElement as HTMLElement | null
 					active?.blur()
 				}
@@ -113,12 +113,12 @@ export class TimePicker implements Component<TimePickerAttrs> {
 		})
 	}
 
-	_renderTimeSelector(attrs: TimePickerAttrs): Children {
+	private renderTimeSelector(attrs: TimePickerAttrs): Children {
 		return m(
 			".fixed.flex.col.mt-s.menu-shadow",
 			{
-				oncreate: (vnode) => this._setScrollTop(attrs, vnode),
-				onupdate: (vnode) => this._setScrollTop(attrs, vnode),
+				oncreate: (vnode) => this.setScrollTop(attrs, vnode),
+				onupdate: (vnode) => this.setScrollTop(attrs, vnode),
 				style: {
 					width: "100px",
 					height: "400px",
@@ -127,18 +127,18 @@ export class TimePicker implements Component<TimePickerAttrs> {
 					overflow: "auto",
 				},
 			},
-			this._values.map((time, i) =>
+			this.values.map((time, i) =>
 				m(
 					"pr-s.pl-s.darker-hover",
 					{
 						key: time,
 						style: {
-							"background-color": this._selectedIndex === i ? theme.list_bg : theme.list_alternate_bg,
+							"background-color": this.selectedIndex === i ? theme.list_bg : theme.list_alternate_bg,
 							flex: "1 0 auto",
 							"line-height": "44px",
 						},
 						onmousedown: () => {
-							this._focused = false
+							this.focused = false
 							attrs.onTimeSelected(Time.parseFromString(time))
 						},
 					},
@@ -148,16 +148,16 @@ export class TimePicker implements Component<TimePickerAttrs> {
 		)
 	}
 
-	_onSelected(attrs: TimePickerAttrs) {
-		this._focused = false
+	private onSelected(attrs: TimePickerAttrs) {
+		this.focused = false
 
-		attrs.onTimeSelected(Time.parseFromString(this._value))
+		attrs.onTimeSelected(Time.parseFromString(this.value))
 	}
 
-	_setScrollTop(attrs: TimePickerAttrs, vnode: VnodeDOM<TimePickerAttrs>) {
-		if (this._selectedIndex !== -1) {
+	private setScrollTop(attrs: TimePickerAttrs, vnode: VnodeDOM<TimePickerAttrs>) {
+		if (this.selectedIndex !== -1) {
 			requestAnimationFrame(() => {
-				vnode.dom.scrollTop = 44 * this._selectedIndex
+				vnode.dom.scrollTop = 44 * this.selectedIndex
 			})
 		}
 	}

--- a/src/gui/AriaUtils.ts
+++ b/src/gui/AriaUtils.ts
@@ -1,7 +1,4 @@
 import { assertMainOrNodeBoot } from "../api/common/Env"
-
-assertMainOrNodeBoot()
-
 /**
  * Collections of utility functions to support Accessible Rich Internet Applications (ARIA).
  *
@@ -12,6 +9,8 @@ assertMainOrNodeBoot()
  *
  */
 import { TabIndex } from "../api/common/TutanotaConstants"
+
+assertMainOrNodeBoot()
 
 // See: https://webaim.org/techniques/aria/#landmarks
 export const enum AriaLandmarks {
@@ -51,6 +50,15 @@ export function liveDataAttrs(): Record<string, string> {
 		"aria-live": AriaLiveData.Polite,
 		"aria-atomic": "true",
 	}
+}
+
+export const enum AriaPopupType {
+	None = "false",
+	Menu = "menu",
+	ListBox = "listbox",
+	Tree = "tree",
+	Grid = "grid",
+	Dialog = "dialog",
 }
 
 /**

--- a/src/gui/base/TextField.ts
+++ b/src/gui/base/TextField.ts
@@ -5,9 +5,10 @@ import { theme } from "../theme"
 import type { TranslationKey } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import type { lazy } from "@tutao/tutanota-utils"
-import { keyboardEventToKeyPress, keyHandler } from "../../misc/KeyManager"
+import { keyHandler, useKeyHandler } from "../../misc/KeyManager"
 import { TabIndex } from "../../api/common/TutanotaConstants"
 import { ClickHandler, getOperatingClasses } from "./GuiUtils"
+import { AriaPopupType } from "../AriaUtils.js"
 
 export type TextFieldAttrs = {
 	id?: string
@@ -15,6 +16,7 @@ export type TextFieldAttrs = {
 	value: string
 	autocompleteAs?: Autocomplete
 	type?: TextFieldType
+	hasPopup?: AriaPopupType
 	helpLabel?: lazy<Children> | null
 	alignRight?: boolean
 	injectionsLeft?: lazy<Children>
@@ -99,6 +101,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 				id: vnode.attrs.id,
 				oncreate: (vnode) => (this._domWrapper = vnode.dom as HTMLElement),
 				onclick: (e: MouseEvent) => (a.onclick ? a.onclick(e, this._domInputWrapper) : this.focus(e, a)),
+				"aria-haspopup": a.hasPopup,
 				class: a.class != null ? a.class : "pt" + " " + getOperatingClasses(a.disabled),
 				style: maxWidth
 					? {
@@ -255,11 +258,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 							a.onfocus && a.onfocus(this._domWrapper, this.domInput)
 						},
 						onblur: (e: FocusEvent) => this.blur(e, a),
-						onkeydown: (e: KeyboardEvent) => {
-							// keydown is used to cancel certain keypresses of the user (mainly needed for the BubbleTextField)
-							const key = keyboardEventToKeyPress(e)
-							return a.keyHandler != null ? a.keyHandler(key) : true
-						},
+						onkeydown: (e: KeyboardEvent) => useKeyHandler(e, a.keyHandler),
 						onupdate: () => {
 							// only change the value if the value has changed otherwise the cursor in Safari and in the iOS App cannot be positioned.
 							if (this.domInput.value !== a.value) {
@@ -310,10 +309,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 				},
 				onfocus: (e: FocusEvent) => this.focus(e, a),
 				onblur: (e: FocusEvent) => this.blur(e, a),
-				onkeydown: (e: KeyboardEvent) => {
-					const key = keyboardEventToKeyPress(e)
-					return a.keyHandler != null ? a.keyHandler(key) : true
-				},
+				onkeydown: (e: KeyboardEvent) => useKeyHandler(e, a.keyHandler),
 				oninput: () => {
 					this.domInput.style.height = "0px"
 					this.domInput.style.height = px(this.domInput.scrollHeight)

--- a/src/misc/KeyManager.ts
+++ b/src/misc/KeyManager.ts
@@ -54,6 +54,12 @@ export function keyboardEventToKeyPress(event: KeyboardEvent): KeyPress {
  */
 export type keyHandler = (key: KeyPress) => boolean
 
+export function useKeyHandler(e: KeyboardEvent, onKey: keyHandler | undefined) {
+	// keydown is used to cancel certain keypresses of the user (mainly needed for the BubbleTextField)
+	const key = keyboardEventToKeyPress(e)
+	return onKey != null ? onKey(key) : true
+}
+
 export interface Shortcut {
 	// key to use (the code/name is important here)
 	key: Key
@@ -252,7 +258,7 @@ class KeyManager {
  * @param key The key to be checked, should correspond to KeyEvent.key
  * @param keys Keys to be checked against, type of Keys
  */
-export function isKeyPressed(key: string | undefined, ...keys: Array<Values<typeof Keys>>): boolean {
+export function isKeyPressed(key: string | undefined, ...keys: Array<Key>): boolean {
 	if (key != null) {
 		return keys.some((k) => k.code === key.toLowerCase())
 	}


### PR DESCRIPTION
This adds keyboard controls based of the material & Gnome date pickers controls in order to fix the tab indexing of the event editor. This also includes a fix for the highlight circle appearing in padding days. The flow style names in `TimePicker` were also removed as a byproduct.

Closes #6656.