### PR TITLE
Fix an issue with system notification emails

### DIFF
--- a/src/api/common/TutanotaConstants.ts
+++ b/src/api/common/TutanotaConstants.ts
@@ -976,9 +976,13 @@ export enum MailAuthenticationStatus {
  * Authentication was only introduced when switching to PQ.
  */
 export enum EncryptionAuthStatus {
+	/** the entity was encrypted with RSA, it had no authentication*/
 	RSA_NO_AUTHENTICATION = "0",
+	/** the entity was encrypted with tuta-crypt and authentication succeeded */
 	PQ_AUTHENTICATION_SUCCEEDED = "1",
+	/** the entity was encrypted with tuta-crypt and authentication failed */
 	PQ_AUTHENTICATION_FAILED = "2",
+	/** the entity was encrypted symmetrically, with AES, it had no authentication, e.g. secure external mailboxes */
 	AES_NO_AUTHENTICATION = "3",
 }
 

--- a/src/mail/model/MailUtils.ts
+++ b/src/mail/model/MailUtils.ts
@@ -40,7 +40,7 @@ import { isDetailsDraft, isLegacyMail, MailWrapper } from "../../api/common/Mail
 import { FolderSystem } from "../../api/common/mail/FolderSystem.js"
 import { ListFilter } from "../../misc/ListModel.js"
 import { MailFacade } from "../../api/worker/facades/lazy/MailFacade.js"
-import { getDisplayedSender, isExcludedMailAddress, MailAddressAndName } from "../../api/common/mail/CommonMailUtils.js"
+import { getDisplayedSender, isSystemNotification } from "../../api/common/mail/CommonMailUtils.js"
 import { ProgrammingError } from "../../api/common/error/ProgrammingError.js"
 import { FontIcons } from "../../gui/base/icons/FontIcons.js"
 
@@ -111,23 +111,6 @@ export function getMailAddressDisplayText(name: string | null, mailAddress: stri
 	}
 }
 
-export function getSenderHeading(mail: Mail, preferNameOnly: boolean) {
-	const sender = getDisplayedSender(mail)
-	if (isExcludedMailAddress(sender.address)) {
-		return ""
-	} else {
-		return getMailAddressDisplayText(sender.name, sender.address, preferNameOnly)
-	}
-}
-
-export function getSenderAddressDisplay(sender: MailAddressAndName): string {
-	if (isExcludedMailAddress(sender.address)) {
-		return ""
-	} else {
-		return sender.address
-	}
-}
-
 export function getRecipientHeading(mail: Mail, preferNameOnly: boolean) {
 	if (isLegacyMail(mail)) {
 		const allRecipients = mail.toRecipients.concat(mail.ccRecipients).concat(mail.bccRecipients)
@@ -149,8 +132,11 @@ export function getRecipientHeading(mail: Mail, preferNameOnly: boolean) {
 }
 
 export function getSenderOrRecipientHeading(mail: Mail, preferNameOnly: boolean): string {
-	if (mail.state === MailState.RECEIVED) {
-		return getSenderHeading(mail, preferNameOnly)
+	if (isSystemNotification(mail)) {
+		return ""
+	} else if (mail.state === MailState.RECEIVED) {
+		const sender = getDisplayedSender(mail)
+		return getMailAddressDisplayText(sender.name, sender.address, preferNameOnly)
 	} else {
 		return getRecipientHeading(mail, preferNameOnly)
 	}

--- a/src/mail/view/CollapsedMailView.ts
+++ b/src/mail/view/CollapsedMailView.ts
@@ -8,7 +8,6 @@ import { Icons } from "../../gui/base/icons/Icons.js"
 import { responsiveCardHPadding } from "../../gui/cards.js"
 import { Keys, TabIndex } from "../../api/common/TutanotaConstants.js"
 import { isKeyPressed } from "../../misc/KeyManager.js"
-import { getDisplayedSender } from "../../api/common/mail/CommonMailUtils.js"
 
 export interface CollapsedMailViewAttrs {
 	viewModel: MailViewerViewModel
@@ -21,8 +20,6 @@ export class CollapsedMailView implements Component<CollapsedMailViewAttrs> {
 		const dateTime = formatDateWithWeekday(mail.receivedDate) + " • " + formatTime(mail.receivedDate)
 		const folderInfo = viewModel.getFolderInfo()
 		if (!folderInfo) return null
-
-		const sender = getDisplayedSender(mail)
 
 		return m(
 			".flex.items-center.pt.pb.click.no-wrap",
@@ -42,7 +39,7 @@ export class CollapsedMailView implements Component<CollapsedMailViewAttrs> {
 			[
 				viewModel.isUnread() ? this.renderUnreadDot() : null,
 				viewModel.isDraftMail() ? m(".mr-xs", this.renderIcon(Icons.Edit)) : null,
-				m(this.getMailAddressDisplayClasses(viewModel), getMailAddressDisplayText(sender.name, sender.address, true)),
+				this.renderSender(viewModel),
 				m(".flex.ml-between-s.items-center", [
 					mail.attachments.length > 0 ? this.renderIcon(Icons.Attachment) : null,
 					viewModel.isConfidential() ? this.renderIcon(getConfidentialIcon(mail)) : null,
@@ -51,6 +48,11 @@ export class CollapsedMailView implements Component<CollapsedMailViewAttrs> {
 				]),
 			],
 		)
+	}
+
+	private renderSender(viewModel: MailViewerViewModel) {
+		const sender = viewModel.getDisplayedSender()
+		return m(this.getMailAddressDisplayClasses(viewModel), sender == null ? "" : getMailAddressDisplayText(sender.name, sender.address, true))
 	}
 
 	private getMailAddressDisplayClasses(viewModel: MailViewerViewModel): string {

--- a/src/mail/view/MailViewerHeader.ts
+++ b/src/mail/view/MailViewerHeader.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { InfoLink, lang } from "../../misc/LanguageViewModel.js"
-import { getConfidentialIcon, getFolderIconByType, getMailAddressDisplayText, getSenderAddressDisplay } from "../model/MailUtils.js"
+import { getConfidentialIcon, getFolderIconByType, getMailAddressDisplayText } from "../model/MailUtils.js"
 import { theme } from "../../gui/theme.js"
 import { styles } from "../../gui/styles.js"
 import { ExpanderButton, ExpanderPanel } from "../../gui/base/Expander.js"
@@ -97,6 +97,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 		const folderInfo = viewModel.getFolderInfo()
 		if (!folderInfo) return null
 
+		const displayedSender = viewModel.getDisplayedSender()
 		return m(
 			".flex.mt-xs.click.col",
 			{
@@ -116,7 +117,11 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 				},
 			},
 			[
-				m(".small.flex.flex-wrap.items-start", [m("span.text-break", getSenderAddressDisplay(viewModel.getDisplayedSender()))]),
+				displayedSender == null
+					? null
+					: m(".small.flex.flex-wrap.items-start", [
+							m("span.text-break", getMailAddressDisplayText(displayedSender.name, displayedSender.address, false)),
+					  ]),
 				m(".flex", [
 					this.getRecipientEmailAddress(attrs),
 					m(".flex-grow"),
@@ -197,7 +202,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 							  )
 							: null,
 						this.tutaoBadge(viewModel),
-						m("span.text-break" + (viewModel.isUnread() ? ".font-weight-600" : ""), viewModel.getDisplayedSender().name),
+						m("span.text-break" + (viewModel.isUnread() ? ".font-weight-600" : ""), viewModel.getDisplayedSender()?.name ?? ""),
 					],
 				),
 				m(
@@ -299,18 +304,22 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 		return m("." + responsiveCardHPadding(), liveDataAttrs(), [
 			m(
 				".mt-s",
-				m(".small.b", lang.get("from_label")),
-				m(RecipientButton, {
-					label: getMailAddressDisplayText(displayedSender.name, displayedSender.address, false),
-					click: createAsyncDropdown({
-						lazyButtons: () =>
-							createMailAddressContextButtons({
-								mailAddress: displayedSender,
-								defaultInboxRuleField: InboxRuleType.FROM_EQUALS,
+				displayedSender == null
+					? null
+					: [
+							m(".small.b", lang.get("from_label")),
+							m(RecipientButton, {
+								label: getMailAddressDisplayText(displayedSender.name, displayedSender.address, false),
+								click: createAsyncDropdown({
+									lazyButtons: () =>
+										createMailAddressContextButtons({
+											mailAddress: displayedSender,
+											defaultInboxRuleField: InboxRuleType.FROM_EQUALS,
+										}),
+									width: bubbleMenuWidth,
+								}),
 							}),
-						width: bubbleMenuWidth,
-					}),
-				}),
+					  ],
 				envelopeSender
 					? [
 							m(".small.b", lang.get("sender_label")),

--- a/test/tests/api/common/mail/CommonMailUtilsTest.ts
+++ b/test/tests/api/common/mail/CommonMailUtilsTest.ts
@@ -1,88 +1,68 @@
 import o from "@tutao/otest"
-import { createEncryptedMailAddress, createMail, createMailAddress, Mail, MailTypeRef } from "../../../../../src/api/entities/tutanota/TypeRefs.js"
-import { EncryptionAuthStatus, MailAuthenticationStatus, MailState } from "../../../../../src/api/common/TutanotaConstants.js"
-import { downcast } from "@tutao/tutanota-utils"
-import { getDisplayedSender, isTutanotaTeamAddress, MailAddressAndName } from "../../../../../src/api/common/mail/CommonMailUtils.js"
+import { createMail, createMailAddress, Mail, MailTypeRef } from "../../../../../src/api/entities/tutanota/TypeRefs.js"
+import { EncryptionAuthStatus, MailState } from "../../../../../src/api/common/TutanotaConstants.js"
+import { getDisplayedSender, isSystemNotification, isTutanotaTeamAddress, isTutanotaTeamMail } from "../../../../../src/api/common/mail/CommonMailUtils.js"
 import { createTestEntity } from "../../../TestUtils.js"
 import { getConfidentialIcon } from "../../../../../src/mail/model/MailUtils.js"
 import { Icons } from "../../../../../src/gui/base/icons/Icons.js"
 import { ProgrammingError } from "../../../../../src/api/common/error/ProgrammingError.js"
 
 o.spec("MailUtilsTest", function () {
-	function createSystemMail(realSender: MailAddressAndName): Mail {
+	function createSystemMail(overrides: Partial<Mail> = {}): Mail {
 		return createMail({
-			sender: createMailAddress({
-				address: "system@tutanota.de",
-				name: "System",
-				_id: "",
+			...{
+				sender: createMailAddress({
+					address: "system@tutanota.de",
+					name: "System",
+					_id: "",
+					_ownerGroup: "",
+					contact: null,
+				}),
+				replyTos: [],
+				state: MailState.RECEIVED,
+				authStatus: null,
+				_errors: {},
+				_id: ["", ""],
+				_ownerEncSessionKey: null,
 				_ownerGroup: "",
-				contact: null,
-			}),
-			replyTos: [createEncryptedMailAddress(realSender)],
-			state: MailState.RECEIVED,
-			authStatus: MailAuthenticationStatus.AUTHENTICATED,
-			_errors: {},
-			_id: ["", ""],
-			_ownerEncSessionKey: null,
-			_ownerGroup: "",
-			_permissions: "",
-			attachments: [],
-			bccRecipients: [],
-			body: null,
-			bucketKey: null,
-			ccRecipients: [],
-			confidential: false,
-			conversationEntry: ["", ""],
-			differentEnvelopeSender: null,
-			encryptionAuthStatus: null,
-			firstRecipient: null,
-			headers: null,
-			listUnsubscribe: false,
-			mailDetails: null,
-			mailDetailsDraft: null,
-			method: "",
-			movedTime: null,
-			phishingStatus: "",
-			receivedDate: new Date(),
-			recipientCount: "",
-			replyType: "",
-			sentDate: null,
-			subject: "",
-			toRecipients: [],
-			unread: false,
+				_permissions: "",
+				attachments: [],
+				bccRecipients: [],
+				body: null,
+				bucketKey: null,
+				ccRecipients: [],
+				confidential: true,
+				conversationEntry: ["", ""],
+				differentEnvelopeSender: null,
+				encryptionAuthStatus: null,
+				firstRecipient: null,
+				headers: null,
+				listUnsubscribe: false,
+				mailDetails: null,
+				mailDetailsDraft: null,
+				method: "",
+				movedTime: null,
+				phishingStatus: "",
+				receivedDate: new Date(),
+				recipientCount: "",
+				replyType: "",
+				sentDate: null,
+				subject: "",
+				toRecipients: [],
+				unread: false,
+			},
+			...overrides,
 		})
 	}
 
+	const tutanotaSender = () => createMailAddress({ address: "sender@tutanota.de", name: "Tutanota sender", contact: null })
+	const tutaoSender = () => createMailAddress({ address: "sender@tutao.de", name: "Tutao sender", contact: null })
+	const tutanotaNoReplySender = () => createMailAddress({ address: "no-reply@tutanota.de", name: "Tutanota no-reply", contact: null })
+	const tutaoNoReplySender = () => createMailAddress({ address: "no-reply@tutao.de", name: "Tutao no-reply", contact: null })
+
 	o("getDisplayedSender", function () {
-		let mail: Mail = downcast("placeholder that won't get used")
-
-		const createSalesMail = () => (mail = createSystemMail({ address: "sales@tutao.de", name: "Sales" }))
-		const assertDisplayedSender = (address: string, name: string) => o(getDisplayedSender(mail)).deepEquals({ address, name })
-		const assertIsSales = () => assertDisplayedSender("sales@tutao.de", "Sales")
-		const assertIsNoReply = () => assertDisplayedSender("no-reply@tutao.de", "Do not reply to this!!!")
-		const assertIsSystem = () => assertDisplayedSender("system@tutanota.de", "System")
-
-		// Should be good
-		createSalesMail()
-		assertIsSales()
-		createSalesMail().replyTos = [createEncryptedMailAddress({ address: "no-reply@tutao.de", name: "Do not reply to this!!!" })]
-		assertIsNoReply()
-
-		// Not authenticated
-		createSalesMail().authStatus = MailAuthenticationStatus.HARD_FAIL
-		assertIsSystem()
-
-		// Not received
-		createSalesMail().state = MailState.DRAFT
-		assertIsSystem()
-
-		// Multiple reply-tos, can't determine which
-		createSalesMail().replyTos = [mail.replyTos[0], mail.replyTos[1]]
-		assertIsSystem()
-
-		// Not a Tutao address
-		createSalesMail().replyTos = [createEncryptedMailAddress({ address: "bed-free@tutanota.de", name: "Bernd das Brot" })]
-		assertIsSystem()
+		const mail = createSystemMail()
+		o(getDisplayedSender(mail)).deepEquals({ address: "system@tutanota.de", name: "System" })
 	})
 
 	o("isTutanotaTeamAddress", function () {
@@ -112,5 +92,233 @@ o.spec("MailUtilsTest", function () {
 
 		mail.confidential = false
 		o(() => getConfidentialIcon(mail)).throws(ProgrammingError)
+	})
+
+	o.spec("isTutanotaTeamMail", function () {
+		o("regular non-confidential email is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: false,
+				state: MailState.RECEIVED,
+				sender: tutanotaSender(),
+			})
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("regular confidential email is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutanotaSender(),
+			})
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("system email without auth is", function () {
+			const mail = createSystemMail()
+			o(isTutanotaTeamMail(mail)).equals(true)
+		})
+
+		o("system email failing PQ auth is not", function () {
+			const mail = createSystemMail({ encryptionAuthStatus: EncryptionAuthStatus.PQ_AUTHENTICATION_FAILED })
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("system email with RSA (no) auth is", function () {
+			const mail = createSystemMail({ encryptionAuthStatus: EncryptionAuthStatus.RSA_NO_AUTHENTICATION })
+			o(isTutanotaTeamMail(mail)).equals(true)
+		})
+
+		o("system email with AES (no) auth is not", function () {
+			const mail = createSystemMail({ encryptionAuthStatus: EncryptionAuthStatus.AES_NO_AUTHENTICATION })
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("confidential email from tutao without auth is", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+				encryptionAuthStatus: null,
+			})
+			o(isTutanotaTeamMail(mail)).equals(true)
+		})
+
+		o("confidential email from tutao with PQ auth is", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+				encryptionAuthStatus: EncryptionAuthStatus.PQ_AUTHENTICATION_SUCCEEDED,
+			})
+			o(isTutanotaTeamMail(mail)).equals(true)
+		})
+
+		o("confidential email from tutao with failing PQ auth is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+				encryptionAuthStatus: EncryptionAuthStatus.PQ_AUTHENTICATION_FAILED,
+			})
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("confidential email from tutao with RSA (no) auth is", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+				encryptionAuthStatus: EncryptionAuthStatus.RSA_NO_AUTHENTICATION,
+			})
+			o(isTutanotaTeamMail(mail)).equals(true)
+		})
+
+		o("confidential email from tutao with AES (no) auth is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+				encryptionAuthStatus: EncryptionAuthStatus.AES_NO_AUTHENTICATION,
+			})
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("confidential email from no-reply is", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutanotaNoReplySender(),
+			})
+			o(isTutanotaTeamMail(mail)).equals(true)
+		})
+
+		o(`non-confidential "system" email is not`, function () {
+			const mail = createMail({ ...createSystemMail(), confidential: false })
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("non-confidential email from tutao is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: false,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+			})
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+
+		o("non confidential email from no-reply is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: false,
+				state: MailState.RECEIVED,
+				sender: tutanotaNoReplySender(),
+			})
+			o(isTutanotaTeamMail(mail)).equals(false)
+		})
+	})
+
+	o.spec("isSystemNotification", function () {
+		o("regular non-confidential email is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: false,
+				state: MailState.RECEIVED,
+				sender: tutanotaSender(),
+			})
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("regular confidential email is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutanotaSender(),
+			})
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("system email without auth is", function () {
+			const mail = createSystemMail()
+			o(isSystemNotification(mail)).equals(true)
+		})
+
+		o("system email with PQ auth is", function () {
+			const mail = createSystemMail({ encryptionAuthStatus: EncryptionAuthStatus.PQ_AUTHENTICATION_SUCCEEDED })
+			o(isSystemNotification(mail)).equals(true)
+		})
+
+		o("system email with failing PQ auth is not", function () {
+			const mail = createSystemMail({ encryptionAuthStatus: EncryptionAuthStatus.PQ_AUTHENTICATION_FAILED })
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("system email with RSA (no) auth is", function () {
+			const mail = createSystemMail({ encryptionAuthStatus: EncryptionAuthStatus.RSA_NO_AUTHENTICATION })
+			o(isSystemNotification(mail)).equals(true)
+		})
+
+		o("system email with AES (no) auth is not", function () {
+			const mail = createSystemMail({ encryptionAuthStatus: EncryptionAuthStatus.AES_NO_AUTHENTICATION })
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("confidential email from tutao is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+				authStatus: null,
+			})
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("confidential email from tutao with PQ auth is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+				authStatus: EncryptionAuthStatus.PQ_AUTHENTICATION_SUCCEEDED,
+			})
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("confidential email from tutanota no-reply is", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutanotaNoReplySender(),
+			})
+			o(isSystemNotification(mail)).equals(true)
+		})
+
+		o("confidential email from tutao no-reply is", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: true,
+				state: MailState.RECEIVED,
+				sender: tutaoNoReplySender(),
+			})
+			o(isSystemNotification(mail)).equals(true)
+		})
+
+		o(`non-confidential "system" email is not`, function () {
+			const mail = createMail({ ...createSystemMail(), confidential: false })
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("non-confidential email from tutao is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: false,
+				state: MailState.RECEIVED,
+				sender: tutaoSender(),
+			})
+			o(isSystemNotification(mail)).equals(false)
+		})
+
+		o("non confidential email from no-reply is not", function () {
+			const mail = createTestEntity(MailTypeRef, {
+				confidential: false,
+				state: MailState.RECEIVED,
+				sender: tutanotaNoReplySender(),
+			})
+			o(isSystemNotification(mail)).equals(false)
+		})
 	})
 })


### PR DESCRIPTION
15713f1 changed to how we detect and display system notifications. Since tuta-crypt we send all system notifications from the system group address. It was attempting then to replace the sender with reply-to address.

This cannot work because system notifications are sent with MailDetails now, and we do not know authStatus nor replyTos until we load MailDetails.

This commit simplifies the handling by not attempting to replace the sender but by hiding it for all system notification mails. Now there will be more cases when they are hidden then before but it should have no effect since sender of system notification emails is irrelevant and replyTos will be used to write a reply.

fix #6708

Please review carefully. Please try legacy announcements/invoice emails/tutao team emails and MailDetails announcements/invoice emails/tutao team emails. Please check reply/forward.