### PR TITLE
Fix the lack of bottom margin in the onboarding wizard in landscape mode

### DIFF
--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -1425,7 +1425,7 @@ styles.registerStyle("main", () => {
 			"margin-left": "0",
 		},
 		".dialog-height-small": {
-			height: "65vh",
+			"min-height": "65vh",
 		},
 		".dialog-max-height": {
 			"max-height": "calc(100vh - 100px)",


### PR DESCRIPTION
Setting the height of the contents caused it not to fill the dialog completely. This frees the height to fill while still requiring the dialog to be the right size.

Fixes problem two of [this comment](https://github.com/tutao/tutanota/issues/6462#issuecomment-1997566218).