### PR TITLE
Register a push identifier regardless of notification permission

### DIFF
--- a/src/login/PostLoginActions.ts
+++ b/src/login/PostLoginActions.ts
@@ -127,11 +127,8 @@ export class PostLoginActions implements PostLoginAction {
 			await this.remindActiveOutOfOfficeNotification()
 		}
 
-		// Only automatically request notification permission on Desktop as the onboarding wizard handles it on mobile
-		if (isDesktop()) {
-			locator.pushService.register()
-		}
 		if (isApp() || isDesktop()) {
+			locator.pushService.register()
 			await this.maybeSetCustomTheme()
 		}
 


### PR DESCRIPTION
This rolls back the changes to the push identifier so the user can still receive notifications if they enable the notification permission later using the system settings. We plan to revert this when we add a notifications section inside settings.

Closes #6727 