### PR TITLE
Fix Non-editable events are draggable on Calendar View

### DIFF
--- a/src/calendar/model/CalendarModel.ts
+++ b/src/calendar/model/CalendarModel.ts
@@ -805,6 +805,10 @@ export class CalendarModel {
 		return this.fileIdToSkippedCalendarEventUpdates
 	}
 
+	/**
+	 * Partially mirrors the logic from CalendarEventModel.prototype.isFullyWritable() to determine
+	 * if the user can edit more than just alarms for a given event
+	 */
 	canFullyEditEvent(event: CalendarEvent): boolean {
 		const userController = this.logins.getUserController()
 		const userMailGroup = userController.getUserMailGroupMembership().group

--- a/src/calendar/view/CalendarViewModel.ts
+++ b/src/calendar/view/CalendarViewModel.ts
@@ -176,11 +176,13 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 	}
 
 	onDragStart(originalEvent: CalendarEvent, timeToMoveBy: number) {
-		let eventClone = clone(originalEvent)
-		updateTemporaryEventWithDiff(eventClone, originalEvent, timeToMoveBy)
-		this._draggedEvent = {
-			originalEvent,
-			eventClone,
+		if (this.calendarModel.canFullyEditEvent(originalEvent)) {
+			let eventClone = clone(originalEvent)
+			updateTemporaryEventWithDiff(eventClone, originalEvent, timeToMoveBy)
+			this._draggedEvent = {
+				originalEvent,
+				eventClone,
+			}
 		}
 	}
 

--- a/src/calendar/view/CalendarViewModel.ts
+++ b/src/calendar/view/CalendarViewModel.ts
@@ -175,8 +175,8 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 		return getWeekStart(this.logins.getUserController().userSettingsGroupRoot)
 	}
 
-	// Public for testing
-	allowDrag(event: CalendarEvent) {
+	// visibleForTesting
+	allowDrag(event: CalendarEvent): boolean {
 		return this.calendarModel.canFullyEditEvent(event)
 	}
 

--- a/src/calendar/view/CalendarViewModel.ts
+++ b/src/calendar/view/CalendarViewModel.ts
@@ -175,8 +175,13 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 		return getWeekStart(this.logins.getUserController().userSettingsGroupRoot)
 	}
 
+	// Public for testing
+	allowDrag(event: CalendarEvent) {
+		return this.calendarModel.canFullyEditEvent(event)
+	}
+
 	onDragStart(originalEvent: CalendarEvent, timeToMoveBy: number) {
-		if (this.calendarModel.canFullyEditEvent(originalEvent)) {
+		if (this.allowDrag(originalEvent)) {
 			let eventClone = clone(originalEvent)
 			updateTemporaryEventWithDiff(eventClone, originalEvent, timeToMoveBy)
 			this._draggedEvent = {


### PR DESCRIPTION
Users were able to move any events belonging to any calendar that they participate. This commit adds a verification if they are allowed to move an event before starting the drag event, preventing it if they aren't.

fix https://github.com/tutao/tutanota/issues/6735