### PR TITLE
Fix can't disable contact sync

### DIFF
--- a/src/contacts/model/NativeContactsSyncManager.ts
+++ b/src/contacts/model/NativeContactsSyncManager.ts
@@ -182,7 +182,7 @@ export class NativeContactsSyncManager {
 	}
 
 	async disableSync() {
-		this.deviceConfig.setUserSyncContactsWithPhonePreference(this.loginController.getUserController().userId, true)
+		this.deviceConfig.setUserSyncContactsWithPhonePreference(this.loginController.getUserController().userId, false)
 		const loginUsername = this.loginController.getUserController().loginUsername
 		await this.mobilContactsFacade
 			.deleteContacts(loginUsername, null)


### PR DESCRIPTION
This commit fixes the problem that was preventing users from fully disable the contact sync. Now when the settings are changed, they're reflected into deviceConfig.

fix #6742