### PR TITLE
Fix the time picker displaying the wrong time format on mobile

### DIFF
--- a/src/calendar/gui/pickers/TimePicker.ts
+++ b/src/calendar/gui/pickers/TimePicker.ts
@@ -65,19 +65,26 @@ export class TimePicker implements Component<TimePickerAttrs> {
 
 		this.value = timeAsString
 
-		return m(TextField, {
-			label: "emptyString_msg",
-			value: this.value,
-			type: TextFieldType.Time,
-			oninput: (value) => {
-				if (this.value === value) {
-					return
-				}
-				this.value = value
-				attrs.onTimeSelected(Time.parseFromString(value))
-			},
-			disabled: attrs.disabled,
-		})
+		const displayTime = attrs.time?.toString(this.amPm) ?? ""
+
+		return [
+			m(TextField, {
+				class: "time-picker pt",
+				label: "emptyString_msg",
+				value: this.value,
+				type: TextFieldType.Time,
+				oninput: (value) => {
+					if (this.value === value) {
+						return
+					}
+					this.value = value
+					attrs.onTimeSelected(Time.parseFromString(value))
+				},
+				disabled: attrs.disabled,
+			}),
+			// A 'fake' display that overlays over the real time input that allows us to show 12 or 24 time format regardless of browser locale
+			m(".time-picker-fake-display.rel.no-hover", displayTime),
+		]
 	}
 
 	private renderCustomTimePicker(attrs: TimePickerAttrs): Children {

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -2184,6 +2184,13 @@ styles.registerStyle("main", () => {
 		".time-field": {
 			width: "80px",
 		},
+		".time-picker input": {
+			color: "rgba(0, 0, 0, 0)",
+		},
+		".time-picker-fake-display": {
+			bottom: "1.6em",
+			left: "0.1em",
+		},
 		".calendar-agenda-time-column": {
 			width: px(80),
 		},


### PR DESCRIPTION
This fixes the display but the dialog still displays in the wrong time format. A custom time picker for mobile will be created later, see #6765.

Closes #6339.