### PR TITLE
Fix notification resize incorrectly

### DIFF
--- a/src/gui/base/NotificationOverlay.ts
+++ b/src/gui/base/NotificationOverlay.ts
@@ -61,9 +61,10 @@ function showNextNotification() {
 	const margin = (width - Math.min(400, width)) / 2
 	const allButtons = buttons.slice()
 	const overlayRect = {
+		width: "fit-content",
 		top: px(0),
-		left: px(margin),
-		right: px(margin),
+		left: px(0),
+		right: px(0),
 	}
 	const closeFunction = displayOverlay(
 		() => overlayRect,
@@ -75,6 +76,8 @@ function showNextNotification() {
 				}),
 		},
 		"slide-top",
+		undefined,
+		"dropdown-shadow center-h notification-min-width",
 	)
 
 	const closeAndOpenNext = () => {

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -860,6 +860,9 @@ styles.registerStyle("main", () => {
 		".large-button-width": {
 			width: px(size.button_floating_size),
 		},
+		".notification-min-width": {
+			"min-width": px(400),
+		},
 		// Stretch editor a little bit more than parent so that the content is visible
 		".full-height": {
 			"min-height": client.isIos() ? "101%" : "100%",


### PR DESCRIPTION
This commit sets the notification width to "fit-content" preventing the notification from disappearing while resizing the screen.

Tested with report error and autoresponder notification

fix #6430