### PR TITLE
Do not create an emspace whenever tab is pressed

### DIFF
--- a/src/gui/editor/Editor.ts
+++ b/src/gui/editor/Editor.ts
@@ -28,7 +28,6 @@ export class Editor implements ImageHandler, Component {
 	private enabled = true
 	private readOnly = false
 	private createsLists = true
-	private tabCreatesWhitespace = true
 	private userHasPasted = false
 	private styleActions = Object.freeze({
 		b: [() => this.squire.bold(), () => this.squire.removeBold(), () => this.styles.b],
@@ -121,11 +120,6 @@ export class Editor implements ImageHandler, Component {
 		return this
 	}
 
-	setTabCreatesWhitespace(tabCreatesWhitespace: boolean): Editor {
-		this.tabCreatesWhitespace = tabCreatesWhitespace
-		return this
-	}
-
 	initSquire(domElement: HTMLElement) {
 		this.squire = new SquireEditor(domElement, {
 			sanitizeToDOMFragment: (html: string) => this.sanitizer(html, this.userHasPasted),
@@ -147,15 +141,6 @@ export class Editor implements ImageHandler, Component {
 		this.squire.addEventListener("pathChange", () => {
 			this.getStylesAtPath()
 			m.redraw() // allow richtexttoolbar to redraw elements
-		})
-
-		// Create an emspace whenever tab is pressed
-		this.squire.addEventListener("keydown", (e: KeyboardEvent) => {
-			if (this.isEditable() && this.tabCreatesWhitespace && e.key === "Tab" && this.styles.listing == null) {
-				this.squire.insertHTML("&emsp;")
-				e.preventDefault()
-				e.stopPropagation()
-			}
 		})
 
 		this.domElement = domElement

--- a/src/gui/editor/HtmlEditor.ts
+++ b/src/gui/editor/HtmlEditor.ts
@@ -30,7 +30,7 @@ export class HtmlEditor implements Component {
 	private toolbarAttrs: Omit<RichTextToolbarAttrs, "editor"> = {}
 
 	constructor(private label?: TranslationText, private readonly injections?: () => Children) {
-		this.editor = new Editor(null, (html) => htmlSanitizer.sanitizeFragment(html, { blockExternalContent: false }).fragment).setTabCreatesWhitespace(false)
+		this.editor = new Editor(null, (html) => htmlSanitizer.sanitizeFragment(html, { blockExternalContent: false }).fragment)
 		this.view = this.view.bind(this)
 		this.initializeEditorListeners()
 	}


### PR DESCRIPTION
Turns out this breaks navigation and templates.

Fixes #6759