### PR TITLE
Show the search bar as disabled when offline in contact and mail views

### DIFF
--- a/src/contacts/view/ContactView.ts
+++ b/src/contacts/view/ContactView.ts
@@ -323,6 +323,7 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 									? null
 									: m(LazySearchBar, {
 											placeholder: lang.get("searchContacts_placeholder"),
+											disabled: !locator.logins.isFullyLoggedIn(),
 									  }),
 							...attrs.header,
 					  }),

--- a/src/gui/base/BaseSearchBar.ts
+++ b/src/gui/base/BaseSearchBar.ts
@@ -11,11 +11,13 @@ import { Icon, IconAttrs } from "./Icon.js"
 import { theme } from "../theme.js"
 import { lang } from "../../misc/LanguageViewModel.js"
 import { BaseButton, BaseButtonAttrs } from "./buttons/BaseButton.js"
+import { getOperatingClasses } from "./GuiUtils.js"
 
 export interface BaseSearchBarAttrs {
 	placeholder?: string | null
 	text: string
 	busy: boolean
+	disabled?: boolean
 	onInput: (text: string) => unknown
 	onFocus?: () => unknown
 	onBlur?: () => unknown
@@ -36,6 +38,7 @@ export class BaseSearchBar implements ClassComponent<BaseSearchBarAttrs> {
 			{
 				focused: String(this.isFocused),
 				...landmarkAttrs(AriaLandmarks.Search),
+				class: getOperatingClasses(attrs.disabled),
 				style: {
 					"min-height": px(inputLineHeight + 2),
 					"margin-top": px(6),
@@ -46,8 +49,10 @@ export class BaseSearchBar implements ClassComponent<BaseSearchBarAttrs> {
 					attrs.onWrapperCreated?.(dom as HTMLElement)
 				},
 				onclick: () => {
-					this.domInput?.focus()
-					attrs.onSearchClick?.()
+					if (!attrs.disabled) {
+						this.domInput?.focus()
+						attrs.onSearchClick?.()
+					}
 				},
 			},
 			[
@@ -86,7 +91,9 @@ export class BaseSearchBar implements ClassComponent<BaseSearchBarAttrs> {
 									fill: theme.header_button,
 								},
 							}),
-							onclick: () => attrs.onClear?.(),
+							onclick: () => {
+								if (!attrs.disabled) attrs.onClear?.()
+							},
 							disabled: attrs.busy,
 							style: {
 								width: size.icon_size_large,
@@ -105,6 +112,7 @@ export class BaseSearchBar implements ClassComponent<BaseSearchBarAttrs> {
 			placeholder: attrs.placeholder,
 			type: TextFieldType.Text,
 			value: attrs.text,
+			disabled: attrs.disabled,
 			oncreate: (vnode) => {
 				this.domInput = vnode.dom as HTMLInputElement
 				attrs.onInputCreated?.(this.domInput)

--- a/src/mail/view/MailView.ts
+++ b/src/mail/view/MailView.ts
@@ -357,6 +357,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 						locator.logins.isInternalUserLoggedIn()
 							? m(LazySearchBar, {
 									placeholder: lang.get("searchEmails_placeholder"),
+									disabled: !locator.logins.isFullyLoggedIn(),
 							  })
 							: null,
 					...attrs.header,

--- a/src/search/SearchBar.ts
+++ b/src/search/SearchBar.ts
@@ -43,6 +43,7 @@ export type ShowMoreAction = {
 export type SearchBarAttrs = {
 	placeholder?: string | null
 	returnListener?: (() => unknown) | null
+	disabled?: boolean
 }
 
 const MAX_SEARCH_PREVIEW_RESULTS = 10
@@ -119,6 +120,7 @@ export class SearchBar implements Component<SearchBarAttrs> {
 			placeholder: vnode.attrs.placeholder,
 			text: this.state().query,
 			busy: this.busy,
+			disabled: vnode.attrs.disabled,
 			onInput: (text) => this.search(text),
 			onSearchClick: () => this.handleSearchClick(),
 			onClear: () => {


### PR DESCRIPTION
This is a temporary mitigation until we switch to using the offline db key instead of the user group key for the indexer.

Related to #6305.