### PR TITLE
Add the custom themes to the themes page of the onboarding flow

### DIFF
--- a/src/misc/TranslationKey.ts
+++ b/src/misc/TranslationKey.ts
@@ -1659,7 +1659,6 @@ export type TranslationKeyType =
 	| "whitelabelDomain_label"
 	| "whitelabelRegistrationCode_label"
 	| "whitelabelRegistrationEmailDomain_label"
-	| "whitelabelThemeDetected_msg"
 	| "whitelabel_label"
 	| "who_label"
 	| "whyLeave_msg"

--- a/src/translations/ar.ts
+++ b/src/translations/ar.ts
@@ -1420,7 +1420,6 @@ export default {
 		"whitelabelDomain_label": "مجال Whitelabel",
 		"whitelabelRegistrationCode_label": "كود التسجيل",
 		"whitelabelRegistrationEmailDomain_label": "تسجيل نطاق البريد الالكتروني",
-		"whitelabelThemeDetected_msg": "تم الكشف عن نسُق مخصص لهذا الحساب. هل تريد تطبيقه الآن؟",
 		"whitelabel_label": "البطاقة البيضاء",
 		"who_label": "من ",
 		"work_label": "العمل",

--- a/src/translations/be.ts
+++ b/src/translations/be.ts
@@ -1628,7 +1628,6 @@ export default {
 		"whitelabelDomain_label": "Дамэйн Whitelabel",
 		"whitelabelRegistrationCode_label": "Рэгістрацыйны код",
 		"whitelabelRegistrationEmailDomain_label": "Імэйлавы дамэйн для рэгістрацыі",
-		"whitelabelThemeDetected_msg": "Карыстальніцкая тэма знойдзена для гэтага акаўнту. Ці жадаеш ты ўжыць яе?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Хто",
 		"whyLeave_msg": "Нам шкада, што ты пакідаеш нас. Што мы маглі б палепшыць?",

--- a/src/translations/ca.ts
+++ b/src/translations/ca.ts
@@ -1111,7 +1111,6 @@ export default {
 		"whitelabelDomain_label": "Domini etiqueta blanca",
 		"whitelabelRegistrationCode_label": "Codi de registre",
 		"whitelabelRegistrationEmailDomain_label": "Domini de correu electrònic de registre",
-		"whitelabelThemeDetected_msg": "S'ha detectat un tema personalitzat per a aquest compte. Voleu aplicar-lo ara?",
 		"whitelabel_label": "Etiqueta blanca",
 		"who_label": "Qui",
 		"work_label": "Feina",

--- a/src/translations/cs.ts
+++ b/src/translations/cs.ts
@@ -1665,7 +1665,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel doména",
 		"whitelabelRegistrationCode_label": "Registrační kód",
 		"whitelabelRegistrationEmailDomain_label": "Doména registračního e-mailu",
-		"whitelabelThemeDetected_msg": "Pro tento účet bylo zjištěno vlastní téma. Chcete ho použít?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Kdo",
 		"whyLeave_msg": "Mrzí nás, že odcházíte! Co můžeme vylepšit?",

--- a/src/translations/da.ts
+++ b/src/translations/da.ts
@@ -1302,7 +1302,6 @@ export default {
 		"whitelabelDomain_label": "Godkendte domæner",
 		"whitelabelRegistrationCode_label": "Registreringskode ",
 		"whitelabelRegistrationEmailDomain_label": "E-maildomæne til registerering",
-		"whitelabelThemeDetected_msg": "Der er fundet et brugerdefinerede tema for denne konto. Vil du anvende det nu? ",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Hvem",
 		"work_label": "Arbejde",

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -1679,7 +1679,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel-Domain",
 		"whitelabelRegistrationCode_label": "Registrierungs-Code",
 		"whitelabelRegistrationEmailDomain_label": "E-Mail-Domain für Registrierung",
-		"whitelabelThemeDetected_msg": "Ein benutzerdefiniertes Design wurde für diesen Account erkannt. Möchtest du es jetzt anwenden?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Wer",
 		"whyLeave_msg": "Schade, dass du kündigen möchtest. Wie können wir uns verbessern?",

--- a/src/translations/de_sie.ts
+++ b/src/translations/de_sie.ts
@@ -1679,7 +1679,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel-Domain",
 		"whitelabelRegistrationCode_label": "Registrierungs-Code",
 		"whitelabelRegistrationEmailDomain_label": "E-Mail-Domain für Registrierung",
-		"whitelabelThemeDetected_msg": "Ein benutzerdefiniertes Design wurde für diesen Account erkannt. Möchten Sie es jetzt anwenden?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Wer",
 		"whyLeave_msg": "Schade, dass Sie kündigen möchten. Wie können wir uns verbessern?",

--- a/src/translations/el.ts
+++ b/src/translations/el.ts
@@ -1628,7 +1628,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel domain",
 		"whitelabelRegistrationCode_label": "Κωδικός εγγραφής ",
 		"whitelabelRegistrationEmailDomain_label": "Καταχώρηση τομέα email",
-		"whitelabelThemeDetected_msg": "Στον λογαριασμό εντοπίστηκε ένα προσαρμοσμένο θέμα. Θέλετε να το εφαρμόσετε; ",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Ποιός",
 		"whyLeave_msg": "Λυπούμαστε που φεύγεις! Πού μπορούμε να βελτιωθούμε;",

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1675,7 +1675,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel domain",
 		"whitelabelRegistrationCode_label": "Registration code",
 		"whitelabelRegistrationEmailDomain_label": "Registration email domain",
-		"whitelabelThemeDetected_msg": "A custom theme has been detected for this account. Do you want to apply it now?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Who",
 		"whyLeave_msg": "We're sorry to see you go! Where can we improve?",

--- a/src/translations/es.ts
+++ b/src/translations/es.ts
@@ -1679,7 +1679,6 @@ export default {
 		"whitelabelDomain_label": "Dominio Etiqueta Blanca",
 		"whitelabelRegistrationCode_label": "Código de registro",
 		"whitelabelRegistrationEmailDomain_label": "Dominio de registro del correo",
-		"whitelabelThemeDetected_msg": "Se ha detectado un tema personalizado para esta cuenta. ¿Quieres aplicarlo ahora?",
 		"whitelabel_label": "Etiqueta Blanca",
 		"who_label": "Quién",
 		"whyLeave_msg": "¿Por qué estás descontento con Tuta?",

--- a/src/translations/fa_ir.ts
+++ b/src/translations/fa_ir.ts
@@ -1486,7 +1486,6 @@ export default {
 		"whitelabelDomain_label": "دامنه برچسب‌ سفید",
 		"whitelabelRegistrationCode_label": "کد ثبت‌نام ",
 		"whitelabelRegistrationEmailDomain_label": "دامنهٔ ثبت‌نام  ایمیل",
-		"whitelabelThemeDetected_msg": "یک زمینه دلخواه برای این حساب شناسایی شده است. آیا می‌خواهید اینک آن را اضافه کنید؟",
 		"whitelabel_label": "برچسب‌ سفید",
 		"who_label": "چه کسی ",
 		"work_label": "کار",

--- a/src/translations/fi.ts
+++ b/src/translations/fi.ts
@@ -1675,7 +1675,6 @@ export default {
 		"whitelabelDomain_label": "Brändätty verkkotunnus",
 		"whitelabelRegistrationCode_label": "Rekisteröintikoodi",
 		"whitelabelRegistrationEmailDomain_label": "Rekisteröity verkkotunnus",
-		"whitelabelThemeDetected_msg": "Tälle tilille on löydetty mukautettu teema. Haluatko ottaa sen käyttöön nyt?",
 		"whitelabel_label": "Brändäys",
 		"who_label": "Kuka",
 		"whyLeave_msg": "Olemme pahoillamme, että olet päättänyt lähteä! Missä meillä on parannettavaa?",

--- a/src/translations/fr.ts
+++ b/src/translations/fr.ts
@@ -1679,7 +1679,6 @@ export default {
 		"whitelabelDomain_label": "Domaine de marque blanche",
 		"whitelabelRegistrationCode_label": "Code d'enregistrement",
 		"whitelabelRegistrationEmailDomain_label": "Domaine d'enregistrement d'e-mail",
-		"whitelabelThemeDetected_msg": "Un thème personnalisé a été détecté pour ce compte. Voulez-vous l'appliquer maintenant?",
 		"whitelabel_label": "Marque blanche",
 		"who_label": "Qui",
 		"whyLeave_msg": "Nous sommes désolés de vous voir partir ! Que pouvons-nous améliorer ?",

--- a/src/translations/gl.ts
+++ b/src/translations/gl.ts
@@ -1628,7 +1628,6 @@ export default {
 		"whitelabelDomain_label": "Dominio de Personalización",
 		"whitelabelRegistrationCode_label": "Código de rexistro",
 		"whitelabelRegistrationEmailDomain_label": "Domino do correo de rexistro",
-		"whitelabelThemeDetected_msg": "Detectamos un decorado personalizado para esta conta. Queres aplicalo agora?",
 		"whitelabel_label": "Personalización",
 		"who_label": "Quen",
 		"whyLeave_msg": "Lamentamos que marches! Como podemos mellorar?",

--- a/src/translations/he.ts
+++ b/src/translations/he.ts
@@ -1529,7 +1529,6 @@ export default {
 		"whitelabelDomain_label": "דומיין מותג מדבקה",
 		"whitelabelRegistrationCode_label": "קוד הרשמה",
 		"whitelabelRegistrationEmailDomain_label": "דומיין דוא\"ל הרשמה",
-		"whitelabelThemeDetected_msg": "זוהתה ערכת נושא מותאמת אישית לחשבון זה. האם ברצונך להפעיל אותה כעת?",
 		"whitelabel_label": "מותג מדבקה",
 		"who_label": "מי",
 		"work_label": "עבודה",

--- a/src/translations/hi.ts
+++ b/src/translations/hi.ts
@@ -1356,7 +1356,6 @@ export default {
 		"whitelabelDomain_label": "श्वेतपद डाॅमेन",
 		"whitelabelRegistrationCode_label": "पंजीकरण संख्या",
 		"whitelabelRegistrationEmailDomain_label": "पंजीकरण के लिए ईमेल डाॅमेन",
-		"whitelabelThemeDetected_msg": "इस खाते के लिए एक कस्टम थीम का पता चला है। क्या आप इसे अभी लागू करना चाहते हैं?",
 		"whitelabel_label": "श्वेतपद",
 		"who_label": "कौन",
 		"work_label": "कार्य",

--- a/src/translations/hr.ts
+++ b/src/translations/hr.ts
@@ -1630,7 +1630,6 @@ export default {
 		"whitelabelDomain_label": "whitelabelDomena_oznaka\nWhitelabel domena",
 		"whitelabelRegistrationCode_label": "Registracijski kod",
 		"whitelabelRegistrationEmailDomain_label": "Domena e-pošte za registraciju",
-		"whitelabelThemeDetected_msg": "Otkrivena je personalizirana tema za ovaj račun. Želite li ju primijeniti sada?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Tko",
 		"whyLeave_msg": "Žao nam je što odlazite! Gdje se možemo poboljšati?",

--- a/src/translations/hu.ts
+++ b/src/translations/hu.ts
@@ -1674,7 +1674,6 @@ export default {
 		"whitelabelDomain_label": "Átcimkézési domain",
 		"whitelabelRegistrationCode_label": "Regisztrációs kód",
 		"whitelabelRegistrationEmailDomain_label": "E-mail domain regisztrálása",
-		"whitelabelThemeDetected_msg": "A szokásos téma észlelhető ehhez a számlához. Kívánja most alkalmazni?",
 		"whitelabel_label": "Átcímkézés",
 		"who_label": "Kik",
 		"whyLeave_msg": "Sajnáljuk távozását! Mit tudnák fejleszteni?",

--- a/src/translations/id.ts
+++ b/src/translations/id.ts
@@ -1323,7 +1323,6 @@ export default {
 		"whitelabelDomain_label": "Domain whitelabel",
 		"whitelabelRegistrationCode_label": "Kode registrasi",
 		"whitelabelRegistrationEmailDomain_label": "Pendaftaran domain surel",
-		"whitelabelThemeDetected_msg": "Tema khusus telah terdeteksi untuk akun ini.  Apakah Anda ingin menerapkannya sekarang?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Siapa",
 		"work_label": "Kerja",

--- a/src/translations/it.ts
+++ b/src/translations/it.ts
@@ -1576,7 +1576,6 @@ export default {
 		"whitelabelDomain_label": "Dominio whitelabel",
 		"whitelabelRegistrationCode_label": "Codice di registrazione",
 		"whitelabelRegistrationEmailDomain_label": "Dominio di registrazione email",
-		"whitelabelThemeDetected_msg": "È stato rilevato un tema personalizzato per questo account. Vuoi applicarlo ora?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Chi",
 		"work_label": "Lavoro",

--- a/src/translations/ja.ts
+++ b/src/translations/ja.ts
@@ -1538,7 +1538,6 @@ export default {
 		"whitelabelDomain_label": "ホワイトラベルのドメイン",
 		"whitelabelRegistrationCode_label": "登録コード",
 		"whitelabelRegistrationEmailDomain_label": "メールドメインの登録",
-		"whitelabelThemeDetected_msg": "このアカウントのカスタム テーマが検出されました。今すぐ適用しますか?",
 		"whitelabel_label": "ホワイトラベル",
 		"who_label": "誰",
 		"work_label": "仕事",

--- a/src/translations/ko.ts
+++ b/src/translations/ko.ts
@@ -1502,7 +1502,6 @@ export default {
 		"whitelabelDomain_label": "맞춤 도메인",
 		"whitelabelRegistrationCode_label": "등록 코드",
 		"whitelabelRegistrationEmailDomain_label": "이메일 도메인 등록",
-		"whitelabelThemeDetected_msg": "이 계정에 사용자 지정 테마가 감지되었습니다. 지금 적용하시겠습니까?",
 		"whitelabel_label": "화이트라벨",
 		"who_label": "누구",
 		"work_label": "직장",

--- a/src/translations/lv.ts
+++ b/src/translations/lv.ts
@@ -1111,7 +1111,6 @@ export default {
 		"whitelabelDomainNeeded_msg": "Lūdzu, sākumā konfigurējiet savu baltā marķējuma domēnu.",
 		"whitelabelDomain_label": "Baltā marķējuma domēns",
 		"whitelabelRegistrationEmailDomain_label": "Reģistrācijas e-pasta domēns",
-		"whitelabelThemeDetected_msg": "Šim kontam ir konstatēta individuāla/pielāgota tēma. Vai vēlaties to iespējot tagad?",
 		"whitelabel_label": "Baltais marķējums",
 		"who_label": "Kas",
 		"work_label": "Darbs",

--- a/src/translations/nl.ts
+++ b/src/translations/nl.ts
@@ -1663,7 +1663,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel domein",
 		"whitelabelRegistrationCode_label": "Registratiecode",
 		"whitelabelRegistrationEmailDomain_label": "Registratie e-maildomein",
-		"whitelabelThemeDetected_msg": "Een op maat gemaakte thema is voor dit account gedetecteerd. Wilt u hem nu toepassen?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Wie",
 		"whyLeave_msg": "We vinden het jammer dat u weggaat! Wat kunnen we verbeteren?",

--- a/src/translations/no.ts
+++ b/src/translations/no.ts
@@ -1648,7 +1648,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel-domene",
 		"whitelabelRegistrationCode_label": "Registreringskode",
 		"whitelabelRegistrationEmailDomain_label": "E-postdomene for registrering",
-		"whitelabelThemeDetected_msg": "Et tilpasset tema er oppdaget for denne kontoen. Vil du bruke det nå?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Hvem",
 		"whyLeave_msg": "Det er trist at du forlater oss! Hvordan kan vi forbedre oss?",

--- a/src/translations/pl.ts
+++ b/src/translations/pl.ts
@@ -1677,7 +1677,6 @@ export default {
 		"whitelabelDomain_label": "Domena Whitelabel ",
 		"whitelabelRegistrationCode_label": "Kod rejestracyjny",
 		"whitelabelRegistrationEmailDomain_label": "Rejestracja domeny e-mail",
-		"whitelabelThemeDetected_msg": "Na tym koncie znaleziono własny motyw. Czy chcesz go teraz zastosować?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Kto",
 		"whyLeave_msg": "Przykro nam, że odchodzisz! Co możemy poprawić?",

--- a/src/translations/pt_br.ts
+++ b/src/translations/pt_br.ts
@@ -1478,7 +1478,6 @@ export default {
 		"whitelabelDomain_label": "Domínio com marca personalizada",
 		"whitelabelRegistrationCode_label": "Código de registro",
 		"whitelabelRegistrationEmailDomain_label": "Domínio de email de registro",
-		"whitelabelThemeDetected_msg": "Um tema personalizado foi detectado para esta conta. Gostaria de aplicá-lo agora?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Quem",
 		"work_label": "Trabalho",

--- a/src/translations/pt_pt.ts
+++ b/src/translations/pt_pt.ts
@@ -1588,7 +1588,6 @@ export default {
 		"whitelabelDomain_label": "Domínio marca branca",
 		"whitelabelRegistrationCode_label": "Código de registo",
 		"whitelabelRegistrationEmailDomain_label": "Registo de domínio de email",
-		"whitelabelThemeDetected_msg": "Foi detectado um tema personalizado para esta conta. Pretende aplicá-lo agora?",
 		"whitelabel_label": "Marca branca",
 		"who_label": "Quem",
 		"work_label": "Trabalho",

--- a/src/translations/ro.ts
+++ b/src/translations/ro.ts
@@ -1655,7 +1655,6 @@ export default {
 		"whitelabelDomain_label": "Domeniu personalizat",
 		"whitelabelRegistrationCode_label": "Cod de înregistrare",
 		"whitelabelRegistrationEmailDomain_label": "Înregistrare domeniu de e-mail",
-		"whitelabelThemeDetected_msg": "A fost găsit un aspect personalizat pentru acest cont. Vrei să-l folosești acum?",
 		"whitelabel_label": "Personalizare",
 		"who_label": "Cine",
 		"whyLeave_msg": "Ne pare rău că pleci! Ce putem îmbunătăți?",

--- a/src/translations/ru.ts
+++ b/src/translations/ru.ts
@@ -1676,7 +1676,6 @@ export default {
 		"whitelabelDomain_label": "Домен Whitelabel",
 		"whitelabelRegistrationCode_label": "Регистрационный код",
 		"whitelabelRegistrationEmailDomain_label": "Регистрация почтового домена",
-		"whitelabelThemeDetected_msg": "Пользовательская тема обнаружена у этой учётной записи.  Хотите ли сейчас применить её?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Кто",
 		"whyLeave_msg": "Нам жаль, что вы уходите! Что мы можем улучшить?",

--- a/src/translations/si.ts
+++ b/src/translations/si.ts
@@ -1571,7 +1571,6 @@ export default {
 		"whitelabel.login_tooltip": "ඔබගේ සේවකයින් සඳහා ඔබගේම අඩවියේ ටුටානෝටා පිවිසුම තබන්න.",
 		"whitelabelRegistrationCode_label": "ලියාපදිංචි කේතය",
 		"whitelabelRegistrationEmailDomain_label": "ලියාපදිංචි කිරීමේ වි-තැපැල් වසම",
-		"whitelabelThemeDetected_msg": "මෙම ගිණුම සඳහා අභිරුචි තේමාවක් අනාවරණය වී ඇත. දැන් ඔබට එය යෙදීමට ඇවැසිද?",
 		"who_label": "කවුද",
 		"work_label": "කාර්යාලය",
 		"wrongUserCsvFormat_msg": "ඔබගේ දත්තවල සීඑස්වී ආකෘතිය නිවරදි කරන්න:\n{format}",

--- a/src/translations/sk.ts
+++ b/src/translations/sk.ts
@@ -1519,7 +1519,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel doména",
 		"whitelabelRegistrationCode_label": "Registračný kód",
 		"whitelabelRegistrationEmailDomain_label": "Doména registračného e-mailu",
-		"whitelabelThemeDetected_msg": "Pri tomto účte sa zistil vlastný motív. Chceš ho použiť teraz?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Kto",
 		"work_label": "Pracovný",

--- a/src/translations/sl.ts
+++ b/src/translations/sl.ts
@@ -1664,7 +1664,6 @@ export default {
 		"whitelabelDomain_label": "Domena z lastno blagovno znamko",
 		"whitelabelRegistrationCode_label": "Registracijska koda",
 		"whitelabelRegistrationEmailDomain_label": "Registracija poštne domene",
-		"whitelabelThemeDetected_msg": "Za ta račun je bila zaznana tema po meri. Želite uporabiti to temo?",
 		"whitelabel_label": "Lastna blagovna znamka",
 		"who_label": "Kdo",
 		"whyLeave_msg": "Žal nam je, da odhajate. Kje se lahko izboljšamo?",

--- a/src/translations/sr_cyrl.ts
+++ b/src/translations/sr_cyrl.ts
@@ -1514,7 +1514,6 @@ export default {
 		"whitelabelDomain_label": "Бела листа домен",
 		"whitelabelRegistrationCode_label": "Регистрацијска лозинка",
 		"whitelabelRegistrationEmailDomain_label": "Регистрација емаил домена",
-		"whitelabelThemeDetected_msg": "Откривена је прилагођена тема за овај налог. Да ли желите сада да је примените?",
 		"whitelabel_label": "Бела ознака",
 		"who_label": "Ko",
 		"work_label": "Посао",

--- a/src/translations/sv.ts
+++ b/src/translations/sv.ts
@@ -1675,7 +1675,6 @@ export default {
 		"whitelabelDomain_label": "Whitelabel-domän",
 		"whitelabelRegistrationCode_label": "Registreringskod",
 		"whitelabelRegistrationEmailDomain_label": "Registrering e-postdomän",
-		"whitelabelThemeDetected_msg": "Ett anpassat tema har upptäckts för det här kontot. Vill du använda det nu?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Vem",
 		"whyLeave_msg": "Vi är ledsna att se dig gå! Vad kan vi förbättra?",

--- a/src/translations/tr.ts
+++ b/src/translations/tr.ts
@@ -1627,7 +1627,6 @@ export default {
 		"whitelabelDomain_label": "Beyaz etiket alanı",
 		"whitelabelRegistrationCode_label": "kayıt kodu",
 		"whitelabelRegistrationEmailDomain_label": "Kayıt e-posta alanı",
-		"whitelabelThemeDetected_msg": "Bu hesap için özel bir renk teması algılandı. Onu şimdi uygulamak istiyor musunuz?",
 		"whitelabel_label": "Beyazetiket",
 		"who_label": "Kim",
 		"whyLeave_msg": "Gittiğinizi gördüğümüz için üzgünüz! Nereyi geliştirebiliriz?",

--- a/src/translations/uk.ts
+++ b/src/translations/uk.ts
@@ -1625,7 +1625,6 @@ export default {
 		"whitelabelDomain_label": "Домен з функцією whitelabel",
 		"whitelabelRegistrationCode_label": "Код реєстрації",
 		"whitelabelRegistrationEmailDomain_label": "Реєстрація домену електронної пошти",
-		"whitelabelThemeDetected_msg": "Для цього облікового запису виявлено настроювану тему. Застосувати  зараз?",
 		"whitelabel_label": "Whitelabel",
 		"who_label": "Хто",
 		"whyLeave_msg": "Нам шкода, що ви покидаєте нас! В чому ми можемо покращитися?",

--- a/src/translations/vi.ts
+++ b/src/translations/vi.ts
@@ -1591,7 +1591,6 @@ export default {
 		"whitelabelDomain_label": "Miền Nhãn trắng",
 		"whitelabelRegistrationCode_label": "Mã đăng kí",
 		"whitelabelRegistrationEmailDomain_label": "Miền thư đăng kí",
-		"whitelabelThemeDetected_msg": "Đã thấy có một chủ đề riêng cho danh khoản này. Bạn có muốn áp dụng nó ngay không?",
 		"whitelabel_label": "Nhãn trắng",
 		"who_label": "Ai",
 		"work_label": "Công sở",

--- a/src/translations/zh_hant.ts
+++ b/src/translations/zh_hant.ts
@@ -1671,7 +1671,6 @@ export default {
 		"whitelabelDomain_label": "白標域名",
 		"whitelabelRegistrationCode_label": "註冊碼",
 		"whitelabelRegistrationEmailDomain_label": "註冊電郵域名",
-		"whitelabelThemeDetected_msg": "偵測到此帳戶的自訂主題。您想現在套用它嗎？",
 		"whitelabel_label": "白標",
 		"who_label": "誰",
 		"whyLeave_msg": "我們很遺憾看到你離開！我們可以改善哪些地方？",


### PR DESCRIPTION
This appends the whitelabel themes to the bottom of the radio buttons on the themes page of the onboarding flow. When there is too many themes to display, it vertically expands the dialog. Which I did not program in but I can change it to scroll if desired.

The whitelabel popup and it's translation keys have also been removed as per acceptance criteria.

Closes #6770.