### PR TITLE
Fix iOS contact hashing

### DIFF
--- a/app-ios/tutanota.xcodeproj/project.pbxproj
+++ b/app-ios/tutanota.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		3DCE7AAC27200E0A0085E40D /* WebviewHacks.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DCE7AAA27200E0A0085E40D /* WebviewHacks.m */; };
 		3DD10DB227EA148D0076C9A2 /* BlobUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD10DB127EA148D0076C9A2 /* BlobUtil.swift */; };
 		3DD272D52BA203E20047ABF8 /* PermissionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD272D42BA203E20047ABF8 /* PermissionType.swift */; };
+		3DD2ADB82BB2CBAB00DE30B8 /* MurMurHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD2ADB72BB2CBAB00DE30B8 /* MurMurHash.swift */; };
 		3DD4A09020F8C6260086EB36 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3DD4A08F20F8C6260086EB36 /* Assets.xcassets */; };
 		3DD4A09320F8C6260086EB36 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3DD4A09120F8C6260086EB36 /* LaunchScreen.storyboard */; };
 		3DD4EA3B2726F41200D58207 /* DictionaryCoding in Frameworks */ = {isa = PBXBuildFile; productRef = 3DD4EA3A2726F41200D58207 /* DictionaryCoding */; };
@@ -601,6 +602,7 @@
 		3DCE7AAA27200E0A0085E40D /* WebviewHacks.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WebviewHacks.m; sourceTree = "<group>"; };
 		3DD10DB127EA148D0076C9A2 /* BlobUtil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlobUtil.swift; sourceTree = "<group>"; };
 		3DD272D42BA203E20047ABF8 /* PermissionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionType.swift; sourceTree = "<group>"; };
+		3DD2ADB72BB2CBAB00DE30B8 /* MurMurHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MurMurHash.swift; sourceTree = "<group>"; };
 		3DD4A08320F8C6240086EB36 /* Tuta D.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Tuta D.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DD4A08F20F8C6260086EB36 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3DD4A09220F8C6260086EB36 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -1035,6 +1037,7 @@
 				3DCC3F462ACED5DB00C9C27E /* UnfairLock.swift */,
 				3DCA74F52B63BE900007A1B0 /* UserPreferences.swift */,
 				3D5C6FA02B7BC15D00342E8C /* PermissionError.swift */,
+				3DD2ADB72BB2CBAB00DE30B8 /* MurMurHash.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1575,7 +1578,6 @@
 				3DEF18F12924E1F1009C4B55 /* TutanotaShareExtension */,
 				3DD4A08420F8C6240086EB36 /* Products */,
 				3D891EEC2105A5590031E528 /* Frameworks */,
-				3DD272D32BA201D00047ABF8 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2244,7 +2246,6 @@
 				3D4FAD162B8F368300BEDF5A /* ThemeFacade.swift in Sources */,
 				3D9B12A6272192C2002B46A1 /* AlarmNotification.swift in Sources */,
 				3D4FACED2B8F368300BEDF5A /* EncryptedFileInfo.swift in Sources */,
-				3DEF392A2B8CA8C000019695 /* PermissionType.swift in Sources */,
 				3D87ECE6212D9EB000FD7315 /* TUTIcons.m in Sources */,
 				3D9B12A32721926E002B46A1 /* ValueEncryption.swift in Sources */,
 				3D891F0D2105B12F0031E528 /* TUTEncodingConverter.m in Sources */,
@@ -2298,6 +2299,7 @@
 				3DE46D2B2848EBDA00DC9D43 /* IosFileFacade.swift in Sources */,
 				3D4A426729B6453700B10451 /* AlarmScheduler.swift in Sources */,
 				3D0E44A72B3C3CE500F933A1 /* poly.c in Sources */,
+				3DD2ADB82BB2CBAB00DE30B8 /* MurMurHash.swift in Sources */,
 				3D4A426329B63C0E00B10451 /* AlarmCryptor.swift in Sources */,
 				3D4FAD082B8F368300BEDF5A /* NativeShortcut.swift in Sources */,
 				3D4FACF02B8F368300BEDF5A /* KyberPublicKey.swift in Sources */,

--- a/app-ios/tutanota/Sources/Contacts/StructuredContactTypes.swift
+++ b/app-ios/tutanota/Sources/Contacts/StructuredContactTypes.swift
@@ -53,124 +53,99 @@ enum ContactWebsiteType: String, Codable {
 	case custom = "3"
 }
 
-extension StructuredMailAddress: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool { lhs.address == rhs.address && lhs.type == rhs.type && lhs.customTypeName == rhs.customTypeName }
+protocol StableHashable { func hash(into: inout MurmurHash3.FourBytesHash) }
+
+extension String: StableHashable { func hash(into hasher: inout MurmurHash3.FourBytesHash) { hasher.update(self.data(using: .utf8)!) } }
+
+extension Optional: StableHashable where Wrapped: StableHashable { func hash(into hasher: inout MurmurHash3.FourBytesHash) {} }
+
+extension Array: StableHashable where Element: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) { for element in self { element.hash(into: &hasher) } }
 }
 
-extension StructuredMailAddress: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(address)
-		hasher.combine(type)
-		hasher.combine(customTypeName)
+extension StructuredMailAddress: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) {
+		address.hash(into: &hasher)
+		type.hash(into: &hasher)
+		customTypeName.hash(into: &hasher)
 	}
 }
 
-extension StructuredAddress: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(address)
-		hasher.combine(type)
-		hasher.combine(customTypeName)
+extension StructuredAddress: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) {
+		address.hash(into: &hasher)
+		type.hash(into: &hasher)
+		customTypeName.hash(into: &hasher)
 	}
 }
 
-extension StructuredAddress: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool { lhs.address == rhs.address && lhs.type == rhs.type && lhs.customTypeName == rhs.customTypeName }
-}
-
-extension StructuredPhoneNumber: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(number)
-		hasher.combine(type)
-		hasher.combine(customTypeName)
+extension StructuredPhoneNumber: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) {
+		number.hash(into: &hasher)
+		type.hash(into: &hasher)
+		customTypeName.hash(into: &hasher)
 	}
 }
 
-extension StructuredWebsite: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool { lhs.type == rhs.type && lhs.customTypeName == rhs.customTypeName && lhs.url == rhs.url }
-}
-
-extension StructuredWebsite: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(url)
-		hasher.combine(type)
-		hasher.combine(customTypeName)
+extension StructuredCustomDate: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) {
+		dateIso.hash(into: &hasher)
+		type.hash(into: &hasher)
+		customTypeName.hash(into: &hasher)
 	}
 }
 
-extension StructuredCustomDate: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool { lhs.type == rhs.type && lhs.customTypeName == rhs.customTypeName && lhs.dateIso == rhs.dateIso }
-}
-
-extension StructuredCustomDate: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(dateIso)
-		hasher.combine(type)
-		hasher.combine(customTypeName)
+extension StructuredMessengerHandle: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) {
+		handle.hash(into: &hasher)
+		type.hash(into: &hasher)
+		customTypeName.hash(into: &hasher)
 	}
 }
 
-extension StructuredMessengerHandle: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool { lhs.type == rhs.type && lhs.customTypeName == rhs.customTypeName && lhs.handle == rhs.handle }
-}
-
-extension StructuredMessengerHandle: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(handle)
-		hasher.combine(type)
-		hasher.combine(customTypeName)
+extension StructuredRelationship: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) {
+		person.hash(into: &hasher)
+		type.hash(into: &hasher)
+		customTypeName.hash(into: &hasher)
 	}
 }
 
-extension StructuredRelationship: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool { lhs.type == rhs.type && lhs.customTypeName == rhs.customTypeName && lhs.person == rhs.person }
-}
-
-extension StructuredRelationship: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(person)
-		hasher.combine(type)
-		hasher.combine(customTypeName)
+extension StructuredWebsite: StableHashable {
+	func hash(into hasher: inout MurmurHash3.FourBytesHash) {
+		url.hash(into: &hasher)
+		type.hash(into: &hasher)
+		customTypeName.hash(into: &hasher)
 	}
 }
 
-extension StructuredPhoneNumber: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool { lhs.number == rhs.number && lhs.type == rhs.type && lhs.customTypeName == rhs.customTypeName }
-}
+extension RawRepresentable where RawValue: StableHashable { func hash(into hasher: inout MurmurHash3.FourBytesHash) { rawValue.hash(into: &hasher) } }
 
-extension StructuredContact: Equatable {
-	public static func == (lhs: Self, rhs: Self) -> Bool {
-		lhs.id == rhs.id && lhs.firstName == rhs.firstName && lhs.lastName == rhs.lastName && lhs.nickname == rhs.nickname && lhs.company == rhs.company
-			&& lhs.birthday == rhs.birthday && lhs.mailAddresses == rhs.mailAddresses && lhs.phoneNumbers == rhs.phoneNumbers && lhs.addresses == rhs.addresses
-			&& lhs.customDate == rhs.customDate && lhs.department == rhs.department && lhs.messengerHandles == rhs.messengerHandles
-			&& lhs.middleName == rhs.middleName && lhs.nameSuffix == rhs.nameSuffix && lhs.phoneticFirst == rhs.phoneticFirst
-			&& lhs.phoneticLast == rhs.phoneticLast && lhs.phoneticMiddle == rhs.phoneticMiddle && lhs.relationships == rhs.relationships
-			&& lhs.websites == rhs.websites && lhs.notes == rhs.notes && lhs.title == rhs.title && lhs.role == rhs.role
-	}
-}
-
-extension StructuredContact: Hashable {
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(id)
-		hasher.combine(firstName)
-		hasher.combine(lastName)
-		hasher.combine(nickname)
-		hasher.combine(company)
-		hasher.combine(birthday)
-		hasher.combine(mailAddresses)
-		hasher.combine(phoneNumbers)
-		hasher.combine(addresses)
-		hasher.combine(customDate)
-		hasher.combine(department)
-		hasher.combine(messengerHandles)
-		hasher.combine(middleName)
-		hasher.combine(nameSuffix)
-		hasher.combine(phoneticFirst)
-		hasher.combine(phoneticLast)
-		hasher.combine(phoneticMiddle)
-		hasher.combine(relationships)
-		hasher.combine(websites)
-		hasher.combine(notes)
-		hasher.combine(title)
-		hasher.combine(role)
+extension StructuredContact {
+	func stableHash() -> UInt32 {
+		var hash = MurmurHash3.FourBytesHash()
+		id?.hash(into: &hash)
+		firstName.hash(into: &hash)
+		lastName.hash(into: &hash)
+		nickname.hash(into: &hash)
+		company.hash(into: &hash)
+		birthday.hash(into: &hash)
+		mailAddresses.hash(into: &hash)
+		phoneNumbers.hash(into: &hash)
+		addresses.hash(into: &hash)
+		customDate.hash(into: &hash)
+		department.hash(into: &hash)
+		messengerHandles.hash(into: &hash)
+		middleName.hash(into: &hash)
+		nameSuffix.hash(into: &hash)
+		phoneticFirst.hash(into: &hash)
+		phoneticLast.hash(into: &hash)
+		phoneticMiddle.hash(into: &hash)
+		relationships.hash(into: &hash)
+		websites.hash(into: &hash)
+		notes.hash(into: &hash)
+		title.hash(into: &hash)
+		role.hash(into: &hash)
+		return hash.digest()
 	}
 }

--- a/app-ios/tutanota/Sources/Utils/MurMurHash.swift
+++ b/app-ios/tutanota/Sources/Utils/MurMurHash.swift
@@ -1,0 +1,328 @@
+//
+//  MurmurHash3.swift
+//  MurmurHash
+//
+//  Created by Daisuke T on 2019/02/06.
+//  Copyright © 2019 MurmurHash. All rights reserved.
+//
+//
+//The MIT License (MIT)
+//
+//Copyright (c) 2019 Daisuke T
+//
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+//
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+//
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+import Foundation
+
+public struct MurmurHash3 {}
+
+extension MurmurHash3 {
+	/// MurmurHash3 x86_32 class
+	public class FourBytesHash {
+		// MARK: - Enum, Const
+		static private let c1: UInt32 = 0xcc9e2d51
+		static private let c2: UInt32 = 0x1b873593
+		// MARK: - Property
+		private let endian = Common.endian()
+		private var state = State()
+		public var seed: UInt32 { didSet { reset() } }
+		// MARK: - Life cycle
+
+		/// Creates a new instance with the seed.
+		///
+		/// - Parameter seed: A seed for generate digest. Default is 0.
+		public init(_ seed: UInt32 = 0) {
+			self.seed = seed
+			reset()
+		}
+	}
+}
+
+// MARK: - State
+extension MurmurHash3.FourBytesHash {
+	private struct State {
+		var totalLen: Int = 0
+		var mem = [UInt8](repeating: 0, count: 3)
+		var memSize: Int = 0
+		var tail = MurmurHash3Tail(3)
+		var h1: UInt32 = 0
+	}
+}
+
+// MARK: - Utility
+extension MurmurHash3.FourBytesHash {
+	static private func body(_ h: UInt32, array: [UInt8]) -> UInt32 {
+		let nblocks = array.count / 4
+		var h1 = h
+		for i in 0..<nblocks {
+			var k1: UInt32 = Common.UInt8ArrayToUInt(array, index: i, endian: Common.endian())
+			k1 &*= c1
+			k1 = Common.rotl(k1, r: 15)
+			k1 &*= c2
+			h1 ^= k1
+			h1 = Common.rotl(h1, r: 13)
+			h1 = h1 &* 5 &+ 0xe6546b64
+		}
+		return h1
+	}
+	static private func tailAndFinalize(_ h1: UInt32, tail: [UInt8], len: Int) -> UInt32 {
+		var k1: UInt32 = 0
+		var h2 = h1
+		// swiftlint:disable fallthrough
+		/**
+		 * tail
+		 */
+		switch len & 3 {
+		case 3:
+			k1 ^= UInt32(tail[2]) << 16
+			fallthrough
+		case 2:
+			k1 ^= UInt32(tail[1]) << 8
+			fallthrough
+		case 1:
+			k1 ^= UInt32(tail[0])
+			k1 &*= c1
+			k1 = Common.rotl(k1, r: 15)
+			k1 &*= c2
+			h2 ^= k1
+		default: break
+		}
+		// swiftlint:enable fallthrough
+		/**
+		 * finalization
+		 */
+		h2 ^= UInt32(len)
+		h2 = Common.fmix32(h2)
+		return h2
+	}
+}
+
+// MARK: - Digest(One-shot)
+extension MurmurHash3.FourBytesHash {
+	/// Generate digest(One-shot)
+	///
+	/// - Parameters:
+	///   - array: A source data for hash.
+	///   - seed: A seed for generate digest. Default is 0.
+	/// - Returns: A generated digest.
+	static public func digest(_ array: [UInt8], seed: UInt32 = 0) -> UInt32 {
+		var h1 = seed
+		/**
+		 * body
+		 */
+		h1 = body(h1, array: array)
+		/**
+		 * tail and finalize
+		 */
+		let nblocks = array.count / 4
+		let tail = MurmurHash3Tail(3)
+		for i in 0..<array.count % 4 { tail.add(array[nblocks * 4 + i]) }
+		h1 = tailAndFinalize(h1, tail: tail.rawArray(), len: array.count)
+		return h1
+	}
+	/// Overload func for "digest(_ array: [UInt8], seed: UInt32 = 0)".
+	static public func digest(_ string: String, seed: UInt32 = 0) -> UInt32 { digest(Array(string.utf8), seed: seed) }
+	/// Overload func for "digest(_ array: [UInt8], seed: UInt32 = 0)".
+	static public func digest(_ data: Data, seed: UInt32 = 0) -> UInt32 { digest([UInt8](data), seed: seed) }
+	/// Generate digest's hex string(One-shot)
+	///
+	/// - Parameters:
+	///   - array: A source data for hash.
+	///   - seed: A seed for generate digest. Default is 0.
+	/// - Returns: A generated digest's hex string.
+	static public func digestHex(_ array: [UInt8], seed: UInt32 = 0) -> String {
+		let h = digest(array, seed: seed)
+		return Common.UInt32ArrayToHex([h])
+	}
+	/// Overload func for "digestHex(_ array: [UInt8], seed: UInt32 = 0)".
+	static public func digestHex(_ string: String, seed: UInt32 = 0) -> String {
+		let h = digest(string, seed: seed)
+		return Common.UInt32ArrayToHex([h])
+	}
+	/// Overload func for "digestHex(_ array: [UInt8], seed: UInt32 = 0)".
+	static public func digestHex(_ data: Data, seed: UInt32 = 0) -> String {
+		let h = digest(data, seed: seed)
+		return Common.UInt32ArrayToHex([h])
+	}
+}
+
+// MARK: - Digest(Streaming)
+extension MurmurHash3.FourBytesHash {
+	/// Reset current streaming state to initial.
+	public func reset() {
+		state = MurmurHash3.FourBytesHash.State()
+		state.h1 = self.seed
+	}
+	/// Update streaming state.
+	///
+	/// - Parameter array: A source data for hash.
+	public func update(_ array: [UInt8]) {
+		let len = array.count
+		state.totalLen += len
+		if state.memSize + len < 4 {
+			// fill in tmp buffer
+			state.mem.replaceSubrange(state.memSize..<state.memSize + len, with: array)
+			state.memSize += len
+			for i in 0..<len { state.tail.add(array[i]) }
+			return
+		}
+		/**
+		 * body
+		 */
+		let array2 = Array(state.mem[0..<state.memSize]) + array
+		state.h1 = MurmurHash3.FourBytesHash.body(state.h1, array: array2)
+		// fill in tmp buffer
+		state.memSize = array2.count % 4
+		state.mem.replaceSubrange(0..<state.memSize, with: array2[array2.count - state.memSize..<array2.count])
+		for i in 0..<3 { state.tail.add(array2[array2.count - (3 - i)]) }
+	}
+	/// Overload func for "update(_ array: [UInt8])".
+	public func update(_ string: String) { update(Array(string.utf8)) }
+	/// Overload func for "update(_ array: [UInt8])".
+	public func update(_ data: Data) { update([UInt8](data)) }
+	/// Generate digest(Streaming)
+	///
+	/// - Returns: A generated digest from current streaming state.
+	public func digest() -> UInt32 {
+		/**
+		 * tail and finalize
+		 */
+		var tail2 = Array(state.tail.rawArray())
+		tail2.removeFirst(tail2.count - state.totalLen % 4)
+		let h1 = MurmurHash3.FourBytesHash.tailAndFinalize(state.h1, tail: tail2, len: state.totalLen)
+		return h1
+	}
+	/// Generate digest's hex string(Streaming)
+	///
+	/// - Returns: A generated digest's hex string from current streaming state.
+	public func digestHex() -> String {
+		let h = digest()
+		return Common.UInt32ArrayToHex([h])
+	}
+}
+
+final class Common {
+	// MARK: - Enum, Const
+	enum Endian {
+		case little
+		case big
+	}
+}
+
+// MARK: - Utility
+extension Common {
+	static func endian() -> Endian {
+		if CFByteOrderGetCurrent() == Int(CFByteOrderLittleEndian.rawValue) { return Endian.little }
+		return Endian.big
+	}
+	static func rotl<T: FixedWidthInteger>(_ x: T, r: Int) -> T { (x << r) | (x >> (T.bitWidth - r)) }
+}
+
+// MARK: - Utility(Swap)
+extension Common {
+	static func swap<T: FixedWidthInteger>(_ x: T) -> T {
+		var res: T = 0
+		var mask: T = 0xff
+		var bit = 0
+		bit = (MemoryLayout<T>.size - 1) * 8
+		for _ in 0..<MemoryLayout<T>.size / 2 {
+			res |= (x & mask) << bit
+			mask = mask << 8
+			bit -= 16
+		}
+		bit = 8
+		for _ in 0..<MemoryLayout<T>.size / 2 {
+			res |= (x & mask) >> bit
+			mask = mask << 8
+			bit += 16
+		}
+		return res
+	}
+}
+
+// MARK: - Utility(Convert)
+extension Common {
+	static private func UInt8ArrayToUInt<T: FixedWidthInteger>(_ array: [UInt8], index: Int) -> T {
+		var block: T = 0
+		for i in 0..<MemoryLayout<T>.size { block |= T(array[index * MemoryLayout<T>.size + i]) << (i * 8) }
+		return block
+	}
+	static func UInt8ArrayToUInt<T: FixedWidthInteger>(_ array: [UInt8], index: Int, endian: Common.Endian) -> T {
+		var block: T = UInt8ArrayToUInt(array, index: index)
+		if endian == Common.Endian.little { return block }
+		// Big Endian
+		block = swap(block)
+		return block
+	}
+	static func UInt32ArrayToHex(_ array: [UInt32]) -> String {
+		var hex = ""
+		for val in array { hex += String.init(format: "%08x", val) }
+		return hex
+	}
+	static func UInt64ArrayToHex(_ array: [UInt64]) -> String {
+		var hex = ""
+		for val in array { hex += String.init(format: "%016lx", val) }
+		return hex
+	}
+}
+
+// MARK: - Utility(Mix)
+extension Common {
+	static func fmix32(_ h: UInt32) -> UInt32 {
+		var h2 = h
+		h2 ^= h2 >> 16
+		h2 &*= 0x85ebca6b
+		h2 ^= h2 >> 13
+		h2 &*= 0xc2b2ae35
+		h2 ^= h2 >> 16
+		return h2
+	}
+	static func fmix64(_ k: UInt64) -> UInt64 {
+		var k2 = k
+		k2 ^= k2 >> 33
+		k2 &*= 0xff51afd7ed558ccd
+		k2 ^= k2 >> 33
+		k2 &*= 0xc4ceb9fe1a85ec53
+		k2 ^= k2 >> 33
+		return k2
+	}
+}
+
+final class MurmurHash3Tail {
+	// MARK: - Property
+	private var array: [UInt8]
+	private var max: Int
+	// MARK: - Life cycle
+	public init(_ max: Int) {
+		self.max = max
+		array = [UInt8]()
+	}
+}
+
+// MARK: - Operation
+extension MurmurHash3Tail {
+	func add(_ newElement: UInt8) {
+		if array.count >= max {
+			array.replaceSubrange(0..<max - 1, with: Array(array[1..<max]))
+			array.removeLast()
+		}
+		array.append(newElement)
+	}
+	func rawArray() -> [UInt8] { Array(array) }
+}


### PR DESCRIPTION
The original contact hashing used to check contact changes was based on Swift's implementation of Hashable that unfortunately is granted to be the same just during the program execution, leading to different hashes every app startup.

This commit replaces the use of Hashble by an implementation of MurmurHash, leading to stable hashes across multiples app startup.

Co-authored-by: ivk <ivk@tutao.de>

fix #6776