### PR TITLE
Fix the calendar date picker showing the wrong month/week on Chromium

### DIFF
--- a/src/calendar/gui/day-selector/DaySelector.ts
+++ b/src/calendar/gui/day-selector/DaySelector.ts
@@ -74,6 +74,7 @@ export class DaySelector implements Component<DaySelectorAttrs> {
 
 		return m(Carousel, {
 			label: "date_label",
+			class: "center-horizontally",
 			style: {
 				fontSize: px(14),
 				lineHeight: px(this.getElementSize(vnode.attrs)),

--- a/src/gui/base/Carousel.ts
+++ b/src/gui/base/Carousel.ts
@@ -7,6 +7,7 @@ type Slide = { label: TranslationKey; element: Children }
 interface CarouselAttrs {
 	label: TranslationKey
 	slides: Slide[]
+	class?: string
 	style?: Record<string, any>
 	onSwipe: (isNext: boolean) => void
 }
@@ -23,6 +24,7 @@ export class Carousel implements Component<CarouselAttrs> {
 				role: "group",
 				"aria-roledescription": "carousel",
 				"aria-label": lang.get(attrs.label),
+				class: attrs.class,
 				style: attrs.style,
 				oncreate: (swiperNode) => {
 					this.containerDom = swiperNode.dom as HTMLElement


### PR DESCRIPTION
This fixes the issues with pressing a date going to the previous month and the wrong week being shown etc. The issue I linked also mentions wanting to return to previous views on back events which I am not sure whether we want to.

Closes #6784.
Closes #6734.