### PR TITLE
Fix not being able to scroll calendar without gestures in mobile layout

### DIFF
--- a/src/calendar/gui/CalendarGuiUtils.ts
+++ b/src/calendar/gui/CalendarGuiUtils.ts
@@ -808,3 +808,14 @@ export function shouldDisplayEvent(e: CalendarEvent, hiddenCalendars: ReadonlySe
 export function daysHaveEvents(eventsOnDays: EventsOnDays): boolean {
 	return eventsOnDays.shortEventsPerDay.some(isNotEmpty) || isNotEmpty(eventsOnDays.longEvents)
 }
+
+/**
+ * A handler for `onwheel` to move to a forwards or previous view based on mouse wheel movement
+ * @returns a function to be used by `onwheel`
+ */
+export function changePeriodOnWheel(callback: (isNext: boolean) => unknown): (event: WheelEvent) => void {
+	return (event: WheelEvent) => {
+		// Go to the next period if scrolling down or right
+		callback(event.deltaY > 0 || event.deltaX > 0)
+	}
+}

--- a/src/calendar/gui/day-selector/DaySelector.ts
+++ b/src/calendar/gui/day-selector/DaySelector.ts
@@ -2,7 +2,7 @@ import m, { Children, Component, Vnode } from "mithril"
 import { assertNotNull, getStartOfDay, incrementDate, isSameDayOfDate, isToday } from "@tutao/tutanota-utils"
 import { DateTime } from "luxon"
 import { Carousel } from "../../../gui/base/Carousel.js"
-import { getCalendarMonth } from "../CalendarGuiUtils.js"
+import { changePeriodOnWheel, getCalendarMonth } from "../CalendarGuiUtils.js"
 import { CalendarDay, CalendarMonth } from "../../date/CalendarUtils.js"
 import { DefaultAnimationTime } from "../../../gui/animation/Animations.js"
 import { ExpanderPanel } from "../../../gui/base/Expander.js"
@@ -54,10 +54,7 @@ export class DaySelector implements Component<DaySelectorAttrs> {
 		return m(
 			".flex.flex-column",
 			{
-				onwheel: (event: WheelEvent) => {
-					// Go to the next period if scrolling down or right
-					this.handleDayPickerSwipe(event.deltaY > 0 || event.deltaX > 0)
-				},
+				onwheel: changePeriodOnWheel(this.handleDayPickerSwipe),
 			},
 			[m(".flex-space-around", this.renderWeekDays(vnode.attrs.wide, weekdays)), this.renderDayPickerCarousel(vnode)],
 		)

--- a/src/calendar/gui/day-selector/DaySelector.ts
+++ b/src/calendar/gui/day-selector/DaySelector.ts
@@ -51,7 +51,16 @@ export class DaySelector implements Component<DaySelectorAttrs> {
 		}
 
 		let { weeks, weekdays } = getCalendarMonth(this.displayingDate, vnode.attrs.startOfTheWeekOffset, vnode.attrs.useNarrowWeekName)
-		return m(".flex.flex-column", [m(".flex-space-around", this.renderWeekDays(vnode.attrs.wide, weekdays)), this.renderDayPickerCarousel(vnode)])
+		return m(
+			".flex.flex-column",
+			{
+				onwheel: (event: WheelEvent) => {
+					// Go to the next period if scrolling down or right
+					this.handleDayPickerSwipe(event.deltaY > 0 || event.deltaX > 0)
+				},
+			},
+			[m(".flex-space-around", this.renderWeekDays(vnode.attrs.wide, weekdays)), this.renderDayPickerCarousel(vnode)],
+		)
 	}
 
 	private renderDayPickerCarousel(vnode: Vnode<DaySelectorAttrs>) {

--- a/src/calendar/view/CalendarMonthView.ts
+++ b/src/calendar/view/CalendarMonthView.ts
@@ -27,6 +27,7 @@ import { showUserError } from "../../misc/ErrorHandlerImpl"
 import {
 	CALENDAR_EVENT_HEIGHT,
 	CalendarViewType,
+	changePeriodOnWheel,
 	EventLayoutMode,
 	getCalendarMonth,
 	getDateFromMousePos,
@@ -124,6 +125,7 @@ export class CalendarMonthView implements Component<CalendarMonthAttrs>, ClassCo
 				class:
 					(!styles.isUsingBottomNavigation() ? "content-bg" : "") +
 					(styles.isDesktopLayout() ? " mlr-l border-radius-big" : " mlr-safe-inset border-radius-top-left-big border-radius-top-right-big"),
+				onwheel: changePeriodOnWheel(attrs.onChangeMonth),
 			},
 			[
 				m(


### PR DESCRIPTION
This adds mouse wheel controls as suggested by the issue to the `DaySelector`.

Closes #1719.