### PR TITLE
fix 404 page not shown for paths with more than one slash

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -474,7 +474,7 @@ import("./translations/en")
 		}
 
 		// append catch all at the end because mithril will stop at the first match
-		resolvers["/:path"] = {
+		resolvers["/:path..."] = {
 			onmatch: async () => {
 				const { NotFoundPage } = await import("./gui/base/NotFoundPage.js")
 				return {


### PR DESCRIPTION
We do not show the 404 page on the webapp correctly if paths that did not exist include more than one slash.
e.g. `/test/test`.

## Test Notes:

- [ ] https://app.test.tuta.com/test/test/ should **show** the 404 page
- [ ] https://app.test.tuta.com/mail/test/ should **not show** the 404 page
- [ ] https://app.test.tuta.com/test/something/ should **show** the 404 page