### PR TITLE
Fix window is not defined when starting the desktop app

### DIFF
--- a/src/api/main/MainLocator.ts
+++ b/src/api/main/MainLocator.ts
@@ -320,6 +320,7 @@ class MainLocator {
 			deviceConfig,
 			await this.receivedGroupInvitationsModel(GroupType.Calendar),
 			timeZone,
+			this.mailModel,
 		)
 	})
 

--- a/src/calendar/model/CalendarModel.ts
+++ b/src/calendar/model/CalendarModel.ts
@@ -804,21 +804,6 @@ export class CalendarModel {
 	getFileIdToSkippedCalendarEventUpdates(): Map<Id, CalendarEventUpdate> {
 		return this.fileIdToSkippedCalendarEventUpdates
 	}
-
-	/**
-	 * Partially mirrors the logic from CalendarEventModel.prototype.isFullyWritable() to determine
-	 * if the user can edit more than just alarms for a given event
-	 */
-	canFullyEditEvent(event: CalendarEvent): boolean {
-		const userController = this.logins.getUserController()
-		const userMailGroup = userController.getUserMailGroupMembership().group
-		const mailboxDetailsArray = this.mailModel.mailboxDetails()
-		const mailboxDetails = assertNotNull(mailboxDetailsArray.find((md) => md.mailGroup._id === userMailGroup))
-		const ownMailAddresses = getEnabledMailAddressesWithUser(mailboxDetails, userController.userGroupInfo)
-		const calendarInfos = this.getCalendarInfosStream()()
-		const eventType = getEventType(event, calendarInfos, ownMailAddresses, userController.user)
-		return eventType === EventType.OWN || eventType === EventType.SHARED_RW
-	}
 }
 
 /** return false when the given events (representing the new and old version of the same event) are both long events

--- a/src/misc/DeviceConfig.ts
+++ b/src/misc/DeviceConfig.ts
@@ -108,7 +108,7 @@ export class DeviceConfig implements CredentialsStorage, UsageTestStorage, NewsI
 			hasParticipatedInCredentialsMigration: loadedConfig.hasParticipatedInCredentialsMigration ?? false,
 			syncContactsWithPhonePreference: loadedConfig.syncContactsWithPhonePreference ?? {},
 			isCalendarDaySelectorExpanded: loadedConfig.isCalendarDaySelectorExpanded ?? false,
-			mailAutoSelectBehavior: loadedConfig.behaviorAfterMoveEmailAction ?? (isApp() ? ListAutoSelectBehavior.NONE : ListAutoSelectBehavior.OLDER),
+			mailAutoSelectBehavior: loadedConfig.mailAutoSelectBehavior ?? (isApp() ? ListAutoSelectBehavior.NONE : ListAutoSelectBehavior.OLDER),
 			isSetupComplete: loadedConfig.isSetupComplete ?? false,
 		}
 

--- a/test/tests/calendar/CalendarViewModelTest.ts
+++ b/test/tests/calendar/CalendarViewModelTest.ts
@@ -23,6 +23,7 @@ import { EntityUpdateData } from "../../../src/api/common/utils/EntityUpdateUtil
 import stream from "mithril/stream"
 import Stream from "mithril/stream"
 import { CalendarEventsRepository, DaysToEvents } from "../../../src/calendar/date/CalendarEventsRepository.js"
+import { MailModel } from "../../../src/mail/model/MailModel.js"
 
 let saveAndSendMock
 let rescheduleEventMock
@@ -68,6 +69,7 @@ o.spec("CalendarViewModel", function () {
 			getUserController: () => userController,
 			isInternalUserLoggedIn: () => true,
 		})
+		const mailModel: MailModel = object()
 		const previewModelFactory: CalendarEventPreviewModelFactory = async () => object()
 		const viewModel = new CalendarViewModel(
 			loginController,
@@ -81,8 +83,9 @@ o.spec("CalendarViewModel", function () {
 			deviceConfig,
 			calendarInvitations,
 			zone,
+			mailModel,
 		)
-
+		viewModel.allowDrag = () => true
 		return { viewModel, calendarModel, eventsRepository }
 	}
 
@@ -296,7 +299,8 @@ o.spec("CalendarViewModel", function () {
 			const event = makeEvent("event", originalEventStartTime, new Date(2021, 8, 23))
 
 			// Try to drag
-			simulateDrag(event, new Date(2021, 8, 24), viewModel, false)
+			viewModel.allowDrag = () => false
+			simulateDrag(event, new Date(2021, 8, 24), viewModel)
 
 			o(viewModel._draggedEvent?.eventClone).equals(undefined)
 		})
@@ -412,9 +416,8 @@ o.spec("CalendarViewModel", function () {
 	})
 })
 
-function simulateDrag(originalEvent: CalendarEvent, newDate: Date, viewModel: CalendarViewModel, allowDrag: boolean = true) {
+function simulateDrag(originalEvent: CalendarEvent, newDate: Date, viewModel: CalendarViewModel) {
 	let diff = newDate.getTime() - originalEvent.startTime.getTime()
-	when(viewModel.allowDrag(originalEvent)).thenReturn(allowDrag)
 	viewModel.onDragStart(originalEvent, diff)
 	return diff
 }


### PR DESCRIPTION
After #6736 the theme was being called too early because of a chain of calls from CalendarModel -> CalendarUtils -> CalendarGuiUtils -> ... -> theme -> DeviceConfig throwing an error inside deviceConfig.

This commit moves the function canFullyEditEvent to CalendarViewModel making sure that all the GUI stuff have been already loaded.

fix #6795