### PR TITLE
Fix the name of events overflowing onto the time

### DIFF
--- a/src/calendar/view/CalendarEventBubble.ts
+++ b/src/calendar/view/CalendarEventBubble.ts
@@ -104,9 +104,10 @@ export class CalendarEventBubble implements Component<CalendarEventBubbleAttrs> 
 			const linesInBubble = Math.floor(height / lineHeight)
 			// leave space for the second text line. it will be restricted to a maximum of one line in height
 			const topSectionMaxLines = secondLineText != null ? linesInBubble - 1 : linesInBubble
-			const topSectionClass = topSectionMaxLines === 1 ? ".text-ellipsis" : ".text-overflow"
+			const topSectionClass = topSectionMaxLines === 1 ? ".text-ellipsis" : ".text-ellipsis-multi-line"
 			return [
-				this.renderTextSection(topSectionClass, text, topSectionMaxLines * lineHeight),
+				// The wrapper around `text` is needed to stop `-webkit-box` from changing the height
+				this.renderTextSection("", m(topSectionClass, text), topSectionMaxLines * lineHeight),
 				secondLineText ? this.renderTextSection(".text-ellipsis", secondLineText, lineHeight) : null,
 			]
 		} else {

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -555,6 +555,11 @@ styles.registerStyle("main", () => {
 			"white-space": "nowrap",
 		},
 		".text-ellipsis-multi-line": {
+			/*
+			 * The `-webkit-line-clamp` property is standardized and supported by all major browsers.
+			 * It will likely be replaced by a property called `line-clamp` in the future.
+			 * See: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+			 */
 			display: "-webkit-box",
 			"-webkit-line-clamp": 3,
 			"-webkit-box-orient": "vertical",

--- a/src/gui/main-styles.ts
+++ b/src/gui/main-styles.ts
@@ -554,6 +554,13 @@ styles.registerStyle("main", () => {
 			"min-width": 0,
 			"white-space": "nowrap",
 		},
+		".text-ellipsis-multi-line": {
+			display: "-webkit-box",
+			"-webkit-line-clamp": 3,
+			"-webkit-box-orient": "vertical",
+			overflow: " hidden",
+			"text-overflow": "ellipsis",
+		},
 		".min-width-0": {
 			"min-width": 0,
 		},


### PR DESCRIPTION
I also experimented with a CSS flow based `CalendarEventBubble` to simplify the code but that is still too difficult because of the absolute positioning and sizing used in `CalendarDayEventsView`.

Closes #6582.