### PR TITLE
Fix not being able to add a custom domain when the domain limit is maxed

### DIFF
--- a/src/settings/mailaddress/AddAliasDialog.ts
+++ b/src/settings/mailaddress/AddAliasDialog.ts
@@ -19,7 +19,7 @@ export function showAddAliasDialog(model: MailAddressTableModel, isNewPaidPlan: 
 		if (model.aliasCount && filterInt(model.aliasCount.usedAliases) >= filterInt(model.aliasCount.totalAliases)) {
 			const hasCustomDomains = domains.some((domain) => !TUTANOTA_MAIL_ADDRESS_DOMAINS.includes(domain.domain))
 
-			if (isNewPaidPlan || !hasCustomDomains) {
+			if (!(isNewPaidPlan && hasCustomDomains)) {
 				model.handleTooManyAliases().catch(ofClass(UpgradeRequiredError, (e) => showPlanUpgradeRequiredDialog(e.plans, e.message)))
 				return
 			}


### PR DESCRIPTION
This was the boolean expression devised by wec's truth table.

Closes #6808.