### PR TITLE
chore: Update GitHub action workflows to use node version from .nvmrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 #v4.0.2
         with:
-          node-version: 20.11.1
+          node-version-file: '.nvmrc'
       - name: npm i
         run: npm i @octokit/rest
       - name: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,16 +24,12 @@ jobs:
       security-events: none
       statuses: none
 
-    strategy:
-      matrix:
-        node-version: [ 20.11.1 ]
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 #v4.0.2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Get better-sqlite3 cached location


### PR DESCRIPTION
- Instead of updating node versions across multiple files, you only need to update the `.nvmrc` and the same version will be picked up by GitHub actions.
- Matrix strategy testing was only using one version of node from the `.nvmrc`