### PR TITLE
Fix paste not triggering `input` events in Editor

### DIFF
--- a/src/gui/editor/Editor.ts
+++ b/src/gui/editor/Editor.ts
@@ -143,22 +143,6 @@ export class Editor implements ImageHandler, Component {
 			m.redraw() // allow richtexttoolbar to redraw elements
 		})
 
-		// Scroll to the cursor if it moves out of view
-		this.squire.addEventListener("cursor", () => {
-			const scrollableContainer = domElement.closest(".scroll") as HTMLElement | null
-			if (scrollableContainer == null) return
-
-			const cursorPosition = this.getCursorPosition()
-
-			// Get whether the cursors edges have exceeded the bounds of the dialog
-			const offsetBottom = scrollableContainer.offsetTop + scrollableContainer.offsetHeight
-			if (cursorPosition.top <= scrollableContainer.offsetTop || cursorPosition.bottom >= offsetBottom) {
-				// Scroll to the cursor minus an arbitrary offset for aesthetic reasons
-				const offset = 10
-				scrollableContainer.scrollTo(cursorPosition.x - offset, cursorPosition.y)
-			}
-		})
-
 		this.domElement = domElement
 		// the _editor might have been disabled before the dom element was there
 		this.setEnabled(this.enabled)


### PR DESCRIPTION
This reverts commit f0d6f2c28a50ac1ec70636e3efb1952980dca0f1.

Squire triggers some DOM modifications in getCursorPosition() and that causes it to skip firing `input` event in `_docWasChanged()`, probably because there are multiple DOM mutations that are done in the same event loop and MutatationObserver is only invoked once for them.

fix #6831