### PR TITLE
[ios] Localize custom labels when doing contact import

### DIFF
--- a/app-ios/tutanota/Sources/Contacts/IosMobileContactsFacade.swift
+++ b/app-ios/tutanota/Sources/Contacts/IosMobileContactsFacade.swift
@@ -520,7 +520,7 @@ private extension CNLabeledValue<CNContactRelation> {
 			case CNLabelContactRelationAssistant: (.assistant, nil)
 			case CNLabelContactRelationManager: (.manager, nil)
 			case CNLabelOther: (.other, nil)
-			default: (.other, self.label)
+			default: (.custom, localizeContactLabel(self))
 			}
 		return StructuredRelationship(person: value.name, type: type, customTypeName: label ?? "")
 	}
@@ -563,7 +563,7 @@ private extension CNLabeledValue<CNInstantMessageAddress> {
 			case StructuredMessengerHandleTypeName.whatsapp.rawValue: (.whatsapp, nil)
 			case StructuredMessengerHandleTypeName.telegram.rawValue: (.telegram, nil)
 			case StructuredMessengerHandleTypeName.discord.rawValue: (.discord, nil)
-			default: (.custom, self.value.service)
+			default: (.custom, Self.localizedString(forLabel: self.value.service))
 			}
 		return StructuredMessengerHandle(handle: value.username, type: type, customTypeName: label ?? "")
 	}
@@ -590,7 +590,7 @@ private extension CNLabeledValue<NSDateComponents> {
 			switch self.label {
 			case CNLabelDateAnniversary: (.anniversary, nil)
 			case CNLabelOther: (.other, nil)
-			default: (.custom, self.label)
+			default: (.custom, localizeContactLabel(self))
 			}
 		return StructuredCustomDate(dateIso: value.toIso(), type: type, customTypeName: label ?? "")
 	}
@@ -618,7 +618,7 @@ private extension CNLabeledValue<CNPhoneNumber> {
 			case CNLabelPhoneNumberMobile: (.mobile, nil)
 			case CNLabelPhoneNumberOtherFax: (.fax, nil)
 			case CNLabelOther: (.other, nil)
-			default: (.custom, self.label)
+			default: (.custom, localizeContactLabel(self))
 			}
 		return StructuredPhoneNumber(number: self.value.stringValue, type: type, customTypeName: label ?? "")
 	}
@@ -631,7 +631,7 @@ private extension CNLabeledValue<NSString> {
 			case CNLabelHome: (._private, nil)
 			case CNLabelWork: (.work, nil)
 			case CNLabelOther: (.other, nil)
-			default: (.custom, self.label)
+			default: (.custom, localizeContactLabel(self))
 			}
 		return StructuredMailAddress(address: self.value as String, type: type, customTypeName: label ?? "")
 	}
@@ -641,7 +641,7 @@ private extension CNLabeledValue<NSString> {
 			case CNLabelHome: (._private, nil)
 			case CNLabelWork: (.work, nil)
 			case CNLabelOther: (.other, nil)
-			default: (.custom, self.label)
+			default: (.custom, localizeContactLabel(self))
 			}
 		return StructuredWebsite(url: self.value as String, type: type, customTypeName: label ?? "")
 	}
@@ -684,7 +684,7 @@ private extension CNLabeledValue<CNPostalAddress> {
 			case CNLabelHome: (._private, nil)
 			case CNLabelWork: (.work, nil)
 			case CNLabelOther: (.other, nil)
-			default: (.custom, self.label)
+			default: (.custom, localizeContactLabel(self))
 			}
 		let address = CNPostalAddressFormatter().string(from: self.value)
 		return StructuredAddress(address: address, type: type, customTypeName: label ?? "")
@@ -777,4 +777,10 @@ private extension CNContact {
 			role: jobTitle
 		)
 	}
+}
+
+/// Calls CNLabeledValue.localizedString, but accepts null values (if so, it returns nil)
+private func localizeContactLabel<ValueType>(_ what: CNLabeledValue<ValueType>) -> String? {
+	guard let label = what.label else { return nil }
+	return type(of: what).localizedString(forLabel: label)
 }


### PR DESCRIPTION
Avoid `_$!XXXXX!$_` names by using CNLabeledValue.localizedString to localize contact labels before importing them.

Fixes #6799