### PR TITLE
[ios] Fix trying to updates contacts with notes on every sync

### DIFF
--- a/app-ios/tutanota/Sources/Contacts/IosMobileContactsFacade.swift
+++ b/app-ios/tutanota/Sources/Contacts/IosMobileContactsFacade.swift
@@ -44,7 +44,7 @@ class IosMobileContactsFacade: MobileContactsFacade {
 		let queryResult = try self.matchStoredContacts(against: contacts, forUser: &mapping)
 		// Here is ok to have an equal count of deletedOnDevice and deletedOnServer since not all server contacts and not all local contacts are inside the contacts array
 		TUTSLog(
-			"Contact SAVE match result: createdOnDevice: \(queryResult.createdOnDevice.count) editedOnDevice: \(queryResult.editedOnDevice.count) deletedOnDevice: \(queryResult.deletedOnDevice.count) newServerContacts: \(queryResult.newServerContacts.count) deletedOnServer: \(queryResult.deletedOnServer.count) existingServerContacts: \(queryResult.existingServerContacts.count) nativeContactWithoutSourceId: \(queryResult.nativeContactWithoutSourceId.count)"
+			"Contact SAVE match result: editedOnDevice: \(queryResult.editedOnDevice.count) newServerContacts: \(queryResult.newServerContacts.count) existingServerContacts: \(queryResult.existingServerContacts.count) nativeContactWithoutSourceId: \(queryResult.nativeContactWithoutSourceId.count)"
 		)
 		try self.insert(contacts: queryResult.newServerContacts, forUser: &mapping)
 		try self.update(contacts: queryResult.existingServerContacts, forUser: &mapping)

--- a/app-ios/tutanota/Sources/Contacts/StructuredContactTypes.swift
+++ b/app-ios/tutanota/Sources/Contacts/StructuredContactTypes.swift
@@ -143,7 +143,9 @@ extension StructuredContact {
 		phoneticMiddle.hash(into: &hash)
 		relationships.hash(into: &hash)
 		websites.hash(into: &hash)
-		notes.hash(into: &hash)
+		// Do not take notes into account for hash as we cannot write them to native contacts anyway.
+		// If we do try to use them for hash we will think that the contact is edited each time.
+		//		notes.hash(into: &hash)
 		title.hash(into: &hash)
 		role.hash(into: &hash)
 		return hash.digest()


### PR DESCRIPTION
We've been taking notes into account for hashing but we cannot read or write notes from native so it would mismatch every time.

We can add it back once we can access notes field.

fix #6827

Co-authored-by wrd <wrd@tutao.de>