### PR TITLE
Update better-sqlite3 commit for browser test crash fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"@types/qrcode-svg": "1.1.1",
 				"@types/systemjs": "6.1.1",
 				"@types/winreg": "1.2.31",
-				"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#c6ee076a4f15671d8a0fa7ddc16d12b179deb350",
+				"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#7e6d8b36cd804b4d5d07264c9a2f4a8820881586",
 				"cborg": "4.0.5",
 				"dompurify": "3.0.11",
 				"electron": "29.2.0",
@@ -3966,11 +3966,10 @@
 		},
 		"node_modules/better-sqlite3": {
 			"name": "@tutao/better-sqlite3-sqlcipher",
-			"version": "8.7.1",
-			"resolved": "git+ssh://git@github.com/tutao/better-sqlite3-sqlcipher.git#c6ee076a4f15671d8a0fa7ddc16d12b179deb350",
-			"integrity": "sha512-4NIGXEWrAAc6nTBvJb7T3JMKXYxHaGwjtmuS4XeYKYAT228lTtvDkLoSIPt8+F8EzfevHdgpEonHahpiAjJpIA==",
+			"version": "8.7.1-1",
+			"resolved": "git+ssh://git@github.com/tutao/better-sqlite3-sqlcipher.git#7e6d8b36cd804b4d5d07264c9a2f4a8820881586",
+			"integrity": "sha512-pqxQhQ0yxPIoozT6ycjOeY2h/4ka3giWLt11LQX5Phz7aoaygtiKyzKzn6ggo4Pvl9rCZGYaSDN7Ak9kHFy2AA==",
 			"hasInstallScript": true,
-			"license": "MIT",
 			"dependencies": {
 				"bindings": "^1.5.0",
 				"prebuild-install": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@types/qrcode-svg": "1.1.1",
 		"@types/systemjs": "6.1.1",
 		"@types/winreg": "1.2.31",
-		"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#c6ee076a4f15671d8a0fa7ddc16d12b179deb350",
+		"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#7e6d8b36cd804b4d5d07264c9a2f4a8820881586",
 		"cborg": "4.0.5",
 		"dompurify": "3.0.11",
 		"electron": "29.2.0",


### PR DESCRIPTION
Existing local repos: run `rm -rf node_modules/better-sqlite3 && npm install && rm -r test/native-cache` for the changes to take effect.