### PR TITLE
update monitor model to v26 and tutanota model to v68

### DIFF
--- a/src/api/entities/monitor/ModelInfo.ts
+++ b/src/api/entities/monitor/ModelInfo.ts
@@ -1,5 +1,5 @@
 const modelInfo = {
-	version: 25,
+	version: 26,
 	compatibleSince: 0,
 }
 		

--- a/src/api/entities/monitor/TypeModels.js
+++ b/src/api/entities/monitor/TypeModels.js
@@ -92,7 +92,7 @@ export const typeModels = {
             }
         },
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     },
     "CounterValue": {
         "name": "CounterValue",
@@ -133,7 +133,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     },
     "ErrorReportData": {
         "name": "ErrorReportData",
@@ -237,7 +237,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     },
     "ErrorReportFile": {
         "name": "ErrorReportFile",
@@ -278,7 +278,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     },
     "ReadCounterData": {
         "name": "ReadCounterData",
@@ -328,7 +328,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     },
     "ReadCounterReturn": {
         "name": "ReadCounterReturn",
@@ -371,7 +371,7 @@ export const typeModels = {
             }
         },
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     },
     "ReportErrorIn": {
         "name": "ReportErrorIn",
@@ -415,7 +415,7 @@ export const typeModels = {
             }
         },
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     },
     "WriteCounterData": {
         "name": "WriteCounterData",
@@ -474,6 +474,6 @@ export const typeModels = {
         },
         "associations": {},
         "app": "monitor",
-        "version": "25"
+        "version": "26"
     }
 }

--- a/src/api/entities/tutanota/ModelInfo.ts
+++ b/src/api/entities/tutanota/ModelInfo.ts
@@ -1,5 +1,5 @@
 const modelInfo = {
-	version: 67,
+	version: 68,
 	compatibleSince: 67,
 }
 		

--- a/src/api/entities/tutanota/TypeModels.js
+++ b/src/api/entities/tutanota/TypeModels.js
@@ -56,7 +56,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "Birthday": {
         "name": "Birthday",
@@ -106,7 +106,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "Body": {
         "name": "Body",
@@ -147,7 +147,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarDeleteData": {
         "name": "CalendarDeleteData",
@@ -181,7 +181,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarEvent": {
         "name": "CalendarEvent",
@@ -371,7 +371,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarEventAttendee": {
         "name": "CalendarEventAttendee",
@@ -414,7 +414,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarEventIndexRef": {
         "name": "CalendarEventIndexRef",
@@ -448,7 +448,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarEventUidIndex": {
         "name": "CalendarEventUidIndex",
@@ -519,7 +519,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarEventUpdate": {
         "name": "CalendarEventUpdate",
@@ -598,7 +598,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarEventUpdateList": {
         "name": "CalendarEventUpdateList",
@@ -632,7 +632,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarGroupRoot": {
         "name": "CalendarGroupRoot",
@@ -722,7 +722,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CalendarRepeatRule": {
         "name": "CalendarRepeatRule",
@@ -801,7 +801,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "Contact": {
         "name": "Contact",
@@ -1142,7 +1142,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactAddress": {
         "name": "ContactAddress",
@@ -1192,7 +1192,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactCustomDate": {
         "name": "ContactCustomDate",
@@ -1242,7 +1242,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactList": {
         "name": "ContactList",
@@ -1322,7 +1322,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactListEntry": {
         "name": "ContactListEntry",
@@ -1390,7 +1390,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactListGroupRoot": {
         "name": "ContactListGroupRoot",
@@ -1460,7 +1460,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactMailAddress": {
         "name": "ContactMailAddress",
@@ -1510,7 +1510,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactMessengerHandle": {
         "name": "ContactMessengerHandle",
@@ -1560,7 +1560,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactPhoneNumber": {
         "name": "ContactPhoneNumber",
@@ -1610,7 +1610,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactPronouns": {
         "name": "ContactPronouns",
@@ -1651,7 +1651,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactRelationship": {
         "name": "ContactRelationship",
@@ -1701,7 +1701,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactSocialId": {
         "name": "ContactSocialId",
@@ -1751,7 +1751,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ContactWebsite": {
         "name": "ContactWebsite",
@@ -1801,7 +1801,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ConversationEntry": {
         "name": "ConversationEntry",
@@ -1890,7 +1890,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CreateExternalUserGroupData": {
         "name": "CreateExternalUserGroupData",
@@ -1940,7 +1940,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CreateGroupPostReturn": {
         "name": "CreateGroupPostReturn",
@@ -1974,7 +1974,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CreateLocalAdminGroupData": {
         "name": "CreateLocalAdminGroupData",
@@ -2017,7 +2017,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CreateMailFolderData": {
         "name": "CreateMailFolderData",
@@ -2078,7 +2078,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CreateMailFolderReturn": {
         "name": "CreateMailFolderReturn",
@@ -2112,7 +2112,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CreateMailGroupData": {
         "name": "CreateMailGroupData",
@@ -2173,7 +2173,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "CustomerAccountCreateData": {
         "name": "CustomerAccountCreateData",
@@ -2327,7 +2327,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DeleteGroupData": {
         "name": "DeleteGroupData",
@@ -2370,7 +2370,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DeleteMailData": {
         "name": "DeleteMailData",
@@ -2414,7 +2414,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DeleteMailFolderData": {
         "name": "DeleteMailFolderData",
@@ -2448,7 +2448,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DraftAttachment": {
         "name": "DraftAttachment",
@@ -2501,7 +2501,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DraftCreateData": {
         "name": "DraftCreateData",
@@ -2571,7 +2571,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DraftCreateReturn": {
         "name": "DraftCreateReturn",
@@ -2605,7 +2605,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DraftData": {
         "name": "DraftData",
@@ -2752,7 +2752,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DraftRecipient": {
         "name": "DraftRecipient",
@@ -2793,7 +2793,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DraftUpdateData": {
         "name": "DraftUpdateData",
@@ -2837,7 +2837,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "DraftUpdateReturn": {
         "name": "DraftUpdateReturn",
@@ -2871,7 +2871,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "EmailTemplate": {
         "name": "EmailTemplate",
@@ -2959,7 +2959,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "EmailTemplateContent": {
         "name": "EmailTemplateContent",
@@ -3000,7 +3000,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "EncryptTutanotaPropertiesData": {
         "name": "EncryptTutanotaPropertiesData",
@@ -3043,7 +3043,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "EncryptedMailAddress": {
         "name": "EncryptedMailAddress",
@@ -3084,7 +3084,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "EntropyData": {
         "name": "EntropyData",
@@ -3116,7 +3116,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ExternalUserData": {
         "name": "ExternalUserData",
@@ -3249,7 +3249,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "File": {
         "name": "File",
@@ -3393,7 +3393,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "FileSystem": {
         "name": "FileSystem",
@@ -3463,7 +3463,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "GroupInvitationDeleteData": {
         "name": "GroupInvitationDeleteData",
@@ -3497,7 +3497,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "GroupInvitationPostData": {
         "name": "GroupInvitationPostData",
@@ -3541,7 +3541,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "GroupInvitationPostReturn": {
         "name": "GroupInvitationPostReturn",
@@ -3595,7 +3595,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "GroupInvitationPutData": {
         "name": "GroupInvitationPutData",
@@ -3647,7 +3647,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "GroupSettings": {
         "name": "GroupSettings",
@@ -3699,7 +3699,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "Header": {
         "name": "Header",
@@ -3740,7 +3740,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ImapFolder": {
         "name": "ImapFolder",
@@ -3801,7 +3801,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ImapSyncConfiguration": {
         "name": "ImapSyncConfiguration",
@@ -3871,7 +3871,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ImapSyncState": {
         "name": "ImapSyncState",
@@ -3932,7 +3932,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "InboxRule": {
         "name": "InboxRule",
@@ -3984,7 +3984,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "InternalGroupData": {
         "name": "InternalGroupData",
@@ -4090,7 +4090,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "InternalRecipientKeyData": {
         "name": "InternalRecipientKeyData",
@@ -4149,7 +4149,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "KnowledgeBaseEntry": {
         "name": "KnowledgeBaseEntry",
@@ -4237,7 +4237,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "KnowledgeBaseEntryKeyword": {
         "name": "KnowledgeBaseEntryKeyword",
@@ -4269,7 +4269,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ListUnsubscribeData": {
         "name": "ListUnsubscribeData",
@@ -4321,7 +4321,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "Mail": {
         "name": "Mail",
@@ -4646,7 +4646,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailAddress": {
         "name": "MailAddress",
@@ -4698,7 +4698,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailAddressProperties": {
         "name": "MailAddressProperties",
@@ -4739,7 +4739,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailBody": {
         "name": "MailBody",
@@ -4834,7 +4834,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailBox": {
         "name": "MailBox",
@@ -4972,7 +4972,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailDetails": {
         "name": "MailDetails",
@@ -5054,7 +5054,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailDetailsBlob": {
         "name": "MailDetailsBlob",
@@ -5124,7 +5124,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailDetailsDraft": {
         "name": "MailDetailsDraft",
@@ -5194,7 +5194,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailDetailsDraftsRef": {
         "name": "MailDetailsDraftsRef",
@@ -5228,7 +5228,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailFolder": {
         "name": "MailFolder",
@@ -5336,7 +5336,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailFolderRef": {
         "name": "MailFolderRef",
@@ -5370,7 +5370,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailHeaders": {
         "name": "MailHeaders",
@@ -5447,7 +5447,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailboxGroupRoot": {
         "name": "MailboxGroupRoot",
@@ -5568,7 +5568,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailboxProperties": {
         "name": "MailboxProperties",
@@ -5647,7 +5647,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MailboxServerProperties": {
         "name": "MailboxServerProperties",
@@ -5706,7 +5706,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "MoveMailData": {
         "name": "MoveMailData",
@@ -5750,7 +5750,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "NewDraftAttachment": {
         "name": "NewDraftAttachment",
@@ -5811,7 +5811,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "NewsId": {
         "name": "NewsId",
@@ -5852,7 +5852,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "NewsIn": {
         "name": "NewsIn",
@@ -5884,7 +5884,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "NewsOut": {
         "name": "NewsOut",
@@ -5918,7 +5918,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "NotificationMail": {
         "name": "NotificationMail",
@@ -5986,7 +5986,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "OutOfOfficeNotification": {
         "name": "OutOfOfficeNotification",
@@ -6074,7 +6074,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "OutOfOfficeNotificationMessage": {
         "name": "OutOfOfficeNotificationMessage",
@@ -6124,7 +6124,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "OutOfOfficeNotificationRecipientList": {
         "name": "OutOfOfficeNotificationRecipientList",
@@ -6158,7 +6158,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PasswordAutoAuthenticationReturn": {
         "name": "PasswordAutoAuthenticationReturn",
@@ -6181,7 +6181,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PasswordChannelPhoneNumber": {
         "name": "PasswordChannelPhoneNumber",
@@ -6213,7 +6213,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PasswordChannelReturn": {
         "name": "PasswordChannelReturn",
@@ -6247,7 +6247,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PasswordMessagingData": {
         "name": "PasswordMessagingData",
@@ -6297,7 +6297,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PasswordMessagingReturn": {
         "name": "PasswordMessagingReturn",
@@ -6329,7 +6329,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PasswordRetrievalData": {
         "name": "PasswordRetrievalData",
@@ -6361,7 +6361,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PasswordRetrievalReturn": {
         "name": "PasswordRetrievalReturn",
@@ -6393,7 +6393,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PhishingMarkerWebsocketData": {
         "name": "PhishingMarkerWebsocketData",
@@ -6436,7 +6436,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "PhotosRef": {
         "name": "PhotosRef",
@@ -6470,7 +6470,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ReceiveInfoServiceData": {
         "name": "ReceiveInfoServiceData",
@@ -6502,7 +6502,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "Recipients": {
         "name": "Recipients",
@@ -6556,7 +6556,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "RemoteImapSyncInfo": {
         "name": "RemoteImapSyncInfo",
@@ -6626,7 +6626,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ReportMailPostData": {
         "name": "ReportMailPostData",
@@ -6678,7 +6678,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "ReportedMailFieldMarker": {
         "name": "ReportedMailFieldMarker",
@@ -6719,7 +6719,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "SecureExternalRecipientKeyData": {
         "name": "SecureExternalRecipientKeyData",
@@ -6834,7 +6834,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "SendDraftData": {
         "name": "SendDraftData",
@@ -6962,7 +6962,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "SendDraftReturn": {
         "name": "SendDraftReturn",
@@ -7024,7 +7024,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "SharedGroupData": {
         "name": "SharedGroupData",
@@ -7119,7 +7119,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "SpamResults": {
         "name": "SpamResults",
@@ -7153,7 +7153,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "Subfiles": {
         "name": "Subfiles",
@@ -7187,7 +7187,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "SymEncInternalRecipientKeyData": {
         "name": "SymEncInternalRecipientKeyData",
@@ -7239,7 +7239,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "TemplateGroupRoot": {
         "name": "TemplateGroupRoot",
@@ -7319,7 +7319,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "TutanotaProperties": {
         "name": "TutanotaProperties",
@@ -7490,7 +7490,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "UpdateMailFolderData": {
         "name": "UpdateMailFolderData",
@@ -7534,7 +7534,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "UserAccountCreateData": {
         "name": "UserAccountCreateData",
@@ -7587,7 +7587,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "UserAccountUserData": {
         "name": "UserAccountUserData",
@@ -7808,7 +7808,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "UserAreaGroupData": {
         "name": "UserAreaGroupData",
@@ -7887,7 +7887,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "UserAreaGroupDeleteData": {
         "name": "UserAreaGroupDeleteData",
@@ -7921,7 +7921,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "UserAreaGroupPostData": {
         "name": "UserAreaGroupPostData",
@@ -7955,7 +7955,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     },
     "UserSettingsGroupRoot": {
         "name": "UserSettingsGroupRoot",
@@ -8052,6 +8052,6 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "67"
+        "version": "68"
     }
 }


### PR DESCRIPTION
We update the model version for the monitor model as we introduced new properties on the ReleaseInfo type, which is available only in the admin client.