### PR TITLE
Fix dropdown filtering by wrong field

### DIFF
--- a/src/gui/base/Dropdown.ts
+++ b/src/gui/base/Dropdown.ts
@@ -352,7 +352,8 @@ export class Dropdown implements ModalComponent {
 			if (isDropDownInfo(b)) {
 				return b.info.includes(this._filterString.toLowerCase())
 			} else if (this._isFilterable) {
-				return lang.getMaybeLazy(b.label).toLowerCase().includes(this._filterString.toLowerCase())
+				const filterable = lang.getMaybeLazy(b.text ?? b.label)
+				return filterable.toLowerCase().includes(this._filterString.toLowerCase())
 			} else {
 				return true
 			}

--- a/src/mail/view/MailGuiUtils.ts
+++ b/src/mail/view/MailGuiUtils.ts
@@ -16,8 +16,7 @@ import { reportMailsAutomatically } from "./MailReportDialog"
 import { DataFile } from "../../api/common/DataFile"
 import { lang, TranslationKey } from "../../misc/LanguageViewModel"
 import { FileController } from "../../file/FileController"
-import { DomRectReadOnlyPolyfilled, Dropdown, PosRect } from "../../gui/base/Dropdown.js"
-import { ButtonSize } from "../../gui/base/ButtonSize.js"
+import { DomRectReadOnlyPolyfilled, Dropdown, DropdownChildAttrs, PosRect } from "../../gui/base/Dropdown.js"
 import { modal } from "../../gui/base/Modal.js"
 import { assertSystemFolderOfType, isOfTypeOrSubfolderOf, isSpamOrTrashFolder } from "../../api/common/mail/CommonMailUtils.js"
 import { ConversationViewModel } from "./ConversationViewModel.js"
@@ -319,17 +318,19 @@ export async function showMoveMailsDropdown(
 	const { width = 300, withBackground = false, onSelected = noOp } = opts ?? {}
 	const folders = await getMoveTargetFolderSystems(model, mails)
 	if (folders.length === 0) return
-	const folderButtons = folders.map((f) => ({
-		// We need to pass in the raw folder name to avoid including it in searches
-		label: () => lang.get("folderDepth_label", { "{folderName}": getFolderName(f.folder), "{depth}": f.level }),
-		text: () => getIndentedFolderNameForDropdown(f),
-		click: () => {
-			onSelected()
-			moveMails({ mailModel: model, mails: mails, targetMailFolder: f.folder })
-		},
-		icon: getFolderIcon(f.folder),
-		size: ButtonSize.Compact,
-	}))
+	const folderButtons = folders.map(
+		(f) =>
+			({
+				// We need to pass in the raw folder name to avoid including it in searches
+				label: () => lang.get("folderDepth_label", { "{folderName}": getFolderName(f.folder), "{depth}": f.level }),
+				text: () => getIndentedFolderNameForDropdown(f),
+				click: () => {
+					onSelected()
+					moveMails({ mailModel: model, mails: mails, targetMailFolder: f.folder })
+				},
+				icon: getFolderIcon(f.folder),
+			} satisfies DropdownChildAttrs),
+	)
 
 	const dropdown = new Dropdown(() => folderButtons, width)
 


### PR DESCRIPTION
Label is a human-readable accessibility description, and it might include parts that we don't want to filter by.

We opted into preferring text to label because that's what users are more likely to see. It is not perfect as in some cases (e.g. folder names) we display something that we don't want to filter by (folder indentation level with dots) but it is less surprising. A proper fix would be to introduce another value/function for filtering.

#5353