### PR TITLE
Fix keyboard navigation in the single-column mail view

### DIFF
--- a/src/RootView.ts
+++ b/src/RootView.ts
@@ -22,7 +22,7 @@ export const enum LayerType {
 	Overlay = 400,
 }
 
-const enum PrimaryNavigationType {
+export const enum PrimaryNavigationType {
 	Keyboard,
 	Touch,
 	Mouse,
@@ -31,7 +31,7 @@ const enum PrimaryNavigationType {
 
 // global, in case we have multiple instances for some reason
 /** What we infer to be the user's preferred navigation type. */
-let currentNavigationType: PrimaryNavigationType = isApp() ? PrimaryNavigationType.Touch : PrimaryNavigationType.Mouse
+export let currentNavigationType: PrimaryNavigationType = isApp() ? PrimaryNavigationType.Touch : PrimaryNavigationType.Mouse
 
 /**
  * View which wraps anything that we render.
@@ -64,7 +64,7 @@ export class RootView implements ClassComponent {
 				},
 				onkeyup: (e: EventRedraw<KeyboardEvent>) => {
 					// tab key can be pressed in some other situations e.g. editor but it would be switched back quickly again if needed.
-					if (isKeyPressed(e.key, Keys.TAB, Keys.UP, Keys.DOWN)) {
+					if (isKeyPressed(e.key, Keys.TAB, Keys.UP, Keys.DOWN, Keys.J, Keys.K)) {
 						this.switchNavType(PrimaryNavigationType.Keyboard)
 					}
 					e.redraw = false

--- a/src/contacts/view/ContactListRecipientView.ts
+++ b/src/contacts/view/ContactListRecipientView.ts
@@ -205,5 +205,7 @@ export class RecipientRow implements VirtualRow<ContactListEntry> {
 		this.titleDom.style.transform = translate
 		this.titleDom.style.paddingRight = padding
 		this.checkboxDom.style.transform = scale
+		// Stop the hidden checkbox from entering the tab index
+		if (!show) this.checkboxDom.style.display = "none"
 	}
 }

--- a/src/contacts/view/ContactRow.ts
+++ b/src/contacts/view/ContactRow.ts
@@ -140,5 +140,7 @@ export class ContactRow implements VirtualRow<Contact> {
 		this.domAddress.style.paddingRight = padding
 		this.domName.style.paddingRight = padding
 		this.checkboxDom.style.transform = scale
+		// Stop the hidden checkbox from entering the tab index
+		if (!show) this.checkboxDom.style.display = "none"
 	}
 }

--- a/src/gui/SelectableRowContainer.ts
+++ b/src/gui/SelectableRowContainer.ts
@@ -48,7 +48,11 @@ export class SelectableRowContainer implements ClassComponent<SelectableRowConta
 				},
 				onblur: () => {
 					if (SelectableRowContainer.getIsUsingKeyboard()) {
-						this.setBackground(theme.list_bg)
+						if (this.selected && !styles.isSingleColumnLayout()) {
+							this.setBackground(stateBgHover)
+						} else {
+							this.setBackground(theme.list_bg)
+						}
 					}
 				},
 				onpointerdown: () => this.setBackground(stateBgActive),

--- a/src/gui/SelectableRowContainer.ts
+++ b/src/gui/SelectableRowContainer.ts
@@ -40,9 +40,18 @@ export class SelectableRowContainer implements ClassComponent<SelectableRowConta
 						this.updateDomBg()
 					})
 				},
-				onpointerdown: () => {
-					if (this.dom) this.dom.style.backgroundColor = stateBgActive
+				// Highlight the row when it is tabbed into
+				onfocus: () => {
+					if (SelectableRowContainer.getIsUsingKeyboard()) {
+						this.setBackground(stateBgActive)
+					}
 				},
+				onblur: () => {
+					if (SelectableRowContainer.getIsUsingKeyboard()) {
+						this.setBackground(theme.list_bg)
+					}
+				},
+				onpointerdown: () => this.setBackground(stateBgActive),
 				onpointerup: this.updateDomBg,
 				onpointercancel: this.updateDomBg,
 				onpointerleave: this.updateDomBg,
@@ -51,14 +60,20 @@ export class SelectableRowContainer implements ClassComponent<SelectableRowConta
 		)
 	}
 
+	private setBackground(color: string) {
+		if (this.dom) this.dom.style.backgroundColor = color
+	}
+
+	private static getIsUsingKeyboard() {
+		return currentNavigationType === PrimaryNavigationType.Keyboard
+	}
+
 	private updateDomBg = () => {
-		const isUsingKeyboard = currentNavigationType === PrimaryNavigationType.Keyboard
+		const isUsingKeyboard = SelectableRowContainer.getIsUsingKeyboard()
 		// In the single column view, a row may be 'selected' by the URL still linking to a specific mail
 		// So do not highlight in that case but in just multiselect mode and keyboard navigation
 		const highlight = styles.isSingleColumnLayout() ? (this.isInMultiselect || isUsingKeyboard) && this.selected : this.selected
-		if (this.dom) {
-			this.dom.style.backgroundColor = highlight ? stateBgHover : theme.list_bg
-		}
+		this.setBackground(highlight ? stateBgHover : theme.list_bg)
 	}
 }
 

--- a/src/gui/SelectableRowContainer.ts
+++ b/src/gui/SelectableRowContainer.ts
@@ -42,12 +42,12 @@ export class SelectableRowContainer implements ClassComponent<SelectableRowConta
 				},
 				// Highlight the row when it is tabbed into
 				onfocus: () => {
-					if (SelectableRowContainer.getIsUsingKeyboard()) {
+					if (SelectableRowContainer.isUsingKeyboard()) {
 						this.setBackground(stateBgActive)
 					}
 				},
 				onblur: () => {
-					if (SelectableRowContainer.getIsUsingKeyboard()) {
+					if (SelectableRowContainer.isUsingKeyboard()) {
 						if (this.selected && !styles.isSingleColumnLayout()) {
 							this.setBackground(stateBgHover)
 						} else {
@@ -68,12 +68,12 @@ export class SelectableRowContainer implements ClassComponent<SelectableRowConta
 		if (this.dom) this.dom.style.backgroundColor = color
 	}
 
-	private static getIsUsingKeyboard() {
+	private static isUsingKeyboard() {
 		return currentNavigationType === PrimaryNavigationType.Keyboard
 	}
 
 	private updateDomBg = () => {
-		const isUsingKeyboard = SelectableRowContainer.getIsUsingKeyboard()
+		const isUsingKeyboard = SelectableRowContainer.isUsingKeyboard()
 		// In the single column view, a row may be 'selected' by the URL still linking to a specific mail
 		// So do not highlight in that case but in just multiselect mode and keyboard navigation
 		const highlight = styles.isSingleColumnLayout() ? (this.isInMultiselect || isUsingKeyboard) && this.selected : this.selected

--- a/src/gui/SelectableRowContainer.ts
+++ b/src/gui/SelectableRowContainer.ts
@@ -4,6 +4,7 @@ import { theme } from "./theme.js"
 import { styles } from "./styles.js"
 import { px, size } from "./size.js"
 import { DefaultAnimationTime } from "./animation/Animations.js"
+import { currentNavigationType, PrimaryNavigationType } from "../RootView.js"
 
 /** A function that can adjust the style of the selectable row. */
 export type SelectableRowSelectedSetter = (selected: boolean, isInMultiselect: boolean) => unknown
@@ -51,8 +52,10 @@ export class SelectableRowContainer implements ClassComponent<SelectableRowConta
 	}
 
 	private updateDomBg = () => {
-		// in single column layout the "current element" selection is not meaningful and is even annoying
-		const highlight = styles.isSingleColumnLayout() ? this.isInMultiselect && this.selected : this.selected
+		const isUsingKeyboard = currentNavigationType === PrimaryNavigationType.Keyboard
+		// In the single column view, a row may be 'selected' by the URL still linking to a specific mail
+		// So do not highlight in that case but in just multiselect mode and keyboard navigation
+		const highlight = styles.isSingleColumnLayout() ? (this.isInMultiselect || isUsingKeyboard) && this.selected : this.selected
 		if (this.dom) {
 			this.dom.style.backgroundColor = highlight ? stateBgHover : theme.list_bg
 		}

--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -264,6 +264,20 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 			}
 		}
 
+		// Handle highlighting the row when tabbed onto or out of
+		const onFocus = (focusType: "focus" | "blur") => {
+			return (e: FocusEvent) => {
+				const dom = e.target as HTMLElement | null
+				// Activate the background colour in `SelectableRowContainer`
+				// TODO: Transition to `state-bg`
+				if (dom && dom.firstElementChild) {
+					dom.firstElementChild?.dispatchEvent(new FocusEvent(focusType))
+				}
+			}
+		}
+		domElement.onfocus = onFocus("focus")
+		domElement.onblur = onFocus("blur")
+
 		domElement.ondragstart = (e: DragEvent) => {
 			// The quick change of the background color is to prevent a white background appearing in dark mode
 			if (row.domElement) row.domElement!.style.background = theme.navigation_bg

--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -231,14 +231,13 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 	}
 
 	private createRow(attrs: ListAttrs<T, VH>, rows: ListRow<T, VH>[]) {
-		return m("li.list-row", {
+		return m("li.list-row.nofocus", {
 			draggable: attrs.renderConfig.dragStart ? "true" : undefined,
 			tabindex: TabIndex.Default,
 			oncreate: (vnode: VnodeDOM) => {
 				const dom = vnode.dom as HTMLElement
-				const r = attrs.renderConfig.createElement(dom)
 				const row = {
-					row: r,
+					row: attrs.renderConfig.createElement(dom),
 					domElement: dom,
 					top: -1,
 					entity: null,
@@ -405,7 +404,6 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 		for (const row of this.rows) {
 			row.top = nextPosition
 			nextPosition += rowHeight
-
 			const pos = row.top / rowHeight
 			const item = attrs.state.items[pos]
 			row.entity = item
@@ -416,6 +414,10 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 				row.domElement.style.display = ""
 				row.domElement.style.transform = `translateY(${row.top}px)`
 				row.row.update(item, attrs.state.selectedItems.has(item), attrs.state.inMultiselect)
+			}
+			// Focus the selected row so it can receive keyboard events
+			if (attrs.state.selectedItems.has(item)) {
+				row.domElement.focus()
 			}
 		}
 		this.updateStatus(attrs.state.loadingStatus)

--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -431,8 +431,8 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 				row.domElement.style.transform = `translateY(${row.top}px)`
 				row.row.update(item, attrs.state.selectedItems.has(item), attrs.state.inMultiselect)
 			}
-			// Focus the selected row so it can receive keyboard events in the single-column layout and on other layouts if the focus is within the list.
-			if (attrs.state.selectedItems.has(item) && (document.activeElement?.tagName === "LI" || styles.isSingleColumnLayout())) {
+			// Focus the selected row so it can receive keyboard events if the user has just changed it
+			if (attrs.state.selectedItems.has(item) && (!this.state?.selectedItems.has(item) || this.state == null)) {
 				row.domElement.focus()
 			}
 		}

--- a/src/gui/base/List.ts
+++ b/src/gui/base/List.ts
@@ -11,6 +11,7 @@ import { applySafeAreaInsetMarginLR } from "../HtmlUtils.js"
 import { theme, ThemeId } from "../theme.js"
 import { ProgrammingError } from "../../api/common/error/ProgrammingError.js"
 import { Coordinate2D } from "./SwipeHandler.js"
+import { styles } from "../styles.js"
 
 export type ListState<T> = Readonly<{
 	items: ReadonlyArray<T>
@@ -154,6 +155,7 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 					this.updateDomElements(attrs)
 					this.state = attrs.state
 					this.lastThemeId = theme.themeId
+					if (styles.isSingleColumnLayout()) this.innerDom.focus()
 				},
 				onupdate: ({ dom }) => {
 					if (oldAttrs.renderConfig !== attrs.renderConfig) {
@@ -429,8 +431,8 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 				row.domElement.style.transform = `translateY(${row.top}px)`
 				row.row.update(item, attrs.state.selectedItems.has(item), attrs.state.inMultiselect)
 			}
-			// Focus the selected row so it can receive keyboard events
-			if (attrs.state.selectedItems.has(item)) {
+			// Focus the selected row so it can receive keyboard events in the single-column layout and on other layouts if the focus is within the list.
+			if (attrs.state.selectedItems.has(item) && (document.activeElement?.tagName === "LI" || styles.isSingleColumnLayout())) {
 				row.domElement.focus()
 			}
 		}

--- a/src/gui/base/ViewColumn.ts
+++ b/src/gui/base/ViewColumn.ts
@@ -78,11 +78,14 @@ export class ViewColumn implements Component<Attrs> {
 	view() {
 		const zIndex = !this.isVisible && this.columnType === ColumnType.Foreground ? LayerType.ForegroundMenu + 1 : ""
 		const landmark = this.ariaRole ? landmarkAttrs(this.ariaRole, this.ariaLabel ? this.ariaLabel() : this.getTitle()) : {}
+		const isInteractable = this.isVisible || this.isInForeground
 		return m(
 			".view-column.fill-absolute",
 			{
 				...landmark,
-				"aria-hidden": this.isVisible || this.isInForeground ? "false" : "true",
+				// As tab index is not inherited, remove the column from the tab index by not rendering it
+				class: isInteractable ? undefined : "hidden",
+				"aria-hidden": isInteractable ? "false" : "true",
 				oncreate: (vnode) => {
 					this.domColumn = vnode.dom as HTMLElement
 					this.domColumn.style.transform =

--- a/src/gui/nav/ViewSlider.ts
+++ b/src/gui/nav/ViewSlider.ts
@@ -330,6 +330,9 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	 * Executes a slide animation for the background buttons.
 	 */
 	private slideBackgroundColumns(nextVisibleViewColumn: ViewColumn, oldOffset: number, newOffset: number): Promise<unknown> {
+		// Remove the `visibility: hidden` from the target column before starting the animation, so it is visible during the animation
+		nextVisibleViewColumn.isVisible = true
+
 		return animations
 			.add(this.domSlidingPart, transform(TransformEnum.TranslateX, oldOffset, newOffset), {
 				easing: ease.inOut,
@@ -339,7 +342,6 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 				const [removed] = this.visibleBackgroundColumns.splice(0, 1, nextVisibleViewColumn)
 
 				removed.isVisible = false
-				nextVisibleViewColumn.isVisible = true
 			})
 	}
 


### PR DESCRIPTION
There is still a possible issue where the tab order and the selection via the arrow keys do not align. If you tab to the third row then press down for instance, the forth row will not be selected.

I am not sure whether to fix this as the arrow keys and tab do slightly different things. The arrow keys focus and open a row while the tab just focuses a row.

Closes #5361.