### PR TITLE
remove canceledPremiumAccount flag from customer type (#6883)

### DIFF
--- a/schemas/sys.json
+++ b/schemas/sys.json
@@ -275,6 +275,16 @@
 					"info": "AddAssociation UserGroupRoot/keyRotations/AGGREGATION/2294."
 				}
 			]
+		},
+		{
+			"version": 97,
+			"changes": [
+				{
+					"name": "RemoveValue",
+					"sourceType": "Customer",
+					"info": "RemoveValue Customer/canceledPremiumAccount/902."
+				}
+			]
 		}
 	]
 }

--- a/src/api/entities/sys/ModelInfo.ts
+++ b/src/api/entities/sys/ModelInfo.ts
@@ -1,6 +1,6 @@
 const modelInfo = {
-	version: 96,
-	compatibleSince: 96,
+	version: 97,
+	compatibleSince: 97,
 }
 		
 export default modelInfo

--- a/src/api/entities/sys/Services.ts
+++ b/src/api/entities/sys/Services.ts
@@ -48,8 +48,6 @@ import {PaymentDataServicePutReturnTypeRef} from "./TypeRefs.js"
 import {PdfInvoiceServiceDataTypeRef} from "./TypeRefs.js"
 import {PdfInvoiceServiceReturnTypeRef} from "./TypeRefs.js"
 import {PlanServiceGetOutTypeRef} from "./TypeRefs.js"
-import {PremiumFeatureDataTypeRef} from "./TypeRefs.js"
-import {PremiumFeatureReturnTypeRef} from "./TypeRefs.js"
 import {PriceServiceDataTypeRef} from "./TypeRefs.js"
 import {PriceServiceReturnTypeRef} from "./TypeRefs.js"
 import {PublicKeyGetInTypeRef} from "./TypeRefs.js"
@@ -306,15 +304,6 @@ export const PlanService = Object.freeze({
 	name: "PlanService",
 	get: {data: null, return: PlanServiceGetOutTypeRef},
 	post: null,
-	put: null,
-	delete: null,
-} as const)
-
-export const PremiumFeatureService = Object.freeze({
-	app: "sys",
-	name: "PremiumFeatureService",
-	get: null,
-	post: {data: PremiumFeatureDataTypeRef, return: PremiumFeatureReturnTypeRef},
 	put: null,
 	delete: null,
 } as const)

--- a/src/api/entities/sys/TypeModels.js
+++ b/src/api/entities/sys/TypeModels.js
@@ -209,7 +209,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AdministratedGroupsRef": {
         "name": "AdministratedGroupsRef",
@@ -243,7 +243,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AlarmInfo": {
         "name": "AlarmInfo",
@@ -295,7 +295,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AlarmNotification": {
         "name": "AlarmNotification",
@@ -395,7 +395,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AlarmServicePost": {
         "name": "AlarmServicePost",
@@ -429,7 +429,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ArchiveRef": {
         "name": "ArchiveRef",
@@ -461,7 +461,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ArchiveType": {
         "name": "ArchiveType",
@@ -515,7 +515,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AuditLogEntry": {
         "name": "AuditLogEntry",
@@ -649,7 +649,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AuditLogRef": {
         "name": "AuditLogRef",
@@ -683,7 +683,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AuthenticatedDevice": {
         "name": "AuthenticatedDevice",
@@ -733,7 +733,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Authentication": {
         "name": "Authentication",
@@ -794,7 +794,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AutoLoginDataDelete": {
         "name": "AutoLoginDataDelete",
@@ -826,7 +826,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AutoLoginDataGet": {
         "name": "AutoLoginDataGet",
@@ -869,7 +869,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AutoLoginDataReturn": {
         "name": "AutoLoginDataReturn",
@@ -901,7 +901,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "AutoLoginPostReturn": {
         "name": "AutoLoginPostReturn",
@@ -933,7 +933,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Blob": {
         "name": "Blob",
@@ -983,7 +983,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BlobReferenceTokenWrapper": {
         "name": "BlobReferenceTokenWrapper",
@@ -1015,7 +1015,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Booking": {
         "name": "Booking",
@@ -1139,7 +1139,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BookingItem": {
         "name": "BookingItem",
@@ -1225,7 +1225,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BookingsRef": {
         "name": "BookingsRef",
@@ -1259,7 +1259,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BootstrapFeature": {
         "name": "BootstrapFeature",
@@ -1291,7 +1291,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Braintree3ds2Request": {
         "name": "Braintree3ds2Request",
@@ -1341,7 +1341,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Braintree3ds2Response": {
         "name": "Braintree3ds2Response",
@@ -1382,7 +1382,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BrandingDomainData": {
         "name": "BrandingDomainData",
@@ -1459,7 +1459,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BrandingDomainDeleteData": {
         "name": "BrandingDomainDeleteData",
@@ -1491,7 +1491,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BrandingDomainGetReturn": {
         "name": "BrandingDomainGetReturn",
@@ -1525,7 +1525,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Bucket": {
         "name": "Bucket",
@@ -1559,7 +1559,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BucketKey": {
         "name": "BucketKey",
@@ -1648,7 +1648,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "BucketPermission": {
         "name": "BucketPermission",
@@ -1790,7 +1790,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CalendarEventRef": {
         "name": "CalendarEventRef",
@@ -1831,7 +1831,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CertificateInfo": {
         "name": "CertificateInfo",
@@ -1892,7 +1892,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Challenge": {
         "name": "Challenge",
@@ -1945,7 +1945,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ChangeKdfPostIn": {
         "name": "ChangeKdfPostIn",
@@ -2013,7 +2013,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ChangePasswordData": {
         "name": "ChangePasswordData",
@@ -2099,7 +2099,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Chat": {
         "name": "Chat",
@@ -2149,7 +2149,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CloseSessionServicePost": {
         "name": "CloseSessionServicePost",
@@ -2192,7 +2192,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CreateCustomerServerPropertiesData": {
         "name": "CreateCustomerServerPropertiesData",
@@ -2233,7 +2233,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CreateCustomerServerPropertiesReturn": {
         "name": "CreateCustomerServerPropertiesReturn",
@@ -2267,7 +2267,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CreateSessionData": {
         "name": "CreateSessionData",
@@ -2355,7 +2355,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CreateSessionReturn": {
         "name": "CreateSessionReturn",
@@ -2408,7 +2408,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CreditCard": {
         "name": "CreditCard",
@@ -2476,7 +2476,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomDomainCheckGetIn": {
         "name": "CustomDomainCheckGetIn",
@@ -2519,7 +2519,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomDomainCheckGetOut": {
         "name": "CustomDomainCheckGetOut",
@@ -2582,7 +2582,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomDomainData": {
         "name": "CustomDomainData",
@@ -2625,7 +2625,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomDomainReturn": {
         "name": "CustomDomainReturn",
@@ -2668,7 +2668,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Customer": {
         "name": "Customer",
@@ -2729,15 +2729,6 @@ export const typeModels = {
                 "name": "businessUse",
                 "id": 1754,
                 "since": 61,
-                "type": "Boolean",
-                "cardinality": "One",
-                "encrypted": false
-            },
-            "canceledPremiumAccount": {
-                "final": false,
-                "name": "canceledPremiumAccount",
-                "id": 902,
-                "since": 10,
                 "type": "Boolean",
                 "cardinality": "One",
                 "encrypted": false
@@ -2934,7 +2925,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomerAccountTerminationPostIn": {
         "name": "CustomerAccountTerminationPostIn",
@@ -2984,7 +2975,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomerAccountTerminationPostOut": {
         "name": "CustomerAccountTerminationPostOut",
@@ -3018,7 +3009,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomerAccountTerminationRequest": {
         "name": "CustomerAccountTerminationRequest",
@@ -3097,7 +3088,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomerInfo": {
         "name": "CustomerInfo",
@@ -3410,7 +3401,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomerProperties": {
         "name": "CustomerProperties",
@@ -3518,7 +3509,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "CustomerServerProperties": {
         "name": "CustomerServerProperties",
@@ -3644,7 +3635,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DateWrapper": {
         "name": "DateWrapper",
@@ -3676,7 +3667,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DebitServicePutData": {
         "name": "DebitServicePutData",
@@ -3710,7 +3701,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DeleteCustomerData": {
         "name": "DeleteCustomerData",
@@ -3789,7 +3780,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DnsRecord": {
         "name": "DnsRecord",
@@ -3839,7 +3830,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DomainInfo": {
         "name": "DomainInfo",
@@ -3901,7 +3892,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DomainMailAddressAvailabilityData": {
         "name": "DomainMailAddressAvailabilityData",
@@ -3933,7 +3924,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DomainMailAddressAvailabilityReturn": {
         "name": "DomainMailAddressAvailabilityReturn",
@@ -3965,7 +3956,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "DomainsRef": {
         "name": "DomainsRef",
@@ -3999,7 +3990,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "EmailSenderListElement": {
         "name": "EmailSenderListElement",
@@ -4058,7 +4049,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "EntityEventBatch": {
         "name": "EntityEventBatch",
@@ -4119,7 +4110,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "EntityUpdate": {
         "name": "EntityUpdate",
@@ -4187,7 +4178,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Exception": {
         "name": "Exception",
@@ -4228,7 +4219,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ExternalPropertiesReturn": {
         "name": "ExternalPropertiesReturn",
@@ -4290,7 +4281,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ExternalUserReference": {
         "name": "ExternalUserReference",
@@ -4361,7 +4352,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Feature": {
         "name": "Feature",
@@ -4393,7 +4384,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "File": {
         "name": "File",
@@ -4443,7 +4434,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GeneratedIdWrapper": {
         "name": "GeneratedIdWrapper",
@@ -4475,7 +4466,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCard": {
         "name": "GiftCard",
@@ -4588,7 +4579,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardCreateData": {
         "name": "GiftCardCreateData",
@@ -4656,7 +4647,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardCreateReturn": {
         "name": "GiftCardCreateReturn",
@@ -4690,7 +4681,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardDeleteData": {
         "name": "GiftCardDeleteData",
@@ -4724,7 +4715,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardGetReturn": {
         "name": "GiftCardGetReturn",
@@ -4776,7 +4767,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardOption": {
         "name": "GiftCardOption",
@@ -4808,7 +4799,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardRedeemData": {
         "name": "GiftCardRedeemData",
@@ -4860,7 +4851,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardRedeemGetReturn": {
         "name": "GiftCardRedeemGetReturn",
@@ -4912,7 +4903,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GiftCardsRef": {
         "name": "GiftCardsRef",
@@ -4946,7 +4937,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Group": {
         "name": "Group",
@@ -5170,7 +5161,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GroupInfo": {
         "name": "GroupInfo",
@@ -5323,7 +5314,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GroupKey": {
         "name": "GroupKey",
@@ -5429,7 +5420,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GroupKeysRef": {
         "name": "GroupKeysRef",
@@ -5463,7 +5454,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GroupMember": {
         "name": "GroupMember",
@@ -5553,7 +5544,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GroupMembership": {
         "name": "GroupMembership",
@@ -5661,7 +5652,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "GroupRoot": {
         "name": "GroupRoot",
@@ -5742,7 +5733,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "InstanceSessionKey": {
         "name": "InstanceSessionKey",
@@ -5821,7 +5812,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Invoice": {
         "name": "Invoice",
@@ -6037,7 +6028,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "InvoiceDataGetIn": {
         "name": "InvoiceDataGetIn",
@@ -6069,7 +6060,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "InvoiceDataGetOut": {
         "name": "InvoiceDataGetOut",
@@ -6211,7 +6202,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "InvoiceDataItem": {
         "name": "InvoiceDataItem",
@@ -6288,7 +6279,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "InvoiceInfo": {
         "name": "InvoiceInfo",
@@ -6467,7 +6458,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "InvoiceItem": {
         "name": "InvoiceItem",
@@ -6553,7 +6544,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "KeyPair": {
         "name": "KeyPair",
@@ -6630,7 +6621,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "KeyRotation": {
         "name": "KeyRotation",
@@ -6698,7 +6689,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "KeyRotationsRef": {
         "name": "KeyRotationsRef",
@@ -6732,7 +6723,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "LocationServiceGetReturn": {
         "name": "LocationServiceGetReturn",
@@ -6764,7 +6755,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Login": {
         "name": "Login",
@@ -6823,7 +6814,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MailAddressAlias": {
         "name": "MailAddressAlias",
@@ -6864,7 +6855,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MailAddressAliasGetIn": {
         "name": "MailAddressAliasGetIn",
@@ -6898,7 +6889,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MailAddressAliasServiceData": {
         "name": "MailAddressAliasServiceData",
@@ -6941,7 +6932,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MailAddressAliasServiceDataDelete": {
         "name": "MailAddressAliasServiceDataDelete",
@@ -6993,7 +6984,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MailAddressAliasServiceReturn": {
         "name": "MailAddressAliasServiceReturn",
@@ -7052,7 +7043,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MailAddressAvailability": {
         "name": "MailAddressAvailability",
@@ -7093,7 +7084,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MailAddressToGroup": {
         "name": "MailAddressToGroup",
@@ -7154,7 +7145,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MembershipAddData": {
         "name": "MembershipAddData",
@@ -7225,7 +7216,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MembershipRemoveData": {
         "name": "MembershipRemoveData",
@@ -7269,7 +7260,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MissedNotification": {
         "name": "MissedNotification",
@@ -7385,7 +7376,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MultipleMailAddressAvailabilityData": {
         "name": "MultipleMailAddressAvailabilityData",
@@ -7419,7 +7410,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "MultipleMailAddressAvailabilityReturn": {
         "name": "MultipleMailAddressAvailabilityReturn",
@@ -7453,7 +7444,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "NotificationInfo": {
         "name": "NotificationInfo",
@@ -7503,7 +7494,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "NotificationMailTemplate": {
         "name": "NotificationMailTemplate",
@@ -7553,7 +7544,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "NotificationSessionKey": {
         "name": "NotificationSessionKey",
@@ -7596,7 +7587,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "OrderProcessingAgreement": {
         "name": "OrderProcessingAgreement",
@@ -7712,7 +7703,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "OtpChallenge": {
         "name": "OtpChallenge",
@@ -7746,7 +7737,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PaymentDataServiceGetData": {
         "name": "PaymentDataServiceGetData",
@@ -7778,7 +7769,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PaymentDataServiceGetReturn": {
         "name": "PaymentDataServiceGetReturn",
@@ -7810,7 +7801,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PaymentDataServicePostData": {
         "name": "PaymentDataServicePostData",
@@ -7844,7 +7835,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PaymentDataServicePutData": {
         "name": "PaymentDataServicePutData",
@@ -7959,7 +7950,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PaymentDataServicePutReturn": {
         "name": "PaymentDataServicePutReturn",
@@ -8002,7 +7993,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PaymentErrorInfo": {
         "name": "PaymentErrorInfo",
@@ -8052,7 +8043,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PdfInvoiceServiceData": {
         "name": "PdfInvoiceServiceData",
@@ -8095,7 +8086,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PdfInvoiceServiceReturn": {
         "name": "PdfInvoiceServiceReturn",
@@ -8154,7 +8145,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Permission": {
         "name": "Permission",
@@ -8306,7 +8297,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PhoneNumber": {
         "name": "PhoneNumber",
@@ -8338,7 +8329,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PlanConfiguration": {
         "name": "PlanConfiguration",
@@ -8451,7 +8442,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PlanPrices": {
         "name": "PlanPrices",
@@ -8593,7 +8584,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PlanServiceGetOut": {
         "name": "PlanServiceGetOut",
@@ -8627,80 +8618,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
-    },
-    "PremiumFeatureData": {
-        "name": "PremiumFeatureData",
-        "since": 6,
-        "type": "DATA_TRANSFER_TYPE",
-        "id": 651,
-        "rootId": "A3N5cwACiw",
-        "versioned": false,
-        "encrypted": false,
-        "values": {
-            "_format": {
-                "final": false,
-                "name": "_format",
-                "id": 652,
-                "since": 6,
-                "type": "Number",
-                "cardinality": "One",
-                "encrypted": false
-            },
-            "activationCode": {
-                "final": false,
-                "name": "activationCode",
-                "id": 654,
-                "since": 6,
-                "type": "String",
-                "cardinality": "One",
-                "encrypted": false
-            },
-            "featureName": {
-                "final": false,
-                "name": "featureName",
-                "id": 653,
-                "since": 6,
-                "type": "String",
-                "cardinality": "One",
-                "encrypted": false
-            }
-        },
-        "associations": {},
-        "app": "sys",
-        "version": "96"
-    },
-    "PremiumFeatureReturn": {
-        "name": "PremiumFeatureReturn",
-        "since": 16,
-        "type": "DATA_TRANSFER_TYPE",
-        "id": 978,
-        "rootId": "A3N5cwAD0g",
-        "versioned": false,
-        "encrypted": false,
-        "values": {
-            "_format": {
-                "final": false,
-                "name": "_format",
-                "id": 979,
-                "since": 16,
-                "type": "Number",
-                "cardinality": "One",
-                "encrypted": false
-            },
-            "activatedFeature": {
-                "final": false,
-                "name": "activatedFeature",
-                "id": 980,
-                "since": 16,
-                "type": "Number",
-                "cardinality": "One",
-                "encrypted": false
-            }
-        },
-        "associations": {},
-        "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PriceData": {
         "name": "PriceData",
@@ -8761,7 +8679,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PriceItemData": {
         "name": "PriceItemData",
@@ -8820,7 +8738,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PriceRequestData": {
         "name": "PriceRequestData",
@@ -8897,7 +8815,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PriceServiceData": {
         "name": "PriceServiceData",
@@ -8940,7 +8858,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PriceServiceReturn": {
         "name": "PriceServiceReturn",
@@ -9012,7 +8930,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PublicKeyGetIn": {
         "name": "PublicKeyGetIn",
@@ -9053,7 +8971,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PublicKeyGetOut": {
         "name": "PublicKeyGetOut",
@@ -9112,7 +9030,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PublicKeyPutIn": {
         "name": "PublicKeyPutIn",
@@ -9164,7 +9082,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PushIdentifier": {
         "name": "PushIdentifier",
@@ -9313,7 +9231,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "PushIdentifierList": {
         "name": "PushIdentifierList",
@@ -9347,7 +9265,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ReceivedGroupInvitation": {
         "name": "ReceivedGroupInvitation",
@@ -9508,7 +9426,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RecoverCode": {
         "name": "RecoverCode",
@@ -9594,7 +9512,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ReferralCodeGetIn": {
         "name": "ReferralCodeGetIn",
@@ -9628,7 +9546,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ReferralCodePostIn": {
         "name": "ReferralCodePostIn",
@@ -9651,7 +9569,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ReferralCodePostOut": {
         "name": "ReferralCodePostOut",
@@ -9685,7 +9603,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RegistrationCaptchaServiceData": {
         "name": "RegistrationCaptchaServiceData",
@@ -9726,7 +9644,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RegistrationCaptchaServiceGetData": {
         "name": "RegistrationCaptchaServiceGetData",
@@ -9794,7 +9712,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RegistrationCaptchaServiceReturn": {
         "name": "RegistrationCaptchaServiceReturn",
@@ -9835,48 +9753,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
-    },
-    "RegistrationConfigReturn": {
-        "name": "RegistrationConfigReturn",
-        "since": 2,
-        "type": "DATA_TRANSFER_TYPE",
-        "id": 606,
-        "rootId": "A3N5cwACXg",
-        "versioned": false,
-        "encrypted": false,
-        "values": {
-            "_format": {
-                "final": false,
-                "name": "_format",
-                "id": 607,
-                "since": 2,
-                "type": "Number",
-                "cardinality": "One",
-                "encrypted": false
-            },
-            "freeEnabled": {
-                "final": false,
-                "name": "freeEnabled",
-                "id": 609,
-                "since": 2,
-                "type": "Boolean",
-                "cardinality": "One",
-                "encrypted": false
-            },
-            "starterEnabled": {
-                "final": false,
-                "name": "starterEnabled",
-                "id": 608,
-                "since": 2,
-                "type": "Boolean",
-                "cardinality": "One",
-                "encrypted": false
-            }
-        },
-        "associations": {},
-        "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RegistrationReturn": {
         "name": "RegistrationReturn",
@@ -9908,7 +9785,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RegistrationServiceData": {
         "name": "RegistrationServiceData",
@@ -9958,7 +9835,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RejectedSender": {
         "name": "RejectedSender",
@@ -10053,7 +9930,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RejectedSendersRef": {
         "name": "RejectedSendersRef",
@@ -10087,7 +9964,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RepeatRule": {
         "name": "RepeatRule",
@@ -10166,7 +10043,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ResetFactorsDeleteData": {
         "name": "ResetFactorsDeleteData",
@@ -10216,7 +10093,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "ResetPasswordData": {
         "name": "ResetPasswordData",
@@ -10286,7 +10163,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "RootInstance": {
         "name": "RootInstance",
@@ -10345,7 +10222,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SaltData": {
         "name": "SaltData",
@@ -10377,7 +10254,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SaltReturn": {
         "name": "SaltReturn",
@@ -10418,7 +10295,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SecondFactor": {
         "name": "SecondFactor",
@@ -10506,7 +10383,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SecondFactorAuthAllowedReturn": {
         "name": "SecondFactorAuthAllowedReturn",
@@ -10538,7 +10415,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SecondFactorAuthData": {
         "name": "SecondFactorAuthData",
@@ -10610,7 +10487,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SecondFactorAuthDeleteData": {
         "name": "SecondFactorAuthDeleteData",
@@ -10644,7 +10521,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SecondFactorAuthGetData": {
         "name": "SecondFactorAuthGetData",
@@ -10676,7 +10553,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SecondFactorAuthGetReturn": {
         "name": "SecondFactorAuthGetReturn",
@@ -10708,7 +10585,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SecondFactorAuthentication": {
         "name": "SecondFactorAuthentication",
@@ -10794,7 +10671,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SendRegistrationCodeData": {
         "name": "SendRegistrationCodeData",
@@ -10853,7 +10730,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SendRegistrationCodeReturn": {
         "name": "SendRegistrationCodeReturn",
@@ -10885,7 +10762,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SentGroupInvitation": {
         "name": "SentGroupInvitation",
@@ -10974,7 +10851,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Session": {
         "name": "Session",
@@ -11117,7 +10994,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SignOrderProcessingAgreementData": {
         "name": "SignOrderProcessingAgreementData",
@@ -11158,7 +11035,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SseConnectData": {
         "name": "SseConnectData",
@@ -11201,7 +11078,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "StringConfigValue": {
         "name": "StringConfigValue",
@@ -11242,7 +11119,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "StringWrapper": {
         "name": "StringWrapper",
@@ -11274,7 +11151,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SwitchAccountTypePostIn": {
         "name": "SwitchAccountTypePostIn",
@@ -11371,7 +11248,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "SystemKeysReturn": {
         "name": "SystemKeysReturn",
@@ -11487,7 +11364,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "TakeOverDeletedAddressData": {
         "name": "TakeOverDeletedAddressData",
@@ -11546,7 +11423,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "TypeInfo": {
         "name": "TypeInfo",
@@ -11587,7 +11464,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "U2fChallenge": {
         "name": "U2fChallenge",
@@ -11630,7 +11507,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "U2fKey": {
         "name": "U2fKey",
@@ -11682,7 +11559,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "U2fRegisteredDevice": {
         "name": "U2fRegisteredDevice",
@@ -11750,7 +11627,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "U2fResponseData": {
         "name": "U2fResponseData",
@@ -11800,7 +11677,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UpdatePermissionKeyData": {
         "name": "UpdatePermissionKeyData",
@@ -11862,7 +11739,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UpdateSessionKeysPostIn": {
         "name": "UpdateSessionKeysPostIn",
@@ -11896,7 +11773,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UpgradePriceServiceData": {
         "name": "UpgradePriceServiceData",
@@ -11948,7 +11825,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UpgradePriceServiceReturn": {
         "name": "UpgradePriceServiceReturn",
@@ -12119,7 +11996,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "User": {
         "name": "User",
@@ -12344,7 +12221,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UserAlarmInfo": {
         "name": "UserAlarmInfo",
@@ -12423,7 +12300,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UserAlarmInfoListType": {
         "name": "UserAlarmInfoListType",
@@ -12457,7 +12334,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UserAreaGroups": {
         "name": "UserAreaGroups",
@@ -12491,7 +12368,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UserAuthentication": {
         "name": "UserAuthentication",
@@ -12545,7 +12422,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UserDataDelete": {
         "name": "UserDataDelete",
@@ -12597,7 +12474,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UserExternalAuthInfo": {
         "name": "UserExternalAuthInfo",
@@ -12667,7 +12544,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "UserGroupRoot": {
         "name": "UserGroupRoot",
@@ -12738,7 +12615,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "VariableExternalAuthInfo": {
         "name": "VariableExternalAuthInfo",
@@ -12842,7 +12719,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "VerifyRegistrationCodeData": {
         "name": "VerifyRegistrationCodeData",
@@ -12883,7 +12760,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "Version": {
         "name": "Version",
@@ -12954,7 +12831,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "VersionData": {
         "name": "VersionData",
@@ -13013,7 +12890,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "VersionInfo": {
         "name": "VersionInfo",
@@ -13138,7 +13015,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "VersionReturn": {
         "name": "VersionReturn",
@@ -13172,7 +13049,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WebauthnResponseData": {
         "name": "WebauthnResponseData",
@@ -13231,7 +13108,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WebsocketCounterData": {
         "name": "WebsocketCounterData",
@@ -13274,7 +13151,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WebsocketCounterValue": {
         "name": "WebsocketCounterValue",
@@ -13315,7 +13192,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WebsocketEntityData": {
         "name": "WebsocketEntityData",
@@ -13367,7 +13244,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WebsocketLeaderStatus": {
         "name": "WebsocketLeaderStatus",
@@ -13399,7 +13276,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WhitelabelChild": {
         "name": "WhitelabelChild",
@@ -13514,7 +13391,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WhitelabelChildrenRef": {
         "name": "WhitelabelChildrenRef",
@@ -13548,7 +13425,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WhitelabelConfig": {
         "name": "WhitelabelConfig",
@@ -13683,7 +13560,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     },
     "WhitelabelParent": {
         "name": "WhitelabelParent",
@@ -13727,6 +13604,6 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "96"
+        "version": "97"
     }
 }

--- a/src/api/entities/sys/TypeRefs.ts
+++ b/src/api/entities/sys/TypeRefs.ts
@@ -716,7 +716,6 @@ export type Customer = {
 	_permissions: Id;
 	approvalStatus: NumberString;
 	businessUse: boolean;
-	canceledPremiumAccount: boolean;
 	orderProcessingAgreementNeeded: boolean;
 	type: NumberString;
 
@@ -2098,31 +2097,6 @@ export type PlanServiceGetOut = {
 
 	config: PlanConfiguration;
 }
-export const PremiumFeatureDataTypeRef: TypeRef<PremiumFeatureData> = new TypeRef("sys", "PremiumFeatureData")
-
-export function createPremiumFeatureData(values: StrippedEntity<PremiumFeatureData>): PremiumFeatureData {
-	return Object.assign(create(typeModels.PremiumFeatureData, PremiumFeatureDataTypeRef), values)
-}
-
-export type PremiumFeatureData = {
-	_type: TypeRef<PremiumFeatureData>;
-
-	_format: NumberString;
-	activationCode: string;
-	featureName: string;
-}
-export const PremiumFeatureReturnTypeRef: TypeRef<PremiumFeatureReturn> = new TypeRef("sys", "PremiumFeatureReturn")
-
-export function createPremiumFeatureReturn(values: StrippedEntity<PremiumFeatureReturn>): PremiumFeatureReturn {
-	return Object.assign(create(typeModels.PremiumFeatureReturn, PremiumFeatureReturnTypeRef), values)
-}
-
-export type PremiumFeatureReturn = {
-	_type: TypeRef<PremiumFeatureReturn>;
-
-	_format: NumberString;
-	activatedFeature: NumberString;
-}
 export const PriceDataTypeRef: TypeRef<PriceData> = new TypeRef("sys", "PriceData")
 
 export function createPriceData(values: StrippedEntity<PriceData>): PriceData {
@@ -2408,19 +2382,6 @@ export type RegistrationCaptchaServiceReturn = {
 	_format: NumberString;
 	challenge: null | Uint8Array;
 	token: string;
-}
-export const RegistrationConfigReturnTypeRef: TypeRef<RegistrationConfigReturn> = new TypeRef("sys", "RegistrationConfigReturn")
-
-export function createRegistrationConfigReturn(values: StrippedEntity<RegistrationConfigReturn>): RegistrationConfigReturn {
-	return Object.assign(create(typeModels.RegistrationConfigReturn, RegistrationConfigReturnTypeRef), values)
-}
-
-export type RegistrationConfigReturn = {
-	_type: TypeRef<RegistrationConfigReturn>;
-
-	_format: NumberString;
-	freeEnabled: boolean;
-	starterEnabled: boolean;
 }
 export const RegistrationReturnTypeRef: TypeRef<RegistrationReturn> = new TypeRef("sys", "RegistrationReturn")
 

--- a/src/api/entities/tutanota/ModelInfo.ts
+++ b/src/api/entities/tutanota/ModelInfo.ts
@@ -1,5 +1,5 @@
 const modelInfo = {
-	version: 69,
+	version: 70,
 	compatibleSince: 69,
 }
 		

--- a/src/api/entities/tutanota/Services.ts
+++ b/src/api/entities/tutanota/Services.ts
@@ -29,6 +29,8 @@ import {ReceiveInfoServiceDataTypeRef} from "./TypeRefs.js"
 import {ReportMailPostDataTypeRef} from "./TypeRefs.js"
 import {SendDraftDataTypeRef} from "./TypeRefs.js"
 import {SendDraftReturnTypeRef} from "./TypeRefs.js"
+import {TranslationGetInTypeRef} from "./TypeRefs.js"
+import {TranslationGetOutTypeRef} from "./TypeRefs.js"
 import {UserAccountCreateDataTypeRef} from "./TypeRefs.js"
 
 export const CalendarService = Object.freeze({
@@ -191,6 +193,15 @@ export const TemplateGroupService = Object.freeze({
 	post: {data: UserAreaGroupPostDataTypeRef, return: CreateGroupPostReturnTypeRef},
 	put: null,
 	delete: {data: UserAreaGroupDeleteDataTypeRef, return: null},
+} as const)
+
+export const TranslationService = Object.freeze({
+	app: "tutanota",
+	name: "TranslationService",
+	get: {data: TranslationGetInTypeRef, return: TranslationGetOutTypeRef},
+	post: null,
+	put: null,
+	delete: null,
 } as const)
 
 export const UserAccountService = Object.freeze({

--- a/src/api/entities/tutanota/TypeModels.js
+++ b/src/api/entities/tutanota/TypeModels.js
@@ -56,7 +56,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "Birthday": {
         "name": "Birthday",
@@ -106,7 +106,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "Body": {
         "name": "Body",
@@ -147,7 +147,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarDeleteData": {
         "name": "CalendarDeleteData",
@@ -181,7 +181,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarEvent": {
         "name": "CalendarEvent",
@@ -380,7 +380,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarEventAttendee": {
         "name": "CalendarEventAttendee",
@@ -423,7 +423,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarEventIndexRef": {
         "name": "CalendarEventIndexRef",
@@ -457,7 +457,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarEventUidIndex": {
         "name": "CalendarEventUidIndex",
@@ -528,7 +528,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarEventUpdate": {
         "name": "CalendarEventUpdate",
@@ -616,7 +616,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarEventUpdateList": {
         "name": "CalendarEventUpdateList",
@@ -650,7 +650,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarGroupRoot": {
         "name": "CalendarGroupRoot",
@@ -749,7 +749,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CalendarRepeatRule": {
         "name": "CalendarRepeatRule",
@@ -828,7 +828,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "Contact": {
         "name": "Contact",
@@ -1178,7 +1178,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactAddress": {
         "name": "ContactAddress",
@@ -1228,7 +1228,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactCustomDate": {
         "name": "ContactCustomDate",
@@ -1278,7 +1278,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactList": {
         "name": "ContactList",
@@ -1367,7 +1367,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactListEntry": {
         "name": "ContactListEntry",
@@ -1444,7 +1444,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactListGroupRoot": {
         "name": "ContactListGroupRoot",
@@ -1523,7 +1523,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactMailAddress": {
         "name": "ContactMailAddress",
@@ -1573,7 +1573,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactMessengerHandle": {
         "name": "ContactMessengerHandle",
@@ -1623,7 +1623,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactPhoneNumber": {
         "name": "ContactPhoneNumber",
@@ -1673,7 +1673,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactPronouns": {
         "name": "ContactPronouns",
@@ -1714,7 +1714,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactRelationship": {
         "name": "ContactRelationship",
@@ -1764,7 +1764,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactSocialId": {
         "name": "ContactSocialId",
@@ -1814,7 +1814,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ContactWebsite": {
         "name": "ContactWebsite",
@@ -1864,7 +1864,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ConversationEntry": {
         "name": "ConversationEntry",
@@ -1953,7 +1953,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CreateExternalUserGroupData": {
         "name": "CreateExternalUserGroupData",
@@ -2012,7 +2012,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CreateGroupPostReturn": {
         "name": "CreateGroupPostReturn",
@@ -2046,7 +2046,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CreateMailFolderData": {
         "name": "CreateMailFolderData",
@@ -2116,7 +2116,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CreateMailFolderReturn": {
         "name": "CreateMailFolderReturn",
@@ -2150,7 +2150,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CreateMailGroupData": {
         "name": "CreateMailGroupData",
@@ -2211,7 +2211,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "CustomerAccountCreateData": {
         "name": "CustomerAccountCreateData",
@@ -2383,7 +2383,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DeleteGroupData": {
         "name": "DeleteGroupData",
@@ -2426,7 +2426,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DeleteMailData": {
         "name": "DeleteMailData",
@@ -2470,7 +2470,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DeleteMailFolderData": {
         "name": "DeleteMailFolderData",
@@ -2504,7 +2504,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DraftAttachment": {
         "name": "DraftAttachment",
@@ -2566,7 +2566,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DraftCreateData": {
         "name": "DraftCreateData",
@@ -2636,7 +2636,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DraftCreateReturn": {
         "name": "DraftCreateReturn",
@@ -2670,7 +2670,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DraftData": {
         "name": "DraftData",
@@ -2817,7 +2817,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DraftRecipient": {
         "name": "DraftRecipient",
@@ -2858,7 +2858,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DraftUpdateData": {
         "name": "DraftUpdateData",
@@ -2902,7 +2902,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "DraftUpdateReturn": {
         "name": "DraftUpdateReturn",
@@ -2936,7 +2936,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "EmailTemplate": {
         "name": "EmailTemplate",
@@ -3033,7 +3033,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "EmailTemplateContent": {
         "name": "EmailTemplateContent",
@@ -3074,7 +3074,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "EncryptTutanotaPropertiesData": {
         "name": "EncryptTutanotaPropertiesData",
@@ -3126,7 +3126,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "EncryptedMailAddress": {
         "name": "EncryptedMailAddress",
@@ -3167,7 +3167,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "EntropyData": {
         "name": "EntropyData",
@@ -3208,7 +3208,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ExternalUserData": {
         "name": "ExternalUserData",
@@ -3341,7 +3341,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "File": {
         "name": "File",
@@ -3494,7 +3494,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "FileSystem": {
         "name": "FileSystem",
@@ -3573,7 +3573,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "GroupInvitationDeleteData": {
         "name": "GroupInvitationDeleteData",
@@ -3607,7 +3607,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "GroupInvitationPostData": {
         "name": "GroupInvitationPostData",
@@ -3651,7 +3651,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "GroupInvitationPostReturn": {
         "name": "GroupInvitationPostReturn",
@@ -3705,7 +3705,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "GroupInvitationPutData": {
         "name": "GroupInvitationPutData",
@@ -3775,7 +3775,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "GroupSettings": {
         "name": "GroupSettings",
@@ -3827,7 +3827,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "Header": {
         "name": "Header",
@@ -3868,7 +3868,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ImapFolder": {
         "name": "ImapFolder",
@@ -3929,7 +3929,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ImapSyncConfiguration": {
         "name": "ImapSyncConfiguration",
@@ -3999,7 +3999,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ImapSyncState": {
         "name": "ImapSyncState",
@@ -4060,7 +4060,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "InboxRule": {
         "name": "InboxRule",
@@ -4112,7 +4112,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "InternalGroupData": {
         "name": "InternalGroupData",
@@ -4236,7 +4236,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "InternalRecipientKeyData": {
         "name": "InternalRecipientKeyData",
@@ -4304,7 +4304,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "KnowledgeBaseEntry": {
         "name": "KnowledgeBaseEntry",
@@ -4401,7 +4401,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "KnowledgeBaseEntryKeyword": {
         "name": "KnowledgeBaseEntryKeyword",
@@ -4433,7 +4433,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ListUnsubscribeData": {
         "name": "ListUnsubscribeData",
@@ -4485,7 +4485,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "Mail": {
         "name": "Mail",
@@ -4819,7 +4819,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailAddress": {
         "name": "MailAddress",
@@ -4871,7 +4871,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailAddressProperties": {
         "name": "MailAddressProperties",
@@ -4912,7 +4912,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailBody": {
         "name": "MailBody",
@@ -5016,7 +5016,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailBox": {
         "name": "MailBox",
@@ -5154,7 +5154,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailDetails": {
         "name": "MailDetails",
@@ -5236,7 +5236,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailDetailsBlob": {
         "name": "MailDetailsBlob",
@@ -5315,7 +5315,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailDetailsDraft": {
         "name": "MailDetailsDraft",
@@ -5394,7 +5394,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailDetailsDraftsRef": {
         "name": "MailDetailsDraftsRef",
@@ -5428,7 +5428,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailFolder": {
         "name": "MailFolder",
@@ -5545,7 +5545,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailFolderRef": {
         "name": "MailFolderRef",
@@ -5579,7 +5579,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailHeaders": {
         "name": "MailHeaders",
@@ -5665,7 +5665,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailboxGroupRoot": {
         "name": "MailboxGroupRoot",
@@ -5786,7 +5786,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailboxProperties": {
         "name": "MailboxProperties",
@@ -5874,7 +5874,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MailboxServerProperties": {
         "name": "MailboxServerProperties",
@@ -5933,7 +5933,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "MoveMailData": {
         "name": "MoveMailData",
@@ -5977,7 +5977,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "NewDraftAttachment": {
         "name": "NewDraftAttachment",
@@ -6038,7 +6038,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "NewsId": {
         "name": "NewsId",
@@ -6079,7 +6079,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "NewsIn": {
         "name": "NewsIn",
@@ -6111,7 +6111,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "NewsOut": {
         "name": "NewsOut",
@@ -6145,7 +6145,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "NotificationMail": {
         "name": "NotificationMail",
@@ -6213,7 +6213,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "OutOfOfficeNotification": {
         "name": "OutOfOfficeNotification",
@@ -6301,7 +6301,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "OutOfOfficeNotificationMessage": {
         "name": "OutOfOfficeNotificationMessage",
@@ -6351,7 +6351,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "OutOfOfficeNotificationRecipientList": {
         "name": "OutOfOfficeNotificationRecipientList",
@@ -6385,7 +6385,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "PasswordAutoAuthenticationReturn": {
         "name": "PasswordAutoAuthenticationReturn",
@@ -6408,7 +6408,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "PasswordChannelPhoneNumber": {
         "name": "PasswordChannelPhoneNumber",
@@ -6440,7 +6440,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "PasswordChannelReturn": {
         "name": "PasswordChannelReturn",
@@ -6474,7 +6474,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "PasswordMessagingData": {
         "name": "PasswordMessagingData",
@@ -6524,7 +6524,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "PasswordMessagingReturn": {
         "name": "PasswordMessagingReturn",
@@ -6556,7 +6556,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "PhishingMarkerWebsocketData": {
         "name": "PhishingMarkerWebsocketData",
@@ -6599,7 +6599,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "PhotosRef": {
         "name": "PhotosRef",
@@ -6633,7 +6633,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ReceiveInfoServiceData": {
         "name": "ReceiveInfoServiceData",
@@ -6665,7 +6665,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "Recipients": {
         "name": "Recipients",
@@ -6719,7 +6719,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "RemoteImapSyncInfo": {
         "name": "RemoteImapSyncInfo",
@@ -6789,7 +6789,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ReportMailPostData": {
         "name": "ReportMailPostData",
@@ -6841,7 +6841,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "ReportedMailFieldMarker": {
         "name": "ReportedMailFieldMarker",
@@ -6882,7 +6882,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "SecureExternalRecipientKeyData": {
         "name": "SecureExternalRecipientKeyData",
@@ -6997,7 +6997,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "SendDraftData": {
         "name": "SendDraftData",
@@ -7125,7 +7125,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "SendDraftReturn": {
         "name": "SendDraftReturn",
@@ -7187,7 +7187,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "SharedGroupData": {
         "name": "SharedGroupData",
@@ -7291,7 +7291,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "SpamResults": {
         "name": "SpamResults",
@@ -7325,7 +7325,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "Subfiles": {
         "name": "Subfiles",
@@ -7359,7 +7359,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "SymEncInternalRecipientKeyData": {
         "name": "SymEncInternalRecipientKeyData",
@@ -7420,7 +7420,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "TemplateGroupRoot": {
         "name": "TemplateGroupRoot",
@@ -7509,7 +7509,80 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
+    },
+    "TranslationGetIn": {
+        "name": "TranslationGetIn",
+        "since": 70,
+        "type": "DATA_TRANSFER_TYPE",
+        "id": 1436,
+        "rootId": "CHR1dGFub3RhAAWc",
+        "versioned": false,
+        "encrypted": false,
+        "values": {
+            "_format": {
+                "final": false,
+                "name": "_format",
+                "id": 1437,
+                "since": 70,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "lang": {
+                "final": true,
+                "name": "lang",
+                "id": 1438,
+                "since": 70,
+                "type": "String",
+                "cardinality": "One",
+                "encrypted": false
+            }
+        },
+        "associations": {},
+        "app": "tutanota",
+        "version": "70"
+    },
+    "TranslationGetOut": {
+        "name": "TranslationGetOut",
+        "since": 70,
+        "type": "DATA_TRANSFER_TYPE",
+        "id": 1439,
+        "rootId": "CHR1dGFub3RhAAWf",
+        "versioned": false,
+        "encrypted": false,
+        "values": {
+            "_format": {
+                "final": false,
+                "name": "_format",
+                "id": 1440,
+                "since": 70,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "giftCardSubject": {
+                "final": false,
+                "name": "giftCardSubject",
+                "id": 1441,
+                "since": 70,
+                "type": "String",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "invitationSubject": {
+                "final": false,
+                "name": "invitationSubject",
+                "id": 1442,
+                "since": 70,
+                "type": "String",
+                "cardinality": "One",
+                "encrypted": false
+            }
+        },
+        "associations": {},
+        "app": "tutanota",
+        "version": "70"
     },
     "TutanotaProperties": {
         "name": "TutanotaProperties",
@@ -7698,7 +7771,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "UpdateMailFolderData": {
         "name": "UpdateMailFolderData",
@@ -7742,7 +7815,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "UserAccountCreateData": {
         "name": "UserAccountCreateData",
@@ -7795,7 +7868,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "UserAccountUserData": {
         "name": "UserAccountUserData",
@@ -8016,7 +8089,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "UserAreaGroupData": {
         "name": "UserAreaGroupData",
@@ -8122,7 +8195,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "UserAreaGroupDeleteData": {
         "name": "UserAreaGroupDeleteData",
@@ -8156,7 +8229,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "UserAreaGroupPostData": {
         "name": "UserAreaGroupPostData",
@@ -8190,7 +8263,7 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     },
     "UserSettingsGroupRoot": {
         "name": "UserSettingsGroupRoot",
@@ -8296,6 +8369,6 @@ export const typeModels = {
             }
         },
         "app": "tutanota",
-        "version": "69"
+        "version": "70"
     }
 }

--- a/src/api/entities/tutanota/TypeRefs.ts
+++ b/src/api/entities/tutanota/TypeRefs.ts
@@ -1837,6 +1837,31 @@ export type TemplateGroupRoot = {
 	knowledgeBase: Id;
 	templates: Id;
 }
+export const TranslationGetInTypeRef: TypeRef<TranslationGetIn> = new TypeRef("tutanota", "TranslationGetIn")
+
+export function createTranslationGetIn(values: StrippedEntity<TranslationGetIn>): TranslationGetIn {
+	return Object.assign(create(typeModels.TranslationGetIn, TranslationGetInTypeRef), values)
+}
+
+export type TranslationGetIn = {
+	_type: TypeRef<TranslationGetIn>;
+
+	_format: NumberString;
+	lang: string;
+}
+export const TranslationGetOutTypeRef: TypeRef<TranslationGetOut> = new TypeRef("tutanota", "TranslationGetOut")
+
+export function createTranslationGetOut(values: StrippedEntity<TranslationGetOut>): TranslationGetOut {
+	return Object.assign(create(typeModels.TranslationGetOut, TranslationGetOutTypeRef), values)
+}
+
+export type TranslationGetOut = {
+	_type: TypeRef<TranslationGetOut>;
+
+	_format: NumberString;
+	giftCardSubject: string;
+	invitationSubject: string;
+}
 export const TutanotaPropertiesTypeRef: TypeRef<TutanotaProperties> = new TypeRef("tutanota", "TutanotaProperties")
 
 export function createTutanotaProperties(values: StrippedEntity<TutanotaProperties>): TutanotaProperties {

--- a/src/api/worker/offline/OfflineStorageMigrator.ts
+++ b/src/api/worker/offline/OfflineStorageMigrator.ts
@@ -14,6 +14,7 @@ import { tutanota64 } from "./migrations/tutanota-v64.js"
 import { tutanota67 } from "./migrations/tutanota-v67.js"
 import { sys96 } from "./migrations/sys-v96.js"
 import { tutanota69 } from "./migrations/tutanota-v69.js"
+import { sys97 } from "./migrations/sys-v97.js"
 
 export interface OfflineMigration {
 	readonly app: VersionMetadataBaseKey
@@ -39,6 +40,7 @@ export const OFFLINE_STORAGE_MIGRATIONS: ReadonlyArray<OfflineMigration> = [
 	tutanota67,
 	sys96,
 	tutanota69,
+	sys97,
 ]
 
 const CURRENT_OFFLINE_VERSION = 1

--- a/src/api/worker/offline/migrations/sys-v94.ts
+++ b/src/api/worker/offline/migrations/sys-v94.ts
@@ -1,6 +1,5 @@
 import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage } from "../OfflineStorage.js"
-import { SqlCipherFacade } from "../../../../native/common/generatedipc/SqlCipherFacade.js"
 import { deleteInstancesOfType, migrateAllListElements } from "../StandardMigrations.js"
 import { MailBodyTypeRef, MailTypeRef } from "../../../entities/tutanota/TypeRefs.js"
 import { createCustomerInfo, CustomerInfoTypeRef, UserTypeRef } from "../../../entities/sys/TypeRefs.js"
@@ -8,7 +7,7 @@ import { createCustomerInfo, CustomerInfoTypeRef, UserTypeRef } from "../../../e
 export const sys94: OfflineMigration = {
 	app: "sys",
 	version: 94,
-	async migrate(storage: OfflineStorage, sqlCipherFacade: SqlCipherFacade) {
+	async migrate(storage: OfflineStorage) {
 		// these are due to the mailbody migration
 		await deleteInstancesOfType(storage, MailTypeRef)
 		await deleteInstancesOfType(storage, MailBodyTypeRef)

--- a/src/api/worker/offline/migrations/sys-v96.ts
+++ b/src/api/worker/offline/migrations/sys-v96.ts
@@ -1,6 +1,5 @@
 import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage } from "../OfflineStorage.js"
-import { SqlCipherFacade } from "../../../../native/common/generatedipc/SqlCipherFacade.js"
 import {
 	AccountingInfoTypeRef,
 	AuditLogEntryTypeRef,
@@ -35,7 +34,7 @@ import { TypeRef } from "@tutao/tutanota-utils"
 export const sys96: OfflineMigration = {
 	app: "sys",
 	version: 96,
-	async migrate(storage: OfflineStorage, sqlCipherFacade: SqlCipherFacade) {
+	async migrate(storage: OfflineStorage) {
 		const encryptedElementTypes: Array<TypeRef<ElementEntity>> = [
 			AccountingInfoTypeRef,
 			CustomerServerPropertiesTypeRef,

--- a/src/api/worker/offline/migrations/sys-v97.ts
+++ b/src/api/worker/offline/migrations/sys-v97.ts
@@ -1,0 +1,14 @@
+import { OfflineMigration } from "../OfflineStorageMigrator.js"
+import { OfflineStorage } from "../OfflineStorage.js"
+import { CustomerTypeRef } from "../../../entities/sys/TypeRefs.js"
+import { migrateAllElements, removeValue } from "../StandardMigrations.js"
+
+export const sys97: OfflineMigration = {
+	app: "sys",
+	version: 97,
+	async migrate(storage: OfflineStorage) {
+		// As of 2020 the canceledPremiumAccount boolean value has always been set to
+		// false therefore this value is no longer needed, and we can remove it.
+		await migrateAllElements(CustomerTypeRef, storage, [removeValue("canceledPremiumAccount")])
+	},
+}

--- a/src/misc/SubscriptionDialogs.ts
+++ b/src/misc/SubscriptionDialogs.ts
@@ -50,13 +50,7 @@ export async function checkPaidSubscription(): Promise<boolean> {
 		showNotAvailableForFreeDialog()
 		return false
 	}
-
-	const customer = await locator.logins.getUserController().loadCustomer()
-	if (customer.canceledPremiumAccount) {
-		return Dialog.message("subscriptionCancelledMessage_msg").then(() => false)
-	} else {
-		return true
-	}
+	return true
 }
 
 export async function showMoreStorageNeededOrderDialog(messageIdOrMessageFunction: TranslationKey): Promise<PlanType | void> {

--- a/src/subscription/SubscriptionViewer.ts
+++ b/src/subscription/SubscriptionViewer.ts
@@ -313,19 +313,12 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 		m.redraw()
 	}
 
-	private async updateSubscriptionField(cancelled: boolean) {
-		const cancelledText =
-			cancelled && this._periodEndDate
-				? " " +
-				  lang.get("cancelledBy_label", {
-						"{endOfSubscriptionPeriod}": formatDate(this._periodEndDate),
-				  })
-				: ""
+	private async updateSubscriptionField() {
 		const userController = locator.logins.getUserController()
 		const accountType: AccountType = downcast(userController.user.accountType)
 		const planType = await userController.getPlanType()
 
-		this._subscriptionFieldValue(_getAccountTypeName(accountType, planType) + cancelledText)
+		this._subscriptionFieldValue(_getAccountTypeName(accountType, planType))
 	}
 
 	private async updateBookings(): Promise<void> {
@@ -348,11 +341,10 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 		const bookings = await locator.entityClient.loadRange(BookingTypeRef, neverNull(customerInfo.bookings).items, GENERATED_MAX_ID, 1, true)
 		this._lastBooking = bookings.length > 0 ? bookings[bookings.length - 1] : null
 		this._customer = customer
-		this._isCancelled = customer.canceledPremiumAccount
 		this.currentPlanType = await userController.getPlanType()
 
 		const planConfig = await userController.getPlanConfig()
-		await this.updateSubscriptionField(this._isCancelled)
+		await this.updateSubscriptionField()
 
 		await Promise.all([
 			this.updateUserField(),


### PR DESCRIPTION
As of 2020 the canceledPremiumAccount boolean value has always been set to false therefore this value is no longer needed, and we can remove it. Additionally, this commit includes model changes for the new TranslationService and removes the following unused services and types.

* PREMIUM_FEATURE_SERVICE
* PREMIUM_FEATURE_DATA
* PREMIUM_FEATURE_RETURN
* MIGRATE_TO_V18_SERVICE
* DEFAULT_SYSTEM_MIGRATE_DATA
* REGISTRATION_CONFIG_SERVICE
* REGISTRATION_CONFIG_RETURN
* SHARE_SERVICE
* SHARE_DATA