### PR TITLE
add buildSrc/checkVendoredVersions.js to .github/workflows/test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
+      - name: Check vendored versions
+        run: |
+          node buildSrc/checkVendoredVersions.js
       - name: Get better-sqlite3 cached location
         run: |
           echo "better_sqlite3_path=$(node buildSrc/getNativeCacheLocation.js better-sqlite3)" >> $GITHUB_ENV

--- a/buildSrc/checkVendoredVersions.js
+++ b/buildSrc/checkVendoredVersions.js
@@ -1,0 +1,23 @@
+#! /bin/env node
+
+import path, { dirname } from "node:path"
+import fs from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const vendoredVersions = JSON.parse(fs.readFileSync(path.join(__dirname, "../libs/", "vendored-versions.json")))
+const packageJsonVersions = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"))).dependencies
+
+for (const vendoredLibName of Object.keys(vendoredVersions)) {
+	const definedVersion = packageJsonVersions[vendoredLibName]
+	const vendoredVersion = vendoredVersions[vendoredLibName]
+	if (definedVersion !== vendoredVersion) {
+		console.error(
+			`Vendored version mismatch: ${vendoredLibName} should be ${definedVersion} but is ${vendoredVersion}. \n\n Forgot to run buildSrc/updateLibs.js ?`,
+		)
+		process.exit(1)
+	}
+}
+
+console.log("all vendored versions are in sync")

--- a/libs/vendored-versions.json
+++ b/libs/vendored-versions.json
@@ -1,0 +1,14 @@
+{
+  "systemjs": "6.10.2",
+  "mithril": "2.2.2",
+  "squire-rte": "2.2.7",
+  "dompurify": "3.1.1",
+  "linkifyjs": "4.1.3",
+  "linkify-html": "4.1.3",
+  "luxon": "3.4.4",
+  "cborg": "4.0.5",
+  "electron-updater": "6.1.7",
+  "better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#c6ee076a4f15671d8a0fa7ddc16d12b179deb350",
+  "winreg": "1.2.4",
+  "undici": "6.11.1"
+}


### PR DESCRIPTION
we have a two-stage approach to vendoring libraries:
* update the packages' version in package.json
* run node buildSrc/updateLibs.js

using this check in the test github workflow prevents that commits that contain step 1 but not step 2 can be merged to master.