### PR TITLE
Fix app asking for contact permission when removing account

### DIFF
--- a/src/api/main/MainLocator.ts
+++ b/src/api/main/MainLocator.ts
@@ -535,7 +535,13 @@ class MainLocator {
 		const { NoopCredentialRemovalHandler, AppsCredentialRemovalHandler } = await import("../../login/CredentialRemovalHandler.js")
 		return isBrowser()
 			? new NoopCredentialRemovalHandler()
-			: new AppsCredentialRemovalHandler(this.indexerFacade, this.pushService, this.configFacade, isApp() ? this.mobileContactsFacade : null)
+			: new AppsCredentialRemovalHandler(
+					deviceConfig,
+					this.indexerFacade,
+					this.pushService,
+					this.configFacade,
+					isApp() ? this.mobileContactsFacade : null,
+			  )
 	}
 
 	async loginViewModelFactory(): Promise<lazy<LoginViewModel>> {


### PR DESCRIPTION
This commit fixes the problem of the app asking for contact permission even if the user hasn't enabled contact sync for that account.

fixes #6813 