### PR TITLE
Add Catppuccin macchiato theme 

### DIFF
--- a/src/gui/builtinThemes.ts
+++ b/src/gui/builtinThemes.ts
@@ -44,6 +44,21 @@ const dark_darker_0 = "#111111"
 const green = "#00d2a7"
 export const logo_text_bright_grey = "#c5c7c7"
 
+/**
+ * 		catppuccin theme
+ */
+
+const catppuccin_logo_text = "#cad3f5"
+const catppuccin_light_lighter_0 = "#6e738d"
+const catppuccin_light_lighter_1 = "#8087a2"
+const catppuccin_dark = "#1e2030"
+const catppuccin_dark_lighter_0 = "#24273a"
+const catppuccin_dark_lighter_1 = "#363a4f"
+const catppuccin_dark_lighter_2 = "#494d64"
+const catppuccin_dark_darker_0 = "#181926"
+const catppuccin_light_grey = "#6e738d"
+const catppuccin_primary = "#c6a0f6"
+
 // These are constants that have been chosen because they work across themes
 // This is even lighter than hover, for special cases like inactive search bar background
 export const stateBgLike = "rgba(139,139,139,0.18)"
@@ -156,5 +171,41 @@ export const themes: Themes = {
 		navigation_button_icon_selected: light_white,
 		navigation_menu_bg: grey_lighter_3,
 		navigation_menu_icon: grey,
+	}),
+	catppuccin: Object.freeze({
+		themeId: "catppuccin",
+		logo: getLogoSvg(catppuccin_primary, catppuccin_logo_text),
+		button_bubble_bg: catppuccin_dark_lighter_2,
+		button_bubble_fg: catppuccin_light_lighter_1,
+		content_fg: catppuccin_light_lighter_1,
+		content_button: catppuccin_light_lighter_0,
+		content_button_selected: catppuccin_primary,
+		content_button_icon_bg: catppuccin_dark_lighter_2,
+		content_button_icon: catppuccin_light_lighter_1,
+		content_button_icon_selected: catppuccin_dark_lighter_0,
+		content_accent: catppuccin_primary,
+		content_bg: catppuccin_dark_darker_0,
+		content_border: catppuccin_dark_lighter_1,
+		content_message_bg: catppuccin_dark_lighter_2,
+		header_bg: catppuccin_dark,
+		header_box_shadow_bg: catppuccin_dark,
+		header_button: catppuccin_light_lighter_0,
+		header_button_selected: catppuccin_primary,
+		list_bg: catppuccin_dark_darker_0,
+		list_alternate_bg: catppuccin_dark_lighter_0,
+		list_accent_fg: catppuccin_primary,
+		list_message_bg: catppuccin_dark_lighter_2,
+		list_border: catppuccin_dark_lighter_1,
+		modal_bg: catppuccin_dark_darker_0,
+		elevated_bg: catppuccin_dark_lighter_0,
+		navigation_bg: catppuccin_dark_lighter_0,
+		navigation_border: catppuccin_dark_lighter_1,
+		navigation_button: catppuccin_light_lighter_0,
+		navigation_button_icon_bg: catppuccin_dark_lighter_2,
+		navigation_button_icon: catppuccin_light_lighter_1,
+		navigation_button_selected: catppuccin_primary,
+		navigation_button_icon_selected: catppuccin_light_lighter_0,
+		navigation_menu_bg: catppuccin_dark_darker_0,
+		navigation_menu_icon: catppuccin_light_grey,
 	}),
 }

--- a/src/gui/builtinThemes.ts
+++ b/src/gui/builtinThemes.ts
@@ -49,8 +49,8 @@ export const logo_text_bright_grey = "#c5c7c7"
  */
 
 const catppuccin_logo_text = "#cad3f5"
-const catppuccin_light_lighter_0 = "#6e738d"
-const catppuccin_light_lighter_1 = "#8087a2"
+const catppuccin_light_lighter_0 = "#b8c0e0"
+const catppuccin_light_lighter_1 = "#cad3f5"
 const catppuccin_dark = "#1e2030"
 const catppuccin_dark_lighter_0 = "#24273a"
 const catppuccin_dark_lighter_1 = "#363a4f"

--- a/src/gui/theme.ts
+++ b/src/gui/theme.ts
@@ -111,6 +111,10 @@ export const themeOptions = [
 		name: "blue_label",
 		value: "blue",
 	},
+	{
+		name: "catppuccin_label",
+		value: "catppuccin",
+	},
 ] as const
 
 export function getContentButtonIconBackground(): string {

--- a/src/login/LoginView.ts
+++ b/src/login/LoginView.ts
@@ -212,6 +212,10 @@ export class LoginView extends BaseTopLevelView implements TopLevelView<LoginVie
 						label: "blue_label",
 						click: () => themeController.setThemePreference("blue"),
 					},
+					{
+						label: "catppuccin_label",
+						click: () => themeController.setThemePreference("catppuccin"),
+					},
 				]
 				const customButtons = (await themeController.getCustomThemes()).map((themeId) => {
 					return {

--- a/src/misc/TranslationKey.ts
+++ b/src/misc/TranslationKey.ts
@@ -194,6 +194,7 @@ export type TranslationKeyType =
 	| "captchaInfo_msg"
 	| "captchaInput_label"
 	| "catchAllMailbox_label"
+	| "catppuccin_label"
 	| "cc_label"
 	| "certificateError_msg"
 	| "certificateExpiryDate_label"

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -210,6 +210,7 @@ export default {
 		"captchaInfo_msg": "Please enter the displayed time to prove you are not a computer.",
 		"captchaInput_label": "Time",
 		"catchAllMailbox_label": "Catch all mailbox",
+		"catppuccin_label": "Catppuccin",
 		"cc_label": "Cc",
 		"certificateError_msg": "The certificate chain or the private key have a bad format or do not match your domain.",
 		"certificateExpiryDate_label": "Certificate expiry date: {date}",


### PR DESCRIPTION
This adds the Catppuccin theme, with the Macchiato flavor and the mauve accent color, as per the Catppuccin [palette](https://catppuccin.com/palette).

I hope just doing a PR with this change is accepted, otherwise feel free to just reject it :)

![login](https://github.com/tutao/tutanota/assets/37251808/4f947453-94b1-4de5-9185-e7d599df8760)
![theme_switcher](https://github.com/tutao/tutanota/assets/37251808/d8e2ec1b-90f5-4dc7-92c0-832c9918a986)
![recovery](https://github.com/tutao/tutanota/assets/37251808/f2a5d7ad-ae6d-492e-ac43-256295f32eb9)
