### PR TITLE
fix login with offline data after argon2 migration by a different client. 

### DIFF
--- a/src/api/worker/facades/LoginFacade.ts
+++ b/src/api/worker/facades/LoginFacade.ts
@@ -701,10 +701,10 @@ export class LoginFacade {
 			const user = await this.noncachingEntityClient.load(UserTypeRef, userId)
 			await this.checkOutdatedVerifier(user, accessToken, userPassphraseKey)
 
-			const wasPartiallyLoggedIn = this.userFacade.isPartiallyLoggedIn()
-			if (!wasPartiallyLoggedIn) {
-				this.userFacade.setUser(user)
-			}
+			// this may be the second time we set user in case we had a partial offline login before
+			// we do it unconditionally here, to make sure we unlock the latest user group key right below
+			this.userFacade.setUser(user)
+
 			const wasFullyLoggedIn = this.userFacade.isFullyLoggedIn()
 
 			this.userFacade.unlockUserGroupKey(userPassphraseKey)

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -386,7 +386,8 @@ o.spec("LoginFacadeTest", function () {
 				await deferred.promise
 
 				// we would love to prove that part of the login is done async but without injecting some asyncExecutor it's a bit tricky to do
-				o(calls).deepEquals(["setUser", "sessionService"])
+				// we assume to have seUser twice, once using caching entity client and once using non caching entity client.
+				o(calls).deepEquals(["setUser", "sessionService", "setUser"])
 
 				// just wait for the async login to not bleed into other test cases or to not randomly fail
 				await fullLoginDeferred.promise


### PR DESCRIPTION
#6935

When doing a login with offline data we initialize the user facade from offline cache. In case another client changed the kdf type (argon2 migration) we need to update the user facade as soon as we go online to unlock the user group key correctly.