### PR TITLE
disable argon2 migration

### DIFF
--- a/src/api/common/TutanotaConstants.ts
+++ b/src/api/common/TutanotaConstants.ts
@@ -303,6 +303,7 @@ type ConstType = {
 	WEBAUTHN_RP_ID: string
 	U2f_APPID_SUFFIX: string
 	U2F_LEGACY_APPID: string
+	EXECUTE_KDF_MIGRATION: boolean
 }
 
 export const Const: ConstType = {
@@ -323,6 +324,7 @@ export const Const: ConstType = {
 	// we'll still get the contents
 	// because it will be redirected to tuta.com after new domain deploy.
 	U2F_LEGACY_APPID: "https://tutanota.com/u2f-appid.json",
+	EXECUTE_KDF_MIGRATION: false,
 } as const
 
 export const TUTANOTA_MAIL_ADDRESS_DOMAINS: ReadonlyArray<string> = Object.freeze([

--- a/src/api/worker/facades/LoginFacade.ts
+++ b/src/api/worker/facades/LoginFacade.ts
@@ -24,7 +24,7 @@ import {
 	SessionService,
 	TakeOverDeletedAddressService,
 } from "../../entities/sys/Services"
-import { AccountType, asKdfType, CloseEventBusOption, DEFAULT_KDF_TYPE, KdfType } from "../../common/TutanotaConstants"
+import { AccountType, asKdfType, CloseEventBusOption, Const, DEFAULT_KDF_TYPE, KdfType } from "../../common/TutanotaConstants"
 import {
 	Challenge,
 	createChangeKdfPostIn,
@@ -295,6 +295,10 @@ export class LoginFacade {
 	 * @param user the user we are updating
 	 */
 	public async migrateKdfType(targetKdfType: KdfType, passphrase: string, user: User): Promise<void> {
+		if (!Const.EXECUTE_KDF_MIGRATION) {
+			// Migration is not yet enabled on this version.
+			return
+		}
 		const currentPassphraseKeyData = {
 			passphrase,
 			kdfType: asKdfType(user.kdfVersion),

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -23,7 +23,7 @@ import { UserFacade } from "../../../../../src/api/worker/facades/UserFacade"
 import { ChangeKdfService, SaltService, SessionService } from "../../../../../src/api/entities/sys/Services"
 import { Credentials } from "../../../../../src/misc/credentials/Credentials"
 import { defer, DeferredObject, uint8ArrayToBase64 } from "@tutao/tutanota-utils"
-import { AccountType, DEFAULT_KDF_TYPE, KdfType } from "../../../../../src/api/common/TutanotaConstants"
+import { AccountType, Const, DEFAULT_KDF_TYPE, KdfType } from "../../../../../src/api/common/TutanotaConstants"
 import { AccessExpiredError, ConnectionError, NotAuthenticatedError } from "../../../../../src/api/common/error/RestError"
 import { SessionType } from "../../../../../src/api/common/SessionType"
 import { HttpMethod } from "../../../../../src/api/common/EntityFunctions"
@@ -753,6 +753,7 @@ o.spec("LoginFacadeTest", function () {
 			user.salt = SALT
 
 			when(userFacade.getCurrentUserGroupKey()).thenReturn({ object: [1, 2, 3, 4], version: 0 })
+			Const.EXECUTE_KDF_MIGRATION = true
 			await facade.migrateKdfType(KdfType.Argon2id, "hunter2", user)
 
 			verify(
@@ -771,6 +772,9 @@ o.spec("LoginFacadeTest", function () {
 					}),
 				),
 			)
+		})
+		o.afterEach(() => {
+			Const.EXECUTE_KDF_MIGRATION = false
 		})
 	})
 })


### PR DESCRIPTION
We disable argon2 migration to prevent that client with offline support prior to 229.240513.0 have unexpected errors