### PR TITLE
Fix VatID number not shown + text overflow on PDF

### DIFF
--- a/src/api/worker/invoicegen/InvoiceTexts.ts
+++ b/src/api/worker/invoicegen/InvoiceTexts.ts
@@ -29,8 +29,8 @@ export default {
 		includedVat: "incl.",
 		vatPercent: "% VAT",
 
-		reverseChargeVatIdNumber:
-			"All prices are net prices. The recipient is liable for VAT under the reverse charge mechanism (German: Steuerschuld des Leistungsempfängers).",
+		reverseChargeVatIdNumber1: "All prices are net prices. The recipient is liable for VAT under the reverse charge mechanism",
+		reverseChargeVatIdNumber2: "(German: Steuerschuld des Leistungsempfängers).",
 		yourVatId: "Your VAT identification number:",
 		netPricesNoVatInGermany: "All prices are net prices and not subject to value added tax in Germany.",
 		noVatInGermany: "Prices are not subject to value added tax in Germany.",
@@ -97,8 +97,9 @@ export default {
 		cancelCredit: "Stornierung Gutschrift",
 		asAgreedBlock: "Vereinbarungsgemäß rechnen wir folgende Leistungen ab:",
 
-		reverseChargeVatIdNumber: "Alle Beträge sind netto. Die Steuerschuldnerschaft geht auf Sie als Leistungsempfänger über.",
-		yourVatId: " Ihre Umsatzsteuer-Identifikationsnummer:",
+		reverseChargeVatIdNumber1: "Alle Beträge sind netto. Die Steuerschuldnerschaft geht auf Sie als Leistungsempfänger über.",
+		reverseChargeVatIdNumber2: "",
+		yourVatId: "Ihre Umsatzsteuer-Identifikationsnummer:",
 		netPricesNoVatInGermany: "Alle Beträge sind netto und werden nicht in Deutschland versteuert.",
 		noVatInGermany: "Beträge werden nicht in Deutschland versteuert.",
 

--- a/src/api/worker/invoicegen/PdfInvoiceGenerator.ts
+++ b/src/api/worker/invoicegen/PdfInvoiceGenerator.ts
@@ -243,8 +243,14 @@ export class PdfInvoiceGenerator {
 			case VatType.NO_VAT:
 			case VatType.NO_VAT_REVERSE_CHARGE:
 				if (this.invoice.vatIdNumber != null) {
-					this.doc.addText(InvoiceTexts[this.languageCode].reverseChargeVatIdNumber)
-					this.doc.addText(`${InvoiceTexts[this.languageCode].reverseChargeVatIdNumber} ${this.invoice.vatIdNumber}`)
+					this.doc
+						.addText(InvoiceTexts[this.languageCode].reverseChargeVatIdNumber1)
+						.addLineBreak()
+						.addText(InvoiceTexts[this.languageCode].reverseChargeVatIdNumber2)
+						.addLineBreak()
+						.addText(`${InvoiceTexts[this.languageCode].yourVatId} `)
+						.changeFont(PDF_FONTS.BOLD, 11)
+						.addText(`${this.invoice.vatIdNumber}`)
 				} else {
 					this.doc.addText(InvoiceTexts[this.languageCode].netPricesNoVatInGermany)
 				}

--- a/test/tests/api/worker/invoicegen/PdfInvoiceGeneratorTest.ts
+++ b/test/tests/api/worker/invoicegen/PdfInvoiceGeneratorTest.ts
@@ -43,6 +43,18 @@ o.spec("PdfInvoiceGenerator", function () {
 		const gen = new PdfInvoiceGenerator(pdfWriter, renderInvoice, "1978197819801981931", "NiiNii")
 		const pdf = await gen.generate()
 	})
+
+	o("VatId number is generated", async function () {
+		const renderInvoice = createTestEntity(InvoiceDataGetOutTypeRef, {
+			address: "BelgianStreet 5\n12345 Zellig\nBelgium",
+			country: "BE",
+			items: dataMock(15),
+			vatType: "4",
+			vatIdNumber: "1111_2222_3333_4444",
+		})
+		const gen = new PdfInvoiceGenerator(pdfWriter, renderInvoice, "1978197819801981931", "NiiNii")
+		const pdf = await gen.generate()
+	})
 })
 
 function dataMock(amount: number) {


### PR DESCRIPTION
Expanded the text that is shown when a VatID number should be displayed.
Also split invoice translation key into two to prevent overflow.

Close #6947 