### PR TITLE
Handle wasm loading from Node process

### DIFF
--- a/buildSrc/DevBuild.js
+++ b/buildSrc/DevBuild.js
@@ -12,7 +12,6 @@ import { checkOfflineDatabaseMigrations } from "./checkOfflineDbMigratons.js"
 import { buildRuntimePackages } from "./packageBuilderFunctions.js"
 import { domainConfigs } from "./DomainConfigs.js"
 import { sh } from "./sh.js"
-import { esbuildWasmLoader } from "@tutao/tuta-wasm-loader"
 
 export async function runDevBuild({ stage, host, desktop, clean, ignoreMigrations }) {
 	if (clean) {
@@ -95,6 +94,7 @@ importScripts("./worker.js")
 	})
 
 	await runStep("Web: Esbuild", async () => {
+		const { esbuildWasmLoader } = await import("@tutao/tuta-wasm-loader")
 		await esbuild({
 			// Using named entry points so that it outputs build/worker.js and not build/api/worker/worker.js
 			entryPoints: { app: "src/app.ts", worker: "src/api/worker/worker.ts" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
 				"node-gyp": "10.0.1",
 				"octokit": "3.1.2",
 				"prettier": "2.8.1",
-				"rollup": "4.9.4",
+				"rollup": "4.18.0",
 				"rollup-plugin-visualizer": "^5.12.0",
 				"testdouble": "3.18.0",
 				"typescript": "5.3.3",
@@ -2368,9 +2368,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.4.tgz",
-			"integrity": "sha512-ub/SN3yWqIv5CWiAZPHVS1DloyZsJbtXmX4HxUTIpS0BHm9pW5iYBo2mIZi+hE3AeiTzHz33blwSnhdUo+9NpA==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
+			"integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
 			"cpu": [
 				"arm"
 			],
@@ -2381,9 +2381,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.4.tgz",
-			"integrity": "sha512-ehcBrOR5XTl0W0t2WxfTyHCR/3Cq2jfb+I4W+Ch8Y9b5G+vbAecVv0Fx/J1QKktOrgUYsIKxWAKgIpvw56IFNA==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
+			"integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2394,9 +2394,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.4.tgz",
-			"integrity": "sha512-1fzh1lWExwSTWy8vJPnNbNM02WZDS8AW3McEOb7wW+nPChLKf3WG2aG7fhaUmfX5FKw9zhsF5+MBwArGyNM7NA==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
+			"integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2407,9 +2407,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.4.tgz",
-			"integrity": "sha512-Gc6cukkF38RcYQ6uPdiXi70JB0f29CwcQ7+r4QpfNpQFVHXRd0DfWFidoGxjSx1DwOETM97JPz1RXL5ISSB0pA==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
+			"integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
 			"cpu": [
 				"x64"
 			],
@@ -2420,9 +2420,22 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.4.tgz",
-			"integrity": "sha512-g21RTeFzoTl8GxosHbnQZ0/JkuFIB13C3T7Y0HtKzOXmoHhewLbVTFBQZu+z5m9STH6FZ7L/oPgU4Nm5ErN2fw==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
+			"integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
+			"integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
 			"cpu": [
 				"arm"
 			],
@@ -2433,9 +2446,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.4.tgz",
-			"integrity": "sha512-TVYVWD/SYwWzGGnbfTkrNpdE4HON46orgMNHCivlXmlsSGQOx/OHHYiQcMIOx38/GWgwr/po2LBn7wypkWw/Mg==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
+			"integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
 			"cpu": [
 				"arm64"
 			],
@@ -2446,9 +2459,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.4.tgz",
-			"integrity": "sha512-XcKvuendwizYYhFxpvQ3xVpzje2HHImzg33wL9zvxtj77HvPStbSGI9czrdbfrf8DGMcNNReH9pVZv8qejAQ5A==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
+			"integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -2458,10 +2471,23 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
+			"integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.4.tgz",
-			"integrity": "sha512-LFHS/8Q+I9YA0yVETyjonMJ3UA+DczeBd/MqNEzsGSTdNvSJa1OJZcSH8GiXLvcizgp9AlHs2walqRcqzjOi3A==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
+			"integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -2471,10 +2497,23 @@
 				"linux"
 			]
 		},
+		"node_modules/@rollup/rollup-linux-s390x-gnu": {
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
+			"integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.4.tgz",
-			"integrity": "sha512-dIYgo+j1+yfy81i0YVU5KnQrIJZE8ERomx17ReU4GREjGtDW4X+nvkBak2xAUpyqLs4eleDSj3RrV72fQos7zw==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
+			"integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
 			"cpu": [
 				"x64"
 			],
@@ -2485,9 +2524,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.4.tgz",
-			"integrity": "sha512-RoaYxjdHQ5TPjaPrLsfKqR3pakMr3JGqZ+jZM0zP2IkDtsGa4CqYaWSfQmZVgFUCgLrTnzX+cnHS3nfl+kB6ZQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
+			"integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
 			"cpu": [
 				"x64"
 			],
@@ -2498,9 +2537,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.4.tgz",
-			"integrity": "sha512-T8Q3XHV+Jjf5e49B4EAaLKV74BbX7/qYBRQ8Wop/+TyyU0k+vSjiLVSHNWdVd1goMjZcbhDmYZUYW5RFqkBNHQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
+			"integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2511,9 +2550,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.4.tgz",
-			"integrity": "sha512-z+JQ7JirDUHAsMecVydnBPWLwJjbppU+7LZjffGf+Jvrxq+dVjIE7By163Sc9DKc3ADSU50qPVw0KonBS+a+HQ==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
+			"integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
 			"cpu": [
 				"ia32"
 			],
@@ -2524,9 +2563,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.4.tgz",
-			"integrity": "sha512-LfdGXCV9rdEify1oxlN9eamvDSjv9md9ZVMAbNHA87xqIfFCxImxan9qZ8+Un54iK2nnqPlbnSi4R54ONtbWBw==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
+			"integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
 			"cpu": [
 				"x64"
 			],
@@ -9443,9 +9482,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.4.tgz",
-			"integrity": "sha512-2ztU7pY/lrQyXSCnnoU4ICjT/tCG9cdH3/G25ERqE3Lst6vl2BCM5hL2Nw+sslAvAf+ccKsAq1SkKQALyqhR7g==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
+			"integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "1.0.5"
@@ -9458,19 +9497,22 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.9.4",
-				"@rollup/rollup-android-arm64": "4.9.4",
-				"@rollup/rollup-darwin-arm64": "4.9.4",
-				"@rollup/rollup-darwin-x64": "4.9.4",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.9.4",
-				"@rollup/rollup-linux-arm64-gnu": "4.9.4",
-				"@rollup/rollup-linux-arm64-musl": "4.9.4",
-				"@rollup/rollup-linux-riscv64-gnu": "4.9.4",
-				"@rollup/rollup-linux-x64-gnu": "4.9.4",
-				"@rollup/rollup-linux-x64-musl": "4.9.4",
-				"@rollup/rollup-win32-arm64-msvc": "4.9.4",
-				"@rollup/rollup-win32-ia32-msvc": "4.9.4",
-				"@rollup/rollup-win32-x64-msvc": "4.9.4",
+				"@rollup/rollup-android-arm-eabi": "4.18.0",
+				"@rollup/rollup-android-arm64": "4.18.0",
+				"@rollup/rollup-darwin-arm64": "4.18.0",
+				"@rollup/rollup-darwin-x64": "4.18.0",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
+				"@rollup/rollup-linux-arm-musleabihf": "4.18.0",
+				"@rollup/rollup-linux-arm64-gnu": "4.18.0",
+				"@rollup/rollup-linux-arm64-musl": "4.18.0",
+				"@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
+				"@rollup/rollup-linux-riscv64-gnu": "4.18.0",
+				"@rollup/rollup-linux-s390x-gnu": "4.18.0",
+				"@rollup/rollup-linux-x64-gnu": "4.18.0",
+				"@rollup/rollup-linux-x64-musl": "4.18.0",
+				"@rollup/rollup-win32-arm64-msvc": "4.18.0",
+				"@rollup/rollup-win32-ia32-msvc": "4.18.0",
+				"@rollup/rollup-win32-x64-msvc": "4.18.0",
 				"fsevents": "~2.3.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"node-gyp": "10.0.1",
 		"octokit": "3.1.2",
 		"prettier": "2.8.1",
-		"rollup": "4.9.4",
+		"rollup": "4.18.0",
 		"rollup-plugin-visualizer": "^5.12.0",
 		"testdouble": "3.18.0",
 		"typescript": "5.3.3",

--- a/packages/tuta-wasm-loader/lib/WasmHandler.ts
+++ b/packages/tuta-wasm-loader/lib/WasmHandler.ts
@@ -43,6 +43,14 @@ async function generateImportCode(wasmFilePath: string) {
 			const shouldForceFallback = options && options.forceFallback
 			if (typeof WebAssembly !== "object" || typeof WebAssembly.instantiate !== "function" || shouldForceFallback) {
 				return await import("${fallback}").catch((e) => console.log(e))
+			} else if (typeof process !== "undefined") {
+				const {readFile} = await import("node:fs/promises")
+				const {dirname, join} = await import("node:path")
+
+				const wasmPath = join(dirname(__filename), "${wasmFilePath}")
+				const wasmSource = await readFile(wasmPath)
+
+				return (await WebAssembly.instantiate(wasmSource)).instance.exports
 			} else {
 				const wasm = fetch("${wasmFilePath}")
 				if (WebAssembly.instantiateStreaming) {

--- a/packages/tuta-wasm-loader/lib/index.ts
+++ b/packages/tuta-wasm-loader/lib/index.ts
@@ -84,6 +84,11 @@ function esbuildWasmLoader(options: LoadOptions) {
 					loader: "js",
 				}
 			})
+			build.onResolve({ filter: /node:*/, namespace: "wasm-loader" }, async (args) => {
+				return {
+					external: true,
+				}
+			})
 		},
 	}
 }
@@ -99,7 +104,10 @@ function rollupWasmLoader(options: LoadOptions & { output: string }) {
 			}
 		},
 		async resolveDynamicImport(specifier: string, importer: string) {
-			if (importer.includes("wasm-loader")) {
+			if (importer.includes("wasm-loader") && specifier.startsWith("node:")) {
+				// rollup chokes on node: imports for some reason
+				return { external: true, id: specifier.substring("node:".length) }
+			} else if (importer.includes("wasm-loader")) {
 				return {
 					id: `\0${specifier}`,
 					external: false,


### PR DESCRIPTION
This commit adds the resolving of wasm files also available to calls from the Node part, reading the file and returning the exports object.