### PR TITLE
Use title instead of aria-label in BaseButton

### DIFF
--- a/src/gui/base/buttons/BaseButton.ts
+++ b/src/gui/base/buttons/BaseButton.ts
@@ -33,7 +33,7 @@ export class BaseButton implements ClassComponent<BaseButtonAttrs> {
 		return m(
 			"button",
 			{
-				"aria-label": attrs.label,
+				title: attrs.label,
 				disabled,
 				"aria-disabled": disabled,
 				pressed,


### PR DESCRIPTION
Title causes the hover text, and aria-label should derive from title.

fix #7031