### PR TITLE
Prevent negative reminder time

### DIFF
--- a/src/calendar/gui/eventeditor-view/CalendarEventEditView.ts
+++ b/src/calendar/gui/eventeditor-view/CalendarEventEditView.ts
@@ -310,7 +310,7 @@ export class CalendarEventEditView implements Component<CalendarEventEditViewAtt
 							oninput: (v) => {
 								const time = Number.parseInt(v)
 								const isEmpty = v === ""
-								if (!Number.isNaN(time) || isEmpty) timeReminderValue = isEmpty ? 0 : time
+								if (!Number.isNaN(time) || isEmpty) timeReminderValue = isEmpty ? 0 : Math.abs(time)
 							},
 							class: "flex-half no-appearance", //Removes the up/down arrow from input number. Pressing arrow up/down key still working
 						}),


### PR DESCRIPTION
This commit gets the modulus of the parsed integer, preventing any non-positive value from being added as a valid reminder time.

fix #6951