### PR TITLE
Fix whitelabel domains unable to store credentials

### DIFF
--- a/src/api/common/Env.ts
+++ b/src/api/common/Env.ts
@@ -1,9 +1,6 @@
 //@bundleInto:common-min
 
 import { ProgrammingError } from "./error/ProgrammingError.js"
-import { getWhitelabelCustomizations } from "../../misc/WhitelabelCustomizations.js"
-import { BootstrapFeatureType } from "./TutanotaConstants.js"
-import { ACTIVATED_MIGRATION, isLegacyDomain } from "../../login/LoginViewModel.js"
 
 // keep in sync with LaunchHtml.js meta tag title
 export const LOGIN_TITLE = "Mail. Done. Right. Tuta Mail Login & Sign up for an Ad-free Mailbox"

--- a/src/api/common/TutanotaConstants.ts
+++ b/src/api/common/TutanotaConstants.ts
@@ -495,10 +495,6 @@ export enum FeatureType {
 	MultipleUsers = "17", // Multi-user support for new personal plans.
 }
 
-export const enum BootstrapFeatureType {
-	DisableSavePassword = "0",
-}
-
 export const FULL_INDEXED_TIMESTAMP: number = 0
 export const NOTHING_INDEXED_TIMESTAMP: number = Math.pow(2, 42) - 1 // maximum Timestamp is 42 bit long (see GeneratedIdData.java)
 

--- a/src/login/LoginForm.ts
+++ b/src/login/LoginForm.ts
@@ -7,8 +7,6 @@ import { Autocomplete, TextField, TextFieldType } from "../gui/base/TextField.js
 import { Checkbox } from "../gui/base/Checkbox.js"
 import { client } from "../misc/ClientDetector"
 import { isApp, isDesktop, isOfflineStorageAvailable } from "../api/common/Env"
-import { getWhitelabelCustomizations } from "../misc/WhitelabelCustomizations.js"
-import { BootstrapFeatureType } from "../api/common/TutanotaConstants.js"
 import { ACTIVATED_MIGRATION, isLegacyDomain } from "./LoginViewModel.js"
 import { LoginButton } from "../gui/base/buttons/LoginButton.js"
 import { PasswordField } from "../misc/passwords/PasswordField.js"
@@ -55,18 +53,14 @@ export class LoginForm implements Component<LoginFormAttrs> {
 		this.passwordTextField.value = ""
 	}
 
-	_passwordDisabled(): boolean {
-		// some whitelabel customers have disabled password saving
-		const hasCustomDisabled = getWhitelabelCustomizations(window)?.bootstrapCustomizations?.includes(BootstrapFeatureType.DisableSavePassword) != null
-		// on the old domain, we don't want to save new credentials.
-		const noSaveLegacyDomain = ACTIVATED_MIGRATION() && isLegacyDomain()
-		return hasCustomDisabled || noSaveLegacyDomain
+	isSavePasswordDisabled(): boolean {
+		return ACTIVATED_MIGRATION() && isLegacyDomain()
 	}
 
 	view(vnode: Vnode<LoginFormAttrs>): Children {
 		const a = vnode.attrs
 		const canSaveCredentials = client.localStorage()
-		if (a.savePassword && (isApp() || isDesktop()) && !this._passwordDisabled()) {
+		if (a.savePassword && (isApp() || isDesktop()) && !this.isSavePasswordDisabled()) {
 			a.savePassword(true)
 		}
 		return m(
@@ -121,7 +115,7 @@ export class LoginForm implements Component<LoginFormAttrs> {
 						},
 					}),
 				),
-				a.savePassword && !this._passwordDisabled()
+				a.savePassword && !this.isSavePasswordDisabled()
 					? isApp() || isDesktop()
 						? m("small.block.content-fg", lang.get("dataWillBeStored_msg"))
 						: m(

--- a/src/misc/WhitelabelCustomizations.ts
+++ b/src/misc/WhitelabelCustomizations.ts
@@ -1,5 +1,4 @@
 import type { BaseThemeId, Theme } from "../gui/theme"
-import type { BootstrapFeatureType } from "../api/common/TutanotaConstants"
 import { assertMainOrNodeBoot } from "../api/common/Env"
 import type { WhitelabelConfig } from "../api/entities/sys/TypeRefs.js"
 
@@ -12,7 +11,6 @@ export type CustomizationKey = keyof ThemeCustomizations
 
 export type WhitelabelCustomizations = {
 	theme: ThemeCustomizations | null
-	bootstrapCustomizations: BootstrapFeatureType[]
 	germanLanguageCode: string
 	registrationDomains: string[] | null
 	imprintUrl: string | null


### PR DESCRIPTION
This commit removes the check for the DisableSavePassword feature since it isn't included anymore in our client and can be safely removed.

fix #6863