### PR TITLE
Move getting asset path into try/catch statement in MainActivity

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -244,10 +244,10 @@ class MainActivity : FragmentActivity() {
 					)
 				} else if (request.method == "GET" && url.toString().startsWith(BASE_WEB_VIEW_URL)) {
 					Log.v(TAG, "replacing asset GET response to ${url.path}")
-					val assetPath = File(BuildConfig.RES_ADDRESS + url.path!!).canonicalPath.run {
-						slice(1..lastIndex)
-					}
 					try {
+						val assetPath = File(BuildConfig.RES_ADDRESS + url.path!!).canonicalPath.run {
+							slice(1..lastIndex)
+						}
 						if (!assetPath.startsWith(BuildConfig.RES_ADDRESS)) throw IOException("can't find this")
 						val mimeType = getMimeTypeForUrl(url.toString())
 						WebResourceResponse(


### PR DESCRIPTION
fix #7035

example:

```html
<table background="radial-gradient(circle, rgba(255,242,0,1) 0%,rgba(255,203,3,1) 75%)" </table>
```

browser interprets background as relative URL and we crash when we try to load the resource