### PR TITLE
Fix both arrow buttons in the Day Selector Popup going to the previous month

### DIFF
--- a/src/calendar/gui/day-selector/DaySelectorPopup.ts
+++ b/src/calendar/gui/day-selector/DaySelectorPopup.ts
@@ -98,7 +98,7 @@ export class DaySelectorPopup implements ModalComponent {
 			),
 			m(".flex.items-center", [
 				renderSwitchMonthArrowIcon(false, 24, () => this.onMonthChange(false)),
-				renderSwitchMonthArrowIcon(true, 24, () => this.onMonthChange(false)),
+				renderSwitchMonthArrowIcon(true, 24, () => this.onMonthChange(true)),
 			]),
 		])
 	}


### PR DESCRIPTION
Closes #6860.