### PR TITLE
Handle async index db initialization errors, fixes tutadb 1805

### DIFF
--- a/src/api/worker/EventBusClient.ts
+++ b/src/api/worker/EventBusClient.ts
@@ -38,7 +38,7 @@ import { SleepDetector } from "./utils/SleepDetector.js"
 import sysModelInfo from "../entities/sys/ModelInfo.js"
 import tutanotaModelInfo from "../entities/tutanota/ModelInfo.js"
 import { resolveTypeReference } from "../common/EntityFunctions.js"
-import { ReportedMailFieldMarker, PhishingMarkerWebsocketData, PhishingMarkerWebsocketDataTypeRef } from "../entities/tutanota/TypeRefs"
+import { PhishingMarkerWebsocketData, PhishingMarkerWebsocketDataTypeRef, ReportedMailFieldMarker } from "../entities/tutanota/TypeRefs"
 import { UserFacade } from "./facades/UserFacade"
 import { ExposedProgressTracker } from "../main/ProgressTracker.js"
 
@@ -558,7 +558,6 @@ export class EventBusClient {
 			await this.processEventBatch(modification)
 		} catch (e) {
 			console.log("ws error while processing event batches", e)
-			this.listener.onError(e)
 			throw e
 		}
 

--- a/src/api/worker/WorkerImpl.ts
+++ b/src/api/worker/WorkerImpl.ts
@@ -121,6 +121,7 @@ export class WorkerImpl implements NativeInterface {
 		// Otherwise uncaught error handler might end up in an infinite loop for test cases.
 		if (workerScope && !isMainOrNode()) {
 			workerScope.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+				console.error("workerImpl.unhandledrejection", event, event.reason)
 				this.sendError(event.reason)
 			})
 

--- a/src/api/worker/search/DbFacade.ts
+++ b/src/api/worker/search/DbFacade.ts
@@ -47,7 +47,7 @@ export class DbFacade {
 	private _activeTransactions: number
 	indexingSupported: boolean = true
 
-	constructor(version: number, onupgrade: (event: any, db: IDBDatabase, dbFacade: DbFacade) => void) {
+	constructor(version: number, onupgrade: (event: any, db: IDBDatabase, dbFacade: DbFacade) => Promise<void> | void) {
 		this._activeTransactions = 0
 		this._db = new LazyLoaded(() => {
 			if (!this.indexingSupported) {
@@ -86,11 +86,11 @@ export class DbFacade {
 							}
 						}
 
-						DBOpenRequest.onupgradeneeded = (event: IDBVersionChangeEvent) => {
+						DBOpenRequest.onupgradeneeded = async (event: IDBVersionChangeEvent) => {
 							//console.log("upgrade db", event)
 							try {
 								// @ts-ignore
-								onupgrade(event, event.target.result, this)
+								await onupgrade(event, event.target.result, this)
 							} catch (e) {
 								reject(new DbError("could not create object store for DB " + this._id, e))
 							}


### PR DESCRIPTION
Errors while initializing the DBFacade are now handled inside DBFacade and re thrown as DBError to prevent uncaught errors.

Errors from the event queue are also not reported as uncaught error by EntityClient anymore as they are thrown anyway.