### PR TITLE
[desktop] Handle DeviceStorageUnavailableError on login

### DIFF
--- a/test/tests/login/LoginViewModelTest.ts
+++ b/test/tests/login/LoginViewModelTest.ts
@@ -251,7 +251,7 @@ o.spec("LoginViewModelTest", () => {
 
 			await viewModel.deleteCredentials(encryptedTestCredentials.credentialInfo)
 
-			verify(credentialRemovalHandler.onCredentialsRemoved(credentialsAndKey))
+			verify(credentialRemovalHandler.onCredentialsRemoved(credentialsAndKey.credentialInfo))
 			verify(loginControllerMock.deleteOldSession(credentialsToUnencrypted(testCredentials, null), pushIdentifier))
 		})
 	})
@@ -296,7 +296,7 @@ o.spec("LoginViewModelTest", () => {
 			o(viewModel.state).equals(LoginState.InvalidCredentials)
 			o(viewModel.displayMode).equals(DisplayMode.Form)
 			verify(credentialsProviderMock.deleteByUserId(testCredentials.userId))
-			verify(credentialRemovalHandler.onCredentialsRemoved(credentialsAndKey))
+			verify(credentialRemovalHandler.onCredentialsRemoved(credentialsAndKey.credentialInfo))
 			o(viewModel.getSavedCredentials()).deepEquals([])
 			o(viewModel.autoLoginCredentials).equals(null)
 		})


### PR DESCRIPTION
Added minimum handling for the cases when secret storage is not avilable so that the users don't see the unexpected error dialog.

Also changed CredentialRemovalHandler to allow using encrypted credentials.

Fix #7077