### PR TITLE
Fixes whitelabel themes being merged with default ones

### DIFF
--- a/src/login/PostLoginActions.ts
+++ b/src/login/PostLoginActions.ts
@@ -209,6 +209,11 @@ export class PostLoginActions implements PostLoginAction {
 			// jsonTheme is stored on WhitelabelConfig as an empty json string ("{}", or whatever JSON.stringify({}) gives you)
 			// so we can't just check `!whitelabelConfig.jsonTheme`
 			if (Object.keys(customizations).length > 0) {
+				// Custom theme is missing themeId, so we update it with the whitelabel domain
+				if (!customizations.themeId) {
+					customizations.themeId = domainInfoAndConfig.domainInfo.domain
+				}
+
 				await themeController.storeCustomThemeForCustomizations(customizations)
 
 				// Update the already loaded custom themes to their latest version


### PR DESCRIPTION
This commit adds the whitelabel domain as the themeId for the whitelabel theme in case it doesn't have an Id.

Co-authored-by: and <and@tutao.de>

Fixes #7090