### PR TITLE
Fix the delete event popup not closing

### DIFF
--- a/src/calendar/gui/eventpopup/CalendarEventPopup.ts
+++ b/src/calendar/gui/eventpopup/CalendarEventPopup.ts
@@ -52,7 +52,7 @@ export class CalendarEventPopup implements ModalComponent {
 	}
 
 	private readonly handleDeleteButtonClick: (ev: MouseEvent, receiver: HTMLElement) => void = async (ev: MouseEvent, receiver: HTMLElement) => {
-		showDeletePopup(this.model, ev, receiver, () => this.close)
+		showDeletePopup(this.model, ev, receiver, () => this.close())
 	}
 
 	private readonly handleEditButtonClick: (ev: MouseEvent, receiver: HTMLElement) => void = (ev: MouseEvent, receiver: HTMLElement) => {


### PR DESCRIPTION
My old enemy, JavaScript's dynamic binding strikes again.
Closes #7107.