### PR TITLE
[SDK] Encrypted entity client with downloading

### DIFF
--- a/tuta-sdk/rust/Cargo.lock
+++ b/tuta-sdk/rust/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +154,21 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "backtrace"
+version = "0.3.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -479,6 +509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +660,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mockall"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +804,12 @@ checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pkcs1"
@@ -945,6 +1005,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -1150,6 +1216,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
+dependencies = [
+ "backtrace",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1271,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror",
+ "tokio",
  "uniffi",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/tuta-sdk/rust/Cargo.toml
+++ b/tuta-sdk/rust/Cargo.toml
@@ -35,6 +35,7 @@ uniffi = { git = "https://github.com/mozilla/uniffi-rs.git", rev = "13a1c559cb37
 [dev-dependencies]
 mockall = "0.12.1"
 rand = "0.8.5"
+tokio = { version = "1.38.0", features = ["rt", "macros"] }
 
 [lib]
 crate-type = ["cdylib", "staticlib", "lib"]

--- a/tuta-sdk/rust/src/crypto/crypto_facade.rs
+++ b/tuta-sdk/rust/src/crypto/crypto_facade.rs
@@ -38,6 +38,7 @@ pub struct CryptoFacade {
     instance_mapper: Arc<InstanceMapper>,
 }
 
+#[cfg_attr(test, mockall::automock)]
 impl CryptoFacade {
     /// Returns the session key from `entity` and resolves the bucket key fields contained inside
     /// if present

--- a/tuta-sdk/rust/src/crypto/mod.rs
+++ b/tuta-sdk/rust/src/crypto/mod.rs
@@ -12,7 +12,7 @@ mod kyber;
 mod rsa;
 mod tuta_crypt;
 mod key_loader_facade;
-mod crypto_facade;
+pub mod crypto_facade;
 pub mod key;
 
 #[cfg(test)]

--- a/tuta-sdk/rust/src/crypto_entity_client.rs
+++ b/tuta-sdk/rust/src/crypto_entity_client.rs
@@ -1,0 +1,233 @@
+use std::sync::Arc;
+use serde::Deserialize;
+use crate::entity_client::IdType;
+#[mockall_double::double]
+use crate::entity_client::EntityClient;
+use crate::ApiCallError;
+#[mockall_double::double]
+use crate::crypto::crypto_facade::CryptoFacade;
+use crate::entities::Entity;
+use crate::entities::entity_facade::EntityFacade;
+#[mockall_double::double]
+use crate::instance_mapper::InstanceMapper;
+
+
+// A high level interface to manipulate encrypted entities/instances via the REST API
+pub struct CryptoEntityClient {
+    entity_client: Arc<EntityClient>,
+    entity_facade: Arc<EntityFacade>,
+    crypto_facade: Arc<CryptoFacade>,
+    instance_mapper: Arc<InstanceMapper>,
+}
+
+impl CryptoEntityClient {
+    pub fn new(
+        entity_client: Arc<EntityClient>,
+        entity_facade: Arc<EntityFacade>,
+        crypto_facade: Arc<CryptoFacade>,
+        instance_mapper: Arc<InstanceMapper>,
+    ) -> Self {
+        CryptoEntityClient { entity_client, entity_facade, crypto_facade, instance_mapper }
+    }
+    pub async fn load<T: Entity + Deserialize<'static>, ID: IdType + 'static>(
+        &self,
+        id: &ID,
+    ) -> Result<T, ApiCallError> {
+        let type_ref = T::type_ref();
+        let type_model = self.entity_client.get_type_model(&type_ref)?;
+        let mut parsed_entity = self.entity_client.load(&type_ref, id).await?;
+
+        if type_model.encrypted {
+            let possible_session_key = self.crypto_facade
+                .resolve_session_key(&mut parsed_entity, type_model)
+                .map_err(|error|
+                    ApiCallError::InternalSdkError {
+                        error_message: format!(
+                            "Failed to resolve session key for entity '{}' with ID: {}; {}",
+                            type_model.name,
+                            type_model.id,
+                            error
+                        )
+                    }
+                )?;
+            match possible_session_key {
+                Some(session_key) => {
+                    let decrypted_entity = self.entity_facade.decrypt_and_map(type_model, parsed_entity, &session_key)?;
+                    let typed_entity = self.instance_mapper.parse_entity::<T>(decrypted_entity)
+                        .map_err(|e|
+                            ApiCallError::InternalSdkError {
+                                error_message: format!(
+                                    "Failed to parse encrypted entity into proper types: {}",
+                                    e
+                                )
+                            }
+                        )?;
+                    Ok(typed_entity)
+                }
+                // `resolve_session_key()` only returns none if the entity is unencrypted, so
+                // no need to handle it
+                None => { unreachable!() }
+            }
+        } else {
+            let typed_entity = self.instance_mapper.parse_entity::<T>(parsed_entity)
+                .map_err(|error|
+                    ApiCallError::InternalSdkError {
+                        error_message: format!(
+                            "Failed to parse unencrypted entity into proper types: {}",
+                            error
+                        )
+                    }
+                )?;
+            Ok(typed_entity)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use rand::random;
+    use crate::crypto::aes::{Aes256Key, Iv};
+    use crate::crypto::crypto_facade::MockCryptoFacade;
+    use crate::crypto::key::GenericAesKey;
+    use crate::crypto_entity_client::CryptoEntityClient;
+    use crate::date::DateTime;
+    use crate::entities::entity_facade::EntityFacade;
+    use crate::entities::tutanota::{Mail, MailAddress};
+    use crate::util::entity_test_utils::generate_email_entity;
+    use crate::entity_client::MockEntityClient;
+    use crate::instance_mapper::MockInstanceMapper;
+    use crate::metamodel::TypeModel;
+    use crate::type_model_provider::{init_type_model_provider, TypeModelProvider};
+    use crate::{IdTuple, TypeRef};
+    use crate::custom_id::CustomId;
+    use crate::generated_id::GeneratedId;
+
+    #[tokio::test]
+    async fn can_load_mail() {
+        // Generate an encrypted type to feed into a mock of the entity client
+        let sk = GenericAesKey::Aes256(Aes256Key::from_bytes(&random::<[u8; 32]>()).unwrap());
+        let iv = Iv::from_bytes(&random::<[u8; 16]>()).unwrap();
+        let is_confidential = false;
+        const SUBJECT: &str = "Subject";
+        const SENDER_NAME: &str = "Sender";
+        const RECIPIENT_NAME: &str = "Recipient";
+        let test_date = DateTime::from_millis(1470039025474);
+        let (encrypted_mail, _) = generate_email_entity(
+            None,
+            &sk,
+            &iv,
+            is_confidential,
+            SUBJECT.to_owned(),
+            SENDER_NAME.to_owned(),
+            RECIPIENT_NAME.to_owned(),
+        );
+
+        // We cause a deliberate memory leak to convert the mail type's lifetime to static because
+        // the callback to `returning` requires returned references to have a static lifetime
+        let my_favorite_leak: &'static TypeModelProvider = Box::leak(
+            Box::new(init_type_model_provider())
+        );
+
+        let raw_mail_id = encrypted_mail.get("_id").unwrap().assert_tuple_id();
+        let mail_id = IdTuple::new(
+            raw_mail_id.list_id.clone(),
+            raw_mail_id.element_id.clone(),
+        );
+        let mail_type_ref = TypeRef { app: "tutanota", type_: "Mail" };
+        let mail_type_model: &'static TypeModel = my_favorite_leak
+            .get_type_model(&mail_type_ref.app, &mail_type_ref.type_)
+            .expect("Error in type_model_provider");
+
+        // Set up the mock of the plain unencrypted entity client
+        let mut mock_entity_client = MockEntityClient::default();
+        mock_entity_client.expect_get_type_model().returning(|_| Ok(mail_type_model));
+        mock_entity_client.expect_load().returning(move |_, _: &IdTuple| Ok(encrypted_mail.clone()));
+
+        // Set up the mock of the crypto facade
+        let mut mock_crypto_facade = MockCryptoFacade::default();
+        mock_crypto_facade.expect_resolve_session_key().returning(move |_, _| Ok(Some(sk.clone())));
+
+        // TODO: it would be nice to mock this
+        let type_model_provider = Arc::new(init_type_model_provider());
+
+        // Use the real `EntityFacade` as it contains the actual decryption logic
+        let entity_facade = EntityFacade::new(Arc::clone(&type_model_provider));
+
+        let mut mock_instance_mapper = MockInstanceMapper::new();
+        {
+            mock_instance_mapper.expect_parse_entity().returning(move |_| {
+                Ok(Mail {
+                    _format: 0,
+                    _id: IdTuple::new(GeneratedId("mail_list_id".to_owned()), GeneratedId("mail_id".to_owned())),
+                    _ownerEncSessionKey: None,
+                    _ownerGroup: Some(GeneratedId("ownerGroupId".to_owned())),
+                    _ownerKeyVersion: None, // Missing in `generate_email_entity()`
+                    _permissions: GeneratedId("permissionListId".to_owned()),
+                    authStatus: Some(0),
+                    confidential: is_confidential.clone(),
+                    differentEnvelopeSender: None,
+                    encryptionAuthStatus: None,
+                    listUnsubscribe: false,
+                    method: 0, // Empty in `generate_email_entity()`
+                    movedTime: None,
+                    phishingStatus: 0,
+                    receivedDate: test_date.clone(),
+                    recipientCount: 0,
+                    replyType: 0, // Empty in `generate_email_entity()`
+                    sentDate: Some(test_date.clone()),
+                    state: 0, // Empty in `generate_email_entity()`
+                    subject: SUBJECT.to_owned(),
+                    unread: true,
+                    attachments: vec![], // Missing in `generate_email_entity()`
+                    bccRecipients: vec![],
+                    body: None, // Missing in `generate_email_entity()`
+                    bucketKey: None,
+                    ccRecipients: vec![],
+                    conversationEntry: IdTuple {
+                        list_id: GeneratedId::test_random(),
+                        element_id: GeneratedId::test_random(),
+                    }, // Missing in `generate_email_entity()`
+                    firstRecipient: None, // Missing in `generate_email_entity()`
+                    headers: None, // Missing in `generate_email_entity()`
+                    mailDetails: None, // Missing in `generate_email_entity()`
+                    mailDetailsDraft: None, // Missing in `generate_email_entity()`
+                    replyTos: vec![],
+                    sender: MailAddress {
+                        _id: CustomId("senderId".to_owned()),
+                        address: "hello@tutao.de".to_owned(),
+                        name: SENDER_NAME.to_owned(),
+                        contact: None, // Missing in `generate_email_entity()`
+                    },
+                    toRecipients: vec![MailAddress {
+                        _id: CustomId("recipientId".to_owned()),
+                        address: "support@yahoo.com".to_owned(),
+                        name: RECIPIENT_NAME.to_string(),
+                        contact: None, // Missing in `generate_email_entity()`
+                    }],
+                })
+            });
+        }
+
+
+        let crypto_entity_client = CryptoEntityClient::new(
+            Arc::new(mock_entity_client),
+            Arc::new(entity_facade),
+            Arc::new(mock_crypto_facade),
+            Arc::new(mock_instance_mapper),
+        );
+
+        let result: Mail = crypto_entity_client.load(&mail_id)
+            .await
+            .unwrap();
+
+        assert_eq!(result.receivedDate, test_date);
+        assert_eq!(result.sentDate, Some(test_date));
+        assert_eq!(result.confidential, is_confidential);
+        assert_eq!(result.subject, SUBJECT.to_owned());
+        assert_eq!(result.sender.name, SENDER_NAME.to_owned());
+        assert_eq!(result.sender.address, "hello@tutao.de".to_owned());
+        assert_eq!(result.toRecipients[0].name, RECIPIENT_NAME.to_owned());
+        assert_eq!(result.toRecipients[0].address, "support@yahoo.com".to_owned());
+    }
+}

--- a/tuta-sdk/rust/src/element_value.rs
+++ b/tuta-sdk/rust/src/element_value.rs
@@ -83,6 +83,12 @@ impl ElementValue {
             _ => panic!("Invalid type"),
         }
     }
+    pub fn assert_tuple_id(&self) -> &IdTuple {
+        match self {
+            ElementValue::IdTupleId(value) => value,
+            _ => panic!("Invalid type"),
+        }
+    }
 
     pub fn assert_date(&self) -> &DateTime {
         match self {

--- a/tuta-sdk/rust/src/entities/entity_facade.rs
+++ b/tuta-sdk/rust/src/entities/entity_facade.rs
@@ -19,15 +19,13 @@ pub struct EntityFacade {
     type_model_provider: Arc<TypeModelProvider>,
 }
 
+#[cfg_attr(test, mockall::automock)]
 impl EntityFacade {
     pub fn new(type_model_provider: Arc<TypeModelProvider>) -> Self {
         EntityFacade {
             type_model_provider
         }
     }
-}
-
-impl EntityFacade {
     pub fn decrypt_and_map(&self, type_model: &TypeModel, mut entity: ParsedEntity, session_key: &GenericAesKey) -> Result<ParsedEntity, ApiCallError> {
         let mut mapped_decrypted: HashMap<String, ElementValue> = Default::default();
         let mut mapped_errors: HashMap<String, ElementValue> = Default::default();
@@ -250,7 +248,7 @@ mod tests {
     use crate::crypto::aes::{Aes256Key, Iv};
     use crate::crypto::key::GenericAesKey;
     use crate::entities::entity_facade::EntityFacade;
-    use crate::entities::entity_facade_test_utils::generate_email_entity;
+    use crate::util::entity_test_utils::{assert_decrypted_mail, generate_email_entity};
     use crate::type_model_provider::init_type_model_provider;
     use crate::TypeRef;
 
@@ -282,13 +280,6 @@ mod tests {
 
         let decrypted_mail = entity_facade.decrypt_and_map(type_model, encrypted_mail, &sk).unwrap();
 
-        assert_eq!(decrypted_mail.get("receivedDate").unwrap(), original_mail.get("receivedDate").unwrap());
-        assert_eq!(decrypted_mail.get("sentDate").unwrap(), original_mail.get("sentDate").unwrap());
-        assert_eq!(decrypted_mail.get("confidential").unwrap(), original_mail.get("confidential").unwrap());
-        assert_eq!(decrypted_mail.get("subject").unwrap(), original_mail.get("subject").unwrap());
-        assert_eq!(decrypted_mail.get("sender").unwrap().assert_dict().get("name").unwrap(), original_mail.get("sender").unwrap().assert_dict().get("name").unwrap());
-        assert_eq!(decrypted_mail.get("sender").unwrap().assert_dict().get("address").unwrap(), original_mail.get("sender").unwrap().assert_dict().get("address").unwrap());
-        assert_eq!(decrypted_mail.get("toRecipients").unwrap().assert_array()[0].assert_dict().get("name").unwrap(), original_mail.get("toRecipients").unwrap().assert_array()[0].assert_dict().get("name").unwrap());
-        assert_eq!(decrypted_mail.get("toRecipients").unwrap().assert_array()[0].assert_dict().get("address").unwrap(), original_mail.get("toRecipients").unwrap().assert_array()[0].assert_dict().get("address").unwrap());
+        assert_decrypted_mail(&decrypted_mail, &original_mail);
     }
 }

--- a/tuta-sdk/rust/src/entities/mod.rs
+++ b/tuta-sdk/rust/src/entities/mod.rs
@@ -9,15 +9,13 @@ pub(crate) mod storage;
 pub(crate) mod sys;
 pub(crate) mod tutanota;
 pub(crate) mod usage;
-mod entity_facade;
+pub(crate) mod entity_facade;
 
 use crate::date::DateTime;
 use crate::generated_id::GeneratedId;
 use crate::custom_id::CustomId;
 
-pub trait Entity {
+pub trait Entity: 'static {
     fn type_ref() -> TypeRef;
 }
 
-#[cfg(test)]
-mod entity_facade_test_utils;

--- a/tuta-sdk/rust/src/entity_client.rs
+++ b/tuta-sdk/rust/src/entity_client.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
-use crate::{ApiCallError, AuthHeadersProvider, IdTuple, RestClient, TypeRef};
+use crate::{ApiCallError, AuthHeadersProvider, IdTuple, ListLoadDirection, RestClient, TypeRef};
 use crate::element_value::{ElementValue, ParsedEntity};
 use crate::generated_id::GeneratedId;
 use crate::json_serializer::JsonSerializer;
@@ -21,7 +21,7 @@ impl IdType for GeneratedId {}
 impl IdType for IdTuple {}
 
 
-/// A high level interface to manipulate entities/instances via the REST API
+/// A high level interface to manipulate unencrypted entities/instances via the REST API
 pub struct EntityClient {
     rest_client: Arc<dyn RestClient>,
     base_url: String,
@@ -30,6 +30,8 @@ pub struct EntityClient {
     type_model_provider: Arc<TypeModelProvider>,
 }
 
+// TODO: remove this allowance after completing the implementation of `EntityClient`
+#[allow(unused_variables)]
 impl EntityClient {
     pub(crate) fn new(
         rest_client: Arc<dyn RestClient>,
@@ -80,6 +82,7 @@ impl EntityClient {
         Ok(parsed_entity)
     }
 
+    /// Returns the definition of an entity/instance type using the internal `TypeModelProvider`
     pub fn get_type_model(&self, type_ref: &TypeRef) -> Result<&TypeModel, ApiCallError> {
         let type_model = match self.type_model_provider.get_type_model(&type_ref.app, &type_ref.type_) {
             Some(value) => value,
@@ -90,40 +93,45 @@ impl EntityClient {
         };
         Ok(type_model)
     }
-    //
-    // pub async fn load_all(
-    //     &self,
-    //     type_ref: &TypeRef,
-    //     list_id: String,
-    //     start: Option<String>,
-    // ) -> Vec<RawEntity> {
-    //     unimplemented!()
-    // }
-    //
-    // pub async fn load_range(
-    //     &self,
-    //     type_ref: &TypeRef,
-    //     list_id: &str,
-    //     start_id: &str,
-    //     count: &str,
-    //     list_load_direction: ListLoadDirection,
-    // ) -> Vec<RawEntity> {
-    //     unimplemented!()
-    // }
-    //
-    // pub async fn setup_element(&self, type_ref: &TypeRef, entity: RawEntity) -> Vec<String> {
-    //     unimplemented!()
-    // }
-    //
-    // pub async fn setup_list_element(
-    //     &self,
-    //     type_ref: &TypeRef,
-    //     list_id: &str,
-    //     entity: RawEntity,
-    // ) -> Vec<String> {
-    //     unimplemented!()
-    // }
-    //
+
+    /// Fetches and returns all entities/instances in a list element type
+    pub async fn load_all(
+        &self,
+        type_ref: &TypeRef,
+        list_id: &IdTuple,
+        start: Option<String>,
+    ) -> Result<Vec<ParsedEntity>, ApiCallError> {
+        todo!()
+    }
+
+    /// Fetches and returns a specified number (`count`) of entities/instances
+    /// in a list element type starting at the index `start_id`
+    pub async fn load_range(
+        &self,
+        type_ref: &TypeRef,
+        list_id: &IdTuple,
+        start_id: &str,
+        count: &str,
+        list_load_direction: ListLoadDirection,
+    ) -> Result<Vec<ParsedEntity>, ApiCallError> {
+        todo!()
+    }
+
+    /// Stores a newly created entity/instance as a single element on the backend
+    pub async fn setup_element(&self, type_ref: &TypeRef, entity: RawEntity) -> Vec<String> {
+        todo!()
+    }
+
+    /// Stores a newly created entity/instance as a part of a list element on the backend
+    pub async fn setup_list_element(
+        &self,
+        type_ref: &TypeRef,
+        list_id: &IdTuple,
+        entity: RawEntity,
+    ) -> Vec<String> {
+        todo!()
+    }
+
     /// Updates an entity/instance in the backend
     pub async fn update(&self, type_ref: &TypeRef, entity: ParsedEntity,
                         model_version: u32) -> Result<(), ApiCallError> {
@@ -147,10 +155,51 @@ impl EntityClient {
             .await?;
         Ok(())
     }
-    //
-    // pub async fn erase_element(&self, type_ref: &TypeRef, id: &str) {
-    //     unimplemented!()
-    // }
-    //
-    // pub async fn erase_list_element(&self, type_ref: &TypeRef, id: IdTuple) {}
+
+    /// Deletes an existing single entity/instance on the backend
+    pub async fn erase_element(&self, type_ref: &TypeRef, id: &GeneratedId) -> Result<(), ApiCallError> {
+        todo!()
+    }
+
+    /// Deletes an existing entity/instance of a list element type on the backend
+    pub async fn erase_list_element(&self, type_ref: &TypeRef, id: IdTuple) -> Result<(), ApiCallError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mockall::mock! {
+    pub EntityClient {
+        pub async fn load<T: IdType  + 'static>(
+            &self,
+            type_ref: &TypeRef,
+            id: &T,
+        ) -> Result<ParsedEntity, ApiCallError>;
+        pub fn get_type_model(&self, type_ref: &TypeRef) -> Result<&'static TypeModel, ApiCallError>;
+        pub async fn load_all(
+            &self,
+            type_ref: &TypeRef,
+            list_id: &IdTuple,
+            start: Option<String>,
+        ) -> Result<Vec<ParsedEntity>, ApiCallError>;
+        pub async fn load_range(
+            &self,
+            type_ref: &TypeRef,
+            list_id: &IdTuple,
+            start_id: &str,
+            count: &str,
+            list_load_direction: ListLoadDirection,
+        ) -> Result<Vec<ParsedEntity>, ApiCallError>;
+        pub async fn setup_element(&self, type_ref: &TypeRef, entity: RawEntity) -> Vec<String>;
+        pub async fn setup_list_element(
+            &self,
+            type_ref: &TypeRef,
+            list_id: &IdTuple,
+            entity: RawEntity,
+        ) -> Vec<String>;
+        pub async fn update(&self, type_ref: &TypeRef, entity: ParsedEntity, model_version: u32)
+                        -> Result<(), ApiCallError>;
+        pub async fn erase_element(&self, type_ref: &TypeRef, id: &GeneratedId) -> Result<(), ApiCallError>;
+        pub async fn erase_list_element(&self, type_ref: &TypeRef, id: IdTuple) -> Result<(), ApiCallError>;
+    }
 }

--- a/tuta-sdk/rust/src/lib.rs
+++ b/tuta-sdk/rust/src/lib.rs
@@ -36,6 +36,7 @@ mod typed_entity_client;
 pub mod date;
 pub mod generated_id;
 mod custom_id;
+mod crypto_entity_client;
 
 uniffi::setup_scaffolding!();
 

--- a/tuta-sdk/rust/src/metamodel.rs
+++ b/tuta-sdk/rust/src/metamodel.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 /// A kind of element that can appear in the model
-#[derive(Deserialize, PartialEq)]
+#[derive(Deserialize, PartialEq, Clone)]
 pub enum ElementType {
     /// Entity referenced by a single id
     #[serde(rename = "ELEMENT_TYPE")]
@@ -67,7 +67,7 @@ pub enum AssociationType {
 }
 
 /// Description of the value (value field of Element)
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 pub struct ModelValue {
     pub id: u64,
     #[serde(rename = "type")]
@@ -98,7 +98,7 @@ pub struct ModelAssociation {
 }
 
 /// Description of a single Element type
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeModel {
     pub id: u64,

--- a/tuta-sdk/rust/src/util/mod.rs
+++ b/tuta-sdk/rust/src/util/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 pub mod test_utils;
+pub mod entity_test_utils;
 
 /// Combine multiple slices into one Vec.
 ///


### PR DESCRIPTION
This PR introduces 'CryptoEntityClient' a wrapper around `EntityClient` that utilizes `CryptoFacade` to provide automatic encryption/decryption to entity operations. Only the entity downloading functionality has been implemented as per the issue.

Closes #6955.