### PR TITLE
[build] Add type checking to buildSrc

### DIFF
--- a/buildSrc/DesktopBuilder.js
+++ b/buildSrc/DesktopBuilder.js
@@ -62,7 +62,6 @@ export async function buildDesktop({ dirname, version, platform, architecture, u
 		notarize,
 		unpacked,
 		sign: (process.env.DEBUG_SIGN && updateUrl !== "") || !!process.env.JENKINS_HOME,
-		linux: platform === "linux",
 		architecture,
 	})
 	console.log("updateUrl is", updateUrl)
@@ -93,6 +92,7 @@ export async function buildDesktop({ dirname, version, platform, architecture, u
 
 	// package for linux, win, mac
 	await electronBuilder.build({
+		// @ts-ignore this is the argument to the cli but it's not in ts types?
 		_: ["build"],
 		win: platform === "win32" ? [] : undefined,
 		mac: platform === "darwin" ? [] : undefined,
@@ -199,16 +199,16 @@ async function downloadLatestMapirs(dllName, dllTrg) {
 		console.log("latest mapirs release", res.url)
 		const asset_id = res.data.assets.find((a) => a.name.startsWith(dllName)).id
 		console.log("Downloading mapirs asset", asset_id)
-		const asset = await octokit.repos.getReleaseAsset(
-			Object.assign(opts, {
-				asset_id,
-				headers: {
-					Accept: "application/octet-stream",
-				},
-			}),
-		)
+		const assetResponse = await octokit.repos.getReleaseAsset({
+			...opts,
+			asset_id,
+			headers: {
+				Accept: "application/octet-stream",
+			},
+		})
 		console.log("Writing mapirs asset")
-		await fs.promises.writeFile(dllTrg, Buffer.from(asset.data))
+		// @ts-ignore not clear how to check for response status so that ts is happy
+		await fs.promises.writeFile(dllTrg, Buffer.from(assetResponse.data))
 		console.log("Mapirs downloaded")
 	} catch (e) {
 		console.error("Failed to download mapirs!", e)

--- a/buildSrc/DevBuild.js
+++ b/buildSrc/DevBuild.js
@@ -38,6 +38,10 @@ export async function runDevBuild({ stage, host, desktop, clean, ignoreMigration
 		await sh`npx tsc --incremental ${true} --noEmit true`
 	})
 
+	/**
+	 * @param host {string|null}
+	 * @return {DomainConfigMap}
+	 */
 	function updateDomainConfigForHostname(host) {
 		if (host == null) {
 			return { ...domainConfigs }
@@ -67,8 +71,7 @@ export async function runDevBuild({ stage, host, desktop, clean, ignoreMigration
 
 	const extendedDomainConfigs = updateDomainConfigForHostname(host)
 
-	const mode = desktop ? "Desktop" : "Browser"
-	await buildWebPart({ stage, host, version, mode, domainConfigs: extendedDomainConfigs })
+	await buildWebPart({ stage, host, version, domainConfigs: extendedDomainConfigs })
 
 	if (desktop) {
 		await buildDesktopPart({ version })
@@ -76,10 +79,11 @@ export async function runDevBuild({ stage, host, desktop, clean, ignoreMigration
 }
 
 /**
- * @param stage {string}
- * @param host {string|null}
- * @param version {string}
- * @param domainConfigs {DomainConfigMap}
+ * @param p {object}
+ * @param p.stage {string}
+ * @param p.host {string|null}
+ * @param p.version {string}
+ * @param p.domainConfigs {DomainConfigMap}
  * @return {Promise<void>}
  */
 async function buildWebPart({ stage, host, version, domainConfigs }) {
@@ -182,7 +186,6 @@ globalThis.buildOptions.sqliteNativePath = "./better-sqlite3.node";`,
 			updateUrl: "http://localhost:9000/client/build",
 			iconPath: path.join(desktopIconsPath, "logo-solo-red.png"),
 			sign: false,
-			linux: process.platform === "linux",
 			architecture: "x64",
 		})
 		const content = JSON.stringify(packageJSON, null, 2)
@@ -269,7 +272,9 @@ export async function prepareAssets(stage, host, version, domainConfigs) {
 	// write empty file
 	await fs.writeFile("build/polyfill.js", "")
 
-	for (const mode of ["Browser", "App", "Desktop"]) {
+	/** @type {EnvMode[]} */
+	const modes = ["Browser", "App", "Desktop"]
+	for (const mode of modes) {
 		await createBootstrap(env.create({ staticUrl: getStaticUrl(stage, mode, host), version, mode, dist: false, domainConfigs }))
 	}
 }

--- a/buildSrc/buildUtils.js
+++ b/buildSrc/buildUtils.js
@@ -13,7 +13,7 @@ var measureStartTime
 
 /**
  * Returns tutanota app version (as in package.json).
- * @returns {string}
+ * @returns {Promise<string>}
  */
 export async function getTutanotaAppVersion() {
 	const packageJson = JSON.parse(await fs.readFile(path.join(__dirname, "..", "package.json"), "utf8"))
@@ -79,7 +79,7 @@ export async function fileExists(filePath) {
 /**
  * There are various possibilities for how a given platform could be identified
  * We need to make sure to be consistent at certain points, such as when caching files or processing CLI args
- * @param platformName {"mac"|"darwin"|"win"|"win32"|"linux"}
+ * @param platformName {string}
  * @returns {"darwin"|"win32"|"linux"}
  */
 export function getCanonicalPlatformName(platformName) {

--- a/buildSrc/bump-version.js
+++ b/buildSrc/bump-version.js
@@ -18,8 +18,8 @@ await program
  */
 
 /**
- * @param which {Which}
- * @param platform {undefined | "webdesktop" | "android" | "ios"}
+ * @param params {object}
+ * @param params.platform {undefined | "webdesktop" | "android" | "ios" | "all"}
  * @return {Promise<void>}
  */
 async function run({ platform }) {
@@ -178,9 +178,7 @@ async function updateDependencyForWorkspaces(version, dependency, workspaces) {
 }
 
 /**
- * @param version {string}
- * @param dependency {string}
- * @param directory {string}
+ * @param {{version: string, dependency: string, directory: string}} params
  * @return {Promise<void>}
  */
 async function updateDependency({ version, dependency, directory }) {

--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -1,14 +1,23 @@
 import path from "node:path"
 import { readFileSync } from "node:fs"
-import { getElectronVersion, getInstalledModuleVersion } from "./getInstalledModuleVersion.js"
+import { getElectronVersion } from "./getInstalledModuleVersion.js"
 
 /**
  * This is used for launching electron:
  * 1. copied to app-desktop/build from make.js
  * 2. copied to app-desktop/build from dist.js (DesktopBuilder)
+ *
+ * @param p {object}
+ * @param p.nameSuffix {string}
+ * @param p.version {string}
+ * @param p.updateUrl {string}
+ * @param p.iconPath {string}
+ * @param p.sign {boolean}
+ * @param [p.notarize] {boolean}
+ * @param [p.unpacked] {boolean}
+ * @param p.architecture
  */
-
-export default async function generateTemplate({ nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked, linux, architecture }) {
+export default async function generateTemplate({ nameSuffix, version, updateUrl, iconPath, sign, notarize, unpacked, architecture }) {
 	const appName = "tutanota-desktop" + nameSuffix
 	const appId = "de.tutao.tutanota" + nameSuffix
 	if (process.env.JENKINS_HOME && process.env.DEBUG_SIGN) throw new Error("Tried to DEBUG_SIGN in CI!")

--- a/buildSrc/env.js
+++ b/buildSrc/env.js
@@ -14,6 +14,7 @@ export function create(params) {
 		mode: mode ?? "Browser",
 		timeout: 20000,
 		domainConfigs,
+		platformId: null,
 	}
 }
 

--- a/buildSrc/fetchDictionaries.js
+++ b/buildSrc/fetchDictionaries.js
@@ -18,10 +18,9 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 		.option("--publish", "Build and publish .deb package for dictionaries.")
 		.action(async (options) => {
 			const outDir = typeof options.outDir !== "undefined" ? options.outDir : getDefaultDistDirectory()
-			const local = typeof options.local !== "undefined" ? options.local : false
 			const publishDictionaries = typeof options.publish !== "undefined" ? options.publish : false
 
-			await getDictionaries(outDir, local)
+			await getDictionaries(outDir)
 				.then(async (v) => {
 					console.log("Dictionaries updated successfully")
 					if (publishDictionaries) {

--- a/buildSrc/getNativeLibrary.js
+++ b/buildSrc/getNativeLibrary.js
@@ -35,7 +35,7 @@ function validateOpts(opts) {
 	}
 }
 
-async function cli(nodeModule, { environment, rootDir, forceRebuild, useExisting, copyTarget }) {
+async function cli(nodeModule, { environment, rootDir, forceRebuild, copyTarget }) {
 	const platform = getCanonicalPlatformName(process.platform)
 	const architecture = process.arch
 	const path = await getCachedLibPath({ rootDir, nodeModule, environment, platform, architecture }, console.log.bind(console))
@@ -49,7 +49,6 @@ async function cli(nodeModule, { environment, rootDir, forceRebuild, useExisting
 		rootDir,
 		nodeModule,
 		log: console.log.bind(console),
-		useExisting,
 		platform,
 		copyTarget,
 		architecture,

--- a/buildSrc/graph.js
+++ b/buildSrc/graph.js
@@ -43,9 +43,9 @@ function getPrefix(ids) {
 
 /**
  * Plugin which will generate .dot file with dependency graph
- * @param options {{exclude: string, output: string, prune: boolean}}
+ * @param options {{exclude: string, output: string, prune: boolean, prefix: string}}
  */
-export default function plugin(options = {}) {
+export default function plugin(options) {
 	let exclude = (str) => options.exclude && str.match(options.exclude)
 	let output = options.output
 	if (!output) throw new Error("Please specify output file")

--- a/buildSrc/publish.js
+++ b/buildSrc/publish.js
@@ -45,6 +45,14 @@ import "zx/globals"
 	}
 })()
 
+/**
+ * @param params {object}
+ * @param params.version {string}
+ * @param params.fpmRootMapping {string}
+ * @param params.name {string}
+ * @param [params.fpmAfterInstallScript] {string}
+ * @param params.destinationDir {string}
+ */
 async function packageAndPublishDeb({ version, fpmRootMapping, name, fpmAfterInstallScript, destinationDir }) {
 	const fpmFlags = [
 		`--force`,

--- a/buildSrc/tsconfig.json
+++ b/buildSrc/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"include": ["./*.js", "../src/types.d.ts"],
+	"exclude": ["../node_modules/**"],
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"noEmit": true,
+		"module": "ESNext",
+		"target": "ESNext",
+		"lib": ["ES2020", "webworker", "dom", "es2015.proxy", "esnext"],
+		"skipLibCheck": true,
+		// moduleResolution set to nodenext breaks default exports of some Rollup plugins
+		"moduleResolution": "Bundler"
+	}
+}

--- a/buildSrc/updateLibs.js
+++ b/buildSrc/updateLibs.js
@@ -102,6 +102,7 @@ async function rollDesktopDep(src, target) {
 		],
 		plugins: [
 			nodeResolve({ preferBuiltins: true }),
+			// @ts-ignore it's a weird default import/export issue
 			commonjs({
 				// better-sqlite3 uses dynamic require to load the binary.
 				// if there is ever another dependency that uses dynamic require

--- a/packages/tuta-wasm-loader/lib/index.ts
+++ b/packages/tuta-wasm-loader/lib/index.ts
@@ -1,19 +1,19 @@
 import { OnLoadResult, OnResolveResult, PluginBuild } from "esbuild"
 import path from "node:path"
-import { FallbackOptions, generateImportCode, generateWasm, generateWasmFallback, WasmGeneratorOptions } from "./WasmHandler.js"
+import { FallbackOptions, generateImportCode, generateWasm, generateWasmFallback } from "./WasmHandler.js"
 import * as fs from "node:fs"
 
-export interface Library extends WasmGeneratorOptions {
-	/**
-	 * Name of the module, how it is imported in JS.
-	 */
+export interface Library {
+	/** Name of the module, how it is imported in JS */
 	name: string
-	/**
-	 * Command to run to generate WASM.
-	 */
+	/** Command to run to generate WASM */
 	command: string
 	/** Optimization level for the JavaScript fallback */
 	optimizationLevel?: string
+	/** Where to run the command */
+	workingDir?: string
+	/** Environment variables to be set for compilation */
+	env?: Record<string, any>
 }
 
 /**


### PR DESCRIPTION
It isn't invoked automatically anywhere but the editors should pick it up and it can also be run manually.

It also fixes few little issues, e.g. getPrebuiltNativeModuleForWindows was getting called with the right arguments.