### PR TITLE
[Calendar] Contacts permission inside Onboarding Wizard

### DIFF
--- a/src/common/api/main/MainLocator.ts
+++ b/src/common/api/main/MainLocator.ts
@@ -886,9 +886,9 @@ class MainLocator {
 				this.webMobileFacade,
 				await this.contactImporter(),
 				this.systemFacade,
-				this.credentialsProvider,
 				await this.nativeContactsSyncManager(),
 				deviceConfig,
+				false, //FIXME: We should check which app is creating it and allow accordingly
 			)
 		}
 	}

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -1710,3 +1710,4 @@ export type TranslationKeyType =
 	| "yourMessage_label"
 	| "you_label"
 	| "emptyString_msg"
+	| "allowContactRead_msg"

--- a/src/common/native/main/wizard/setupwizardpages/SetupContactsPage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupContactsPage.ts
@@ -7,12 +7,18 @@ import { ContactImporter } from "../../../../../mail-app/contacts/ContactImporte
 import { Dialog } from "../../../../gui/base/Dialog.js"
 import { MobileSystemFacade } from "../../../common/generatedipc/MobileSystemFacade.js"
 import { renderBannerButton } from "../SetupWizard.js"
+import { SystemPermissionHandler } from "../../SystemPermissionHandler.js"
+import { PermissionType } from "../../../common/generatedipc/PermissionType.js"
 
 export class SetupContactsPage implements Component<SetupContactsPageAttrs> {
 	view({ attrs }: Vnode<SetupContactsPageAttrs>): Children {
+		return m(SetupPageLayout, { image: "contacts" }, this.renderImportAndSyncButtons(attrs))
+	}
+
+	private renderImportAndSyncButtons(attrs: SetupContactsPageAttrs) {
 		const isContactSyncEnabled = attrs.syncManager.isEnabled()
 
-		return m(SetupPageLayout, { image: "contacts" }, [
+		return [
 			m("p.mb-s", lang.get("importContacts_msg")),
 			renderBannerButton("import_action", () => {
 				attrs.contactImporter.importContactsFromDeviceSafely()
@@ -26,7 +32,7 @@ export class SetupContactsPage implements Component<SetupContactsPageAttrs> {
 				isContactSyncEnabled,
 				"mb-l",
 			),
-		])
+		]
 	}
 
 	private async enableSync(attrs: SetupContactsPageAttrs) {
@@ -42,13 +48,21 @@ export class SetupContactsPage implements Component<SetupContactsPageAttrs> {
 
 export class SetupContactsPageAttrs implements WizardPageAttrs<null> {
 	hidePagingButtonForPage = false
+	hasContactPermission = false
+	private readonly isPageVisible: boolean
 	data: null = null
 
 	constructor(
 		public readonly syncManager: NativeContactsSyncManager,
 		public readonly contactImporter: ContactImporter,
 		public readonly mobileSystemFacade: MobileSystemFacade,
-	) {}
+		public readonly systemPermissionHandler: SystemPermissionHandler,
+		hasContactPermission: boolean,
+		public readonly enableSyncAndImport: boolean = true,
+	) {
+		this.hasContactPermission = hasContactPermission
+		this.isPageVisible = this.enableSyncAndImport
+	}
 
 	headerTitle(): string {
 		return lang.get("contacts_label")
@@ -64,6 +78,6 @@ export class SetupContactsPageAttrs implements WizardPageAttrs<null> {
 	}
 
 	isEnabled(): boolean {
-		return true
+		return this.isPageVisible
 	}
 }

--- a/src/common/native/main/wizard/setupwizardpages/SetupNotificationsPage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupNotificationsPage.ts
@@ -50,10 +50,15 @@ export class SetupNotificationsPageAttrs implements WizardPageAttrs<Notification
 		visiblityStream.map((isVisible) => {
 			// Redraw the page when the user resumes the app to check for changes in permissions
 			if (isVisible) {
-				this.systemPermissionHandler.queryPermissionsState().then((permissionState) => {
-					this.data = permissionState
-					m.redraw()
-				})
+				this.systemPermissionHandler
+					.queryPermissionsState([PermissionType.Notification, PermissionType.IgnoreBatteryOptimization])
+					.then((permissionState) => {
+						this.data = {
+							isNotificationPermissionGranted: permissionState.get(PermissionType.Notification) ?? false,
+							isBatteryPermissionGranted: permissionState.get(PermissionType.IgnoreBatteryOptimization) ?? false,
+						}
+						m.redraw()
+					})
 			}
 		})
 	}

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -1728,6 +1728,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "DEINE ORDNER",
 		"yourMessage_label": "Deine Nachricht",
-		"you_label": "Du"
+		"you_label": "Du",
+		"allowContactRead_msg": "Um Kontakte für Veranstaltungseinladungen vorzuschlagen, benötigen Sie die Berechtigung, Ihr Adressbuch zu lesen. Sie können dies jederzeit in den Systemeinstellungen ändern."
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -1728,6 +1728,7 @@ export default {
 		"yourCalendars_label": "Deine Kalender",
 		"yourFolders_action": "Ihre ORDNER",
 		"yourMessage_label": "Ihre Nachricht",
-		"you_label": "Sie"
+		"you_label": "Sie",
+		"allowContactRead_msg": "Um Kontakte für Veranstaltungseinladungen vorzuschlagen, benötigen Sie die Berechtigung, Ihr Adressbuch zu lesen. Sie können dies jederzeit in den Systemeinstellungen ändern."
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -1724,6 +1724,7 @@ export default {
 		"yourCalendars_label": "Your calendars",
 		"yourFolders_action": "YOUR FOLDERS",
 		"yourMessage_label": "Your message",
-		"you_label": "You"
+		"you_label": "You",
+		"allowContactRead_msg": "To suggest contacts for event invitations, the permission to read your address book is needed. You can change this anytime in the system settings."
 	}
 }


### PR DESCRIPTION
This commit adds the contacts permission page instead of the contacts
import and sync when using the Calendar app. The permission is needed
to suggest contacts when creating an event and inviting guests.

Co-authored-by: André Dias <and@tutao.de>

Fixes https://github.com/tutao/tutanota/issues/7150