### PR TITLE
[CI] Add Jenkins publish calendar mobile artifacts

### DIFF
--- a/ci/Ios.Jenkinsfile
+++ b/ci/Ios.Jenkinsfile
@@ -76,11 +76,12 @@ pipeline {
 					}
 					steps {
 						script {
+							def util = load "ci/jenkins-lib/util.groovy"
 							buildWebapp("test")
 							generateXCodeProjects()
-							runFastlane("de.tutao.tutanota.test", "adhoc_staging")
+							util.runFastlane("de.tutao.tutanota.test", "adhoc_staging")
 							if (params.RELEASE) {
-								runFastlane("de.tutao.tutanota.test", "testflight_staging")
+								util.runFastlane("de.tutao.tutanota.test", "testflight_staging")
 							}
 							stash includes: "app-ios/releases/tutanota-${VERSION}-adhoc-test.ipa", name: 'ipa-testing'
 						}
@@ -92,12 +93,13 @@ pipeline {
 					}
 					steps {
 						script {
+							def util = load "ci/jenkins-lib/util.groovy"
 							buildWebapp("prod")
 							generateXCodeProjects()
-							runFastlane("de.tutao.tutanota", "adhoc_prod")
+							util.runFastlane("de.tutao.tutanota", "adhoc_prod")
 							if (params.RELEASE) {
 								writeReleaseNotesForAppStore()
-								runFastlane("de.tutao.tutanota", "appstore_prod submit:true")
+								util.runFastlane("de.tutao.tutanota", "appstore_prod submit:true")
 							}
 							stash includes: "app-ios/releases/tutanota-${VERSION}-adhoc.ipa", name: 'ipa-production'
 						}
@@ -219,43 +221,6 @@ void writeReleaseNotesForAppStore() {
 	}
 
 	sh "echo Created release notes for fastlane ${RELEASE_NOTES_PATH}"
-}
-
-void runFastlane(String app_identifier, String  lane) {
-	// Prepare the fastlane Appfile which defines the required ids for the ios app build.
-	script {
-		def appfile = './app-ios/fastlane/Appfile'
-
-		sh "echo \"app_identifier('${app_identifier}')\" > ${appfile}"
-
-		withCredentials([string(credentialsId: 'apple-id', variable: 'apple_id')]) {
-			sh "echo \"apple_id('${apple_id}')\" >> ${appfile}"
-		}
-		withCredentials([string(credentialsId: 'itc-team-id', variable: 'itc_team_id')]) {
-			sh "echo \"itc_team_id('${itc_team_id}')\" >> ${appfile}"
-		}
-		withCredentials([string(credentialsId: 'team-id', variable: 'team_id')]) {
-			sh "echo \"team_id('${team_id}')\" >> ${appfile}"
-		}
-	}
-
-	withCredentials([
-			file(credentialsId: 'appstore-api-key-json', variable: "API_KEY_JSON_FILE_PATH"),
-			string(credentialsId: 'match-password', variable: 'MATCH_PASSWORD'),
-			string(credentialsId: 'team-id', variable: 'FASTLANE_TEAM_ID'),
-			sshUserPrivateKey(credentialsId: 'jenkins', keyFileVariable: 'MATCH_GIT_PRIVATE_KEY'),
-			string(credentialsId: 'fastlane-keychain-password', variable: 'FASTLANE_KEYCHAIN_PASSWORD')
-	]) {
-		dir('app-ios') {
-			sh "security unlock-keychain -p ${FASTLANE_KEYCHAIN_PASSWORD}"
-
-			script {
-				// Set git ssh command to avoid ssh prompting to confirm an unknown host
-				// (since we don't have console access we can't confirm and it gets stuck)
-				sh "GIT_SSH_COMMAND=\"ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\" fastlane ${lane}"
-			}
-		}
-	}
 }
 
 void publishToNexus(String artifactId, String ipaFileName) {

--- a/ci/Publish-CalendarMobileArtifacts.Jenkinsfile
+++ b/ci/Publish-CalendarMobileArtifacts.Jenkinsfile
@@ -1,0 +1,221 @@
+def releaseNotes // global var to store releaseNotes after confirmation at stage "Prepare Release Notes"
+
+pipeline {
+	environment {
+		PATH="${env.NODE_PATH}:${env.PATH}"
+		VERSION = sh(returnStdout: true, script: "${env.NODE_PATH}/node -p -e \"require('./package.json').version\" | tr -d \"\n\"")
+	}
+
+    parameters {
+        booleanParam(
+            name: 'googlePlayStore',
+            defaultValue: true,
+            description: "Uploads android artifacts (apk) to Google PlayStore as a Draft on the public track."
+        )
+        booleanParam(
+            name: 'appleAppStore',
+            defaultValue: false,
+            description: "Uploads iOS artifacts to Apple App Store as a Draft on the public track."
+        )
+		string(
+			name: 'appVersion',
+			defaultValue: "",
+			description: 'Which version should be published.'
+		)
+		booleanParam(
+			name: "generateReleaseNotes",
+			defaultValue: true,
+			description: "Generate Release notes for this build."
+		 )
+    }
+
+    agent any
+
+    stages {
+    	stage("Checking params") {
+			steps {
+				script{
+					if(!params.googlePlayStore && !params.appleAppStore) {
+						currentBuild.result = 'ABORTED'
+						error('No artifacts were selected.')
+					}
+				}
+				echo "Params OKAY"
+			}
+    	}
+		stage("Prepare Release Notes") {
+			environment {
+				VERSION = "${params.appVersion.trim() ?: env.VERSION}"
+			}
+			when {
+				expression {
+					params.generateReleaseNotes && (params.googlePlayStore || params.appleAppStore)
+				}
+			}
+			steps {
+				sh "npm ci"
+				script { // create release notes
+					def android = params.googlePlayStore ? pregenerateReleaseNotes("android", env.VERSION) : null
+					def ios = params.appleAppStore ? pregenerateReleaseNotes("ios", env.VERSION) : null
+
+					// Assigns the dict returned by reviewReleaseNotes with the notes for each platform to the global var releaseNotes
+					releaseNotes = reviewReleaseNotes(android, ios, env.VERSION)
+					echo("${releaseNotes}")
+				}
+			} // steps
+		} // stage Prepare Release Notes
+		stage("Publishing Artifacts") {
+			parallel {
+				stage("Android App") {
+					environment {
+						VERSION = "${params.appVersion.trim() ?: env.VERSION}"
+						FILE_PATH = "build-calendar-app/app-android/calendar-tutao-release-${VERSION}.apk"
+						GITHUB_RELEASE_PAGE = "https://github.com/tutao/tutanota/releases/tag/tuta-calendar-android-release-${VERSION}"
+					}
+					when {
+						expression {
+							params.googlePlayStore
+						}
+					}
+					steps {
+						script {
+							def util = load "ci/jenkins-lib/util.groovy"
+							util.downloadFromNexus(	groupId: "app",
+													artifactId: "calendar-android",
+													version: "${env.VERSION}",
+													outFile: "${env.WORKSPACE}/${env.FILE_PATH}",
+													fileExtension: 'apk')
+							if (!fileExists("${env.FILE_PATH}")) {
+								currentBuild.result = 'ABORTED'
+								error("Unable to find file ${env.FILE_PATH}")
+							}
+							echo "File ${env.FILE_PATH} found!"
+
+							catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS', message: 'Failed to upload android test app to Play Store') {
+								androidApkUpload(
+									googleCredentialsId: 'android-app-publisher-credentials',
+									apkFilesPattern: "${env.FILE_PATH}",
+									trackName: 'production',
+									// Don't publish the app to users directly
+									// It will require manual intervention at play.google.com/console
+									rolloutPercentage: '0%',
+									recentChangeList: [
+										[
+											language: "en-US",
+											text    : "see: ${env.GITHUB_RELEASE_PAGE}"
+										]
+									]
+								)
+							}
+						} // script
+					} // steps
+				} // stage Android App
+				stage("iOS App") {
+					environment {
+						VERSION = "${params.appVersion.trim() ?: env.VERSION}"
+						FILE_PATH = "build-calendar-app/app-ios/calendar-tutao-${VERSION}-release.ipa"
+						GITHUB_RELEASE_PAGE = "https://github.com/tutao/tutanota/releases/tag/tuta-calendar-ios-release-${VERSION}"
+					}
+					when {
+						expression {
+							params.appleAppStore
+						}
+					}
+					steps {
+						script {
+							def util = load "ci/jenkins-lib/util.groovy"
+							util.downloadFromNexus(groupId: "app",
+												   artifactId: "ios",
+												   version: "${env.VERSION}",
+												   outFile: "${env.WORKSPACE}/${env.FILE_PATH}",
+												   fileExtension: "ipa")
+							if (!fileExists("${env.FILE_PATH}")) {
+								currentBuild.result = 'ABORTED'
+								error("Unable to find file ${env.FILE_PATH}")
+							}
+							echo "File ${env.FILE_PATH} found!"
+							util.runFastlane("de.tutao.calendar", "appstore_prod submit:true")
+						} // script
+					} // steps
+				} // stage iOS App
+			} // parallel apps
+		} // stage Publishing Artifacts
+		stage('Tag and publish release page') {
+			parallel {
+				stage("Github Android Release Notes") {
+					environment {
+						VERSION = "${params.appVersion.trim() ?: env.VERSION}"
+						FILE_PATH = "build-calendar-app/app-android/calendar-tutao-release-${env.VERSION}.apk"
+					}
+					when {
+						expression {
+							params.googlePlayStore && releaseNotes.android.trim()
+						}
+					}
+					steps {
+						script {
+							writeReleaseNotesDraft("android", "Android", "${env.VERSION}", "${env.WORKSPACE}/${env.FILE_PATH}")
+						} // script
+					} // steps
+				}// Stage Github Android Release Notes
+				stage("Github iOS Release Notes") {
+					environment {
+						VERSION = "${params.appVersion.trim() ?: env.VERSION}"
+					}
+					when {
+						expression {
+							params.appleAppStore && releaseNotes.ios.trim()
+						}
+					}
+					steps {
+						script {
+							writeReleaseNotesDraft("ios", "iOS", "${env.VERSION}")
+						} // script
+					} // steps
+				}// Stage Github iOS Release Notes
+			} // parallel release notes
+		} // stage Tag and publish release page
+    } // stages
+} // pipeline
+
+
+/**
+platform must be one of the strings "ios", "android"
+*/
+def pregenerateReleaseNotes(platform, version) {
+        return sh(returnStdout: true, script: """node buildSrc/releaseNotes.js --platform ${platform} --milestone ${version} """)
+}
+
+/**
+ all parameters are nullable strings.
+*/
+def reviewReleaseNotes(android, ios, version) {
+	// only display input fields for the clients we're actually building.
+    def parameters = [
+         android ? text(defaultValue: android, description: "Android release notes built from Github Milestone", name: "android") : null,
+         ios ? text(defaultValue: ios, description: 'Ios release notes built from Github Milestone', name: 'ios') : null,
+         // If the dummy field is removed, when there is only an option a string will be returned instead(we dont want that)
+         booleanParam(defaultValue: true, description: "dummy param so we always get a dict back", name: "dummy"),
+     ].findAll { it != null }
+    // Get the input
+    // https://www.jenkins.io/doc/pipeline/steps/pipeline-input-step/
+    return input(id: 'releaseNotesInput', message: 'Release Notes', parameters: parameters)
+}
+
+/**
+platform must be one of the strings "ios", "android"
+filePath can be null
+*/
+def writeReleaseNotesDraft(String platform, String displayName, String version, String filePath) {
+	sh "npm ci"
+	writeFile file: "notes.txt", text: releaseNotes[platform]
+	catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS', message: "Failed to create github release page for ${platform}") {
+		withCredentials([string(credentialsId: 'github-access-token', variable: 'GITHUB_TOKEN')]) {
+			sh """node buildSrc/createReleaseDraft.js --name '${version} (${displayName})' \
+													  --tag 'tuta-calendar-${platform}-release-${version}' \
+													  ${filePath ? "--uploadFile ${filePath}" : "" } \
+													  --notes notes.txt"""
+		}
+	}
+	sh "rm notes.txt"
+}

--- a/ci/jenkins-lib/util.groovy
+++ b/ci/jenkins-lib/util.groovy
@@ -34,5 +34,43 @@ def checkGithub() {
 	'''
 }
 
+
+def runFastlane(String app_identifier, String  lane) {
+	// Prepare the fastlane Appfile which defines the required ids for the ios app build.
+	script {
+		def appfile = './app-ios/fastlane/Appfile'
+
+		sh "echo \"app_identifier('${app_identifier}')\" > ${appfile}"
+
+		withCredentials([string(credentialsId: 'apple-id', variable: 'apple_id')]) {
+			sh "echo \"apple_id('${apple_id}')\" >> ${appfile}"
+		}
+		withCredentials([string(credentialsId: 'itc-team-id', variable: 'itc_team_id')]) {
+			sh "echo \"itc_team_id('${itc_team_id}')\" >> ${appfile}"
+		}
+		withCredentials([string(credentialsId: 'team-id', variable: 'team_id')]) {
+			sh "echo \"team_id('${team_id}')\" >> ${appfile}"
+		}
+	}
+
+	withCredentials([
+			file(credentialsId: 'appstore-api-key-json', variable: "API_KEY_JSON_FILE_PATH"),
+			string(credentialsId: 'match-password', variable: 'MATCH_PASSWORD'),
+			string(credentialsId: 'team-id', variable: 'FASTLANE_TEAM_ID'),
+			sshUserPrivateKey(credentialsId: 'jenkins', keyFileVariable: 'MATCH_GIT_PRIVATE_KEY'),
+			string(credentialsId: 'fastlane-keychain-password', variable: 'FASTLANE_KEYCHAIN_PASSWORD')
+	]) {
+		dir('app-ios') {
+			sh "security unlock-keychain -p ${FASTLANE_KEYCHAIN_PASSWORD}"
+
+			script {
+				// Set git ssh command to avoid ssh prompting to confirm an unknown host
+				// (since we don't have console access we can't confirm and it gets stuck)
+				sh "GIT_SSH_COMMAND=\"ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\" fastlane ${lane}"
+			}
+		}
+	}
+}
+
 // required in order to be able to use "load" to include this script in a jenkins pipleline
 return this


### PR DESCRIPTION
This commit adds a new jenkins file responsible for publishing the Calendar mobile artifacts to each app store on the public release track.

We also move the runFastLane function to util.groovy since it's being used on multiple files.