### PR TITLE
[android] Fix crash when downloading cmap on invoice

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -378,6 +378,7 @@ class MainActivity : FragmentActivity() {
 			"ttf" -> "font/ttf"
 			"wasm" -> "application/wasm"
 			"icc" -> "application/vnd.iccprofile"
+			"cmap" -> "text/plain" // used for invoices; no good mime type for cmap, so just use plain text
 			else -> error("Unknown extension $ext for url $url")
 		}
 	}


### PR DESCRIPTION
It seems we did not specify the mime type for .cmap extensions, thus downloading invoices can result in an uncaught exception.

Fixes #7235
Fixes #7160