### PR TITLE
Fix contact selection issues

### DIFF
--- a/src/mail-app/contacts/view/ContactView.ts
+++ b/src/mail-app/contacts/view/ContactView.ts
@@ -812,19 +812,15 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 	}
 
 	onNewUrl(args: Record<string, any>) {
-		const isSingleColumnLayout = styles.isSingleColumnLayout()
 		if (this.inContactListView()) {
 			this.contactListViewModel.showListAndEntry(args.listId, args.Id).then(m.redraw)
-		} else if (args.listId == null && args.contactId == null) {
-			// Redirect to the contacts view with the selected contact stored in the models if no arguments are given
-			this.contactViewModel.updateUrl(!isSingleColumnLayout)
 		} else {
-			this.contactViewModel.init(isSingleColumnLayout, args.listId, args.contactId)
+			this.contactViewModel.init(args.listId).then(() => this.contactViewModel.selectContact(args.contactId))
 		}
-
-		// Show the details of the contact on mobile instead of just all contacts
-		const isWithContact = !(args.Id == null && args.contactId == null)
-		if (isWithContact) this.viewSlider.focus(this.detailsColumn)
+		// focus the details column if asked explicitly, e.g. to show a specific contact
+		if (args.focusItem) {
+			this.viewSlider.focus(this.detailsColumn)
+		}
 	}
 
 	private deleteSelectedContacts(): Promise<void> {

--- a/src/mail-app/mail/view/MailViewer.ts
+++ b/src/mail-app/mail/view/MailViewer.ts
@@ -608,7 +608,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 						label: "showContact_action",
 						click: () => {
 							const [listId, contactId] = assertNotNull(contact)._id
-							m.route.set("/contact/:listId/:contactId", { listId, contactId })
+							m.route.set("/contact/:listId/:contactId", { listId, contactId, focusItem: true })
 						},
 					})
 				} else {


### PR DESCRIPTION
This is another spin on solving #7256.

This reverts 5be83674 and 26dfa0f5 as they introduced some issues with initialization, namely `initOnce` could run multiple times.

In this commit we try to acknowledge that existing URL pattern is not sufficient to distinguish between the cases as we might have selection without focus.

Instead, we introduce an explicit argument to focus the item details.

We considered synchronizing the column focus state using this argument in all cases but this would entail a larger refactoring.