### PR TITLE
Fix the credit card verification

### DIFF
--- a/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
+++ b/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
@@ -160,7 +160,7 @@ export class UpgradeConfirmSubscriptionPage implements WizardPageN<UpgradeSubscr
 				}),
 				m(TextField, {
 					label: isYearly ? "priceFirstYear_label" : "price_label",
-					value: buildPriceString(attrs.data.price, attrs.data.options),
+					value: buildPriceString(attrs.data.displayPrice, attrs.data.options),
 					isReadOnly: true,
 				}),
 				this.renderPriceNextYear(attrs),

--- a/src/common/subscription/UpgradeSubscriptionPage.ts
+++ b/src/common/subscription/UpgradeSubscriptionPage.ts
@@ -3,8 +3,6 @@ import stream from "mithril/stream"
 import { lang } from "../misc/LanguageViewModel"
 import type { SubscriptionParameters, UpgradeSubscriptionData } from "./UpgradeSubscriptionWizard"
 import { SubscriptionActionButtons, SubscriptionSelector } from "./SubscriptionSelector"
-import { isApp } from "../api/common/Env"
-import { client } from "../misc/ClientDetector"
 import { Button, ButtonType } from "../gui/base/Button.js"
 import { UpgradeType } from "./SubscriptionUtils"
 import { Dialog, DialogType } from "../gui/base/Dialog"
@@ -193,8 +191,11 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 		data.type = planType
 		const { planPrices, options } = data
 		try {
-			data.price = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanActualPrice)
-			const nextYear = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanNextYearsPrice)
+			// `data.price` is used for the amount parameter in the Braintree credit card verification call, so we do not include currency locale outside iOS.
+			const subscriptionPrice = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanActualPrice)
+			data.price = subscriptionPrice.rawPrice
+			data.displayPrice = subscriptionPrice.displayPrice
+			const nextYear = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanNextYearsPrice).displayPrice
 			data.priceNextYear = data.price !== nextYear ? nextYear : null
 		} catch (e) {
 			console.error(e)

--- a/src/common/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/common/subscription/UpgradeSubscriptionWizard.ts
@@ -31,7 +31,6 @@ import { formatNameAndAddress } from "../api/common/utils/CommonFormatter.js"
 import { LoginController } from "../api/main/LoginController.js"
 import { MobilePaymentSubscriptionOwnership } from "../native/common/generatedipc/MobilePaymentSubscriptionOwnership.js"
 import { Dialog, DialogType } from "../gui/base/Dialog.js"
-import { showNotAvailableForFreeDialog } from "../misc/SubscriptionDialogs.js"
 
 assertMainOrNode()
 export type SubscriptionParameters = {
@@ -50,7 +49,12 @@ export type UpgradeSubscriptionData = {
 	invoiceData: InvoiceData
 	paymentData: PaymentData
 	type: PlanType
+	// Subscription price as a float
 	price: string
+	// Subscription price as a formatted string with the currency symbol and with decimal separator from local
+	// On iOS: in the local currency
+	// Else: in Euro
+	displayPrice: string
 	priceNextYear: string | null
 	accountingInfo: AccountingInfo | null
 	// not initially set for signup but loaded in InvoiceAndPaymentDataPage
@@ -98,6 +102,7 @@ export async function showUpgradeWizard(logins: LoginController, acceptedPlans: 
 			creditCardData: null,
 		},
 		price: "",
+		displayPrice: "",
 		type: PlanType.Revolutionary,
 		priceNextYear: null,
 		accountingInfo: accountingInfo,
@@ -186,6 +191,7 @@ export async function loadSignupWizard(
 			creditCardData: null,
 		},
 		price: "",
+		displayPrice: "",
 		priceNextYear: null,
 		type: PlanType.Free,
 		accountingInfo: null,


### PR DESCRIPTION
This fixes the currency symbol being included and the decimal separator in the call to the Braintree card verification causing it to fail.

It is not possible to have `getSubscriptionPriceWithCurrency` return without currency formatting because the return of `getPlanPrices` cannot be changed as `StoreKit` can only return the price in the local currency.

Closes #7370.