### PR TITLE
Move usageTestController initialization to before nativeInterfaces

### DIFF
--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -570,6 +570,27 @@ class CalendarLocator {
 			noOp()
 		})
 
+		this.usageTestModel = new UsageTestModel(
+			{
+				[StorageBehavior.Persist]: deviceConfig,
+				[StorageBehavior.Ephemeral]: new EphemeralUsageTestStorage(),
+			},
+			{
+				now(): number {
+					return Date.now()
+				},
+				timeZone(): string {
+					throw new Error("Not implemented by this provider")
+				},
+			},
+			this.serviceExecutor,
+			this.entityClient,
+			this.logins,
+			this.eventController,
+			() => this.usageTestController,
+		)
+		this.usageTestController = new UsageTestController(this.usageTestModel)
+
 		this.Const = Const
 		if (!isBrowser()) {
 			const { WebDesktopFacade } = await import("../common/native/main/WebDesktopFacade")
@@ -632,26 +653,6 @@ class CalendarLocator {
 		this.loginListener = new PageContextLoginListener(this.secondFactorHandler, this.credentialsProvider)
 		this.random = random
 
-		this.usageTestModel = new UsageTestModel(
-			{
-				[StorageBehavior.Persist]: deviceConfig,
-				[StorageBehavior.Ephemeral]: new EphemeralUsageTestStorage(),
-			},
-			{
-				now(): number {
-					return Date.now()
-				},
-				timeZone(): string {
-					throw new Error("Not implemented by this provider")
-				},
-			},
-			this.serviceExecutor,
-			this.entityClient,
-			this.logins,
-			this.eventController,
-			() => this.usageTestController,
-		)
-
 		this.newsModel = new NewsModel(this.serviceExecutor, deviceConfig, async (name: string) => {
 			switch (name) {
 				case "usageOptIn":
@@ -686,7 +687,6 @@ class CalendarLocator {
 
 		const { ContactModel } = await import("../common/contactsFunctionality/ContactModel.js")
 		this.contactModel = new ContactModel(this.searchFacade, this.entityClient, this.logins, this.eventController)
-		this.usageTestController = new UsageTestController(this.usageTestModel)
 		this.appStorePaymentPicker = new AppStorePaymentPicker()
 
 		// THEME

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -685,6 +685,27 @@ class MailLocator {
 			mailLocator.search.indexState(state)
 		})
 
+		this.usageTestModel = new UsageTestModel(
+			{
+				[StorageBehavior.Persist]: deviceConfig,
+				[StorageBehavior.Ephemeral]: new EphemeralUsageTestStorage(),
+			},
+			{
+				now(): number {
+					return Date.now()
+				},
+				timeZone(): string {
+					throw new Error("Not implemented by this provider")
+				},
+			},
+			this.serviceExecutor,
+			this.entityClient,
+			this.logins,
+			this.eventController,
+			() => this.usageTestController,
+		)
+		this.usageTestController = new UsageTestController(this.usageTestModel)
+
 		this.Const = Const
 		if (!isBrowser()) {
 			const { WebDesktopFacade } = await import("../common/native/main/WebDesktopFacade")
@@ -740,7 +761,6 @@ class MailLocator {
 				this.webAuthn = new WebauthnClient(new WebAuthnFacadeSendDispatcher(this.native), this.domainConfigProvider(), isApp())
 			}
 		}
-
 		if (this.webAuthn == null) {
 			this.webAuthn = new WebauthnClient(
 				new BrowserWebauthn(navigator.credentials, this.domainConfigProvider().getCurrentDomainConfig()),
@@ -758,26 +778,6 @@ class MailLocator {
 		this.credentialsProvider = await this.createCredentialsProvider()
 		this.loginListener = new PageContextLoginListener(this.secondFactorHandler, this.credentialsProvider)
 		this.random = random
-
-		this.usageTestModel = new UsageTestModel(
-			{
-				[StorageBehavior.Persist]: deviceConfig,
-				[StorageBehavior.Ephemeral]: new EphemeralUsageTestStorage(),
-			},
-			{
-				now(): number {
-					return Date.now()
-				},
-				timeZone(): string {
-					throw new Error("Not implemented by this provider")
-				},
-			},
-			this.serviceExecutor,
-			this.entityClient,
-			this.logins,
-			this.eventController,
-			() => this.usageTestController,
-		)
 
 		this.newsModel = new NewsModel(this.serviceExecutor, deviceConfig, async (name: string) => {
 			switch (name) {
@@ -811,7 +811,6 @@ class MailLocator {
 		const { ContactModel } = await import("../common/contactsFunctionality/ContactModel.js")
 		this.contactModel = new ContactModel(this.searchFacade, this.entityClient, this.logins, this.eventController)
 		this.minimizedMailModel = new MinimizedMailEditorViewModel()
-		this.usageTestController = new UsageTestController(this.usageTestModel)
 		this.appStorePaymentPicker = new AppStorePaymentPicker()
 
 		// THEME


### PR DESCRIPTION
We were using usageTestController before it was being initialized, and this broke some things that depend on usage tests, such as the App Password unlock method (when setting a password).

Fixes #7377