### PR TITLE
fix delete account dialog asking for a new password

### DIFF
--- a/src/common/api/worker/facades/KeyRotationFacade.ts
+++ b/src/common/api/worker/facades/KeyRotationFacade.ts
@@ -58,6 +58,7 @@ import { GroupInvitationPostData, type InternalRecipientKeyData, InternalRecipie
 import { ShareFacade } from "./lazy/ShareFacade.js"
 import { GroupManagementFacade } from "./lazy/GroupManagementFacade.js"
 import { RecipientsNotFoundError } from "../../common/error/RecipientsNotFoundError.js"
+import { LockedError } from "../../common/error/RestError.js"
 
 assertWorkerOrNode()
 
@@ -162,8 +163,12 @@ export class KeyRotationFacade {
 				await this.updateGroupMemberships(this.pendingGroupKeyUpdateIds)
 			}
 		} catch (e) {
-			// we catch here so that we also catch errors in the finally block
-			console.log("error when processing key rotation or group key update", e)
+			if (e instanceof LockedError) {
+				// we catch here so that we also catch errors in the finally block
+				console.log("error when processing key rotation or group key update", e)
+			} else {
+				throw e
+			}
 		}
 	}
 

--- a/src/common/subscription/DeleteAccountDialog.ts
+++ b/src/common/subscription/DeleteAccountDialog.ts
@@ -34,7 +34,7 @@ export function showDeleteAccountDialog(surveyData: SurveyData | null = null) {
 						oninput: (value) => (password = value),
 						status: {
 							type: "neutral",
-							text: "password1Neutral_msg",
+							text: "passwordEnterNeutral_msg",
 						},
 					}),
 				]),


### PR DESCRIPTION
## Test Notes

* get to the last dialog for confirming the account deletion from the settings 
* check that it's asking for the password for confirmation, not "please enter a new password" in the password fields' help text