### PR TITLE
[sdk] Improve API & internal state

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -31,6 +31,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - name: sdk format
+        working-directory: tuta-sdk/rust
+        run: cargo fmt --check
       - name: sdk warning check with clippy
         working-directory: tuta-sdk/rust
         run: cargo clippy --package tuta-sdk --no-deps -- -Dwarnings # -Dwarnings changes warnings to errors so that the check fails

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/TutanotaNotificationsHandler.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/TutanotaNotificationsHandler.kt
@@ -259,7 +259,7 @@ class TutanotaNotificationsHandler(
 			credentialType = CredentialType.INTERNAL
 		)
 
-		val sdk = Sdk(sseInfo.sseOrigin, SdkRestClient(), credentials, BuildConfig.VERSION_NAME).login()
+		val sdk = Sdk(sseInfo.sseOrigin, SdkRestClient(), BuildConfig.VERSION_NAME).login(credentials)
 
 		val mailId = notificationInfo.mailId?.toSdkIdTuple()
 			?: throw IllegalArgumentException("Missing mailId for notification ${sseInfo.pushIdentifier}")

--- a/app-ios/TutanotaNotificationExtension/NotificationService.swift
+++ b/app-ios/TutanotaNotificationExtension/NotificationService.swift
@@ -53,7 +53,7 @@ class NotificationService: UNNotificationServiceExtension {
 			encryptedPassphraseKey: encryptedPassphraseKey.data,
 			credentialType: tutasdk.CredentialType.internal
 		)
-		let sdk = try await Sdk(baseUrl: origin, restClient: SdkRestClient(), credentials: credentials, clientVersion: clientVersion).login()
+		let sdk = try await Sdk(baseUrl: origin, restClient: SdkRestClient(), clientVersion: clientVersion).login(credentials: credentials)
 		return try await sdk.mailFacade().loadEmailByIdEncrypted(idTuple: tutasdk.IdTuple(listId: mailId[0], elementId: mailId[1]))
 	}
 	private func getSenderOfMail(_ mail: tutasdk.Mail) -> String {

--- a/buildSrc/RustGenerator.js
+++ b/buildSrc/RustGenerator.js
@@ -18,13 +18,13 @@ pub struct ${typeName} {\n`
 	for (let [valueName, valueProperties] of Object.entries(type.values)) {
 		const rustType = rustValueType(valueName, type, valueProperties)
 		if (valueName === "type") {
-			buf += `    #[serde(rename = "type")]\n`
-			buf += `    pub r#type: ${rustType},\n`
+			buf += `\t#[serde(rename = "type")]\n`
+			buf += `\tpub r#type: ${rustType},\n`
 		} else if (valueProperties.type === "Bytes") {
-			buf += `    #[serde(with = "serde_bytes")]\n`
-			buf += `    pub ${valueName}: ${rustType},\n`
+			buf += `\t#[serde(with = "serde_bytes")]\n`
+			buf += `\tpub ${valueName}: ${rustType},\n`
 		} else {
-			buf += `    pub ${valueName}: ${rustType},\n`
+			buf += `\tpub ${valueName}: ${rustType},\n`
 		}
 	}
 
@@ -44,10 +44,10 @@ pub struct ${typeName} {\n`
 		}
 
 		if (associationName === "type") {
-			buf += `    #[serde(rename = "type")]\n`
-			buf += `    pub r#type: ${rustType},\n`
+			buf += `\t#[serde(rename = "type")]\n`
+			buf += `\tpub r#type: ${rustType},\n`
 		} else {
-			buf += `    pub ${associationName}: ${rustType},\n`
+			buf += `\tpub ${associationName}: ${rustType},\n`
 		}
 	}
 
@@ -64,13 +64,13 @@ pub struct ${typeName} {\n`
 	buf += "\n\n"
 
 	buf += `impl Entity for ${typeName} {\n`
-	buf += "    fn type_ref() -> TypeRef {\n"
-	buf += `        TypeRef {\n`
-	buf += `            app: "${modelName}",\n`
-	buf += `            type_: "${typeName}",\n`
-	buf += `         }\n`
-	buf += "    }\n"
-	buf += "}\n"
+	buf += "\tfn type_ref() -> TypeRef {\n"
+	buf += `\t\tTypeRef {\n`
+	buf += `\t\t\tapp: "${modelName}",\n`
+	buf += `\t\t\ttype_: "${typeName}",\n`
+	buf += `\t\t}\n`
+	buf += "\t}\n"
+	buf += "}"
 
 	return buf
 }
@@ -80,11 +80,13 @@ pub struct ${typeName} {\n`
  * @return {string}
  */
 export function combineRustTypes(types) {
+	if (types.length === 0) return "\n"
 	return `#![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
-${types.join("\n\n")}`
+${types.join("\n\n")}
+`
 }
 
 /**

--- a/src/common/api/entities/sys/ModelInfo.ts
+++ b/src/common/api/entities/sys/ModelInfo.ts
@@ -1,5 +1,5 @@
 const modelInfo = {
-	version: 108,
+	version: 109,
 	compatibleSince: 107,
 }
 		

--- a/src/common/api/entities/sys/TypeModels.js
+++ b/src/common/api/entities/sys/TypeModels.js
@@ -219,7 +219,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AdminGroupKeyRotationPostIn": {
         "name": "AdminGroupKeyRotationPostIn",
@@ -263,7 +263,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AdministratedGroupsRef": {
         "name": "AdministratedGroupsRef",
@@ -297,7 +297,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AlarmInfo": {
         "name": "AlarmInfo",
@@ -349,7 +349,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AlarmNotification": {
         "name": "AlarmNotification",
@@ -449,7 +449,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AlarmServicePost": {
         "name": "AlarmServicePost",
@@ -483,7 +483,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ArchiveRef": {
         "name": "ArchiveRef",
@@ -515,7 +515,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ArchiveType": {
         "name": "ArchiveType",
@@ -569,7 +569,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AuditLogEntry": {
         "name": "AuditLogEntry",
@@ -703,7 +703,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AuditLogRef": {
         "name": "AuditLogRef",
@@ -737,7 +737,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AuthenticatedDevice": {
         "name": "AuthenticatedDevice",
@@ -787,7 +787,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Authentication": {
         "name": "Authentication",
@@ -848,7 +848,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AutoLoginDataDelete": {
         "name": "AutoLoginDataDelete",
@@ -880,7 +880,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AutoLoginDataGet": {
         "name": "AutoLoginDataGet",
@@ -923,7 +923,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AutoLoginDataReturn": {
         "name": "AutoLoginDataReturn",
@@ -955,7 +955,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "AutoLoginPostReturn": {
         "name": "AutoLoginPostReturn",
@@ -987,7 +987,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Blob": {
         "name": "Blob",
@@ -1037,7 +1037,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BlobReferenceTokenWrapper": {
         "name": "BlobReferenceTokenWrapper",
@@ -1069,7 +1069,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Booking": {
         "name": "Booking",
@@ -1193,7 +1193,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BookingItem": {
         "name": "BookingItem",
@@ -1279,7 +1279,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BookingsRef": {
         "name": "BookingsRef",
@@ -1313,7 +1313,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BootstrapFeature": {
         "name": "BootstrapFeature",
@@ -1345,7 +1345,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Braintree3ds2Request": {
         "name": "Braintree3ds2Request",
@@ -1395,7 +1395,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Braintree3ds2Response": {
         "name": "Braintree3ds2Response",
@@ -1436,7 +1436,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BrandingDomainData": {
         "name": "BrandingDomainData",
@@ -1513,7 +1513,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BrandingDomainDeleteData": {
         "name": "BrandingDomainDeleteData",
@@ -1545,7 +1545,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BrandingDomainGetReturn": {
         "name": "BrandingDomainGetReturn",
@@ -1579,7 +1579,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Bucket": {
         "name": "Bucket",
@@ -1613,7 +1613,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BucketKey": {
         "name": "BucketKey",
@@ -1702,7 +1702,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "BucketPermission": {
         "name": "BucketPermission",
@@ -1844,7 +1844,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CalendarEventRef": {
         "name": "CalendarEventRef",
@@ -1885,7 +1885,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CertificateInfo": {
         "name": "CertificateInfo",
@@ -1946,7 +1946,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Challenge": {
         "name": "Challenge",
@@ -1999,7 +1999,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ChangeKdfPostIn": {
         "name": "ChangeKdfPostIn",
@@ -2076,7 +2076,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ChangePasswordPostIn": {
         "name": "ChangePasswordPostIn",
@@ -2171,7 +2171,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Chat": {
         "name": "Chat",
@@ -2221,7 +2221,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CloseSessionServicePost": {
         "name": "CloseSessionServicePost",
@@ -2264,7 +2264,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CreateCustomerServerPropertiesData": {
         "name": "CreateCustomerServerPropertiesData",
@@ -2305,7 +2305,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CreateCustomerServerPropertiesReturn": {
         "name": "CreateCustomerServerPropertiesReturn",
@@ -2339,7 +2339,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CreateSessionData": {
         "name": "CreateSessionData",
@@ -2427,7 +2427,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CreateSessionReturn": {
         "name": "CreateSessionReturn",
@@ -2480,7 +2480,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CreditCard": {
         "name": "CreditCard",
@@ -2548,7 +2548,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomDomainCheckGetIn": {
         "name": "CustomDomainCheckGetIn",
@@ -2591,7 +2591,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomDomainCheckGetOut": {
         "name": "CustomDomainCheckGetOut",
@@ -2654,7 +2654,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomDomainData": {
         "name": "CustomDomainData",
@@ -2697,7 +2697,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomDomainReturn": {
         "name": "CustomDomainReturn",
@@ -2740,7 +2740,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Customer": {
         "name": "Customer",
@@ -2997,7 +2997,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomerAccountTerminationPostIn": {
         "name": "CustomerAccountTerminationPostIn",
@@ -3040,7 +3040,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomerAccountTerminationPostOut": {
         "name": "CustomerAccountTerminationPostOut",
@@ -3074,7 +3074,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomerAccountTerminationRequest": {
         "name": "CustomerAccountTerminationRequest",
@@ -3153,7 +3153,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomerInfo": {
         "name": "CustomerInfo",
@@ -3466,7 +3466,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomerProperties": {
         "name": "CustomerProperties",
@@ -3574,7 +3574,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "CustomerServerProperties": {
         "name": "CustomerServerProperties",
@@ -3700,7 +3700,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DateWrapper": {
         "name": "DateWrapper",
@@ -3732,7 +3732,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DebitServicePutData": {
         "name": "DebitServicePutData",
@@ -3766,7 +3766,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DeleteCustomerData": {
         "name": "DeleteCustomerData",
@@ -3846,7 +3846,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DnsRecord": {
         "name": "DnsRecord",
@@ -3896,7 +3896,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DomainInfo": {
         "name": "DomainInfo",
@@ -3958,7 +3958,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DomainMailAddressAvailabilityData": {
         "name": "DomainMailAddressAvailabilityData",
@@ -3990,7 +3990,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DomainMailAddressAvailabilityReturn": {
         "name": "DomainMailAddressAvailabilityReturn",
@@ -4022,7 +4022,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "DomainsRef": {
         "name": "DomainsRef",
@@ -4056,7 +4056,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "EmailSenderListElement": {
         "name": "EmailSenderListElement",
@@ -4115,7 +4115,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "EntityEventBatch": {
         "name": "EntityEventBatch",
@@ -4176,7 +4176,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "EntityUpdate": {
         "name": "EntityUpdate",
@@ -4244,7 +4244,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Exception": {
         "name": "Exception",
@@ -4285,7 +4285,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ExternalPropertiesReturn": {
         "name": "ExternalPropertiesReturn",
@@ -4347,7 +4347,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ExternalUserReference": {
         "name": "ExternalUserReference",
@@ -4418,7 +4418,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Feature": {
         "name": "Feature",
@@ -4450,7 +4450,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "File": {
         "name": "File",
@@ -4500,7 +4500,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GeneratedIdWrapper": {
         "name": "GeneratedIdWrapper",
@@ -4532,7 +4532,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCard": {
         "name": "GiftCard",
@@ -4645,7 +4645,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardCreateData": {
         "name": "GiftCardCreateData",
@@ -4713,7 +4713,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardCreateReturn": {
         "name": "GiftCardCreateReturn",
@@ -4747,7 +4747,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardDeleteData": {
         "name": "GiftCardDeleteData",
@@ -4781,7 +4781,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardGetReturn": {
         "name": "GiftCardGetReturn",
@@ -4833,7 +4833,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardOption": {
         "name": "GiftCardOption",
@@ -4865,7 +4865,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardRedeemData": {
         "name": "GiftCardRedeemData",
@@ -4917,7 +4917,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardRedeemGetReturn": {
         "name": "GiftCardRedeemGetReturn",
@@ -4969,7 +4969,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GiftCardsRef": {
         "name": "GiftCardsRef",
@@ -5003,7 +5003,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Group": {
         "name": "Group",
@@ -5227,7 +5227,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupInfo": {
         "name": "GroupInfo",
@@ -5380,7 +5380,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKey": {
         "name": "GroupKey",
@@ -5486,7 +5486,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKeyRotationData": {
         "name": "GroupKeyRotationData",
@@ -5586,7 +5586,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKeyRotationInfoGetOut": {
         "name": "GroupKeyRotationInfoGetOut",
@@ -5629,7 +5629,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKeyRotationPostIn": {
         "name": "GroupKeyRotationPostIn",
@@ -5663,7 +5663,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKeyUpdate": {
         "name": "GroupKeyUpdate",
@@ -5760,7 +5760,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKeyUpdateData": {
         "name": "GroupKeyUpdateData",
@@ -5821,7 +5821,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKeyUpdatesRef": {
         "name": "GroupKeyUpdatesRef",
@@ -5855,7 +5855,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupKeysRef": {
         "name": "GroupKeysRef",
@@ -5889,7 +5889,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupMember": {
         "name": "GroupMember",
@@ -5979,7 +5979,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupMembership": {
         "name": "GroupMembership",
@@ -6087,7 +6087,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupMembershipKeyData": {
         "name": "GroupMembershipKeyData",
@@ -6148,7 +6148,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupMembershipUpdateData": {
         "name": "GroupMembershipUpdateData",
@@ -6200,7 +6200,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "GroupRoot": {
         "name": "GroupRoot",
@@ -6281,7 +6281,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "IdTupleWrapper": {
         "name": "IdTupleWrapper",
@@ -6322,7 +6322,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "InstanceSessionKey": {
         "name": "InstanceSessionKey",
@@ -6401,7 +6401,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Invoice": {
         "name": "Invoice",
@@ -6617,7 +6617,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "InvoiceDataGetIn": {
         "name": "InvoiceDataGetIn",
@@ -6649,7 +6649,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "InvoiceDataGetOut": {
         "name": "InvoiceDataGetOut",
@@ -6791,7 +6791,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "InvoiceDataItem": {
         "name": "InvoiceDataItem",
@@ -6868,7 +6868,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "InvoiceInfo": {
         "name": "InvoiceInfo",
@@ -7047,7 +7047,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "InvoiceItem": {
         "name": "InvoiceItem",
@@ -7133,7 +7133,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "KeyPair": {
         "name": "KeyPair",
@@ -7210,7 +7210,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "KeyRotation": {
         "name": "KeyRotation",
@@ -7278,7 +7278,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "KeyRotationsRef": {
         "name": "KeyRotationsRef",
@@ -7312,7 +7312,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "LocationServiceGetReturn": {
         "name": "LocationServiceGetReturn",
@@ -7344,7 +7344,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Login": {
         "name": "Login",
@@ -7403,7 +7403,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MailAddressAlias": {
         "name": "MailAddressAlias",
@@ -7444,7 +7444,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MailAddressAliasGetIn": {
         "name": "MailAddressAliasGetIn",
@@ -7478,7 +7478,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MailAddressAliasServiceData": {
         "name": "MailAddressAliasServiceData",
@@ -7521,7 +7521,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MailAddressAliasServiceDataDelete": {
         "name": "MailAddressAliasServiceDataDelete",
@@ -7573,7 +7573,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MailAddressAliasServiceReturn": {
         "name": "MailAddressAliasServiceReturn",
@@ -7632,7 +7632,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MailAddressAvailability": {
         "name": "MailAddressAvailability",
@@ -7673,7 +7673,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MailAddressToGroup": {
         "name": "MailAddressToGroup",
@@ -7734,7 +7734,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MembershipAddData": {
         "name": "MembershipAddData",
@@ -7805,7 +7805,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MembershipPutIn": {
         "name": "MembershipPutIn",
@@ -7839,7 +7839,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MembershipRemoveData": {
         "name": "MembershipRemoveData",
@@ -7883,7 +7883,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MissedNotification": {
         "name": "MissedNotification",
@@ -7999,7 +7999,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MultipleMailAddressAvailabilityData": {
         "name": "MultipleMailAddressAvailabilityData",
@@ -8033,7 +8033,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "MultipleMailAddressAvailabilityReturn": {
         "name": "MultipleMailAddressAvailabilityReturn",
@@ -8067,7 +8067,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "NotificationInfo": {
         "name": "NotificationInfo",
@@ -8119,7 +8119,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "NotificationMailTemplate": {
         "name": "NotificationMailTemplate",
@@ -8169,7 +8169,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "NotificationSessionKey": {
         "name": "NotificationSessionKey",
@@ -8212,7 +8212,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "OrderProcessingAgreement": {
         "name": "OrderProcessingAgreement",
@@ -8328,7 +8328,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "OtpChallenge": {
         "name": "OtpChallenge",
@@ -8362,7 +8362,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PaymentDataServiceGetData": {
         "name": "PaymentDataServiceGetData",
@@ -8394,7 +8394,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PaymentDataServiceGetReturn": {
         "name": "PaymentDataServiceGetReturn",
@@ -8426,7 +8426,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PaymentDataServicePostData": {
         "name": "PaymentDataServicePostData",
@@ -8460,7 +8460,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PaymentDataServicePutData": {
         "name": "PaymentDataServicePutData",
@@ -8575,7 +8575,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PaymentDataServicePutReturn": {
         "name": "PaymentDataServicePutReturn",
@@ -8618,7 +8618,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PaymentErrorInfo": {
         "name": "PaymentErrorInfo",
@@ -8668,7 +8668,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Permission": {
         "name": "Permission",
@@ -8820,7 +8820,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PlanConfiguration": {
         "name": "PlanConfiguration",
@@ -8933,7 +8933,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PlanPrices": {
         "name": "PlanPrices",
@@ -9075,7 +9075,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PlanServiceGetOut": {
         "name": "PlanServiceGetOut",
@@ -9109,7 +9109,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PriceData": {
         "name": "PriceData",
@@ -9170,7 +9170,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PriceItemData": {
         "name": "PriceItemData",
@@ -9229,7 +9229,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PriceRequestData": {
         "name": "PriceRequestData",
@@ -9306,7 +9306,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PriceServiceData": {
         "name": "PriceServiceData",
@@ -9349,7 +9349,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PriceServiceReturn": {
         "name": "PriceServiceReturn",
@@ -9421,7 +9421,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PubEncKeyData": {
         "name": "PubEncKeyData",
@@ -9489,7 +9489,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PublicKeyGetIn": {
         "name": "PublicKeyGetIn",
@@ -9530,7 +9530,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PublicKeyGetOut": {
         "name": "PublicKeyGetOut",
@@ -9589,7 +9589,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PublicKeyPutIn": {
         "name": "PublicKeyPutIn",
@@ -9641,7 +9641,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PushIdentifier": {
         "name": "PushIdentifier",
@@ -9799,7 +9799,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "PushIdentifierList": {
         "name": "PushIdentifierList",
@@ -9833,7 +9833,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ReceivedGroupInvitation": {
         "name": "ReceivedGroupInvitation",
@@ -9994,7 +9994,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RecoverCode": {
         "name": "RecoverCode",
@@ -10080,7 +10080,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RecoverCodeData": {
         "name": "RecoverCodeData",
@@ -10139,7 +10139,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ReferralCodeGetIn": {
         "name": "ReferralCodeGetIn",
@@ -10173,7 +10173,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ReferralCodePostIn": {
         "name": "ReferralCodePostIn",
@@ -10196,7 +10196,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ReferralCodePostOut": {
         "name": "ReferralCodePostOut",
@@ -10230,7 +10230,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RegistrationCaptchaServiceData": {
         "name": "RegistrationCaptchaServiceData",
@@ -10271,7 +10271,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RegistrationCaptchaServiceGetData": {
         "name": "RegistrationCaptchaServiceGetData",
@@ -10339,7 +10339,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RegistrationCaptchaServiceReturn": {
         "name": "RegistrationCaptchaServiceReturn",
@@ -10380,7 +10380,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RegistrationReturn": {
         "name": "RegistrationReturn",
@@ -10412,7 +10412,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RegistrationServiceData": {
         "name": "RegistrationServiceData",
@@ -10462,7 +10462,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RejectedSender": {
         "name": "RejectedSender",
@@ -10557,7 +10557,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RejectedSendersRef": {
         "name": "RejectedSendersRef",
@@ -10591,7 +10591,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RepeatRule": {
         "name": "RepeatRule",
@@ -10670,7 +10670,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ResetFactorsDeleteData": {
         "name": "ResetFactorsDeleteData",
@@ -10720,7 +10720,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "ResetPasswordPostIn": {
         "name": "ResetPasswordPostIn",
@@ -10799,7 +10799,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "RootInstance": {
         "name": "RootInstance",
@@ -10858,7 +10858,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SaltData": {
         "name": "SaltData",
@@ -10890,7 +10890,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SaltReturn": {
         "name": "SaltReturn",
@@ -10931,7 +10931,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SecondFactor": {
         "name": "SecondFactor",
@@ -11019,7 +11019,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SecondFactorAuthAllowedReturn": {
         "name": "SecondFactorAuthAllowedReturn",
@@ -11051,7 +11051,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SecondFactorAuthData": {
         "name": "SecondFactorAuthData",
@@ -11123,7 +11123,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SecondFactorAuthDeleteData": {
         "name": "SecondFactorAuthDeleteData",
@@ -11157,7 +11157,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SecondFactorAuthGetData": {
         "name": "SecondFactorAuthGetData",
@@ -11189,7 +11189,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SecondFactorAuthGetReturn": {
         "name": "SecondFactorAuthGetReturn",
@@ -11221,7 +11221,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SecondFactorAuthentication": {
         "name": "SecondFactorAuthentication",
@@ -11307,7 +11307,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SendRegistrationCodeData": {
         "name": "SendRegistrationCodeData",
@@ -11366,7 +11366,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SendRegistrationCodeReturn": {
         "name": "SendRegistrationCodeReturn",
@@ -11398,7 +11398,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SentGroupInvitation": {
         "name": "SentGroupInvitation",
@@ -11487,7 +11487,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Session": {
         "name": "Session",
@@ -11630,7 +11630,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SignOrderProcessingAgreementData": {
         "name": "SignOrderProcessingAgreementData",
@@ -11671,7 +11671,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SseConnectData": {
         "name": "SseConnectData",
@@ -11714,7 +11714,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "StringConfigValue": {
         "name": "StringConfigValue",
@@ -11755,7 +11755,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "StringWrapper": {
         "name": "StringWrapper",
@@ -11787,7 +11787,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SurveyData": {
         "name": "SurveyData",
@@ -11846,7 +11846,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SwitchAccountTypePostIn": {
         "name": "SwitchAccountTypePostIn",
@@ -11935,7 +11935,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "SystemKeysReturn": {
         "name": "SystemKeysReturn",
@@ -12051,7 +12051,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "TakeOverDeletedAddressData": {
         "name": "TakeOverDeletedAddressData",
@@ -12110,7 +12110,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "TypeInfo": {
         "name": "TypeInfo",
@@ -12151,7 +12151,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "U2fChallenge": {
         "name": "U2fChallenge",
@@ -12194,7 +12194,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "U2fKey": {
         "name": "U2fKey",
@@ -12246,7 +12246,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "U2fRegisteredDevice": {
         "name": "U2fRegisteredDevice",
@@ -12314,7 +12314,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "U2fResponseData": {
         "name": "U2fResponseData",
@@ -12364,7 +12364,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UpdatePermissionKeyData": {
         "name": "UpdatePermissionKeyData",
@@ -12426,7 +12426,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UpdateSessionKeysPostIn": {
         "name": "UpdateSessionKeysPostIn",
@@ -12460,7 +12460,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UpgradePriceServiceData": {
         "name": "UpgradePriceServiceData",
@@ -12512,7 +12512,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UpgradePriceServiceReturn": {
         "name": "UpgradePriceServiceReturn",
@@ -12683,7 +12683,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "User": {
         "name": "User",
@@ -12898,7 +12898,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserAlarmInfo": {
         "name": "UserAlarmInfo",
@@ -12977,7 +12977,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserAlarmInfoListType": {
         "name": "UserAlarmInfoListType",
@@ -13011,7 +13011,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserAreaGroups": {
         "name": "UserAreaGroups",
@@ -13045,7 +13045,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserAuthentication": {
         "name": "UserAuthentication",
@@ -13099,7 +13099,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserDataDelete": {
         "name": "UserDataDelete",
@@ -13151,7 +13151,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserExternalAuthInfo": {
         "name": "UserExternalAuthInfo",
@@ -13221,7 +13221,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserGroupKeyDistribution": {
         "name": "UserGroupKeyDistribution",
@@ -13289,7 +13289,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserGroupKeyRotationData": {
         "name": "UserGroupKeyRotationData",
@@ -13406,7 +13406,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "UserGroupRoot": {
         "name": "UserGroupRoot",
@@ -13487,7 +13487,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "VariableExternalAuthInfo": {
         "name": "VariableExternalAuthInfo",
@@ -13591,7 +13591,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "VerifyRegistrationCodeData": {
         "name": "VerifyRegistrationCodeData",
@@ -13632,7 +13632,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "Version": {
         "name": "Version",
@@ -13703,7 +13703,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "VersionData": {
         "name": "VersionData",
@@ -13762,7 +13762,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "VersionInfo": {
         "name": "VersionInfo",
@@ -13887,7 +13887,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "VersionReturn": {
         "name": "VersionReturn",
@@ -13921,7 +13921,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WebauthnResponseData": {
         "name": "WebauthnResponseData",
@@ -13980,7 +13980,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WebsocketCounterData": {
         "name": "WebsocketCounterData",
@@ -14023,7 +14023,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WebsocketCounterValue": {
         "name": "WebsocketCounterValue",
@@ -14064,7 +14064,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WebsocketEntityData": {
         "name": "WebsocketEntityData",
@@ -14116,7 +14116,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WebsocketLeaderStatus": {
         "name": "WebsocketLeaderStatus",
@@ -14148,7 +14148,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WhitelabelChild": {
         "name": "WhitelabelChild",
@@ -14263,7 +14263,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WhitelabelChildrenRef": {
         "name": "WhitelabelChildrenRef",
@@ -14297,7 +14297,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WhitelabelConfig": {
         "name": "WhitelabelConfig",
@@ -14432,7 +14432,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     },
     "WhitelabelParent": {
         "name": "WhitelabelParent",
@@ -14476,6 +14476,6 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "108"
+        "version": "109"
     }
 }

--- a/tuta-sdk/rust/rustfmt.toml
+++ b/tuta-sdk/rust/rustfmt.toml
@@ -1,0 +1,16 @@
+edition = "2024"
+
+tab_spaces = 4
+hard_tabs = true
+newline_style = "Unix"
+max_width = 100
+match_block_trailing_comma = true
+use_field_init_shorthand = true
+
+# TODO: Very nice-to-have, but currently nightly only
+#normalize_comments = true
+#normalize_doc_attributes = true
+#group_imports = "StdExternalCrate"
+#reorder_impl_items = true
+#combine_control_expr = false
+#condense_wildcard_suffixes = true

--- a/tuta-sdk/rust/sdk/src/crypto/aes.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/aes.rs
@@ -1,40 +1,39 @@
 //! Contains code to handle AES128/AES256 encryption and decryption
 
-use aes::cipher::{BlockCipher, BlockSizeUser};
-use aes::cipher::block_padding::Pkcs7;
-use cbc::cipher::{BlockDecrypt, BlockDecryptMut, BlockEncrypt, BlockEncryptMut, KeyIvInit};
-use cbc::cipher::block_padding::UnpadError;
-use zeroize::ZeroizeOnDrop;
 use crate::crypto::randomizer_facade::RandomizerFacade;
 use crate::join_slices;
-use crate::util::{ArrayCastingError, array_cast_slice, array_cast_size};
+use crate::util::{array_cast_size, array_cast_slice, ArrayCastingError};
+use aes::cipher::block_padding::Pkcs7;
+use aes::cipher::{BlockCipher, BlockSizeUser};
+use cbc::cipher::block_padding::UnpadError;
+use cbc::cipher::{BlockDecrypt, BlockDecryptMut, BlockEncrypt, BlockEncryptMut, KeyIvInit};
+use zeroize::ZeroizeOnDrop;
 
 /// Denotes whether a text is/should be padded
 pub enum PaddingMode {
-    /// Do not use padding; used for encrypting fixed-length values (i.e. keys).
-    NoPadding,
+	/// Do not use padding; used for encrypting fixed-length values (i.e. keys).
+	NoPadding,
 
-    /// Use padding; used for variable-length encrypted data.
-    WithPadding,
+	/// Use padding; used for variable-length encrypted data.
+	WithPadding,
 }
 
 /// Denotes whether a text should include a message authentication code
 pub enum MacMode {
-    /// No verification will be done on the ciphertext.
-    ///
-    /// This is only supported for legacy compatibility. You should not use this to encrypt new data.
-    NoMac,
+	/// No verification will be done on the ciphertext.
+	///
+	/// This is only supported for legacy compatibility. You should not use this to encrypt new data.
+	NoMac,
 
-    /// Perform verification on the ciphertext by deriving subkeys from the provided AES key.
-    WithMac,
+	/// Perform verification on the ciphertext by deriving subkeys from the provided AES key.
+	WithMac,
 }
-
 
 /// Denotes whether a presence of MAC authentication is enforced
 #[derive(PartialEq)]
 pub enum EnforceMac {
-    AllowNoMac,
-    EnforceMac,
+	AllowNoMac,
+	EnforceMac,
 }
 
 /// Generates a struct that implements the `AesKey` trait to represent an AES key.
@@ -46,89 +45,98 @@ pub enum EnforceMac {
 /// - $cbc: The type from the `aes` dependency.
 /// - $subkey_digest: The type of SHA hasher from the `sha2` dependency to use.
 macro_rules! aes_key {
-    ($name:tt, $type_name:literal, $size:expr, $cbc:ty, $subkey_digest:ty) => {
-        #[derive(Clone, ZeroizeOnDrop, PartialEq)]
-        #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
-        pub struct $name([u8; $size]);
+	($name:tt, $type_name:literal, $size:expr, $cbc:ty, $subkey_digest:ty) => {
+		#[derive(Clone, ZeroizeOnDrop, PartialEq)]
+		#[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
+		pub struct $name([u8; $size]);
 
-        impl $name {
-            /// Generate an AES key.
-            pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
-                let key: [u8; $size] = randomizer_facade.generate_random_array();
-                Self(key)
-            }
+		impl $name {
+			/// Generate an AES key.
+			pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
+				let key: [u8; $size] = randomizer_facade.generate_random_array();
+				Self(key)
+			}
 
-            /// Get the key represented as bytes.
-            pub fn as_bytes(&self) -> &[u8; $size] {
-                &self.0
-            }
+			/// Get the key represented as bytes.
+			pub fn as_bytes(&self) -> &[u8; $size] {
+				&self.0
+			}
 
-            /// Load the key from bytes.
-            ///
-            /// Returns Err if the key is not the correct size.
-            pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
-                Ok(Self(array_cast_slice(bytes, $type_name)?))
-            }
-        }
+			/// Load the key from bytes.
+			///
+			/// Returns Err if the key is not the correct size.
+			pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
+				Ok(Self(array_cast_slice(bytes, $type_name)?))
+			}
+		}
 
-        impl<const SIZE: usize> TryFrom<[u8; SIZE]> for $name {
-            type Error = ArrayCastingError;
-            fn try_from(value: [u8; SIZE]) -> Result<Self, Self::Error> {
-                Ok(Self(array_cast_size(value, $type_name)?))
-            }
-        }
+		impl<const SIZE: usize> TryFrom<[u8; SIZE]> for $name {
+			type Error = ArrayCastingError;
+			fn try_from(value: [u8; SIZE]) -> Result<Self, Self::Error> {
+				Ok(Self(array_cast_size(value, $type_name)?))
+			}
+		}
 
-        impl TryFrom<Vec<u8>> for $name {
-            type Error = ArrayCastingError;
-            fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
-                Ok(Self(array_cast_slice(value.as_slice(), $type_name)?))
-            }
-        }
+		impl TryFrom<Vec<u8>> for $name {
+			type Error = ArrayCastingError;
+			fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+				Ok(Self(array_cast_slice(value.as_slice(), $type_name)?))
+			}
+		}
 
-        impl AesKey for $name {
-            type CbcKeyType = $cbc;
-            fn get_bytes(&self) -> &[u8] {
-                &self.0
-            }
+		impl AesKey for $name {
+			type CbcKeyType = $cbc;
+			fn get_bytes(&self) -> &[u8] {
+				&self.0
+			}
 
-            fn derive_subkeys(&self) -> AesSubKeys<Self> {
-                use sha2::Digest;
-                use cbc::cipher::KeySizeUser;
+			fn derive_subkeys(&self) -> AesSubKeys<Self> {
+				use cbc::cipher::KeySizeUser;
+				use sha2::Digest;
 
-                let mut hasher = <$subkey_digest>::new();
-                hasher.update(self.get_bytes());
-                let hashed_key = hasher.finalize();
+				let mut hasher = <$subkey_digest>::new();
+				hasher.update(self.get_bytes());
+				let hashed_key = hasher.finalize();
 
-                let (c_key_slice, m_key_slice) = hashed_key.split_at(<Self as AesKey>::CbcKeyType::key_size());
-                AesSubKeys { c_key: Self::from_bytes(c_key_slice).unwrap(), m_key: Self::from_bytes(m_key_slice).unwrap() }
-            }
-        }
-    };
+				let (c_key_slice, m_key_slice) =
+					hashed_key.split_at(<Self as AesKey>::CbcKeyType::key_size());
+				AesSubKeys {
+					c_key: Self::from_bytes(c_key_slice).unwrap(),
+					m_key: Self::from_bytes(m_key_slice).unwrap(),
+				}
+			}
+		}
+	};
 }
 
 aes_key!(
-    Aes128Key,
-    "Aes128Key",
-    AES_128_KEY_SIZE,
-    aes::Aes128,
-    sha2::Sha256
+	Aes128Key,
+	"Aes128Key",
+	AES_128_KEY_SIZE,
+	aes::Aes128,
+	sha2::Sha256
 );
 
 aes_key!(
-    Aes256Key,
-    "Aes256Key",
-    AES_256_KEY_SIZE,
-    aes::Aes256,
-    sha2::Sha512
+	Aes256Key,
+	"Aes256Key",
+	AES_256_KEY_SIZE,
+	aes::Aes256,
+	sha2::Sha512
 );
 
 trait AesKey: Clone {
-    /// The equivalent type in the RustCrypto packages to this key type
-    type CbcKeyType: BlockEncryptMut + BlockDecryptMut + BlockEncrypt + BlockDecrypt + BlockCipher + cbc::cipher::KeyInit;
-    /// Returns the key in raw byte form
-    fn get_bytes(&self) -> &[u8];
-    /// Generates the AES (`c`) and HMAC (`m`) subkeys from the key
-    fn derive_subkeys(&self) -> AesSubKeys<Self>;
+	/// The equivalent type in the RustCrypto packages to this key type
+	type CbcKeyType: BlockEncryptMut
+		+ BlockDecryptMut
+		+ BlockEncrypt
+		+ BlockDecrypt
+		+ BlockCipher
+		+ cbc::cipher::KeyInit;
+	/// Returns the key in raw byte form
+	fn get_bytes(&self) -> &[u8];
+	/// Generates the AES (`c`) and HMAC (`m`) subkeys from the key
+	fn derive_subkeys(&self) -> AesSubKeys<Self>;
 }
 
 /// An initialisation vector for AES encryption
@@ -136,102 +144,143 @@ pub struct Iv([u8; IV_BYTE_SIZE]);
 
 #[cfg(test)]
 impl Clone for Iv {
-    /// Clone the initialization vector
-    ///
-    /// This is implemented so that entity_facade_test_utils will work. You should never, ever, ever
-    /// re-use an IV, as this can lead to information leakage.
-    fn clone(&self) -> Self {
-        Iv(self.0)
-    }
+	/// Clone the initialization vector
+	///
+	/// This is implemented so that entity_facade_test_utils will work. You should never, ever, ever
+	/// re-use an IV, as this can lead to information leakage.
+	fn clone(&self) -> Self {
+		Iv(self.0)
+	}
 }
 
 impl Iv {
-    /// Generate an initialisation vector.
-    pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
-        Self(randomizer_facade.generate_random_array())
-    }
+	/// Generate an initialisation vector.
+	pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
+		Self(randomizer_facade.generate_random_array())
+	}
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
-        Ok(Self(array_cast_slice(bytes, "Iv")?))
-    }
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
+		Ok(Self(array_cast_slice(bytes, "Iv")?))
+	}
 
-    fn from_slice(slice: &[u8]) -> Option<Self> {
-        Self::from_bytes(slice).ok()
-    }
+	fn from_slice(slice: &[u8]) -> Option<Self> {
+		Self::from_bytes(slice).ok()
+	}
 }
 
 #[derive(thiserror::Error, Debug)]
 pub enum AesEncryptError {
-    #[error("InvalidDataLength")]
-    InvalidDataLength
+	#[error("InvalidDataLength")]
+	InvalidDataLength,
 }
 
 /// Encrypts the raw string `plaintext` using AES-128-CBC with optional PKCS7 padding and optional HMAC-SHA-256
-pub fn aes_128_encrypt(key: &Aes128Key, plaintext: &[u8], iv: &Iv, padding_mode: PaddingMode, mac_mode: MacMode) -> Result<Vec<u8>, AesEncryptError> {
-    aes_encrypt(key, plaintext, iv, padding_mode, mac_mode)
+pub fn aes_128_encrypt(
+	key: &Aes128Key,
+	plaintext: &[u8],
+	iv: &Iv,
+	padding_mode: PaddingMode,
+	mac_mode: MacMode,
+) -> Result<Vec<u8>, AesEncryptError> {
+	aes_encrypt(key, plaintext, iv, padding_mode, mac_mode)
 }
 
 /// Encrypts `plaintext` with `FIXED_IV` and without padding nor a MAC using AES128-CBC
 /// Mainly used for encrypting keys
-pub fn aes_128_encrypt_no_padding_fixed_iv(key: &Aes128Key, plaintext: &[u8]) -> Result<Vec<u8>, AesEncryptError> {
-    let mut encryptor = cbc::Encryptor::<aes::Aes128>::new_from_slices(key.get_bytes(), &FIXED_IV).unwrap();
-    let block_size = <aes::Aes128 as BlockSizeUser>::block_size();
-    if plaintext.len() % block_size != 0 {
-        return Err(AesEncryptError::InvalidDataLength);
-    }
-    Ok(encrypt_unpadded_vec_mut(&mut encryptor, plaintext))
+pub fn aes_128_encrypt_no_padding_fixed_iv(
+	key: &Aes128Key,
+	plaintext: &[u8],
+) -> Result<Vec<u8>, AesEncryptError> {
+	let mut encryptor =
+		cbc::Encryptor::<aes::Aes128>::new_from_slices(key.get_bytes(), &FIXED_IV).unwrap();
+	let block_size = <aes::Aes128 as BlockSizeUser>::block_size();
+	if plaintext.len() % block_size != 0 {
+		return Err(AesEncryptError::InvalidDataLength);
+	}
+	Ok(encrypt_unpadded_vec_mut(&mut encryptor, plaintext))
 }
 
 /// Encrypts the raw string `plaintext` using AES-256-CBC with optional PKCS7 padding and optional HMAC-SHA-512
-pub fn aes_256_encrypt(key: &Aes256Key, plaintext: &[u8], iv: &Iv, padding_mode: PaddingMode) -> Result<Vec<u8>, AesEncryptError> {
-    aes_encrypt(key, plaintext, iv, padding_mode, MacMode::WithMac)
+pub fn aes_256_encrypt(
+	key: &Aes256Key,
+	plaintext: &[u8],
+	iv: &Iv,
+	padding_mode: PaddingMode,
+) -> Result<Vec<u8>, AesEncryptError> {
+	aes_encrypt(key, plaintext, iv, padding_mode, MacMode::WithMac)
 }
-
 
 /// The possible errors that can occur while decrypting an AES text
 #[derive(thiserror::Error, Debug)]
 pub enum AesDecryptError {
-    #[error("InvalidDataSizeError")]
-    InvalidDataSizeError,
-    #[error("PaddingError")]
-    PaddingError(#[from] UnpadError),
-    #[error("HmacError")]
-    HmacError,
+	#[error("InvalidDataSizeError")]
+	InvalidDataSizeError,
+	#[error("PaddingError")]
+	PaddingError(#[from] UnpadError),
+	#[error("HmacError")]
+	HmacError,
 }
 
 /// Result of decryption operation.
 /// IV is usually part of the ciphertext. Returned iv is a part of the provided ciphertext.
 pub struct PlaintextAndIv {
-    pub data: Vec<u8>,
-    // IV is small enough that a copy is the same size as a reference
-    pub iv: [u8; IV_BYTE_SIZE],
+	pub data: Vec<u8>,
+	// IV is small enough that a copy is the same size as a reference
+	pub iv: [u8; IV_BYTE_SIZE],
 }
 
 /// Decrypt using AES-128-CBC using prepended IV with PKCS7 padding and optional HMAC-SHA-256
-pub fn aes_128_decrypt(key: &Aes128Key, encrypted_bytes: &[u8]) -> Result<PlaintextAndIv, AesDecryptError> {
-    aes_decrypt(key, encrypted_bytes, PaddingMode::WithPadding, EnforceMac::AllowNoMac)
+pub fn aes_128_decrypt(
+	key: &Aes128Key,
+	encrypted_bytes: &[u8],
+) -> Result<PlaintextAndIv, AesDecryptError> {
+	aes_decrypt(
+		key,
+		encrypted_bytes,
+		PaddingMode::WithPadding,
+		EnforceMac::AllowNoMac,
+	)
 }
 
 /// Decrypt an encryption key with AES-128 using fixed IV, without authentication
-pub fn aes_128_decrypt_no_padding_fixed_iv(key: &Aes128Key, encrypted_bytes: &[u8]) -> Result<Vec<u8>, AesDecryptError> {
-    if has_mac(encrypted_bytes) {
-        return Err(AesDecryptError::InvalidDataSizeError);
-    }
+pub fn aes_128_decrypt_no_padding_fixed_iv(
+	key: &Aes128Key,
+	encrypted_bytes: &[u8],
+) -> Result<Vec<u8>, AesDecryptError> {
+	if has_mac(encrypted_bytes) {
+		return Err(AesDecryptError::InvalidDataSizeError);
+	}
 
-    let mut decryptor = cbc::Decryptor::<aes::Aes128>::new(&key.0.into(), &FIXED_IV.into());
-    let plaintext_data = decrypt_unpadded_vec_mut(&mut decryptor, encrypted_bytes);
+	let mut decryptor = cbc::Decryptor::<aes::Aes128>::new(&key.0.into(), &FIXED_IV.into());
+	let plaintext_data = decrypt_unpadded_vec_mut(&mut decryptor, encrypted_bytes);
 
-    Ok(plaintext_data)
+	Ok(plaintext_data)
 }
 
 /// Decrypt using AES-256-CBC using prepended IV with PKCS7 padding and HMAC-SHA-512
-pub fn aes_256_decrypt(key: &Aes256Key, encrypted_bytes: &[u8]) -> Result<PlaintextAndIv, AesDecryptError> {
-    aes_decrypt(key, encrypted_bytes, PaddingMode::WithPadding, EnforceMac::EnforceMac)
+pub fn aes_256_decrypt(
+	key: &Aes256Key,
+	encrypted_bytes: &[u8],
+) -> Result<PlaintextAndIv, AesDecryptError> {
+	aes_decrypt(
+		key,
+		encrypted_bytes,
+		PaddingMode::WithPadding,
+		EnforceMac::EnforceMac,
+	)
 }
 
 /// Decrypt an encryption key with AES-256-CBC using prepended IV without padding and HMAC-SHA-512
-pub fn aes_256_decrypt_no_padding(key: &Aes256Key, encrypted_bytes: &[u8]) -> Result<PlaintextAndIv, AesDecryptError> {
-    aes_decrypt(key, encrypted_bytes, PaddingMode::NoPadding, EnforceMac::EnforceMac)
+pub fn aes_256_decrypt_no_padding(
+	key: &Aes256Key,
+	encrypted_bytes: &[u8],
+) -> Result<PlaintextAndIv, AesDecryptError> {
+	aes_decrypt(
+		key,
+		encrypted_bytes,
+		PaddingMode::NoPadding,
+		EnforceMac::EnforceMac,
+	)
 }
 
 pub const AES_128_KEY_SIZE: usize = 16;
@@ -244,80 +293,109 @@ pub const IV_BYTE_SIZE: usize = 16;
 const MAC_SIZE: usize = 32;
 
 /// Encrypts a plaintext without adding padding and returns the encrypted text as a vector
-fn encrypt_unpadded_vec_mut<C: BlockCipher + BlockEncryptMut>(encryptor: &mut cbc::Encryptor<C>, plaintext: &[u8]) -> Vec<u8> {
-    let mut output_buffer = vec![0; plaintext.len()];
-    for (chunk, output) in plaintext.chunks(C::block_size()).zip(output_buffer.chunks_mut(C::block_size())) {
-        encryptor.encrypt_block_b2b_mut(chunk.into(), output.into());
-    }
-    output_buffer
+fn encrypt_unpadded_vec_mut<C: BlockCipher + BlockEncryptMut>(
+	encryptor: &mut cbc::Encryptor<C>,
+	plaintext: &[u8],
+) -> Vec<u8> {
+	let mut output_buffer = vec![0; plaintext.len()];
+	for (chunk, output) in plaintext
+		.chunks(C::block_size())
+		.zip(output_buffer.chunks_mut(C::block_size()))
+	{
+		encryptor.encrypt_block_b2b_mut(chunk.into(), output.into());
+	}
+	output_buffer
 }
 
 /// Keys derived for AES key to enable authentication
 struct AesSubKeys<Key: AesKey> {
-    /// Key used for encrypting data
-    c_key: Key,
-    /// Key used for HMAC (authentication)
-    m_key: Key,
+	/// Key used for encrypting data
+	c_key: Key,
+	/// Key used for HMAC (authentication)
+	m_key: Key,
 }
 
 type Aes128SubKeys = AesSubKeys<Aes128Key>;
 type Aes256SubKeys = AesSubKeys<Aes256Key>;
 
 impl<Key: AesKey> AesSubKeys<Key> {
-    fn compute_mac(&self, iv: &[u8], ciphertext: &[u8]) -> [u8; MAC_SIZE] {
-        use sha2::Sha256;
-        use hmac::Mac;
+	fn compute_mac(&self, iv: &[u8], ciphertext: &[u8]) -> [u8; MAC_SIZE] {
+		use hmac::Mac;
+		use sha2::Sha256;
 
-        let mut hmac = hmac::Hmac::<Sha256>::new_from_slice(self.m_key.get_bytes()).unwrap();
-        hmac.update(iv);
-        hmac.update(ciphertext);
-        hmac.finalize().into_bytes().into()
-    }
+		let mut hmac = hmac::Hmac::<Sha256>::new_from_slice(self.m_key.get_bytes()).unwrap();
+		hmac.update(iv);
+		hmac.update(ciphertext);
+		hmac.finalize().into_bytes().into()
+	}
 }
 
 /// Generic AES-CBC function with optional PKCS7 padding and with optional HMAC-SHA support
-fn aes_encrypt<Key: AesKey>(key: &Key, plaintext: &[u8], iv: &Iv, padding_mode: PaddingMode, mac_mode: MacMode) -> Result<Vec<u8>, AesEncryptError> {
-    // Extract the correct key into an encryptor depending on
-    // whether `c` needs to be derived for MAC s (note that no mac means no sub keys)
-    let (mut encryptor, sub_keys) = match mac_mode {
-        MacMode::NoMac => (cbc::Encryptor::<Key::CbcKeyType>::new_from_slices(key.get_bytes(), &iv.0).unwrap(), None),
-        MacMode::WithMac => {
-            let sub_keys = key.derive_subkeys();
-            (cbc::Encryptor::<Key::CbcKeyType>::new_from_slices(sub_keys.c_key.get_bytes(), &iv.0).unwrap(), Some(sub_keys))
-        }
-    };
+fn aes_encrypt<Key: AesKey>(
+	key: &Key,
+	plaintext: &[u8],
+	iv: &Iv,
+	padding_mode: PaddingMode,
+	mac_mode: MacMode,
+) -> Result<Vec<u8>, AesEncryptError> {
+	// Extract the correct key into an encryptor depending on
+	// whether `c` needs to be derived for MAC s (note that no mac means no sub keys)
+	let (mut encryptor, sub_keys) = match mac_mode {
+		MacMode::NoMac => (
+			cbc::Encryptor::<Key::CbcKeyType>::new_from_slices(key.get_bytes(), &iv.0).unwrap(),
+			None,
+		),
+		MacMode::WithMac => {
+			let sub_keys = key.derive_subkeys();
+			(
+				cbc::Encryptor::<Key::CbcKeyType>::new_from_slices(
+					sub_keys.c_key.get_bytes(),
+					&iv.0,
+				)
+				.unwrap(),
+				Some(sub_keys),
+			)
+		},
+	};
 
-    // Pad/verify block size
-    let block_size = <Key::CbcKeyType as BlockSizeUser>::block_size();
-    let encrypted_data = match padding_mode {
-        PaddingMode::NoPadding => {
-            if plaintext.len() % block_size != 0 {
-                return Err(AesEncryptError::InvalidDataLength);
-            }
-            encrypt_unpadded_vec_mut(&mut encryptor, plaintext)
-        }
-        PaddingMode::WithPadding => encryptor.encrypt_padded_vec_mut::<Pkcs7>(plaintext),
-    };
+	// Pad/verify block size
+	let block_size = <Key::CbcKeyType as BlockSizeUser>::block_size();
+	let encrypted_data = match padding_mode {
+		PaddingMode::NoPadding => {
+			if plaintext.len() % block_size != 0 {
+				return Err(AesEncryptError::InvalidDataLength);
+			}
+			encrypt_unpadded_vec_mut(&mut encryptor, plaintext)
+		},
+		PaddingMode::WithPadding => encryptor.encrypt_padded_vec_mut::<Pkcs7>(plaintext),
+	};
 
-    if let Some(subkeys) = sub_keys {
-        let ciphertext_with_auth = CiphertextWithAuthentication::compute(&encrypted_data, &iv.0, &subkeys);
-        Ok(ciphertext_with_auth.serialize())
-    } else {
-        // without HMAC it is just
-        // - iv
-        // - encrypted data
-        Ok(join_slices!(iv.0.as_slice(), &encrypted_data))
-    }
+	if let Some(subkeys) = sub_keys {
+		let ciphertext_with_auth =
+			CiphertextWithAuthentication::compute(&encrypted_data, &iv.0, &subkeys);
+		Ok(ciphertext_with_auth.serialize())
+	} else {
+		// without HMAC it is just
+		// - iv
+		// - encrypted data
+		Ok(join_slices!(iv.0.as_slice(), &encrypted_data))
+	}
 }
 
 /// Decrypts an encrypted plain text that does not have padding using AES-CBC and returns
 /// the decrypted text as a vector.
-fn decrypt_unpadded_vec_mut<C: BlockCipher + BlockDecrypt>(decryptor: &mut cbc::Decryptor<C>, buf: &[u8]) -> Vec<u8> {
-    let mut output_buffer = vec![0; buf.len()];
-    for (chunk, output) in buf.chunks(C::block_size()).zip(output_buffer.chunks_mut(C::block_size())) {
-        decryptor.decrypt_block_b2b_mut(chunk.into(), output.into());
-    }
-    output_buffer
+fn decrypt_unpadded_vec_mut<C: BlockCipher + BlockDecrypt>(
+	decryptor: &mut cbc::Decryptor<C>,
+	buf: &[u8],
+) -> Vec<u8> {
+	let mut output_buffer = vec![0; buf.len()];
+	for (chunk, output) in buf
+		.chunks(C::block_size())
+		.zip(output_buffer.chunks_mut(C::block_size()))
+	{
+		decryptor.decrypt_block_b2b_mut(chunk.into(), output.into());
+	}
+	output_buffer
 }
 
 /// The initialisation vector used when encrypting keys
@@ -325,362 +403,385 @@ const FIXED_IV: [u8; IV_BYTE_SIZE] = [0x88; IV_BYTE_SIZE];
 
 #[derive(Debug)]
 struct CiphertextWithAuthentication<'a> {
-    iv: &'a [u8],
-    ciphertext: &'a [u8],
-    // it's smol enough to just copy it around
-    mac: [u8; MAC_SIZE],
+	iv: &'a [u8],
+	ciphertext: &'a [u8],
+	// it's smol enough to just copy it around
+	mac: [u8; MAC_SIZE],
 }
 
 impl<'a> CiphertextWithAuthentication<'a> {
-    fn parse(bytes: &'a [u8]) -> Result<Option<CiphertextWithAuthentication<'a>>, AesDecryptError> {
-        // No MAC
-        if !has_mac(bytes) {
-            return Ok(None);
-        }
+	fn parse(bytes: &'a [u8]) -> Result<Option<CiphertextWithAuthentication<'a>>, AesDecryptError> {
+		// No MAC
+		if !has_mac(bytes) {
+			return Ok(None);
+		}
 
-        // Incorrect size for Hmac
-        if bytes.len() <= IV_BYTE_SIZE + MAC_SIZE {
-            return Err(AesDecryptError::HmacError);
-        }
+		// Incorrect size for Hmac
+		if bytes.len() <= IV_BYTE_SIZE + MAC_SIZE {
+			return Err(AesDecryptError::HmacError);
+		}
 
-        // Split `bytes` into the MAC and combined ciphertext with iv
-        let encrypted_bytes_without_marker = &bytes[1..];
-        let end_of_ciphertext = encrypted_bytes_without_marker.len() - MAC_SIZE;
-        let (ciphertext_without_mac, provided_mac_bytes) =
-            encrypted_bytes_without_marker.split_at(end_of_ciphertext);
+		// Split `bytes` into the MAC and combined ciphertext with iv
+		let encrypted_bytes_without_marker = &bytes[1..];
+		let end_of_ciphertext = encrypted_bytes_without_marker.len() - MAC_SIZE;
+		let (ciphertext_without_mac, provided_mac_bytes) =
+			encrypted_bytes_without_marker.split_at(end_of_ciphertext);
 
-        // Extract the iv from the ciphertext and return the extracted components
-        let (iv, ciphertext) = ciphertext_without_mac.split_at(IV_BYTE_SIZE);
-        let mac: [u8; MAC_SIZE] = array_cast_slice(provided_mac_bytes, "MAC")
-            .map_err(|_| { AesDecryptError::HmacError })?;
-        Ok(Some(CiphertextWithAuthentication {
-            iv,
-            ciphertext,
-            mac,
-        }))
-    }
+		// Extract the iv from the ciphertext and return the extracted components
+		let (iv, ciphertext) = ciphertext_without_mac.split_at(IV_BYTE_SIZE);
+		let mac: [u8; MAC_SIZE] =
+			array_cast_slice(provided_mac_bytes, "MAC").map_err(|_| AesDecryptError::HmacError)?;
+		Ok(Some(CiphertextWithAuthentication {
+			iv,
+			ciphertext,
+			mac,
+		}))
+	}
 
-    fn compute<Key: AesKey>(ciphertext: &'a [u8], iv: &'a [u8], subkeys: &AesSubKeys<Key>) -> CiphertextWithAuthentication<'a> {
-        CiphertextWithAuthentication {
-            iv,
-            ciphertext,
-            mac: subkeys.compute_mac(iv, ciphertext),
-        }
-    }
+	fn compute<Key: AesKey>(
+		ciphertext: &'a [u8],
+		iv: &'a [u8],
+		subkeys: &AesSubKeys<Key>,
+	) -> CiphertextWithAuthentication<'a> {
+		CiphertextWithAuthentication {
+			iv,
+			ciphertext,
+			mac: subkeys.compute_mac(iv, ciphertext),
+		}
+	}
 
-    fn matches<Key: AesKey>(&self, subkeys: &AesSubKeys<Key>) -> bool {
-        self.mac == subkeys.compute_mac(self.iv, self.ciphertext)
-    }
+	fn matches<Key: AesKey>(&self, subkeys: &AesSubKeys<Key>) -> bool {
+		self.mac == subkeys.compute_mac(self.iv, self.ciphertext)
+	}
 
-    fn serialize(&self) -> Vec<u8> {
-        // - marker that HMAC is there (a single byte with "1" in the front, this makes the length
-        //   un-even)
-        // - iv
-        // - encrypted data
-        // - HMAC bytes
+	fn serialize(&self) -> Vec<u8> {
+		// - marker that HMAC is there (a single byte with "1" in the front, this makes the length
+		//   un-even)
+		// - iv
+		// - encrypted data
+		// - HMAC bytes
 
-        join_slices!(&[1u8; 1], self.iv, self.ciphertext, &self.mac)
-    }
+		join_slices!(&[1u8; 1], self.iv, self.ciphertext, &self.mac)
+	}
 }
 
 /// Returns whether the raw ciphertext `bytes` has a MAC included.
 fn has_mac(bytes: &[u8]) -> bool {
-    bytes.len() % 2 == 1 && bytes[0] == 1
+	bytes.len() % 2 == 1 && bytes[0] == 1
 }
 
 /// Decrypts the AES-encrypted raw string `encrypted_bytes` into a plain text raw string
 /// using AES using prepended IV with optional PKCS7 padding and optional HMAC-SHA
-fn aes_decrypt<Key: AesKey>(key: &Key, encrypted_bytes: &[u8], padding_mode: PaddingMode, enforce_mac: EnforceMac) -> Result<PlaintextAndIv, AesDecryptError> {
-    if encrypted_bytes.len() < IV_BYTE_SIZE {
-        return Err(AesDecryptError::InvalidDataSizeError);
-    }
+fn aes_decrypt<Key: AesKey>(
+	key: &Key,
+	encrypted_bytes: &[u8],
+	padding_mode: PaddingMode,
+	enforce_mac: EnforceMac,
+) -> Result<PlaintextAndIv, AesDecryptError> {
+	if encrypted_bytes.len() < IV_BYTE_SIZE {
+		return Err(AesDecryptError::InvalidDataSizeError);
+	}
 
-    // Split `encrypted_bytes` into the key for the ciphertext, the iv and the ciphertext itself
-    let (key, iv_bytes, encrypted_bytes) = if let Some(ciphertext_with_auth) = CiphertextWithAuthentication::parse(encrypted_bytes)? {
-        let subkeys = key.derive_subkeys();
-        if !ciphertext_with_auth.matches(&subkeys) {
-            return Err(AesDecryptError::HmacError);
-        }
+	// Split `encrypted_bytes` into the key for the ciphertext, the iv and the ciphertext itself
+	let (key, iv_bytes, encrypted_bytes) =
+		if let Some(ciphertext_with_auth) = CiphertextWithAuthentication::parse(encrypted_bytes)? {
+			let subkeys = key.derive_subkeys();
+			if !ciphertext_with_auth.matches(&subkeys) {
+				return Err(AesDecryptError::HmacError);
+			}
 
-        (subkeys.c_key, ciphertext_with_auth.iv, ciphertext_with_auth.ciphertext)
-    } else if enforce_mac == EnforceMac::EnforceMac {
-        return Err(AesDecryptError::HmacError);
-    } else {
-        // Separate and check both the initialisation vector
-        let (iv_bytes, cipher_text) = encrypted_bytes.split_at(IV_BYTE_SIZE);
-        (key.clone(), iv_bytes, cipher_text)
-    };
+			(
+				subkeys.c_key,
+				ciphertext_with_auth.iv,
+				ciphertext_with_auth.ciphertext,
+			)
+		} else if enforce_mac == EnforceMac::EnforceMac {
+			return Err(AesDecryptError::HmacError);
+		} else {
+			// Separate and check both the initialisation vector
+			let (iv_bytes, cipher_text) = encrypted_bytes.split_at(IV_BYTE_SIZE);
+			(key.clone(), iv_bytes, cipher_text)
+		};
 
-    // Return early if there is nothing to decrypt
-    if encrypted_bytes.is_empty() {
-        return Ok(PlaintextAndIv { data: vec![], iv: iv_bytes.try_into().expect("iv is correct size")});
-    }
+	// Return early if there is nothing to decrypt
+	if encrypted_bytes.is_empty() {
+		return Ok(PlaintextAndIv {
+			data: vec![],
+			iv: iv_bytes.try_into().expect("iv is correct size"),
+		});
+	}
 
-    let mut decryptor = cbc::Decryptor::<Key::CbcKeyType>::new_from_slices(key.get_bytes(), iv_bytes).unwrap();
-    let plaintext_data = match padding_mode {
-        // Unpadded encrypted texts do not include the IV
-        PaddingMode::NoPadding => decrypt_unpadded_vec_mut(&mut decryptor, encrypted_bytes),
-        PaddingMode::WithPadding => decryptor.decrypt_padded_vec_mut::<Pkcs7>(encrypted_bytes)?
-    };
+	let mut decryptor =
+		cbc::Decryptor::<Key::CbcKeyType>::new_from_slices(key.get_bytes(), iv_bytes).unwrap();
+	let plaintext_data = match padding_mode {
+		// Unpadded encrypted texts do not include the IV
+		PaddingMode::NoPadding => decrypt_unpadded_vec_mut(&mut decryptor, encrypted_bytes),
+		PaddingMode::WithPadding => decryptor.decrypt_padded_vec_mut::<Pkcs7>(encrypted_bytes)?,
+	};
 
-    Ok(PlaintextAndIv { data: plaintext_data, iv: iv_bytes.try_into().expect("iv is correct size") })
+	Ok(PlaintextAndIv {
+		data: plaintext_data,
+		iv: iv_bytes.try_into().expect("iv is correct size"),
+	})
 }
 
 #[cfg(test)]
 mod tests {
-    use base64::engine::Engine;
-    use base64::prelude::BASE64_STANDARD;
+	use base64::engine::Engine;
+	use base64::prelude::BASE64_STANDARD;
 
-    use crate::crypto::compatibility_test_utils::*;
-    use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
+	use crate::crypto::compatibility_test_utils::*;
+	use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
 
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_aes_128_encrypt_with_padding_no_mac() {
-        for td in get_test_data().aes128_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let plaintext = td.plain_text_base64;
-            let iv = &Iv(td.iv_base64.try_into().unwrap());
-            let encrypted_bytes = aes_128_encrypt(
-                &key,
-                &plaintext,
-                iv,
-                PaddingMode::WithPadding,
-                MacMode::NoMac,
-            ).unwrap();
-            let expected_ciphertext = td.cipher_text_base64;
-            assert_eq!(expected_ciphertext, encrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_128_encrypt_with_padding_no_mac() {
+		for td in get_test_data().aes128_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let plaintext = td.plain_text_base64;
+			let iv = &Iv(td.iv_base64.try_into().unwrap());
+			let encrypted_bytes = aes_128_encrypt(
+				&key,
+				&plaintext,
+				iv,
+				PaddingMode::WithPadding,
+				MacMode::NoMac,
+			)
+			.unwrap();
+			let expected_ciphertext = td.cipher_text_base64;
+			assert_eq!(expected_ciphertext, encrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_128_encrypt_with_padding_mac() {
-        for td in get_test_data().aes128_mac_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let plaintext = td.plain_text_base64;
-            let iv = &Iv(td.iv_base64.try_into().unwrap());
-            let encrypted_bytes = aes_128_encrypt(
-                &key,
-                &plaintext,
-                iv,
-                PaddingMode::WithPadding,
-                MacMode::WithMac,
-            ).unwrap();
-            let expected_ciphertext = td.cipher_text_base64;
-            assert_eq!(expected_ciphertext, encrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_128_encrypt_with_padding_mac() {
+		for td in get_test_data().aes128_mac_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let plaintext = td.plain_text_base64;
+			let iv = &Iv(td.iv_base64.try_into().unwrap());
+			let encrypted_bytes = aes_128_encrypt(
+				&key,
+				&plaintext,
+				iv,
+				PaddingMode::WithPadding,
+				MacMode::WithMac,
+			)
+			.unwrap();
+			let expected_ciphertext = td.cipher_text_base64;
+			assert_eq!(expected_ciphertext, encrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_128_encrypt_128_key() {
-        for td in get_test_data().aes128_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let plain_key = td.key_to_encrypt128;
-            let encrypted_bytes = aes_128_encrypt_no_padding_fixed_iv(
-                &key,
-                &plain_key,
-            ).unwrap();
-            let expected_encrypted_key = td.encrypted_key128;
-            assert_eq!(expected_encrypted_key, encrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_128_encrypt_128_key() {
+		for td in get_test_data().aes128_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let plain_key = td.key_to_encrypt128;
+			let encrypted_bytes = aes_128_encrypt_no_padding_fixed_iv(&key, &plain_key).unwrap();
+			let expected_encrypted_key = td.encrypted_key128;
+			assert_eq!(expected_encrypted_key, encrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_128_encrypt_256_key() {
-        for td in get_test_data().aes128_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let plain_key = td.key_to_encrypt256;
-            let encrypted_bytes = aes_128_encrypt_no_padding_fixed_iv(
-                &key,
-                &plain_key,
-            ).unwrap();
-            let expected_encrypted_key = td.encrypted_key256;
-            assert_eq!(expected_encrypted_key, encrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_128_encrypt_256_key() {
+		for td in get_test_data().aes128_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let plain_key = td.key_to_encrypt256;
+			let encrypted_bytes = aes_128_encrypt_no_padding_fixed_iv(&key, &plain_key).unwrap();
+			let expected_encrypted_key = td.encrypted_key256;
+			assert_eq!(expected_encrypted_key, encrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_128_decrypt_no_mac() {
-        for td in get_test_data().aes128_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let ciphertext = td.cipher_text_base64;
+	#[test]
+	fn test_aes_128_decrypt_no_mac() {
+		for td in get_test_data().aes128_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let ciphertext = td.cipher_text_base64;
 
-            let decrypted_bytes = aes_128_decrypt(
-                &key,
-                &ciphertext,
-            ).unwrap().data;
+			let decrypted_bytes = aes_128_decrypt(&key, &ciphertext).unwrap().data;
 
-            let expected_plaintext = td.plain_text_base64;
-            assert_eq!(expected_plaintext, decrypted_bytes);
-        }
-    }
+			let expected_plaintext = td.plain_text_base64;
+			assert_eq!(expected_plaintext, decrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_128_decrypt_128_key() {
-        for td in get_test_data().aes128_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let encrypted_key = td.encrypted_key128;
+	#[test]
+	fn test_aes_128_decrypt_128_key() {
+		for td in get_test_data().aes128_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let encrypted_key = td.encrypted_key128;
 
-            let decrypted_bytes = aes_128_decrypt_no_padding_fixed_iv(
-                &key,
-                encrypted_key.as_slice(),
-            ).unwrap();
+			let decrypted_bytes =
+				aes_128_decrypt_no_padding_fixed_iv(&key, encrypted_key.as_slice()).unwrap();
 
-            let expected_plain_key = td.key_to_encrypt128;
-            assert_eq!(expected_plain_key, decrypted_bytes);
-        }
-    }
+			let expected_plain_key = td.key_to_encrypt128;
+			assert_eq!(expected_plain_key, decrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_128_decrypt_256_key() {
-        for td in get_test_data().aes128_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let encrypted_key = td.encrypted_key256;
+	#[test]
+	fn test_aes_128_decrypt_256_key() {
+		for td in get_test_data().aes128_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let encrypted_key = td.encrypted_key256;
 
-            let decrypted_bytes = aes_128_decrypt_no_padding_fixed_iv(
-                &key,
-                encrypted_key.as_slice(),
-            ).unwrap();
+			let decrypted_bytes =
+				aes_128_decrypt_no_padding_fixed_iv(&key, encrypted_key.as_slice()).unwrap();
 
-            let expected_plain_key = td.key_to_encrypt256;
-            assert_eq!(expected_plain_key, decrypted_bytes);
-        }
-    }
+			let expected_plain_key = td.key_to_encrypt256;
+			assert_eq!(expected_plain_key, decrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_128_decrypt_mac() {
-        for td in get_test_data().aes128_mac_tests {
-            let key: Aes128Key = td.hex_key.try_into().unwrap();
-            let ciphertext = td.cipher_text_base64;
+	#[test]
+	fn test_aes_128_decrypt_mac() {
+		for td in get_test_data().aes128_mac_tests {
+			let key: Aes128Key = td.hex_key.try_into().unwrap();
+			let ciphertext = td.cipher_text_base64;
 
-            let decrypted_bytes = aes_128_decrypt(
-                &key,
-                &ciphertext,
-            ).unwrap().data;
+			let decrypted_bytes = aes_128_decrypt(&key, &ciphertext).unwrap().data;
 
-            let expected_plaintext = td.plain_text_base64;
-            assert_eq!(expected_plaintext, decrypted_bytes, "failed test: {}", BASE64_STANDARD.encode(&ciphertext));
-        }
-    }
+			let expected_plaintext = td.plain_text_base64;
+			assert_eq!(
+				expected_plaintext,
+				decrypted_bytes,
+				"failed test: {}",
+				BASE64_STANDARD.encode(&ciphertext)
+			);
+		}
+	}
 
-    #[test]
-    fn test_aes_256_encrypt_with_padding_mac() {
-        for td in get_test_data().aes256_tests {
-            let key: Aes256Key = td.hex_key.try_into().unwrap();
-            let plaintext = td.plain_text_base64;
-            let iv = &Iv(td.iv_base64.try_into().unwrap());
-            let encrypted_bytes = aes_256_encrypt(
-                &key,
-                &plaintext,
-                iv,
-                PaddingMode::WithPadding,
-            ).unwrap();
-            let expected_ciphertext = td.cipher_text_base64;
-            assert_eq!(expected_ciphertext, encrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_256_encrypt_with_padding_mac() {
+		for td in get_test_data().aes256_tests {
+			let key: Aes256Key = td.hex_key.try_into().unwrap();
+			let plaintext = td.plain_text_base64;
+			let iv = &Iv(td.iv_base64.try_into().unwrap());
+			let encrypted_bytes =
+				aes_256_encrypt(&key, &plaintext, iv, PaddingMode::WithPadding).unwrap();
+			let expected_ciphertext = td.cipher_text_base64;
+			assert_eq!(expected_ciphertext, encrypted_bytes);
+		}
+	}
 
+	#[test]
+	fn test_aes_256_decrypt_mac() {
+		for td in get_test_data().aes256_tests {
+			let key: Aes256Key = td.hex_key.try_into().unwrap();
+			let ciphertext = td.cipher_text_base64;
 
-    #[test]
-    fn test_aes_256_decrypt_mac() {
-        for td in get_test_data().aes256_tests {
-            let key: Aes256Key = td.hex_key.try_into().unwrap();
-            let ciphertext = td.cipher_text_base64;
+			let decrypted_bytes = aes_256_decrypt(&key, &ciphertext).unwrap().data;
 
-            let decrypted_bytes = aes_256_decrypt(
-                &key,
-                &ciphertext,
-            ).unwrap().data;
+			let expected_plaintext = td.plain_text_base64;
+			assert_eq!(
+				expected_plaintext,
+				decrypted_bytes,
+				"failed test: {}",
+				BASE64_STANDARD.encode(&ciphertext)
+			);
+		}
+	}
 
-            let expected_plaintext = td.plain_text_base64;
-            assert_eq!(expected_plaintext, decrypted_bytes, "failed test: {}", BASE64_STANDARD.encode(&ciphertext));
-        }
-    }
+	#[test]
+	fn test_aes_256_encrypt_256_key() {
+		for td in get_test_data().aes256_tests {
+			let key: Aes256Key = td.hex_key.try_into().unwrap();
+			let plain_key = td.key_to_encrypt256;
+			let iv = &Iv(td.iv_base64.try_into().unwrap());
+			let encrypted_bytes =
+				aes_256_encrypt(&key, &plain_key, iv, PaddingMode::NoPadding).unwrap();
+			let expected_encrypted_key = td.encrypted_key256;
+			assert_eq!(expected_encrypted_key, encrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_256_encrypt_256_key() {
-        for td in get_test_data().aes256_tests {
-            let key: Aes256Key = td.hex_key.try_into().unwrap();
-            let plain_key = td.key_to_encrypt256;
-            let iv = &Iv(td.iv_base64.try_into().unwrap());
-            let encrypted_bytes = aes_256_encrypt(
-                &key,
-                &plain_key,
-                iv,
-                PaddingMode::NoPadding,
-            ).unwrap();
-            let expected_encrypted_key = td.encrypted_key256;
-            assert_eq!(expected_encrypted_key, encrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_256_decrypt_256_key() {
+		for td in get_test_data().aes256_tests {
+			let key: Aes256Key = td.hex_key.try_into().unwrap();
+			let encrypted_key = td.encrypted_key256;
 
-    #[test]
-    fn test_aes_256_decrypt_256_key() {
-        for td in get_test_data().aes256_tests {
-            let key: Aes256Key = td.hex_key.try_into().unwrap();
-            let encrypted_key = td.encrypted_key256;
+			let decrypted_bytes = aes_256_decrypt_no_padding(&key, encrypted_key.as_slice())
+				.unwrap()
+				.data;
 
-            let decrypted_bytes = aes_256_decrypt_no_padding(
-                &key,
-                encrypted_key.as_slice(),
-            ).unwrap().data;
+			let expected_plain_key = td.key_to_encrypt256;
+			assert_eq!(expected_plain_key, decrypted_bytes);
+		}
+	}
 
-            let expected_plain_key = td.key_to_encrypt256;
-            assert_eq!(expected_plain_key, decrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_256_encrypt_128_key() {
+		for td in get_test_data().aes256_tests {
+			let key: Aes256Key = td.hex_key.try_into().unwrap();
+			let plain_key = td.key_to_encrypt128;
+			let iv = &Iv(td.iv_base64.try_into().unwrap());
+			let encrypted_bytes =
+				aes_256_encrypt(&key, &plain_key, iv, PaddingMode::NoPadding).unwrap();
+			let expected_encrypted_key = td.encrypted_key128;
+			assert_eq!(expected_encrypted_key, encrypted_bytes);
+		}
+	}
 
-    #[test]
-    fn test_aes_256_encrypt_128_key() {
-        for td in get_test_data().aes256_tests {
-            let key: Aes256Key = td.hex_key.try_into().unwrap();
-            let plain_key = td.key_to_encrypt128;
-            let iv = &Iv(td.iv_base64.try_into().unwrap());
-            let encrypted_bytes = aes_256_encrypt(
-                &key,
-                &plain_key,
-                iv,
-                PaddingMode::NoPadding,
-            ).unwrap();
-            let expected_encrypted_key = td.encrypted_key128;
-            assert_eq!(expected_encrypted_key, encrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_256_decrypt_128_key() {
+		for td in get_test_data().aes256_tests {
+			let key: Aes256Key = td.hex_key.try_into().unwrap();
+			let encrypted_key = td.encrypted_key128;
 
-    #[test]
-    fn test_aes_256_decrypt_128_key() {
-        for td in get_test_data().aes256_tests {
-            let key: Aes256Key = td.hex_key.try_into().unwrap();
-            let encrypted_key = td.encrypted_key128;
+			let decrypted_bytes = aes_256_decrypt_no_padding(&key, encrypted_key.as_slice())
+				.unwrap()
+				.data;
 
-            let decrypted_bytes = aes_256_decrypt_no_padding(
-                &key,
-                encrypted_key.as_slice(),
-            ).unwrap().data;
+			let expected_plain_key = td.key_to_encrypt128;
+			assert_eq!(expected_plain_key, decrypted_bytes);
+		}
+	}
 
-            let expected_plain_key = td.key_to_encrypt128;
-            assert_eq!(expected_plain_key, decrypted_bytes);
-        }
-    }
+	#[test]
+	fn test_aes_decrypt_does_not_panic_with_invalid_data() {
+		let randomizer = make_thread_rng_facade();
+		let key_128 = Aes128Key::generate(&randomizer);
+		let key_256 = Aes256Key::generate(&randomizer);
 
-    #[test]
-    fn test_aes_decrypt_does_not_panic_with_invalid_data() {
-        let randomizer = make_thread_rng_facade();
-        let key_128 = Aes128Key::generate(&randomizer);
-        let key_256 = Aes256Key::generate(&randomizer);
-
-        let mut v = Vec::with_capacity(256);
-        for length in 0..256 {
-            v.resize(length, 0);
-            let o = aes_decrypt(&key_128, v.as_slice(), PaddingMode::WithPadding, EnforceMac::EnforceMac).is_err();
-            assert!(o);
-            let o = aes_decrypt(&key_128, v.as_slice(), PaddingMode::NoPadding, EnforceMac::EnforceMac).is_err();
-            assert!(o);
-            let o = aes_decrypt(&key_256, v.as_slice(), PaddingMode::WithPadding, EnforceMac::EnforceMac).is_err();
-            assert!(o);
-            let o = aes_decrypt(&key_256, v.as_slice(), PaddingMode::NoPadding, EnforceMac::EnforceMac).is_err();
-            assert!(o);
-        }
-    }
+		let mut v = Vec::with_capacity(256);
+		for length in 0..256 {
+			v.resize(length, 0);
+			let o = aes_decrypt(
+				&key_128,
+				v.as_slice(),
+				PaddingMode::WithPadding,
+				EnforceMac::EnforceMac,
+			)
+			.is_err();
+			assert!(o);
+			let o = aes_decrypt(
+				&key_128,
+				v.as_slice(),
+				PaddingMode::NoPadding,
+				EnforceMac::EnforceMac,
+			)
+			.is_err();
+			assert!(o);
+			let o = aes_decrypt(
+				&key_256,
+				v.as_slice(),
+				PaddingMode::WithPadding,
+				EnforceMac::EnforceMac,
+			)
+			.is_err();
+			assert!(o);
+			let o = aes_decrypt(
+				&key_256,
+				v.as_slice(),
+				PaddingMode::NoPadding,
+				EnforceMac::EnforceMac,
+			)
+			.is_err();
+			assert!(o);
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/argon2_id.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/argon2_id.rs
@@ -1,5 +1,5 @@
 use crate::crypto::aes::Aes256Key;
-use argon2::{Argon2, Algorithm, Version, Params};
+use argon2::{Algorithm, Argon2, Params, Version};
 use zeroize::Zeroizing;
 
 const ARGON2ID_ITERATIONS: u32 = 4;
@@ -12,28 +12,34 @@ const ARGON2ID_KEY_LENGTH: usize = 32;
 /// `salt` 16 bytes of random data
 /// returns resolved with the key
 pub fn generate_key_from_passphrase(password: &str, salt: [u8; 16]) -> Aes256Key {
-    let params = Params::new(
-        ARGON2ID_MEMORY_IN_KIB,
-        ARGON2ID_ITERATIONS,
-        ARGON2ID_PARALLELISM,
-        Some(ARGON2ID_KEY_LENGTH),
-    ).unwrap();
-    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
-    let mut output = Zeroizing::new([0u8; ARGON2ID_KEY_LENGTH]);
-    argon2.hash_password_into(password.as_bytes(), salt.as_ref(), output.as_mut()).unwrap();
-    Aes256Key::from_bytes(output.as_ref()).unwrap()
+	let params = Params::new(
+		ARGON2ID_MEMORY_IN_KIB,
+		ARGON2ID_ITERATIONS,
+		ARGON2ID_PARALLELISM,
+		Some(ARGON2ID_KEY_LENGTH),
+	)
+	.unwrap();
+	let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+	let mut output = Zeroizing::new([0u8; ARGON2ID_KEY_LENGTH]);
+	argon2
+		.hash_password_into(password.as_bytes(), salt.as_ref(), output.as_mut())
+		.unwrap();
+	Aes256Key::from_bytes(output.as_ref()).unwrap()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::compatibility_test_utils::get_test_data;
-    use super::*;
+	use super::*;
+	use crate::crypto::compatibility_test_utils::get_test_data;
 
-    #[test]
-    fn test_argon2() {
-        for test_data in get_test_data().argon2id_tests {
-            let key = generate_key_from_passphrase(&test_data.password, test_data.salt_hex.as_slice().try_into().unwrap());
-            assert_eq!(test_data.key_hex.as_slice(), key.as_bytes());
-        }
-    }
+	#[test]
+	fn test_argon2() {
+		for test_data in get_test_data().argon2id_tests {
+			let key = generate_key_from_passphrase(
+				&test_data.password,
+				test_data.salt_hex.as_slice().try_into().unwrap(),
+			);
+			assert_eq!(test_data.key_hex.as_slice(), key.as_bytes());
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/compatibility_test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/compatibility_test_utils.rs
@@ -1,166 +1,166 @@
+use base64::engine::{general_purpose::STANDARD as BASE64, Engine};
 use serde::{Deserialize, Deserializer, Serializer};
-use base64::engine::{Engine, general_purpose::STANDARD as BASE64};
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AesTest {
-    #[serde(with = "Base64")]
-    pub plain_text_base64: Vec<u8>,
-    #[serde(with = "Base64")]
-    pub iv_base64: Vec<u8>,
-    #[serde(with = "Base64")]
-    pub cipher_text_base64: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub hex_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub key_to_encrypt256: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub key_to_encrypt128: Vec<u8>,
-    #[serde(with = "Base64")]
-    pub encrypted_key256: Vec<u8>,
-    #[serde(with = "Base64")]
-    pub encrypted_key128: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub plain_text_base64: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub iv_base64: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub cipher_text_base64: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub hex_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub key_to_encrypt256: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub key_to_encrypt128: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub encrypted_key256: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub encrypted_key128: Vec<u8>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Aes128MacTest {
-    #[serde(with = "Base64")]
-    pub plain_text_base64: Vec<u8>,
-    #[serde(with = "Base64")]
-    pub iv_base64: Vec<u8>,
-    #[serde(with = "Base64")]
-    pub cipher_text_base64: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub hex_key: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub plain_text_base64: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub iv_base64: Vec<u8>,
+	#[serde(with = "Base64")]
+	pub cipher_text_base64: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub hex_key: Vec<u8>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HkdfTest {
-    #[serde(with = "const_hex")]
-    pub salt_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub input_key_material_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub info_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub hkdf_hex: Vec<u8>,
-    pub length_in_bytes: usize,
+	#[serde(with = "const_hex")]
+	pub salt_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub input_key_material_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub info_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub hkdf_hex: Vec<u8>,
+	pub length_in_bytes: usize,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Argon2Test {
-    pub password: String,
-    #[serde(with = "const_hex")]
-    pub key_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub salt_hex: Vec<u8>,
+	pub password: String,
+	#[serde(with = "const_hex")]
+	pub key_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub salt_hex: Vec<u8>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct X25519Test {
-    #[serde(with = "const_hex")]
-    pub alice_private_key_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub alice_public_key_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub ephemeral_private_key_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub ephemeral_public_key_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub bob_private_key_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub bob_public_key_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub ephemeral_shared_secret_hex: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub auth_shared_secret_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub alice_private_key_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub alice_public_key_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub ephemeral_private_key_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub ephemeral_public_key_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub bob_private_key_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub bob_public_key_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub ephemeral_shared_secret_hex: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub auth_shared_secret_hex: Vec<u8>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KyberEncryptionTest {
-    #[serde(with = "const_hex")]
-    pub public_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub private_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub seed: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub cipher_text: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub shared_secret: Vec<u8>
+	#[serde(with = "const_hex")]
+	pub public_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub private_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub seed: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub cipher_text: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub shared_secret: Vec<u8>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RSAEncryptionTest {
-    #[serde(with = "const_hex")]
-    pub public_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub private_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub input: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub seed: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub result: Vec<u8>
+	#[serde(with = "const_hex")]
+	pub public_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub private_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub input: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub seed: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub result: Vec<u8>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PQCryptEncryptionTest {
-    #[serde(with = "const_hex")]
-    pub private_kyber_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub public_kyber_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub public_x25519_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub private_x25519_key: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub epheremal_public_x25519_key: Vec<u8>, // note: misspelling of "ephemeral"
-    #[serde(with = "const_hex")]
-    pub epheremal_private_x25519_key: Vec<u8>, // note: misspelling of "ephemeral"
-    #[serde(with = "const_hex")]
-    pub pq_message: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub seed: Vec<u8>,
-    #[serde(with = "const_hex")]
-    pub bucket_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub private_kyber_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub public_kyber_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub public_x25519_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub private_x25519_key: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub epheremal_public_x25519_key: Vec<u8>, // note: misspelling of "ephemeral"
+	#[serde(with = "const_hex")]
+	pub epheremal_private_x25519_key: Vec<u8>, // note: misspelling of "ephemeral"
+	#[serde(with = "const_hex")]
+	pub pq_message: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub seed: Vec<u8>,
+	#[serde(with = "const_hex")]
+	pub bucket_key: Vec<u8>,
 }
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CompatibilityTestData {
-    pub aes128_tests: Vec<AesTest>,
-    pub aes128_mac_tests: Vec<Aes128MacTest>,
-    pub aes256_tests: Vec<AesTest>,
-    pub hkdf_tests: Vec<HkdfTest>,
-    pub argon2id_tests: Vec<Argon2Test>,
-    pub x25519_tests: Vec<X25519Test>,
-    pub kyber_encryption_tests: Vec<KyberEncryptionTest>,
-    pub rsa_encryption_tests: Vec<RSAEncryptionTest>,
-    pub pqcrypt_encryption_tests: Vec<PQCryptEncryptionTest>
+	pub aes128_tests: Vec<AesTest>,
+	pub aes128_mac_tests: Vec<Aes128MacTest>,
+	pub aes256_tests: Vec<AesTest>,
+	pub hkdf_tests: Vec<HkdfTest>,
+	pub argon2id_tests: Vec<Argon2Test>,
+	pub x25519_tests: Vec<X25519Test>,
+	pub kyber_encryption_tests: Vec<KyberEncryptionTest>,
+	pub rsa_encryption_tests: Vec<RSAEncryptionTest>,
+	pub pqcrypt_encryption_tests: Vec<PQCryptEncryptionTest>,
 }
 
 struct Base64;
 
 impl Base64 {
-    fn serialize<S: Serializer>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&BASE64.encode(data))
-    }
+	fn serialize<S: Serializer>(data: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+		serializer.serialize_str(&BASE64.encode(data))
+	}
 
-    fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
-        let base64_str = <&str>::deserialize(deserializer)?;
-        BASE64.decode(base64_str).map_err(serde::de::Error::custom)
-    }
+	fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+		let base64_str = <&str>::deserialize(deserializer)?;
+		BASE64.decode(base64_str).map_err(serde::de::Error::custom)
+	}
 }
 
 pub fn get_test_data() -> CompatibilityTestData {
-    let data_json = include_str!("../../test_data/CompatibilityTestData.json");
-    serde_json::from_str(data_json).unwrap()
+	let data_json = include_str!("../../test_data/CompatibilityTestData.json");
+	serde_json::from_str(data_json).unwrap()
 }

--- a/tuta-sdk/rust/sdk/src/crypto/crypto_facade.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/crypto_facade.rs
@@ -11,12 +11,12 @@ use crate::crypto::tuta_crypt::{PQError, PQMessage};
 use crate::element_value::{ElementValue, ParsedEntity};
 use crate::entities::sys::BucketKey;
 use crate::generated_id::GeneratedId;
-use crate::IdTuple;
 use crate::instance_mapper::InstanceMapper;
 #[mockall_double::double]
 use crate::key_loader_facade::KeyLoaderFacade;
 use crate::metamodel::TypeModel;
 use crate::util::ArrayCastingError;
+use crate::IdTuple;
 
 /// The name of the field that contains the session key encrypted
 /// by the owner group's key in an entity
@@ -32,212 +32,284 @@ const BUCKET_KEY_FIELD: &str = "bucketKey";
 
 #[derive(uniffi::Object)]
 pub struct CryptoFacade {
-    key_loader_facade: Arc<KeyLoaderFacade>,
-    instance_mapper: Arc<InstanceMapper>,
-    randomizer_facade: RandomizerFacade,
+	key_loader_facade: Arc<KeyLoaderFacade>,
+	instance_mapper: Arc<InstanceMapper>,
+	randomizer_facade: RandomizerFacade,
 }
 
 /// Session key that encrypts an entity and the same key encrypted with the owner group.
 /// owner_enc_session_key is stored on entities to avoid public key encryption on subsequent loads.
 pub struct ResolvedSessionKey {
-    pub session_key: GenericAesKey,
-    pub owner_enc_session_key: Vec<u8>,
+	pub session_key: GenericAesKey,
+	pub owner_enc_session_key: Vec<u8>,
 }
 
 #[cfg_attr(test, mockall::automock)]
 impl CryptoFacade {
-    pub fn new(
-        key_loader_facade: Arc<KeyLoaderFacade>,
-        instance_mapper: Arc<InstanceMapper>,
-        randomizer_facade: RandomizerFacade,
-    ) -> Self {
-        Self {
-            key_loader_facade,
-            instance_mapper,
-            randomizer_facade,
-        }
-    }
+	pub fn new(
+		key_loader_facade: Arc<KeyLoaderFacade>,
+		instance_mapper: Arc<InstanceMapper>,
+		randomizer_facade: RandomizerFacade,
+	) -> Self {
+		Self {
+			key_loader_facade,
+			instance_mapper,
+			randomizer_facade,
+		}
+	}
 
-    /// Returns the session key from `entity` and resolves the bucket key fields contained inside
-    /// if present
-    pub async fn resolve_session_key(&self, entity: &mut ParsedEntity, model: &TypeModel) -> Result<Option<ResolvedSessionKey>, SessionKeyResolutionError> {
-        if !model.marked_encrypted() {
-            return Ok(None);
-        }
+	/// Returns the session key from `entity` and resolves the bucket key fields contained inside
+	/// if present
+	pub async fn resolve_session_key(
+		&self,
+		entity: &mut ParsedEntity,
+		model: &TypeModel,
+	) -> Result<Option<ResolvedSessionKey>, SessionKeyResolutionError> {
+		if !model.marked_encrypted() {
+			return Ok(None);
+		}
 
-        // Derive the session key from the bucket key
-        if let Some(bucket_key_value) = entity.get(BUCKET_KEY_FIELD) {
-            match bucket_key_value {
-                ElementValue::Dict(_) => {
-                    let resolved_key = self.resolve_bucket_key(entity, model).await?;
-                    return Ok(Some(resolved_key));
-                }
-                ElementValue::Null => {}
-                _ => return Err(SessionKeyResolutionError { reason: "bucketKey is invalid!".to_string() })
-            }
-        }
+		// Derive the session key from the bucket key
+		if let Some(bucket_key_value) = entity.get(BUCKET_KEY_FIELD) {
+			match bucket_key_value {
+				ElementValue::Dict(_) => {
+					let resolved_key = self.resolve_bucket_key(entity, model).await?;
+					return Ok(Some(resolved_key));
+				},
+				ElementValue::Null => {},
+				_ => {
+					return Err(SessionKeyResolutionError {
+						reason: "bucketKey is invalid!".to_string(),
+					})
+				},
+			}
+		}
 
-        // Extract the session key data from the owner group of the entity
-        let EntityOwnerKeyData {
-            owner_enc_session_key: Some(owner_enc_session_key),
-            owner_key_version: Some(owner_key_version),
-            owner_group: Some(owner_group)
-        } = EntityOwnerKeyData::extract_owner_key_data(entity)? else {
-            return Err(SessionKeyResolutionError { reason: "instance missing owner key/group data".to_string() });
-        };
+		// Extract the session key data from the owner group of the entity
+		let EntityOwnerKeyData {
+			owner_enc_session_key: Some(owner_enc_session_key),
+			owner_key_version: Some(owner_key_version),
+			owner_group: Some(owner_group),
+		} = EntityOwnerKeyData::extract_owner_key_data(entity)?
+		else {
+			return Err(SessionKeyResolutionError {
+				reason: "instance missing owner key/group data".to_string(),
+			});
+		};
 
-        let group_key: GenericAesKey = self.key_loader_facade.load_sym_group_key(owner_group, owner_key_version, None).await?;
+		let group_key: GenericAesKey = self
+			.key_loader_facade
+			.load_sym_group_key(owner_group, owner_key_version, None)
+			.await?;
 
-        let session_key = group_key.decrypt_aes_key(owner_enc_session_key)?;
-        // TODO: performance: should we reuse owner_enc_session_key?
-        Ok(Some(ResolvedSessionKey { session_key, owner_enc_session_key: owner_enc_session_key.clone() }))
-    }
+		let session_key = group_key.decrypt_aes_key(owner_enc_session_key)?;
+		// TODO: performance: should we reuse owner_enc_session_key?
+		Ok(Some(ResolvedSessionKey {
+			session_key,
+			owner_enc_session_key: owner_enc_session_key.clone(),
+		}))
+	}
 
-    /// Resolves the bucket key fields inside `entity` and returns the session key
-    async fn resolve_bucket_key(&self, entity: &mut ParsedEntity, model: &TypeModel) -> Result<ResolvedSessionKey, SessionKeyResolutionError> {
-        let Some(ElementValue::Dict(bucket_key_map)) = entity.get(BUCKET_KEY_FIELD) else {
-            return Err(SessionKeyResolutionError { reason: format!("{BUCKET_KEY_FIELD} is not a dictionary type") });
-        };
+	/// Resolves the bucket key fields inside `entity` and returns the session key
+	async fn resolve_bucket_key(
+		&self,
+		entity: &mut ParsedEntity,
+		model: &TypeModel,
+	) -> Result<ResolvedSessionKey, SessionKeyResolutionError> {
+		let Some(ElementValue::Dict(bucket_key_map)) = entity.get(BUCKET_KEY_FIELD) else {
+			return Err(SessionKeyResolutionError {
+				reason: format!("{BUCKET_KEY_FIELD} is not a dictionary type"),
+			});
+		};
 
-        let bucket_key: BucketKey = match self.instance_mapper.parse_entity(bucket_key_map.to_owned()) {
-            Ok(n) => n,
-            Err(e) => return Err(SessionKeyResolutionError { reason: format!("{BUCKET_KEY_FIELD} could not be deserialized: {e}") })
-        };
+		let bucket_key: BucketKey =
+			match self.instance_mapper.parse_entity(bucket_key_map.to_owned()) {
+				Ok(n) => n,
+				Err(e) => {
+					return Err(SessionKeyResolutionError {
+						reason: format!("{BUCKET_KEY_FIELD} could not be deserialized: {e}"),
+					})
+				},
+			};
 
-        let owner_key_data = EntityOwnerKeyData::extract_owner_key_data(entity)?;
-        let Some(owner_group) = owner_key_data.owner_group else {
-            return Err(SessionKeyResolutionError { reason: "entity has no ownerGroup".to_owned() });
-        };
+		let owner_key_data = EntityOwnerKeyData::extract_owner_key_data(entity)?;
+		let Some(owner_group) = owner_key_data.owner_group else {
+			return Err(SessionKeyResolutionError {
+				reason: "entity has no ownerGroup".to_owned(),
+			});
+		};
 
-        let ResolvedBucketKey {
-            decrypted_bucket_key,
-            sender_identity_key: _sender_identity_key // TODO: Use when implementing authentication
-        } = self.decrypt_bucket_key(&bucket_key, owner_group, model).await?;
+		let ResolvedBucketKey {
+			decrypted_bucket_key,
+			sender_identity_key: _sender_identity_key, // TODO: Use when implementing authentication
+		} = self
+			.decrypt_bucket_key(&bucket_key, owner_group, model)
+			.await?;
 
-        let mut session_key_for_this_instance = None;
+		let mut session_key_for_this_instance = None;
 
-        for instance_session_key in bucket_key.bucketEncSessionKeys {
-            let decrypted_session_key = decrypted_bucket_key.decrypt_aes_key(instance_session_key.symEncSessionKey.as_slice())?;
+		for instance_session_key in bucket_key.bucketEncSessionKeys {
+			let decrypted_session_key = decrypted_bucket_key
+				.decrypt_aes_key(instance_session_key.symEncSessionKey.as_slice())?;
 
-            let instance_id = parse_id_field(entity.get(ID_FIELD))?;
+			let instance_id = parse_id_field(entity.get(ID_FIELD))?;
 
-            if &instance_session_key.instanceId == instance_id {
-                session_key_for_this_instance = Some(decrypted_session_key.clone());
-            }
-        }
+			if &instance_session_key.instanceId == instance_id {
+				session_key_for_this_instance = Some(decrypted_session_key.clone());
+			}
+		}
 
-        let Some(session_key) = session_key_for_this_instance else {
-            return Err(SessionKeyResolutionError { reason: "no session key found in bucket key for this instance".to_string() });
-        };
+		let Some(session_key) = session_key_for_this_instance else {
+			return Err(SessionKeyResolutionError {
+				reason: "no session key found in bucket key for this instance".to_string(),
+			});
+		};
 
-        // TODO: authenticate
-        let versioned_key = self.key_loader_facade.get_current_sym_group_key(owner_group).await?;
+		// TODO: authenticate
+		let versioned_key = self
+			.key_loader_facade
+			.get_current_sym_group_key(owner_group)
+			.await?;
 
-        let owner_enc_session_key = versioned_key.object.encrypt_key(&session_key, Iv::generate(&self.randomizer_facade));
-        Ok(ResolvedSessionKey { session_key, owner_enc_session_key })
-    }
+		let owner_enc_session_key = versioned_key
+			.object
+			.encrypt_key(&session_key, Iv::generate(&self.randomizer_facade));
+		Ok(ResolvedSessionKey {
+			session_key,
+			owner_enc_session_key,
+		})
+	}
 
-    /// Decrypts a bucket key, using `owner_group` in the case of secure external.
-    ///
-    /// `model` should be the type model of the instance being decrypted (e.g. `Mail`).
-    // Remove allowance after implementing secure external resolveWithGroupReference
-    #[allow(unused_variables, unused_assignments)]
-    async fn decrypt_bucket_key(&self, bucket_key: &BucketKey, owner_group: &GeneratedId, model: &TypeModel) -> Result<ResolvedBucketKey, SessionKeyResolutionError> {
-        let mut auth_status = None;
+	/// Decrypts a bucket key, using `owner_group` in the case of secure external.
+	///
+	/// `model` should be the type model of the instance being decrypted (e.g. `Mail`).
+	// Remove allowance after implementing secure external resolveWithGroupReference
+	#[allow(unused_variables, unused_assignments)]
+	async fn decrypt_bucket_key(
+		&self,
+		bucket_key: &BucketKey,
+		owner_group: &GeneratedId,
+		model: &TypeModel,
+	) -> Result<ResolvedBucketKey, SessionKeyResolutionError> {
+		let mut auth_status = None;
 
-        let resolved_key = if let (Some(key_group), Some(pub_enc_bucket_key)) = (&bucket_key.keyGroup, &bucket_key.pubEncBucketKey) {
-            let keypair = self.key_loader_facade.load_key_pair(key_group, bucket_key.recipientKeyVersion).await?;
-            match keypair {
-                AsymmetricKeyPair::PQKeyPairs(k) => {
-                    let decrypted_bucket_key = PQMessage::deserialize(pub_enc_bucket_key)?.decapsulate(&k)?.into();
-                    ResolvedBucketKey {
-                        decrypted_bucket_key,
-                        sender_identity_key: Some(k.ecc_keys.public_key),
-                    }
-                }
-                AsymmetricKeyPair::RSAEccKeyPair(RSAEccKeyPair { rsa_key_pair: k, .. }) | AsymmetricKeyPair::RSAKeyPair(k) => {
-                    let bucket_key_bytes = Zeroizing::new(k.private_key.decrypt(pub_enc_bucket_key)?);
-                    let decrypted_bucket_key = GenericAesKey::from_bytes(bucket_key_bytes.as_slice())?;
-                    ResolvedBucketKey {
-                        decrypted_bucket_key,
-                        sender_identity_key: None,
-                    }
-                }
-            }
-        } else if let Some(_group_enc_bucket_key) = &bucket_key.groupEncBucketKey {
-            // TODO: to be used with secure external
-            let _key_group = bucket_key.keyGroup.as_ref().unwrap_or(owner_group);
-            auth_status = Some(EncryptionAuthStatus::AESNoAuthentication);
-            todo!("secure external resolveWithGroupReference")
-        } else {
-            return Err(SessionKeyResolutionError { reason: format!("encrypted bucket key not set on instance {}/{}", model.app, model.name) });
-        };
+		let resolved_key = if let (Some(key_group), Some(pub_enc_bucket_key)) =
+			(&bucket_key.keyGroup, &bucket_key.pubEncBucketKey)
+		{
+			let keypair = self
+				.key_loader_facade
+				.load_key_pair(key_group, bucket_key.recipientKeyVersion)
+				.await?;
+			match keypair {
+				AsymmetricKeyPair::PQKeyPairs(k) => {
+					let decrypted_bucket_key = PQMessage::deserialize(pub_enc_bucket_key)?
+						.decapsulate(&k)?
+						.into();
+					ResolvedBucketKey {
+						decrypted_bucket_key,
+						sender_identity_key: Some(k.ecc_keys.public_key),
+					}
+				},
+				AsymmetricKeyPair::RSAEccKeyPair(RSAEccKeyPair {
+					rsa_key_pair: k, ..
+				})
+				| AsymmetricKeyPair::RSAKeyPair(k) => {
+					let bucket_key_bytes =
+						Zeroizing::new(k.private_key.decrypt(pub_enc_bucket_key)?);
+					let decrypted_bucket_key =
+						GenericAesKey::from_bytes(bucket_key_bytes.as_slice())?;
+					ResolvedBucketKey {
+						decrypted_bucket_key,
+						sender_identity_key: None,
+					}
+				},
+			}
+		} else if let Some(_group_enc_bucket_key) = &bucket_key.groupEncBucketKey {
+			// TODO: to be used with secure external
+			let _key_group = bucket_key.keyGroup.as_ref().unwrap_or(owner_group);
+			auth_status = Some(EncryptionAuthStatus::AESNoAuthentication);
+			todo!("secure external resolveWithGroupReference")
+		} else {
+			return Err(SessionKeyResolutionError {
+				reason: format!(
+					"encrypted bucket key not set on instance {}/{}",
+					model.app, model.name
+				),
+			});
+		};
 
-        Ok(resolved_key)
-    }
+		Ok(resolved_key)
+	}
 }
 
 /// Resolves the id field of an entity into a generated id
-fn parse_id_field(id_field: Option<&ElementValue>) -> Result<&GeneratedId, SessionKeyResolutionError> {
-    match id_field {
-        Some(ElementValue::IdGeneratedId(id)) => Ok(id),
-        Some(ElementValue::IdTupleId(IdTuple { element_id, .. })) => Ok(element_id),
-        None => Err(SessionKeyResolutionError {
-            reason: "no id present on instance".to_string()
-        }),
-        Some(actual) => Err(SessionKeyResolutionError {
-            reason: format!("unexpected {} type for id on instance", actual.type_variant_name())
-        }),
-    }
+fn parse_id_field(
+	id_field: Option<&ElementValue>,
+) -> Result<&GeneratedId, SessionKeyResolutionError> {
+	match id_field {
+		Some(ElementValue::IdGeneratedId(id)) => Ok(id),
+		Some(ElementValue::IdTupleId(IdTuple { element_id, .. })) => Ok(element_id),
+		None => Err(SessionKeyResolutionError {
+			reason: "no id present on instance".to_string(),
+		}),
+		Some(actual) => Err(SessionKeyResolutionError {
+			reason: format!(
+				"unexpected {} type for id on instance",
+				actual.type_variant_name()
+			),
+		}),
+	}
 }
 
 /// Denotes if an entity was authenticated successfully.
 ///
 /// Not all decryption methods use authentication.
 pub enum EncryptionAuthStatus {
-    /// The entity was decrypted with RSA which does not use authentication.
-    RSANoAuthentication = 0,
+	/// The entity was decrypted with RSA which does not use authentication.
+	RSANoAuthentication = 0,
 
-    /// The entity was decrypted with Tutacrypt (PQ) and successfully authenticated.
-    TutacryptAuthenticationSucceeded = 1,
+	/// The entity was decrypted with Tutacrypt (PQ) and successfully authenticated.
+	TutacryptAuthenticationSucceeded = 1,
 
-    /// The entity was decrypted with Tutacrypt (PQ), but authentication failed.
-    TutacryptAuthenticationFailed = 2,
+	/// The entity was decrypted with Tutacrypt (PQ), but authentication failed.
+	TutacryptAuthenticationFailed = 2,
 
-    /// The entity was decrypted symmetrically (i.e. secure external) which does not use authentication.
-    AESNoAuthentication = 3,
+	/// The entity was decrypted symmetrically (i.e. secure external) which does not use authentication.
+	AESNoAuthentication = 3,
 
-    /// The entity was sent by the user and doesn't need authenticated.
-    TutacryptSender = 4,
+	/// The entity was sent by the user and doesn't need authenticated.
+	TutacryptSender = 4,
 }
 
 /// Used for identifying the protocol version used for encrypting a session key.
 #[repr(i64)]
 pub enum CryptoProtocolVersion {
-    /// Legacy asymmetric encryption (RSA-2048)
-    Rsa = 0,
+	/// Legacy asymmetric encryption (RSA-2048)
+	Rsa = 0,
 
-    /// Secure external
-    SymmetricEncryption = 1,
+	/// Secure external
+	SymmetricEncryption = 1,
 
-    /// PQ encryption (Kyber+X25519)
-    Tutacrypt = 2,
+	/// PQ encryption (Kyber+X25519)
+	Tutacrypt = 2,
 }
 
 struct ResolvedBucketKey {
-    decrypted_bucket_key: GenericAesKey,
-    sender_identity_key: Option<EccPublicKey>,
+	decrypted_bucket_key: GenericAesKey,
+	sender_identity_key: Option<EccPublicKey>,
 }
 
 struct EntityOwnerKeyData<'a> {
-    owner_enc_session_key: Option<&'a Vec<u8>>,
-    owner_key_version: Option<i64>,
-    owner_group: Option<&'a GeneratedId>,
+	owner_enc_session_key: Option<&'a Vec<u8>>,
+	owner_key_version: Option<i64>,
+	owner_group: Option<&'a GeneratedId>,
 }
 
 impl<'a> EntityOwnerKeyData<'a> {
-    fn extract_owner_key_data(entity: &'a ParsedEntity) -> Result<EntityOwnerKeyData<'a>, SessionKeyResolutionError> {
-        macro_rules! get_nullable_field {
+	fn extract_owner_key_data(
+		entity: &'a ParsedEntity,
+	) -> Result<EntityOwnerKeyData<'a>, SessionKeyResolutionError> {
+		macro_rules! get_nullable_field {
             ($entity:expr, $field:expr, $type:tt) => {
                 match $entity.get($field) {
                     Some(ElementValue::$type(q)) => Ok(Some(q)),
@@ -247,31 +319,34 @@ impl<'a> EntityOwnerKeyData<'a> {
             };
         }
 
-        let owner_enc_session_key = get_nullable_field!(entity, OWNER_ENC_SESSION_FIELD, Bytes)?;
-        let owner_key_version = get_nullable_field!(entity, OWNER_KEY_VERSION_FIELD, Number)?.copied();
-        let owner_group = get_nullable_field!(entity, OWNER_GROUP_FIELD, IdGeneratedId)?;
+		let owner_enc_session_key = get_nullable_field!(entity, OWNER_ENC_SESSION_FIELD, Bytes)?;
+		let owner_key_version =
+			get_nullable_field!(entity, OWNER_KEY_VERSION_FIELD, Number)?.copied();
+		let owner_group = get_nullable_field!(entity, OWNER_GROUP_FIELD, IdGeneratedId)?;
 
-        Ok(EntityOwnerKeyData {
-            owner_enc_session_key,
-            owner_key_version,
-            owner_group,
-        })
-    }
+		Ok(EntityOwnerKeyData {
+			owner_enc_session_key,
+			owner_key_version,
+			owner_group,
+		})
+	}
 }
 
 #[derive(thiserror::Error, Debug)]
 #[error("Session key resolution failure: {reason}")]
 pub struct SessionKeyResolutionError {
-    reason: String,
+	reason: String,
 }
 
 /// Used to map various errors to `SessionKeyResolutionError`
 trait SessionKeyResolutionErrorSubtype: ToString {}
 
 impl<T: SessionKeyResolutionErrorSubtype> From<T> for SessionKeyResolutionError {
-    fn from(value: T) -> Self {
-        Self { reason: value.to_string() }
-    }
+	fn from(value: T) -> Self {
+		Self {
+			reason: value.to_string(),
+		}
+	}
 }
 
 impl SessionKeyResolutionErrorSubtype for KeyLoadError {}
@@ -285,203 +360,279 @@ impl SessionKeyResolutionErrorSubtype for RSAEncryptionError {}
 // FIXME: check for returned owner_enc_session_key
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
+	use std::sync::Arc;
 
-    use crate::crypto::aes::{Aes256Key, Iv};
-    use crate::crypto::crypto_facade::{CryptoFacade, CryptoProtocolVersion};
-    use crate::crypto::ecc::EccKeyPair;
-    use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey};
-    use crate::crypto::randomizer_facade::RandomizerFacade;
-    use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
-    use crate::crypto::rsa::{RSAEccKeyPair, RSAKeyPair};
-    use crate::crypto::tuta_crypt::{PQKeyPairs, PQMessage};
-    use crate::element_value::ParsedEntity;
-    use crate::entities::Entity;
-    use crate::entities::sys::{BucketKey, InstanceSessionKey};
-    use crate::entities::tutanota::Mail;
-    use crate::generated_id::GeneratedId;
-    use crate::IdTuple;
-    use crate::instance_mapper::InstanceMapper;
-    use crate::key_loader_facade::{MockKeyLoaderFacade, VersionedAesKey};
-    use crate::metamodel::TypeModel;
-    use crate::type_model_provider::init_type_model_provider;
-    use crate::util::test_utils::{create_test_entity, typed_entity_to_parsed_entity};
+	use crate::crypto::aes::{Aes256Key, Iv};
+	use crate::crypto::crypto_facade::{CryptoFacade, CryptoProtocolVersion};
+	use crate::crypto::ecc::EccKeyPair;
+	use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey};
+	use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
+	use crate::crypto::randomizer_facade::RandomizerFacade;
+	use crate::crypto::rsa::{RSAEccKeyPair, RSAKeyPair};
+	use crate::crypto::tuta_crypt::{PQKeyPairs, PQMessage};
+	use crate::element_value::ParsedEntity;
+	use crate::entities::sys::{BucketKey, InstanceSessionKey};
+	use crate::entities::tutanota::Mail;
+	use crate::entities::Entity;
+	use crate::generated_id::GeneratedId;
+	use crate::instance_mapper::InstanceMapper;
+	use crate::key_loader_facade::{MockKeyLoaderFacade, VersionedAesKey};
+	use crate::metamodel::TypeModel;
+	use crate::type_model_provider::init_type_model_provider;
+	use crate::util::test_utils::{create_test_entity, typed_entity_to_parsed_entity};
+	use crate::IdTuple;
 
-    #[tokio::test]
-    async fn test_pq_bucket_key_resolves() {
-        let randomizer_facade = make_thread_rng_facade();
-        let constants = BucketKeyConstants::new(&randomizer_facade);
+	#[tokio::test]
+	async fn test_pq_bucket_key_resolves() {
+		let randomizer_facade = make_thread_rng_facade();
+		let constants = BucketKeyConstants::new(&randomizer_facade);
 
-        let ephemeral_keys = EccKeyPair::generate(&randomizer_facade);
-        let asymmetric_keypair = PQKeyPairs::generate(&randomizer_facade);
-        let crypto_facade = make_crypto_facade(randomizer_facade.clone(), constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
+		let ephemeral_keys = EccKeyPair::generate(&randomizer_facade);
+		let asymmetric_keypair = PQKeyPairs::generate(&randomizer_facade);
+		let crypto_facade = make_crypto_facade(
+			randomizer_facade.clone(),
+			constants.group_key.clone(),
+			constants.sender_key_version,
+			asymmetric_keypair.clone(),
+		);
 
-        let encapsulation_iv = Iv::generate(&randomizer_facade);
-        let encapsulation = PQMessage::encapsulate(
-            &asymmetric_keypair.ecc_keys,
-            &ephemeral_keys,
-            &asymmetric_keypair.ecc_keys.public_key,
-            &asymmetric_keypair.kyber_keys.public_key,
-            &constants.bucket_key,
-            encapsulation_iv,
-        ).unwrap();
+		let encapsulation_iv = Iv::generate(&randomizer_facade);
+		let encapsulation = PQMessage::encapsulate(
+			&asymmetric_keypair.ecc_keys,
+			&ephemeral_keys,
+			&asymmetric_keypair.ecc_keys.public_key,
+			&asymmetric_keypair.kyber_keys.public_key,
+			&constants.bucket_key,
+			encapsulation_iv,
+		)
+		.unwrap();
 
-        let mut raw_mail = make_raw_mail(&constants, encapsulation.serialize(), CryptoProtocolVersion::Tutacrypt as i64);
-        let mail_type_model = get_mail_type_model();
+		let mut raw_mail = make_raw_mail(
+			&constants,
+			encapsulation.serialize(),
+			CryptoProtocolVersion::Tutacrypt as i64,
+		);
+		let mail_type_model = get_mail_type_model();
 
-        let key = crypto_facade.resolve_session_key(&mut raw_mail, &mail_type_model)
-            .await
-            .expect("should not have errored")
-            .expect("where is the key");
+		let key = crypto_facade
+			.resolve_session_key(&mut raw_mail, &mail_type_model)
+			.await
+			.expect("should not have errored")
+			.expect("where is the key");
 
-        assert_eq!(constants.mail_session_key.as_bytes(), key.session_key.as_bytes());
-    }
+		assert_eq!(
+			constants.mail_session_key.as_bytes(),
+			key.session_key.as_bytes()
+		);
+	}
 
-    #[tokio::test]
-    async fn test_rsa_bucket_key_resolves() {
-        let randomizer_facade = make_thread_rng_facade();
+	#[tokio::test]
+	async fn test_rsa_bucket_key_resolves() {
+		let randomizer_facade = make_thread_rng_facade();
 
-        let constants = BucketKeyConstants::new(&randomizer_facade);
-        let asymmetric_keypair = RSAKeyPair::generate(&randomizer_facade);
-        let crypto_facade = make_crypto_facade(randomizer_facade.clone(), constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
-        let pub_enc_bucket_key = asymmetric_keypair.public_key.encrypt(&randomizer_facade, constants.bucket_key.as_bytes()).unwrap();
+		let constants = BucketKeyConstants::new(&randomizer_facade);
+		let asymmetric_keypair = RSAKeyPair::generate(&randomizer_facade);
+		let crypto_facade = make_crypto_facade(
+			randomizer_facade.clone(),
+			constants.group_key.clone(),
+			constants.sender_key_version,
+			asymmetric_keypair.clone(),
+		);
+		let pub_enc_bucket_key = asymmetric_keypair
+			.public_key
+			.encrypt(&randomizer_facade, constants.bucket_key.as_bytes())
+			.unwrap();
 
-        let mut raw_mail = make_raw_mail(&constants, pub_enc_bucket_key, CryptoProtocolVersion::Rsa as i64);
-        let mail_type_model = get_mail_type_model();
-        let key = crypto_facade.resolve_session_key(&mut raw_mail, &mail_type_model)
-            .await
-            .expect("should not have errored")
-            .expect("where is the key");
+		let mut raw_mail = make_raw_mail(
+			&constants,
+			pub_enc_bucket_key,
+			CryptoProtocolVersion::Rsa as i64,
+		);
+		let mail_type_model = get_mail_type_model();
+		let key = crypto_facade
+			.resolve_session_key(&mut raw_mail, &mail_type_model)
+			.await
+			.expect("should not have errored")
+			.expect("where is the key");
 
-        assert_eq!(constants.mail_session_key.as_bytes(), key.session_key.as_bytes());
-    }
+		assert_eq!(
+			constants.mail_session_key.as_bytes(),
+			key.session_key.as_bytes()
+		);
+	}
 
-    #[tokio::test]
-    async fn test_rsa_ecc_bucket_key_resolves() {
-        let randomizer_facade = make_thread_rng_facade();
+	#[tokio::test]
+	async fn test_rsa_ecc_bucket_key_resolves() {
+		let randomizer_facade = make_thread_rng_facade();
 
-        let constants = BucketKeyConstants::new(&randomizer_facade);
-        let asymmetric_keypair = RSAEccKeyPair::generate(&randomizer_facade);
-        let crypto_facade = make_crypto_facade(randomizer_facade.clone(), constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
-        let pub_enc_bucket_key = asymmetric_keypair.rsa_key_pair.public_key.encrypt(&randomizer_facade, constants.bucket_key.as_bytes()).unwrap();
+		let constants = BucketKeyConstants::new(&randomizer_facade);
+		let asymmetric_keypair = RSAEccKeyPair::generate(&randomizer_facade);
+		let crypto_facade = make_crypto_facade(
+			randomizer_facade.clone(),
+			constants.group_key.clone(),
+			constants.sender_key_version,
+			asymmetric_keypair.clone(),
+		);
+		let pub_enc_bucket_key = asymmetric_keypair
+			.rsa_key_pair
+			.public_key
+			.encrypt(&randomizer_facade, constants.bucket_key.as_bytes())
+			.unwrap();
 
-        let mut raw_mail = make_raw_mail(&constants, pub_enc_bucket_key, CryptoProtocolVersion::Rsa as i64);
-        let mail_type_model = get_mail_type_model();
-        let key = crypto_facade.resolve_session_key(&mut raw_mail, &mail_type_model)
-            .await
-            .expect("should not have errored")
-            .expect("where is the key");
+		let mut raw_mail = make_raw_mail(
+			&constants,
+			pub_enc_bucket_key,
+			CryptoProtocolVersion::Rsa as i64,
+		);
+		let mail_type_model = get_mail_type_model();
+		let key = crypto_facade
+			.resolve_session_key(&mut raw_mail, &mail_type_model)
+			.await
+			.expect("should not have errored")
+			.expect("where is the key");
 
-        assert_eq!(constants.mail_session_key.as_bytes(), key.session_key.as_bytes());
-    }
+		assert_eq!(
+			constants.mail_session_key.as_bytes(),
+			key.session_key.as_bytes()
+		);
+	}
 
-    fn get_mail_type_model() -> TypeModel {
-        let provider = init_type_model_provider();
-        let mail_type_ref = Mail::type_ref();
-        provider.get_type_model(mail_type_ref.app, mail_type_ref.type_).unwrap().to_owned()
-    }
+	fn get_mail_type_model() -> TypeModel {
+		let provider = init_type_model_provider();
+		let mail_type_ref = Mail::type_ref();
+		provider
+			.get_type_model(mail_type_ref.app, mail_type_ref.type_)
+			.unwrap()
+			.to_owned()
+	}
 
-    fn make_raw_mail(constants: &BucketKeyConstants, pub_enc_bucket_key: Vec<u8>, protocol_version: i64) -> ParsedEntity {
-        let bucket_key_data = make_bucket_key(
-            constants.recipient_key_version,
-            pub_enc_bucket_key,
-            &constants.instance_id,
-            &constants.instance_list,
-            &constants.key_group,
-            constants.bucket_enc_session_key.clone(),
-            protocol_version,
-        );
+	fn make_raw_mail(
+		constants: &BucketKeyConstants,
+		pub_enc_bucket_key: Vec<u8>,
+		protocol_version: i64,
+	) -> ParsedEntity {
+		let bucket_key_data = make_bucket_key(
+			constants.recipient_key_version,
+			pub_enc_bucket_key,
+			&constants.instance_id,
+			&constants.instance_list,
+			&constants.key_group,
+			constants.bucket_enc_session_key.clone(),
+			protocol_version,
+		);
 
-        let mail = Mail {
-            _id: IdTuple { list_id: constants.instance_list.clone(), element_id: constants.instance_id.clone() },
-            _ownerGroup: Some(constants.key_group.clone()),
-            bucketKey: Some(bucket_key_data),
-            ..create_test_entity()
-        };
+		let mail = Mail {
+			_id: IdTuple {
+				list_id: constants.instance_list.clone(),
+				element_id: constants.instance_id.clone(),
+			},
+			_ownerGroup: Some(constants.key_group.clone()),
+			bucketKey: Some(bucket_key_data),
+			..create_test_entity()
+		};
 
-        typed_entity_to_parsed_entity(mail)
-    }
+		typed_entity_to_parsed_entity(mail)
+	}
 
-    struct BucketKeyConstants {
-        group_key: GenericAesKey,
-        mail_session_key: GenericAesKey,
-        instance_id: GeneratedId,
-        instance_list: GeneratedId,
-        key_group: GeneratedId,
-        bucket_key: Aes256Key,
-        bucket_key_generic: GenericAesKey,
-        bucket_enc_session_key: Vec<u8>,
-        sender_key_version: i64,
-        recipient_key_version: i64,
-    }
+	struct BucketKeyConstants {
+		group_key: GenericAesKey,
+		mail_session_key: GenericAesKey,
+		instance_id: GeneratedId,
+		instance_list: GeneratedId,
+		key_group: GeneratedId,
+		bucket_key: Aes256Key,
+		bucket_key_generic: GenericAesKey,
+		bucket_enc_session_key: Vec<u8>,
+		sender_key_version: i64,
+		recipient_key_version: i64,
+	}
 
-    impl BucketKeyConstants {
-        fn new(randomizer_facade: &RandomizerFacade) -> Self {
-            let group_key = GenericAesKey::from(Aes256Key::generate(randomizer_facade));
-            let bucket_key = Aes256Key::generate(randomizer_facade);
-            let mail_session_key = GenericAesKey::from(Aes256Key::generate(randomizer_facade));
-            let instance_id = GeneratedId::test_random();
-            let instance_list = GeneratedId::test_random();
-            let key_group = GeneratedId::test_random();
-            let bucket_key_generic = GenericAesKey::from(bucket_key.clone());
+	impl BucketKeyConstants {
+		fn new(randomizer_facade: &RandomizerFacade) -> Self {
+			let group_key = GenericAesKey::from(Aes256Key::generate(randomizer_facade));
+			let bucket_key = Aes256Key::generate(randomizer_facade);
+			let mail_session_key = GenericAesKey::from(Aes256Key::generate(randomizer_facade));
+			let instance_id = GeneratedId::test_random();
+			let instance_list = GeneratedId::test_random();
+			let key_group = GeneratedId::test_random();
+			let bucket_key_generic = GenericAesKey::from(bucket_key.clone());
 
-            let bucket_enc_session_key_iv = Iv::generate(randomizer_facade);
-            let bucket_enc_session_key = bucket_key_generic.encrypt_key(&mail_session_key, bucket_enc_session_key_iv);
-            let sender_key_version = 1;
-            let recipient_key_version = sender_key_version;
+			let bucket_enc_session_key_iv = Iv::generate(randomizer_facade);
+			let bucket_enc_session_key =
+				bucket_key_generic.encrypt_key(&mail_session_key, bucket_enc_session_key_iv);
+			let sender_key_version = 1;
+			let recipient_key_version = sender_key_version;
 
-            Self {
-                group_key,
-                bucket_key,
-                mail_session_key,
-                instance_id,
-                instance_list,
-                key_group,
-                bucket_key_generic,
-                bucket_enc_session_key,
-                sender_key_version,
-                recipient_key_version,
-            }
-        }
-    }
+			Self {
+				group_key,
+				bucket_key,
+				mail_session_key,
+				instance_id,
+				instance_list,
+				key_group,
+				bucket_key_generic,
+				bucket_enc_session_key,
+				sender_key_version,
+				recipient_key_version,
+			}
+		}
+	}
 
-    fn make_crypto_facade<T: Into<AsymmetricKeyPair> + Clone + Send + Sync + 'static>(randomizer_facade: RandomizerFacade, group_key: GenericAesKey, sender_key_version: i64, asymmetric_keypair: T) -> CryptoFacade {
-        let group_key = group_key.clone();
+	fn make_crypto_facade<T: Into<AsymmetricKeyPair> + Clone + Send + Sync + 'static>(
+		randomizer_facade: RandomizerFacade,
+		group_key: GenericAesKey,
+		sender_key_version: i64,
+		asymmetric_keypair: T,
+	) -> CryptoFacade {
+		let group_key = group_key.clone();
 
-        let mut key_loader = MockKeyLoaderFacade::default();
-        key_loader.expect_get_current_sym_group_key()
-            .returning(move |_| Ok(VersionedAesKey { version: sender_key_version, object: group_key.clone() }))
-            .once();
-        key_loader.expect_load_key_pair()
-            .returning(move |_, _| Ok(asymmetric_keypair.clone().into()))
-            .once();
+		let mut key_loader = MockKeyLoaderFacade::default();
+		key_loader
+			.expect_get_current_sym_group_key()
+			.returning(move |_| {
+				Ok(VersionedAesKey {
+					version: sender_key_version,
+					object: group_key.clone(),
+				})
+			})
+			.once();
+		key_loader
+			.expect_load_key_pair()
+			.returning(move |_, _| Ok(asymmetric_keypair.clone().into()))
+			.once();
 
-        CryptoFacade {
-            key_loader_facade: Arc::new(key_loader),
-            instance_mapper: Arc::new(InstanceMapper::new()),
-            randomizer_facade,
-        }
-    }
+		CryptoFacade {
+			key_loader_facade: Arc::new(key_loader),
+			instance_mapper: Arc::new(InstanceMapper::new()),
+			randomizer_facade,
+		}
+	}
 
-    fn make_bucket_key(recipient_key_version: i64, pub_enc_bucket_key: Vec<u8>, instance_id: &GeneratedId, instance_list: &GeneratedId, key_group: &GeneratedId, bucket_enc_session_key: Vec<u8>, protocol_version: i64) -> BucketKey {
-        BucketKey {
-            groupEncBucketKey: None,
-            protocolVersion: protocol_version,
-            pubEncBucketKey: Some(pub_enc_bucket_key),
-            recipientKeyVersion: recipient_key_version,
-            senderKeyVersion: None,
-            bucketEncSessionKeys: vec![
-                InstanceSessionKey {
-                    encryptionAuthStatus: None,
-                    instanceId: instance_id.clone(),
-                    instanceList: instance_list.clone(),
-                    symEncSessionKey: bucket_enc_session_key.clone(),
-                    symKeyVersion: recipient_key_version,
-                    ..create_test_entity()
-                }
-            ],
-            keyGroup: Some(key_group.clone()),
-            ..create_test_entity()
-        }
-    }
+	fn make_bucket_key(
+		recipient_key_version: i64,
+		pub_enc_bucket_key: Vec<u8>,
+		instance_id: &GeneratedId,
+		instance_list: &GeneratedId,
+		key_group: &GeneratedId,
+		bucket_enc_session_key: Vec<u8>,
+		protocol_version: i64,
+	) -> BucketKey {
+		BucketKey {
+			groupEncBucketKey: None,
+			protocolVersion: protocol_version,
+			pubEncBucketKey: Some(pub_enc_bucket_key),
+			recipientKeyVersion: recipient_key_version,
+			senderKeyVersion: None,
+			bucketEncSessionKeys: vec![InstanceSessionKey {
+				encryptionAuthStatus: None,
+				instanceId: instance_id.clone(),
+				instanceList: instance_list.clone(),
+				symEncSessionKey: bucket_enc_session_key.clone(),
+				symKeyVersion: recipient_key_version,
+				..create_test_entity()
+			}],
+			keyGroup: Some(key_group.clone()),
+			..create_test_entity()
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/ecc.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/ecc.rs
@@ -1,7 +1,7 @@
+use crate::crypto::randomizer_facade::RandomizerFacade;
+use crate::util::{array_cast_slice, ArrayCastingError};
 use std::ops::Deref;
 use zeroize::*;
-use crate::crypto::randomizer_facade::RandomizerFacade;
-use crate::util::{ArrayCastingError, array_cast_slice};
 
 const ECC_KEY_SIZE: usize = 32;
 
@@ -10,35 +10,35 @@ const ECC_KEY_SIZE: usize = 32;
 pub struct EccPrivateKey([u8; ECC_KEY_SIZE]);
 
 impl EccPrivateKey {
-    /// Get a reference to the underlying bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_slice()
-    }
+	/// Get a reference to the underlying bytes.
+	pub fn as_bytes(&self) -> &[u8] {
+		self.0.as_slice()
+	}
 
-    /// Calculate the public key for this private key.
-    pub fn derive_public_key(&self) -> EccPublicKey {
-        use curve25519_dalek::Scalar;
-        use curve25519_dalek::montgomery::MontgomeryPoint;
+	/// Calculate the public key for this private key.
+	pub fn derive_public_key(&self) -> EccPublicKey {
+		use curve25519_dalek::montgomery::MontgomeryPoint;
+		use curve25519_dalek::Scalar;
 
-        // public key = private key * base point
-        let public_key = Zeroizing::new(
-            MontgomeryPoint::mul_base(Zeroizing::new(Scalar::from_bytes_mod_order(self.0)).deref())
-        );
+		// public key = private key * base point
+		let public_key = Zeroizing::new(MontgomeryPoint::mul_base(
+			Zeroizing::new(Scalar::from_bytes_mod_order(self.0)).deref(),
+		));
 
-        EccPublicKey(public_key.0)
-    }
+		EccPublicKey(public_key.0)
+	}
 
-    /// Attempt to convert a slice of bytes into an ECC key.
-    ///
-    /// Returns `Err` on failure.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
-        Ok(Self(array_cast_slice(bytes, "EccPrivateKey")?))
-    }
+	/// Attempt to convert a slice of bytes into an ECC key.
+	///
+	/// Returns `Err` on failure.
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
+		Ok(Self(array_cast_slice(bytes, "EccPrivateKey")?))
+	}
 
-    fn from_bytes_clamped(bytes: [u8; 32]) -> Self {
-        let clamped = curve25519_dalek::scalar::clamp_integer(bytes);
-        Self(clamped)
-    }
+	fn from_bytes_clamped(bytes: [u8; 32]) -> Self {
+		let clamped = curve25519_dalek::scalar::clamp_integer(bytes);
+		Self(clamped)
+	}
 }
 
 #[derive(ZeroizeOnDrop, Clone, PartialEq)]
@@ -48,108 +48,138 @@ pub struct EccPublicKey([u8; ECC_KEY_SIZE]);
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
 pub struct EccKeyPair {
-    pub public_key: EccPublicKey,
-    pub private_key: EccPrivateKey,
+	pub public_key: EccPublicKey,
+	pub private_key: EccPrivateKey,
 }
 
 impl EccKeyPair {
-    /// Generate a keypair with the given random number generator.
-    pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
-        let seed: [u8; 32] = randomizer_facade.generate_random_array();
+	/// Generate a keypair with the given random number generator.
+	pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
+		let seed: [u8; 32] = randomizer_facade.generate_random_array();
 
-        let private_key = EccPrivateKey::from_bytes_clamped(seed);
-        let public_key = private_key.derive_public_key();
+		let private_key = EccPrivateKey::from_bytes_clamped(seed);
+		let public_key = private_key.derive_public_key();
 
-        Self { public_key, private_key }
-    }
+		Self {
+			public_key,
+			private_key,
+		}
+	}
 }
 
 impl EccPublicKey {
-    /// Get a reference to the underlying bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_slice()
-    }
+	/// Get a reference to the underlying bytes.
+	pub fn as_bytes(&self) -> &[u8] {
+		self.0.as_slice()
+	}
 
-    /// Attempt to convert a slice of bytes into an ECC key.
-    ///
-    /// Returns `Err` on failure.
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
-        Ok(Self(array_cast_slice(bytes, "EccPublicKey")?))
-    }
+	/// Attempt to convert a slice of bytes into an ECC key.
+	///
+	/// Returns `Err` on failure.
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
+		Ok(Self(array_cast_slice(bytes, "EccPublicKey")?))
+	}
 }
 
 #[derive(Zeroize, ZeroizeOnDrop)]
 pub struct EccSharedSecret([u8; ECC_KEY_SIZE]);
 
 impl EccSharedSecret {
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_slice()
-    }
+	pub fn as_bytes(&self) -> &[u8] {
+		self.0.as_slice()
+	}
 }
 
 /// Describes shared secrets for encrypting/decrypting a message and verifying authenticity.
 pub struct EccSharedSecrets {
-    pub ephemeral_shared_secret: EccSharedSecret,
-    pub auth_shared_secret: EccSharedSecret,
+	pub ephemeral_shared_secret: EccSharedSecret,
+	pub auth_shared_secret: EccSharedSecret,
 }
 
 /// Generate a shared secret using the sender's identity key, an ephemeral key, and the recipient's public key.
-pub fn ecc_encapsulate(sender_key: &EccPrivateKey, ephemeral_key: &EccPrivateKey, recipient_key: &EccPublicKey) -> EccSharedSecrets {
-    EccSharedSecrets {
-        ephemeral_shared_secret: generate_shared_secret(ephemeral_key, recipient_key),
-        auth_shared_secret: generate_shared_secret(sender_key, recipient_key),
-    }
+pub fn ecc_encapsulate(
+	sender_key: &EccPrivateKey,
+	ephemeral_key: &EccPrivateKey,
+	recipient_key: &EccPublicKey,
+) -> EccSharedSecrets {
+	EccSharedSecrets {
+		ephemeral_shared_secret: generate_shared_secret(ephemeral_key, recipient_key),
+		auth_shared_secret: generate_shared_secret(sender_key, recipient_key),
+	}
 }
 
 /// Generate a shared secret using the sender's identity key, an ephemeral key, and the recipient's private key.
-pub fn ecc_decapsulate(sender_key: &EccPublicKey, ephemeral_key: &EccPublicKey, recipient_key: &EccPrivateKey) -> EccSharedSecrets {
-    EccSharedSecrets {
-        ephemeral_shared_secret: generate_shared_secret(recipient_key, ephemeral_key),
-        auth_shared_secret: generate_shared_secret(recipient_key, sender_key),
-    }
+pub fn ecc_decapsulate(
+	sender_key: &EccPublicKey,
+	ephemeral_key: &EccPublicKey,
+	recipient_key: &EccPrivateKey,
+) -> EccSharedSecrets {
+	EccSharedSecrets {
+		ephemeral_shared_secret: generate_shared_secret(recipient_key, ephemeral_key),
+		auth_shared_secret: generate_shared_secret(recipient_key, sender_key),
+	}
 }
 
 fn generate_shared_secret(local_key: &EccPrivateKey, remote_key: &EccPublicKey) -> EccSharedSecret {
-    use curve25519_dalek::Scalar;
-    use curve25519_dalek::montgomery::MontgomeryPoint;
+	use curve25519_dalek::montgomery::MontgomeryPoint;
+	use curve25519_dalek::Scalar;
 
-    let point = Zeroizing::new(MontgomeryPoint(remote_key.0));
-    let scalar = Zeroizing::new(Scalar::from_bytes_mod_order(local_key.0));
-    let secret = (point.deref() * scalar.deref()).0;
+	let point = Zeroizing::new(MontgomeryPoint(remote_key.0));
+	let scalar = Zeroizing::new(Scalar::from_bytes_mod_order(local_key.0));
+	let secret = (point.deref() * scalar.deref()).0;
 
-    EccSharedSecret(secret)
+	EccSharedSecret(secret)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::compatibility_test_utils::get_test_data;
-    use super::*;
+	use super::*;
+	use crate::crypto::compatibility_test_utils::get_test_data;
 
-    #[test]
-    fn test_x25519() {
-        let data = get_test_data();
-        for i in data.x25519_tests {
-            let alice_private_key = EccPrivateKey(i.alice_private_key_hex.try_into().unwrap());
-            let alice_public_key = EccPublicKey(i.alice_public_key_hex.try_into().unwrap());
-            let ephemeral_private_key = EccPrivateKey(i.ephemeral_private_key_hex.try_into().unwrap());
-            let ephemeral_public_key = EccPublicKey(i.ephemeral_public_key_hex.try_into().unwrap());
-            let bob_private_key = EccPrivateKey(i.bob_private_key_hex.try_into().unwrap());
-            let bob_public_key = EccPublicKey(i.bob_public_key_hex.try_into().unwrap());
+	#[test]
+	fn test_x25519() {
+		let data = get_test_data();
+		for i in data.x25519_tests {
+			let alice_private_key = EccPrivateKey(i.alice_private_key_hex.try_into().unwrap());
+			let alice_public_key = EccPublicKey(i.alice_public_key_hex.try_into().unwrap());
+			let ephemeral_private_key =
+				EccPrivateKey(i.ephemeral_private_key_hex.try_into().unwrap());
+			let ephemeral_public_key = EccPublicKey(i.ephemeral_public_key_hex.try_into().unwrap());
+			let bob_private_key = EccPrivateKey(i.bob_private_key_hex.try_into().unwrap());
+			let bob_public_key = EccPublicKey(i.bob_public_key_hex.try_into().unwrap());
 
-            assert_eq!(alice_public_key.0, alice_private_key.derive_public_key().0);
-            assert_eq!(ephemeral_public_key.0, ephemeral_private_key.derive_public_key().0);
-            assert_eq!(bob_public_key.0, bob_private_key.derive_public_key().0);
+			assert_eq!(alice_public_key.0, alice_private_key.derive_public_key().0);
+			assert_eq!(
+				ephemeral_public_key.0,
+				ephemeral_private_key.derive_public_key().0
+			);
+			assert_eq!(bob_public_key.0, bob_private_key.derive_public_key().0);
 
-            let ephemeral_secret = EccSharedSecret(i.ephemeral_shared_secret_hex.try_into().unwrap());
-            let auth_secret = EccSharedSecret(i.auth_shared_secret_hex.try_into().unwrap());
+			let ephemeral_secret =
+				EccSharedSecret(i.ephemeral_shared_secret_hex.try_into().unwrap());
+			let auth_secret = EccSharedSecret(i.auth_shared_secret_hex.try_into().unwrap());
 
-            let encapsulation = ecc_encapsulate(&alice_private_key, &ephemeral_private_key, &bob_public_key);
-            assert_eq!(ephemeral_secret.0, encapsulation.ephemeral_shared_secret.0, "encaps: ephemeral shared secret mismatch");
-            assert_eq!(auth_secret.0, encapsulation.auth_shared_secret.0, "encaps: auth shared secret mismatch");
+			let encapsulation =
+				ecc_encapsulate(&alice_private_key, &ephemeral_private_key, &bob_public_key);
+			assert_eq!(
+				ephemeral_secret.0, encapsulation.ephemeral_shared_secret.0,
+				"encaps: ephemeral shared secret mismatch"
+			);
+			assert_eq!(
+				auth_secret.0, encapsulation.auth_shared_secret.0,
+				"encaps: auth shared secret mismatch"
+			);
 
-            let decapsulation = ecc_decapsulate(&alice_public_key, &ephemeral_public_key, &bob_private_key);
-            assert_eq!(ephemeral_secret.0, decapsulation.ephemeral_shared_secret.0, "decaps: ephemeral shared secret mismatch");
-            assert_eq!(auth_secret.0, decapsulation.auth_shared_secret.0, "decaps: auth shared secret mismatch");
-        }
-    }
+			let decapsulation =
+				ecc_decapsulate(&alice_public_key, &ephemeral_public_key, &bob_private_key);
+			assert_eq!(
+				ephemeral_secret.0, decapsulation.ephemeral_shared_secret.0,
+				"decaps: ephemeral shared secret mismatch"
+			);
+			assert_eq!(
+				auth_secret.0, decapsulation.auth_shared_secret.0,
+				"decaps: auth shared secret mismatch"
+			);
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/hkdf.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/hkdf.rs
@@ -1,22 +1,26 @@
 /// Derives a key of a defined length from `salt`, `input_key_material` and `info`.
 pub fn hkdf(salt: &[u8], input_key_material: &[u8], info: &[u8], length_bytes: usize) -> Vec<u8> {
-    let generator = hkdf::Hkdf::<sha2::Sha256>::new(Some(salt), input_key_material);
-    let mut output_buffer = vec![0u8; length_bytes];
-    generator.expand(info, &mut output_buffer).unwrap();
-    output_buffer
+	let generator = hkdf::Hkdf::<sha2::Sha256>::new(Some(salt), input_key_material);
+	let mut output_buffer = vec![0u8; length_bytes];
+	generator.expand(info, &mut output_buffer).unwrap();
+	output_buffer
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::compatibility_test_utils::*;
-    use super::*;
+	use super::*;
+	use crate::crypto::compatibility_test_utils::*;
 
-
-    #[test]
-    fn test_hkdf() {
-        for test_data in get_test_data().hkdf_tests {
-            let result = hkdf(&test_data.salt_hex, &test_data.input_key_material_hex, &test_data.info_hex, test_data.length_in_bytes);
-            assert_eq!(test_data.hkdf_hex, result);
-        }
-    }
+	#[test]
+	fn test_hkdf() {
+		for test_data in get_test_data().hkdf_tests {
+			let result = hkdf(
+				&test_data.salt_hex,
+				&test_data.input_key_material_hex,
+				&test_data.info_hex,
+				test_data.length_in_bytes,
+			);
+			assert_eq!(test_data.hkdf_hex, result);
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/key.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/key.rs
@@ -1,136 +1,151 @@
-use zeroize::Zeroizing;
-use crate::ApiCallError;
-use crate::util::ArrayCastingError;
 use super::aes::*;
 use super::rsa::*;
 use super::tuta_crypt::*;
+use crate::util::ArrayCastingError;
+use crate::ApiCallError;
+use zeroize::Zeroizing;
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
 #[allow(clippy::large_enum_variant)]
 pub enum AsymmetricKeyPair {
-    RSAKeyPair(RSAKeyPair),
-    RSAEccKeyPair(RSAEccKeyPair),
-    PQKeyPairs(PQKeyPairs),
+	RSAKeyPair(RSAKeyPair),
+	RSAEccKeyPair(RSAEccKeyPair),
+	PQKeyPairs(PQKeyPairs),
 }
 
 impl From<RSAKeyPair> for AsymmetricKeyPair {
-    fn from(value: RSAKeyPair) -> Self {
-        Self::RSAKeyPair(value)
-    }
+	fn from(value: RSAKeyPair) -> Self {
+		Self::RSAKeyPair(value)
+	}
 }
 
 impl From<RSAEccKeyPair> for AsymmetricKeyPair {
-    fn from(value: RSAEccKeyPair) -> Self {
-        Self::RSAEccKeyPair(value)
-    }
+	fn from(value: RSAEccKeyPair) -> Self {
+		Self::RSAEccKeyPair(value)
+	}
 }
 
 impl From<PQKeyPairs> for AsymmetricKeyPair {
-    fn from(value: PQKeyPairs) -> Self {
-        Self::PQKeyPairs(value)
-    }
+	fn from(value: PQKeyPairs) -> Self {
+		Self::PQKeyPairs(value)
+	}
 }
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
 pub enum GenericAesKey {
-    Aes128(Aes128Key),
-    Aes256(Aes256Key),
+	Aes128(Aes128Key),
+	Aes256(Aes256Key),
 }
 
 impl GenericAesKey {
-    /// Decrypts the AES key: `encrypted_key` with this key.
-    ///
-    /// The returned AES key is zeroized on drop
-    pub fn decrypt_aes_key(&self, encrypted_key: &[u8]) -> Result<GenericAesKey, KeyLoadError> {
-        let decrypted = match self {
-            Self::Aes128(key) => aes_128_decrypt_no_padding_fixed_iv(key, encrypted_key)?,
-            Self::Aes256(key) => aes_256_decrypt_no_padding(key, encrypted_key)?.data,
-        };
+	/// Decrypts the AES key: `encrypted_key` with this key.
+	///
+	/// The returned AES key is zeroized on drop
+	pub fn decrypt_aes_key(&self, encrypted_key: &[u8]) -> Result<GenericAesKey, KeyLoadError> {
+		let decrypted = match self {
+			Self::Aes128(key) => aes_128_decrypt_no_padding_fixed_iv(key, encrypted_key)?,
+			Self::Aes256(key) => aes_256_decrypt_no_padding(key, encrypted_key)?.data,
+		};
 
-        let decrypted = Zeroizing::new(decrypted);
-        Self::from_bytes(decrypted.as_slice()).map_err(|error| error.into())
-    }
+		let decrypted = Zeroizing::new(decrypted);
+		Self::from_bytes(decrypted.as_slice()).map_err(|error| error.into())
+	}
 
-    /// Decrypts `ciphertext` with this key.
-    ///
-    /// The return decrypted data is not zeroized
-    pub fn decrypt_data(&self, ciphertext: &[u8]) -> Result<Vec<u8>, AesDecryptError> {
-        let decrypted = match self {
-            Self::Aes128(key) => aes_128_decrypt(key, ciphertext)?,
-            Self::Aes256(key) => aes_256_decrypt(key, ciphertext)?,
-        };
-        Ok(decrypted.data)
-    }
+	/// Decrypts `ciphertext` with this key.
+	///
+	/// The return decrypted data is not zeroized
+	pub fn decrypt_data(&self, ciphertext: &[u8]) -> Result<Vec<u8>, AesDecryptError> {
+		let decrypted = match self {
+			Self::Aes128(key) => aes_128_decrypt(key, ciphertext)?,
+			Self::Aes256(key) => aes_256_decrypt(key, ciphertext)?,
+		};
+		Ok(decrypted.data)
+	}
 
-    pub fn decrypt_data_and_iv(&self, ciphertext: &[u8]) -> Result<PlaintextAndIv, AesDecryptError> {
-        let decrypted = match self {
-            Self::Aes128(key) => aes_128_decrypt(key, ciphertext)?,
-            Self::Aes256(key) => aes_256_decrypt(key, ciphertext)?,
-        };
-        Ok(decrypted)
-    }
+	pub fn decrypt_data_and_iv(
+		&self,
+		ciphertext: &[u8],
+	) -> Result<PlaintextAndIv, AesDecryptError> {
+		let decrypted = match self {
+			Self::Aes128(key) => aes_128_decrypt(key, ciphertext)?,
+			Self::Aes256(key) => aes_256_decrypt(key, ciphertext)?,
+		};
+		Ok(decrypted)
+	}
 
-    /// Encrypts `key_to_encrypt` with this key.
-    pub fn encrypt_key(&self, key_to_encrypt: &GenericAesKey, iv: Iv) -> Vec<u8> {
-        match self {
-            Self::Aes128(key) => aes_128_encrypt_no_padding_fixed_iv(key, key_to_encrypt.as_bytes()).unwrap(),
-            Self::Aes256(key) => aes_256_encrypt(key, key_to_encrypt.as_bytes(), &iv, PaddingMode::NoPadding).unwrap(),
-        }
-    }
+	/// Encrypts `key_to_encrypt` with this key.
+	pub fn encrypt_key(&self, key_to_encrypt: &GenericAesKey, iv: Iv) -> Vec<u8> {
+		match self {
+			Self::Aes128(key) => {
+				aes_128_encrypt_no_padding_fixed_iv(key, key_to_encrypt.as_bytes()).unwrap()
+			},
+			Self::Aes256(key) => {
+				aes_256_encrypt(key, key_to_encrypt.as_bytes(), &iv, PaddingMode::NoPadding)
+					.unwrap()
+			},
+		}
+	}
 
-    /// Encrypts `text` with this key.
-    pub fn encrypt_data(&self, text: &[u8], iv: Iv) -> Result<Vec<u8>, AesEncryptError> {
-        let ciphertext = match self {
-            Self::Aes128(key) => aes_128_encrypt(key, text, &iv, PaddingMode::WithPadding, MacMode::WithMac)?,
-            Self::Aes256(key) => aes_256_encrypt(key, text, &iv, PaddingMode::WithPadding)?,
-        };
-        Ok(ciphertext)
-    }
+	/// Encrypts `text` with this key.
+	pub fn encrypt_data(&self, text: &[u8], iv: Iv) -> Result<Vec<u8>, AesEncryptError> {
+		let ciphertext = match self {
+			Self::Aes128(key) => {
+				aes_128_encrypt(key, text, &iv, PaddingMode::WithPadding, MacMode::WithMac)?
+			},
+			Self::Aes256(key) => aes_256_encrypt(key, text, &iv, PaddingMode::WithPadding)?,
+		};
+		Ok(ciphertext)
+	}
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
-        match bytes.len() {
-            // The unwraps here are optimised away
-            AES_128_KEY_SIZE => Ok(Aes128Key::from_bytes(bytes).unwrap().into()),
-            AES_256_KEY_SIZE => Ok(Aes256Key::from_bytes(bytes).unwrap().into()),
-            n => Err(ArrayCastingError { type_name: "GenericAesKey", actual_size: n })
-        }
-    }
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, ArrayCastingError> {
+		match bytes.len() {
+			// The unwraps here are optimised away
+			AES_128_KEY_SIZE => Ok(Aes128Key::from_bytes(bytes).unwrap().into()),
+			AES_256_KEY_SIZE => Ok(Aes256Key::from_bytes(bytes).unwrap().into()),
+			n => Err(ArrayCastingError {
+				type_name: "GenericAesKey",
+				actual_size: n,
+			}),
+		}
+	}
 
-    pub fn as_bytes(&self) -> &[u8] {
-        match self {
-            Self::Aes128(n) => n.as_bytes(),
-            Self::Aes256(n) => n.as_bytes()
-        }
-    }
+	pub fn as_bytes(&self) -> &[u8] {
+		match self {
+			Self::Aes128(n) => n.as_bytes(),
+			Self::Aes256(n) => n.as_bytes(),
+		}
+	}
 }
 
 impl From<Aes128Key> for GenericAesKey {
-    fn from(value: Aes128Key) -> Self {
-        Self::Aes128(value)
-    }
+	fn from(value: Aes128Key) -> Self {
+		Self::Aes128(value)
+	}
 }
 
 impl From<Aes256Key> for GenericAesKey {
-    fn from(value: Aes256Key) -> Self {
-        Self::Aes256(value)
-    }
+	fn from(value: Aes256Key) -> Self {
+		Self::Aes256(value)
+	}
 }
 
 #[derive(thiserror::Error, Debug)]
 #[error("Failed to load key: {reason}")]
 pub struct KeyLoadError {
-    pub(crate) reason: String,
+	pub(crate) reason: String,
 }
 
 /// Used to convert key related error types to `KeyLoadError`
 trait KeyLoadErrorSubtype: ToString {}
 
 impl<T: KeyLoadErrorSubtype> From<T> for KeyLoadError {
-    fn from(value: T) -> Self {
-        Self { reason: value.to_string() }
-    }
+	fn from(value: T) -> Self {
+		Self {
+			reason: value.to_string(),
+		}
+	}
 }
 
 impl KeyLoadErrorSubtype for AesDecryptError {}
@@ -142,41 +157,40 @@ impl KeyLoadErrorSubtype for RSAKeyError {}
 /// Used to handle errors from the entity client
 impl KeyLoadErrorSubtype for ApiCallError {}
 
-
 #[cfg(test)]
 mod tests {
-    use crate::crypto::Aes128Key;
-    use super::*;
-    use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
-    use crate::util::test_utils::generate_random_string;
+	use super::*;
+	use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
+	use crate::crypto::Aes128Key;
+	use crate::util::test_utils::generate_random_string;
 
-    #[test]
-    fn encrypt_data_aes128_roundtrip() {
-        let randomizer = make_thread_rng_facade();
+	#[test]
+	fn encrypt_data_aes128_roundtrip() {
+		let randomizer = make_thread_rng_facade();
 
-        let random_string = generate_random_string::<10>();
-        let raw_text = random_string.as_bytes();
-        let iv = Iv::generate(&randomizer);
-        let key: GenericAesKey = Aes128Key::generate(&randomizer).into();
+		let random_string = generate_random_string::<10>();
+		let raw_text = random_string.as_bytes();
+		let iv = Iv::generate(&randomizer);
+		let key: GenericAesKey = Aes128Key::generate(&randomizer).into();
 
-        let ciphertext = key.encrypt_data(raw_text, iv).unwrap();
-        let text = key.decrypt_data(ciphertext.as_slice()).unwrap();
+		let ciphertext = key.encrypt_data(raw_text, iv).unwrap();
+		let text = key.decrypt_data(ciphertext.as_slice()).unwrap();
 
-        assert_eq!(raw_text, text.as_slice());
-    }
+		assert_eq!(raw_text, text.as_slice());
+	}
 
-    #[test]
-    fn encrypt_data_aes256_roundtrip() {
-        let randomizer = make_thread_rng_facade();
+	#[test]
+	fn encrypt_data_aes256_roundtrip() {
+		let randomizer = make_thread_rng_facade();
 
-        let random_string = generate_random_string::<10>();
-        let raw_text = random_string.as_bytes();
-        let iv = Iv::generate(&randomizer);
-        let key: GenericAesKey = Aes256Key::generate(&randomizer).into();
+		let random_string = generate_random_string::<10>();
+		let raw_text = random_string.as_bytes();
+		let iv = Iv::generate(&randomizer);
+		let key: GenericAesKey = Aes256Key::generate(&randomizer).into();
 
-        let ciphertext = key.encrypt_data(raw_text, iv).unwrap();
-        let text = key.decrypt_data(ciphertext.as_slice()).unwrap();
+		let ciphertext = key.encrypt_data(raw_text, iv).unwrap();
+		let text = key.decrypt_data(ciphertext.as_slice()).unwrap();
 
-        assert_eq!(raw_text, text.as_slice());
-    }
+		assert_eq!(raw_text, text.as_slice());
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/key_encryption.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/key_encryption.rs
@@ -1,175 +1,264 @@
-use zeroize::Zeroizing;
-use crate::ApiCallError;
 use crate::crypto::ecc::{EccKeyPair, EccPrivateKey, EccPublicKey};
 use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey, KeyLoadError};
 use crate::crypto::kyber::{KyberKeyPair, KyberPrivateKey, KyberPublicKey};
 use crate::crypto::rsa::{RSAEccKeyPair, RSAKeyPair, RSAPrivateKey, RSAPublicKey};
 use crate::crypto::tuta_crypt::PQKeyPairs;
 use crate::entities::sys::KeyPair;
+use crate::ApiCallError;
+use zeroize::Zeroizing;
 
-pub fn decrypt_key_pair(encryption_key: &GenericAesKey, key_pair: &KeyPair) -> Result<AsymmetricKeyPair, KeyLoadError> {
-    match key_pair.symEncPrivRsaKey {
-        Some(_) => decrypt_rsa_or_rsa_ecc_key_pair(encryption_key, key_pair),
-        None => decrypt_pq_key_pair(encryption_key, key_pair)
-    }
+pub fn decrypt_key_pair(
+	encryption_key: &GenericAesKey,
+	key_pair: &KeyPair,
+) -> Result<AsymmetricKeyPair, KeyLoadError> {
+	match key_pair.symEncPrivRsaKey {
+		Some(_) => decrypt_rsa_or_rsa_ecc_key_pair(encryption_key, key_pair),
+		None => decrypt_pq_key_pair(encryption_key, key_pair),
+	}
 }
 
 fn mapped_error<E: std::error::Error>(e: E) -> ApiCallError {
-    ApiCallError::InternalSdkError { error_message: e.to_string() }
+	ApiCallError::InternalSdkError {
+		error_message: e.to_string(),
+	}
 }
 
 fn require_field<'a>(field: &'a Option<Vec<u8>>, name: &str) -> Result<&'a [u8], KeyLoadError> {
-    field
-        .as_ref()
-        .ok_or_else(|| KeyLoadError { reason: format!("Missing field `{name}`") })
-        .map(|k| k.as_slice())
+	field
+		.as_ref()
+		.ok_or_else(|| KeyLoadError {
+			reason: format!("Missing field `{name}`"),
+		})
+		.map(|k| k.as_slice())
 }
 
 macro_rules! require_field {
-    ($object:expr) => {
-        $object
-            .as_ref()
-            .ok_or_else(|| KeyLoadError { reason: format!("Missing field `{}`", stringify!($object)) })
-            .map(|k| k.as_slice())
-    };
+	($object:expr) => {
+		$object
+			.as_ref()
+			.ok_or_else(|| KeyLoadError {
+				reason: format!("Missing field `{}`", stringify!($object)),
+			})
+			.map(|k| k.as_slice())
+	};
 }
 
-fn decrypt_pq_key_pair(encryption_key: &GenericAesKey, key_pair: &KeyPair) -> Result<AsymmetricKeyPair, KeyLoadError> {
-    if !matches!(encryption_key, GenericAesKey::Aes256(_)) {
-        return Err(KeyLoadError { reason: "Invalid AES key length for PQ key pair".to_owned() });
-    }
+fn decrypt_pq_key_pair(
+	encryption_key: &GenericAesKey,
+	key_pair: &KeyPair,
+) -> Result<AsymmetricKeyPair, KeyLoadError> {
+	if !matches!(encryption_key, GenericAesKey::Aes256(_)) {
+		return Err(KeyLoadError {
+			reason: "Invalid AES key length for PQ key pair".to_owned(),
+		});
+	}
 
-    let ecc_public_key = require_field!(key_pair.pubEccKey)?;
-    let ecc_private_key_enc = require_field!(key_pair.symEncPrivEccKey)?;
-    let ecc_private_key = Zeroizing::new(encryption_key.decrypt_data(ecc_private_key_enc)?);
+	let ecc_public_key = require_field!(key_pair.pubEccKey)?;
+	let ecc_private_key_enc = require_field!(key_pair.symEncPrivEccKey)?;
+	let ecc_private_key = Zeroizing::new(encryption_key.decrypt_data(ecc_private_key_enc)?);
 
-    let kyber_public_key = KyberPublicKey::deserialize(require_field!(key_pair.pubKyberKey)?).map_err(mapped_error)?;
-    let kyber_private_key_enc = require_field!(key_pair.symEncPrivKyberKey)?;
-    let kyber_private_key_raw = Zeroizing::new(encryption_key.decrypt_data(kyber_private_key_enc)?);
-    let kyber_private_key = KyberPrivateKey::deserialize(kyber_private_key_raw.as_slice()).map_err(mapped_error)?;
+	let kyber_public_key =
+		KyberPublicKey::deserialize(require_field!(key_pair.pubKyberKey)?).map_err(mapped_error)?;
+	let kyber_private_key_enc = require_field!(key_pair.symEncPrivKyberKey)?;
+	let kyber_private_key_raw = Zeroizing::new(encryption_key.decrypt_data(kyber_private_key_enc)?);
+	let kyber_private_key =
+		KyberPrivateKey::deserialize(kyber_private_key_raw.as_slice()).map_err(mapped_error)?;
 
-    Ok(AsymmetricKeyPair::PQKeyPairs(PQKeyPairs {
-        ecc_keys: EccKeyPair { public_key: EccPublicKey::from_bytes(ecc_public_key).map_err(mapped_error)?, private_key: EccPrivateKey::from_bytes(ecc_private_key.as_slice()).map_err(mapped_error)? },
-        kyber_keys: KyberKeyPair { public_key: kyber_public_key, private_key: kyber_private_key },
-    }))
+	Ok(AsymmetricKeyPair::PQKeyPairs(PQKeyPairs {
+		ecc_keys: EccKeyPair {
+			public_key: EccPublicKey::from_bytes(ecc_public_key).map_err(mapped_error)?,
+			private_key: EccPrivateKey::from_bytes(ecc_private_key.as_slice())
+				.map_err(mapped_error)?,
+		},
+		kyber_keys: KyberKeyPair {
+			public_key: kyber_public_key,
+			private_key: kyber_private_key,
+		},
+	}))
 }
 
-fn decrypt_rsa_or_rsa_ecc_key_pair(encryption_key: &GenericAesKey, key_pair: &KeyPair) -> Result<AsymmetricKeyPair, KeyLoadError> {
-    let public_key = RSAPublicKey::deserialize(require_field!(key_pair.pubRsaKey)?)?;
-    let sym_enc_priv_rsa_key = require_field!(key_pair.symEncPrivRsaKey)?;
-    let private_key = RSAPrivateKey::deserialize(encryption_key.decrypt_data(sym_enc_priv_rsa_key)?.as_slice())?;
+fn decrypt_rsa_or_rsa_ecc_key_pair(
+	encryption_key: &GenericAesKey,
+	key_pair: &KeyPair,
+) -> Result<AsymmetricKeyPair, KeyLoadError> {
+	let public_key = RSAPublicKey::deserialize(require_field!(key_pair.pubRsaKey)?)?;
+	let sym_enc_priv_rsa_key = require_field!(key_pair.symEncPrivRsaKey)?;
+	let private_key = RSAPrivateKey::deserialize(
+		encryption_key
+			.decrypt_data(sym_enc_priv_rsa_key)?
+			.as_slice(),
+	)?;
 
-    let rsa_key_pair = RSAKeyPair {
-        public_key,
-        private_key,
-    };
+	let rsa_key_pair = RSAKeyPair {
+		public_key,
+		private_key,
+	};
 
-    if let Some(ecc_key) = key_pair.symEncPrivEccKey.as_ref() {
-        let public_ecc_key = require_field!(key_pair.pubEccKey)?;
-        let private_ecc_key = Zeroizing::new(encryption_key.decrypt_data(ecc_key)?);
-        Ok(AsymmetricKeyPair::RSAEccKeyPair(RSAEccKeyPair {
-            rsa_key_pair,
-            ecc_key_pair: EccKeyPair {
-                public_key: EccPublicKey::from_bytes(public_ecc_key)?,
-                private_key: EccPrivateKey::from_bytes(private_ecc_key.as_slice())?,
-            },
-        }))
-    } else {
-        Ok(AsymmetricKeyPair::RSAKeyPair(rsa_key_pair))
-    }
+	if let Some(ecc_key) = key_pair.symEncPrivEccKey.as_ref() {
+		let public_ecc_key = require_field!(key_pair.pubEccKey)?;
+		let private_ecc_key = Zeroizing::new(encryption_key.decrypt_data(ecc_key)?);
+		Ok(AsymmetricKeyPair::RSAEccKeyPair(RSAEccKeyPair {
+			rsa_key_pair,
+			ecc_key_pair: EccKeyPair {
+				public_key: EccPublicKey::from_bytes(public_ecc_key)?,
+				private_key: EccPrivateKey::from_bytes(private_ecc_key.as_slice())?,
+			},
+		}))
+	} else {
+		Ok(AsymmetricKeyPair::RSAKeyPair(rsa_key_pair))
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::crypto::{Aes256Key, Iv, PQKeyPairs};
-    use crate::crypto::ecc::EccKeyPair;
-    use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey};
-    use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
-    use crate::entities::sys::KeyPair;
-    use crate::util::test_utils::generate_random_string;
+	use super::*;
+	use crate::crypto::ecc::EccKeyPair;
+	use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey};
+	use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
+	use crate::crypto::{Aes256Key, Iv, PQKeyPairs};
+	use crate::entities::sys::KeyPair;
+	use crate::util::test_utils::generate_random_string;
 
-    #[test]
-    fn pq_roundtrip() {
-        let randomizer = make_thread_rng_facade();
-        let pq_key_pair = PQKeyPairs::generate(&randomizer);
-        let parent_key: GenericAesKey = Aes256Key::generate(&randomizer).into();
+	#[test]
+	fn pq_roundtrip() {
+		let randomizer = make_thread_rng_facade();
+		let pq_key_pair = PQKeyPairs::generate(&randomizer);
+		let parent_key: GenericAesKey = Aes256Key::generate(&randomizer).into();
 
-        let junk_ecc_pair = EccKeyPair::generate(&randomizer);
-        let encrypted_key_pair = KeyPair {
-            _id: Default::default(),
-            pubEccKey: Some(pq_key_pair.ecc_keys.public_key.as_bytes().to_vec()),
-            pubKyberKey: Some(pq_key_pair.kyber_keys.public_key.serialize()),
-            pubRsaKey: Some(generate_random_string::<17>().as_bytes().to_vec()),
-            symEncPrivEccKey: Some(parent_key.encrypt_data(junk_ecc_pair.private_key.as_bytes(), Iv::generate(&randomizer)).unwrap()),
-            symEncPrivKyberKey: Some(parent_key.encrypt_data(&pq_key_pair.kyber_keys.private_key.serialize(), Iv::generate(&randomizer)).unwrap()),
-            symEncPrivRsaKey: Some(generate_random_string::<17>().as_bytes().to_vec()),
-        };
+		let junk_ecc_pair = EccKeyPair::generate(&randomizer);
+		let encrypted_key_pair = KeyPair {
+			_id: Default::default(),
+			pubEccKey: Some(pq_key_pair.ecc_keys.public_key.as_bytes().to_vec()),
+			pubKyberKey: Some(pq_key_pair.kyber_keys.public_key.serialize()),
+			pubRsaKey: Some(generate_random_string::<17>().as_bytes().to_vec()),
+			symEncPrivEccKey: Some(
+				parent_key
+					.encrypt_data(
+						junk_ecc_pair.private_key.as_bytes(),
+						Iv::generate(&randomizer),
+					)
+					.unwrap(),
+			),
+			symEncPrivKyberKey: Some(
+				parent_key
+					.encrypt_data(
+						&pq_key_pair.kyber_keys.private_key.serialize(),
+						Iv::generate(&randomizer),
+					)
+					.unwrap(),
+			),
+			symEncPrivRsaKey: Some(generate_random_string::<17>().as_bytes().to_vec()),
+		};
 
-        let decrypted_key_pair = decrypt_pq_key_pair(&parent_key, &encrypted_key_pair).unwrap();
+		let decrypted_key_pair = decrypt_pq_key_pair(&parent_key, &encrypted_key_pair).unwrap();
 
-        match decrypted_key_pair {
-            AsymmetricKeyPair::PQKeyPairs(decrypted_key_pair) => {
-                assert_eq!(pq_key_pair.kyber_keys.public_key, decrypted_key_pair.kyber_keys.public_key);
-                assert_eq!(pq_key_pair.kyber_keys.private_key, decrypted_key_pair.kyber_keys.private_key);
-            }
-            _ => panic!()
-        }
-    }
+		match decrypted_key_pair {
+			AsymmetricKeyPair::PQKeyPairs(decrypted_key_pair) => {
+				assert_eq!(
+					pq_key_pair.kyber_keys.public_key,
+					decrypted_key_pair.kyber_keys.public_key
+				);
+				assert_eq!(
+					pq_key_pair.kyber_keys.private_key,
+					decrypted_key_pair.kyber_keys.private_key
+				);
+			},
+			_ => panic!(),
+		}
+	}
 
-    #[test]
-    fn rsa_roundtrip() {
-        let randomizer = make_thread_rng_facade();
-        let rsa_key_pair = RSAKeyPair::generate(&randomizer);
-        let parent_key: GenericAesKey = Aes256Key::generate(&randomizer).into();
+	#[test]
+	fn rsa_roundtrip() {
+		let randomizer = make_thread_rng_facade();
+		let rsa_key_pair = RSAKeyPair::generate(&randomizer);
+		let parent_key: GenericAesKey = Aes256Key::generate(&randomizer).into();
 
-        let encrypted_key_pair = KeyPair {
-            _id: Default::default(),
-            pubEccKey: None,
-            pubKyberKey: None,
-            pubRsaKey: Some(rsa_key_pair.public_key.serialize()),
-            symEncPrivEccKey: None,
-            symEncPrivKyberKey: None,
-            symEncPrivRsaKey: Some(parent_key.encrypt_data(rsa_key_pair.private_key.serialize().as_slice(), Iv::generate(&randomizer)).unwrap()),
-        };
+		let encrypted_key_pair = KeyPair {
+			_id: Default::default(),
+			pubEccKey: None,
+			pubKyberKey: None,
+			pubRsaKey: Some(rsa_key_pair.public_key.serialize()),
+			symEncPrivEccKey: None,
+			symEncPrivKyberKey: None,
+			symEncPrivRsaKey: Some(
+				parent_key
+					.encrypt_data(
+						rsa_key_pair.private_key.serialize().as_slice(),
+						Iv::generate(&randomizer),
+					)
+					.unwrap(),
+			),
+		};
 
-        let decrypted_key_pair = decrypt_rsa_or_rsa_ecc_key_pair(&parent_key, &encrypted_key_pair).unwrap();
+		let decrypted_key_pair =
+			decrypt_rsa_or_rsa_ecc_key_pair(&parent_key, &encrypted_key_pair).unwrap();
 
-        match decrypted_key_pair {
-            AsymmetricKeyPair::RSAKeyPair(decrypted_key_pair) => {
-                assert_eq!(rsa_key_pair.public_key, decrypted_key_pair.public_key);
-                assert_eq!(rsa_key_pair.private_key, decrypted_key_pair.private_key);
-            }
-            _ => panic!()
-        }
-    }
+		match decrypted_key_pair {
+			AsymmetricKeyPair::RSAKeyPair(decrypted_key_pair) => {
+				assert_eq!(rsa_key_pair.public_key, decrypted_key_pair.public_key);
+				assert_eq!(rsa_key_pair.private_key, decrypted_key_pair.private_key);
+			},
+			_ => panic!(),
+		}
+	}
 
-    #[test]
-    fn rsa_ecc_roundtrip() {
-        let randomizer = make_thread_rng_facade();
-        let rsa_ecc_key_pair = RSAEccKeyPair::generate(&randomizer);
-        let parent_key: GenericAesKey = Aes256Key::generate(&randomizer).into();
+	#[test]
+	fn rsa_ecc_roundtrip() {
+		let randomizer = make_thread_rng_facade();
+		let rsa_ecc_key_pair = RSAEccKeyPair::generate(&randomizer);
+		let parent_key: GenericAesKey = Aes256Key::generate(&randomizer).into();
 
-        let encrypted_key_pair = KeyPair {
-            _id: Default::default(),
-            pubEccKey: Some(rsa_ecc_key_pair.ecc_key_pair.public_key.as_bytes().to_vec()),
-            pubKyberKey: None,
-            pubRsaKey: Some(rsa_ecc_key_pair.rsa_key_pair.public_key.serialize()),
-            symEncPrivEccKey: Some(parent_key.encrypt_data(rsa_ecc_key_pair.ecc_key_pair.private_key.as_bytes(), Iv::generate(&randomizer)).unwrap()),
-            symEncPrivKyberKey: None,
-            symEncPrivRsaKey: Some(parent_key.encrypt_data(rsa_ecc_key_pair.rsa_key_pair.private_key.serialize().as_slice(), Iv::generate(&randomizer)).unwrap()),
-        };
+		let encrypted_key_pair = KeyPair {
+			_id: Default::default(),
+			pubEccKey: Some(rsa_ecc_key_pair.ecc_key_pair.public_key.as_bytes().to_vec()),
+			pubKyberKey: None,
+			pubRsaKey: Some(rsa_ecc_key_pair.rsa_key_pair.public_key.serialize()),
+			symEncPrivEccKey: Some(
+				parent_key
+					.encrypt_data(
+						rsa_ecc_key_pair.ecc_key_pair.private_key.as_bytes(),
+						Iv::generate(&randomizer),
+					)
+					.unwrap(),
+			),
+			symEncPrivKyberKey: None,
+			symEncPrivRsaKey: Some(
+				parent_key
+					.encrypt_data(
+						rsa_ecc_key_pair
+							.rsa_key_pair
+							.private_key
+							.serialize()
+							.as_slice(),
+						Iv::generate(&randomizer),
+					)
+					.unwrap(),
+			),
+		};
 
-        let decrypted_key_pair = decrypt_rsa_or_rsa_ecc_key_pair(&parent_key, &encrypted_key_pair).unwrap();
+		let decrypted_key_pair =
+			decrypt_rsa_or_rsa_ecc_key_pair(&parent_key, &encrypted_key_pair).unwrap();
 
-        match decrypted_key_pair {
-            AsymmetricKeyPair::RSAEccKeyPair(decrypted_key_pair) => {
-                assert_eq!(rsa_ecc_key_pair.rsa_key_pair.public_key, decrypted_key_pair.rsa_key_pair.public_key);
-                assert_eq!(rsa_ecc_key_pair.rsa_key_pair.private_key, decrypted_key_pair.rsa_key_pair.private_key);
-                assert_eq!(rsa_ecc_key_pair.ecc_key_pair.public_key, decrypted_key_pair.ecc_key_pair.public_key);
-                assert_eq!(rsa_ecc_key_pair.ecc_key_pair.private_key, decrypted_key_pair.ecc_key_pair.private_key);
-            }
-            _ => panic!()
-        }
-    }
+		match decrypted_key_pair {
+			AsymmetricKeyPair::RSAEccKeyPair(decrypted_key_pair) => {
+				assert_eq!(
+					rsa_ecc_key_pair.rsa_key_pair.public_key,
+					decrypted_key_pair.rsa_key_pair.public_key
+				);
+				assert_eq!(
+					rsa_ecc_key_pair.rsa_key_pair.private_key,
+					decrypted_key_pair.rsa_key_pair.private_key
+				);
+				assert_eq!(
+					rsa_ecc_key_pair.ecc_key_pair.public_key,
+					decrypted_key_pair.ecc_key_pair.public_key
+				);
+				assert_eq!(
+					rsa_ecc_key_pair.ecc_key_pair.private_key,
+					decrypted_key_pair.ecc_key_pair.private_key
+				);
+			},
+			_ => panic!(),
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/kyber.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/kyber.rs
@@ -1,10 +1,10 @@
 //! Contains code to handle Kyber-1024 encapsulation and decapsulation.
 
-use std::fmt::Debug;
+use crate::join_slices;
+use crate::util::{array_cast_slice, decode_byte_arrays, encode_byte_arrays, ArrayCastingError};
 use pqcrypto_kyber::{kyber1024_decapsulate, kyber1024_encapsulate};
+use std::fmt::Debug;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
-use crate::util::{ArrayCastingError, decode_byte_arrays, encode_byte_arrays, array_cast_slice};
-use crate::{join_slices};
 
 use pqcrypto_kyber::kyber1024::PublicKey as PQCryptoKyber1024PublicKey;
 use pqcrypto_kyber::kyber1024::SecretKey as PQCryptoKyber1024SecretKey;
@@ -27,196 +27,235 @@ pub(crate) const KYBER_SECRET_KEY_LEN: usize = 2 * KYBER_POLYVECBYTES + 3 * KYBE
 /// Key used for performing encapsulation, owned by the recipient.
 #[derive(Clone, PartialEq)]
 pub struct KyberPublicKey {
-    public_key: PQCryptoKyber1024PublicKey,
+	public_key: PQCryptoKyber1024PublicKey,
 }
 
 impl KyberPublicKey {
-    pub fn as_bytes(&self) -> &[u8] {
-        self.public_key.as_bytes()
-    }
+	pub fn as_bytes(&self) -> &[u8] {
+		self.public_key.as_bytes()
+	}
 }
 
 #[cfg(test)] // only allow Debug in tests because this prints the key!
 impl Debug for KyberPublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.public_key.as_bytes().fmt(f)
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		self.public_key.as_bytes().fmt(f)
+	}
 }
 
 impl KyberPublicKey {
-    /// Instantiate a public key from bytes
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, KyberKeyError> {
-        let public_key = PQCryptoKyber1024PublicKey::from_bytes(bytes).
-            map_err(|reason| KyberKeyError { reason: format!("kyber API error: {reason}") })?;
-        Ok(Self { public_key })
-    }
+	/// Instantiate a public key from bytes
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, KyberKeyError> {
+		let public_key =
+			PQCryptoKyber1024PublicKey::from_bytes(bytes).map_err(|reason| KyberKeyError {
+				reason: format!("kyber API error: {reason}"),
+			})?;
+		Ok(Self { public_key })
+	}
 
-    /// Instantiate a public key from encoded (length + content) byte arrays.
-    ///
-    /// Returns `Err` if the key is invalid.
-    pub fn deserialize(arrays: &[u8]) -> Result<Self, KyberKeyError> {
-        use pqcrypto_traits::kem::*;
+	/// Instantiate a public key from encoded (length + content) byte arrays.
+	///
+	/// Returns `Err` if the key is invalid.
+	pub fn deserialize(arrays: &[u8]) -> Result<Self, KyberKeyError> {
+		use pqcrypto_traits::kem::*;
 
-        // Extract the components
-        let [t, rho] = decode_byte_arrays(arrays).map_err(|reason| KyberKeyError { reason: reason.to_string() })?;
+		// Extract the components
+		let [t, rho] = decode_byte_arrays(arrays).map_err(|reason| KyberKeyError {
+			reason: reason.to_string(),
+		})?;
 
-        if t.len() != KYBER_POLYVECBYTES {
-            return Err(KyberKeyError { reason: "t length is incorrect".to_owned() });
-        }
+		if t.len() != KYBER_POLYVECBYTES {
+			return Err(KyberKeyError {
+				reason: "t length is incorrect".to_owned(),
+			});
+		}
 
-        if rho.len() != KYBER_SYMBYTES {
-            return Err(KyberKeyError { reason: "rho length is incorrect".to_owned() });
-        }
+		if rho.len() != KYBER_SYMBYTES {
+			return Err(KyberKeyError {
+				reason: "rho length is incorrect".to_owned(),
+			});
+		}
 
-        let key_data = Zeroizing::new(join_slices!(t, rho));
-        let public_key = PQCryptoKyber1024PublicKey::from_bytes(key_data.as_slice()).
-            map_err(|reason| KyberKeyError { reason: format!("kyber API error: {reason}") })?;
+		let key_data = Zeroizing::new(join_slices!(t, rho));
+		let public_key =
+			PQCryptoKyber1024PublicKey::from_bytes(key_data.as_slice()).map_err(|reason| {
+				KyberKeyError {
+					reason: format!("kyber API error: {reason}"),
+				}
+			})?;
 
-        Ok(Self { public_key })
-    }
+		Ok(Self { public_key })
+	}
 
-    /// Serialize into encoded byte arrays.
-    pub fn serialize(&self) -> Vec<u8> {
-        let (t, rho) = self.public_key.as_bytes().split_at(KYBER_POLYVECBYTES);
-        encode_byte_arrays(&[t, rho]).unwrap()
-    }
+	/// Serialize into encoded byte arrays.
+	pub fn serialize(&self) -> Vec<u8> {
+		let (t, rho) = self.public_key.as_bytes().split_at(KYBER_POLYVECBYTES);
+		encode_byte_arrays(&[t, rho]).unwrap()
+	}
 
-    /// Generate a shared secret and ciphertext with this public key.
-    pub fn encapsulate(&self) -> KyberEncapsulation {
-        use pqcrypto_traits::kem::*;
+	/// Generate a shared secret and ciphertext with this public key.
+	pub fn encapsulate(&self) -> KyberEncapsulation {
+		use pqcrypto_traits::kem::*;
 
-        let (shared_secret, ciphertext) = kyber1024_encapsulate(&self.public_key);
+		let (shared_secret, ciphertext) = kyber1024_encapsulate(&self.public_key);
 
-        KyberEncapsulation {
-            ciphertext: KyberCiphertext(ciphertext.as_bytes().try_into().unwrap()),
-            shared_secret: KyberSharedSecret(shared_secret.as_bytes().try_into().unwrap()),
-        }
-    }
+		KyberEncapsulation {
+			ciphertext: KyberCiphertext(ciphertext.as_bytes().try_into().unwrap()),
+			shared_secret: KyberSharedSecret(shared_secret.as_bytes().try_into().unwrap()),
+		}
+	}
 }
 
 impl From<PQCryptoKyber1024PublicKey> for KyberPublicKey {
-    fn from(value: PQCryptoKyber1024PublicKey) -> Self {
-        Self { public_key: value }
-    }
+	fn from(value: PQCryptoKyber1024PublicKey) -> Self {
+		Self { public_key: value }
+	}
 }
 
 /// Key used for performing decapsulation, owned by the recipient.
 #[derive(Clone, PartialEq)]
 pub struct KyberPrivateKey {
-    private_key: PQCryptoKyber1024SecretKey,
+	private_key: PQCryptoKyber1024SecretKey,
 }
 
 impl KyberPrivateKey {
-    /// Returns this private key as a slice of bytes
-    pub fn as_bytes(&self) -> &[u8] {
-        self.private_key.as_bytes()
-    }
+	/// Returns this private key as a slice of bytes
+	pub fn as_bytes(&self) -> &[u8] {
+		self.private_key.as_bytes()
+	}
 }
 
 #[cfg(test)] // only allow Debug in tests because this prints the key!
 impl Debug for KyberPrivateKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.private_key.as_bytes().fmt(f)
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		self.private_key.as_bytes().fmt(f)
+	}
 }
 
 impl KyberPrivateKey {
-    /// Instantiate a private key from bytes
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, KyberKeyError> {
-        let private_key = PQCryptoKyber1024SecretKey::from_bytes(bytes)
-            .map_err(|reason| KyberKeyError { reason: format!("kyber API error: {reason}") })?;
+	/// Instantiate a private key from bytes
+	pub fn from_bytes(bytes: &[u8]) -> Result<Self, KyberKeyError> {
+		let private_key =
+			PQCryptoKyber1024SecretKey::from_bytes(bytes).map_err(|reason| KyberKeyError {
+				reason: format!("kyber API error: {reason}"),
+			})?;
 
-        Ok(Self { private_key })
-    }
+		Ok(Self { private_key })
+	}
 
-    /// Instantiate a private key from encoded (length + content)  byte arrays.
-    ///
-    /// Returns `Err` if the key is invalid.
-    pub fn deserialize(bytes: &[u8]) -> Result<Self, KyberKeyError> {
-        use pqcrypto_traits::kem::*;
+	/// Instantiate a private key from encoded (length + content)  byte arrays.
+	///
+	/// Returns `Err` if the key is invalid.
+	pub fn deserialize(bytes: &[u8]) -> Result<Self, KyberKeyError> {
+		use pqcrypto_traits::kem::*;
 
-        // Extract the components.
-        let [s, hpk, nonce, t, rho] = decode_byte_arrays(bytes).map_err(|reason| KyberKeyError { reason: reason.to_string() })?;
+		// Extract the components.
+		let [s, hpk, nonce, t, rho] =
+			decode_byte_arrays(bytes).map_err(|reason| KyberKeyError {
+				reason: reason.to_string(),
+			})?;
 
-        // Ensure the lengths are correct.
-        if s.len() != KYBER_POLYVECBYTES {
-            return Err(KyberKeyError { reason: "s length is incorrect".to_owned() });
-        }
-        if hpk.len() != KYBER_SYMBYTES {
-            return Err(KyberKeyError { reason: "hpk length is incorrect".to_owned() });
-        }
-        if nonce.len() != KYBER_SYMBYTES {
-            return Err(KyberKeyError { reason: "nonce length is incorrect".to_owned() });
-        }
-        if t.len() != KYBER_POLYVECBYTES {
-            return Err(KyberKeyError { reason: "t length is incorrect".to_owned() });
-        }
-        if rho.len() != KYBER_SYMBYTES {
-            return Err(KyberKeyError { reason: "rho length is incorrect".to_owned() });
-        }
+		// Ensure the lengths are correct.
+		if s.len() != KYBER_POLYVECBYTES {
+			return Err(KyberKeyError {
+				reason: "s length is incorrect".to_owned(),
+			});
+		}
+		if hpk.len() != KYBER_SYMBYTES {
+			return Err(KyberKeyError {
+				reason: "hpk length is incorrect".to_owned(),
+			});
+		}
+		if nonce.len() != KYBER_SYMBYTES {
+			return Err(KyberKeyError {
+				reason: "nonce length is incorrect".to_owned(),
+			});
+		}
+		if t.len() != KYBER_POLYVECBYTES {
+			return Err(KyberKeyError {
+				reason: "t length is incorrect".to_owned(),
+			});
+		}
+		if rho.len() != KYBER_SYMBYTES {
+			return Err(KyberKeyError {
+				reason: "rho length is incorrect".to_owned(),
+			});
+		}
 
-        // IMPORTANT: We have to reorder the components, since the byte array order is not the same as liboqs's order.
-        let key_data = Zeroizing::new(join_slices!(s, t, rho, hpk, nonce));
-        let private_key = PQCryptoKyber1024SecretKey::from_bytes(&key_data)
-            .map_err(|reason| KyberKeyError { reason: format!("kyber API error: {reason}") })?;
+		// IMPORTANT: We have to reorder the components, since the byte array order is not the same as liboqs's order.
+		let key_data = Zeroizing::new(join_slices!(s, t, rho, hpk, nonce));
+		let private_key =
+			PQCryptoKyber1024SecretKey::from_bytes(&key_data).map_err(|reason| KyberKeyError {
+				reason: format!("kyber API error: {reason}"),
+			})?;
 
-        Ok(Self { private_key })
-    }
+		Ok(Self { private_key })
+	}
 
-    /// Serialize into encoded byte arrays.
-    pub fn serialize(&self) -> Vec<u8> {
-        let bytes = self.private_key.as_bytes();
+	/// Serialize into encoded byte arrays.
+	pub fn serialize(&self) -> Vec<u8> {
+		let bytes = self.private_key.as_bytes();
 
-        let (s, bytes) = bytes.split_at(KYBER_POLYVECBYTES);
-        let (t, bytes) = bytes.split_at(KYBER_POLYVECBYTES);
-        let (rho, bytes) = bytes.split_at(KYBER_SYMBYTES);
-        let (hpk, nonce) = bytes.split_at(KYBER_SYMBYTES);
+		let (s, bytes) = bytes.split_at(KYBER_POLYVECBYTES);
+		let (t, bytes) = bytes.split_at(KYBER_POLYVECBYTES);
+		let (rho, bytes) = bytes.split_at(KYBER_SYMBYTES);
+		let (hpk, nonce) = bytes.split_at(KYBER_SYMBYTES);
 
-        encode_byte_arrays(&[s, hpk, nonce, t, rho]).unwrap()
-    }
+		encode_byte_arrays(&[s, hpk, nonce, t, rho]).unwrap()
+	}
 
-    /// Derive the public key.
-    pub fn get_public_key(&self) -> KyberPublicKey {
-        let bytes = self.private_key.as_bytes();
-        let t_rho = &bytes[KYBER_POLYVECBYTES..KYBER_POLYVECBYTES * 2 + KYBER_SYMBYTES];
-        let public_key = PQCryptoKyber1024PublicKey::from_bytes(t_rho).unwrap();
+	/// Derive the public key.
+	pub fn get_public_key(&self) -> KyberPublicKey {
+		let bytes = self.private_key.as_bytes();
+		let t_rho = &bytes[KYBER_POLYVECBYTES..KYBER_POLYVECBYTES * 2 + KYBER_SYMBYTES];
+		let public_key = PQCryptoKyber1024PublicKey::from_bytes(t_rho).unwrap();
 
-        KyberPublicKey { public_key }
-    }
+		KyberPublicKey { public_key }
+	}
 
-    /// Attempt to decapsulate the ciphertext with this private key, returning the shared secret.
-    ///
-    /// Returns `Err` if the ciphertext is invalid.
-    pub fn decapsulate(&self, ciphertext: &KyberCiphertext) -> Result<KyberSharedSecret, KyberDecapsulationError> {
-        use pqcrypto_kyber::kyber1024::Ciphertext as Kyber1024Ciphertext;
-        use pqcrypto_traits::kem::*;
+	/// Attempt to decapsulate the ciphertext with this private key, returning the shared secret.
+	///
+	/// Returns `Err` if the ciphertext is invalid.
+	pub fn decapsulate(
+		&self,
+		ciphertext: &KyberCiphertext,
+	) -> Result<KyberSharedSecret, KyberDecapsulationError> {
+		use pqcrypto_kyber::kyber1024::Ciphertext as Kyber1024Ciphertext;
+		use pqcrypto_traits::kem::*;
 
-        let ciphertext = Kyber1024Ciphertext::from_bytes(&ciphertext.0)
-            .map_err(|reason| KyberDecapsulationError { reason: format!("failed to parse ciphertext: {reason}") })?;
-        let encapsulation = kyber1024_decapsulate(&ciphertext, &self.private_key).as_bytes().try_into()
-            .map_err(|reason| KyberDecapsulationError { reason: format!("failed to parse ciphertext: {reason}") })?;
-        Ok(KyberSharedSecret(encapsulation))
-    }
+		let ciphertext = Kyber1024Ciphertext::from_bytes(&ciphertext.0).map_err(|reason| {
+			KyberDecapsulationError {
+				reason: format!("failed to parse ciphertext: {reason}"),
+			}
+		})?;
+		let encapsulation = kyber1024_decapsulate(&ciphertext, &self.private_key)
+			.as_bytes()
+			.try_into()
+			.map_err(|reason| KyberDecapsulationError {
+				reason: format!("failed to parse ciphertext: {reason}"),
+			})?;
+		Ok(KyberSharedSecret(encapsulation))
+	}
 }
 
 impl From<PQCryptoKyber1024SecretKey> for KyberPrivateKey {
-    fn from(value: PQCryptoKyber1024SecretKey) -> Self {
-        Self { private_key: value }
-    }
+	fn from(value: PQCryptoKyber1024SecretKey) -> Self {
+		Self { private_key: value }
+	}
 }
 
 /// Error occurred from trying to read a Kyber public/private key.
 #[derive(thiserror::Error, Debug)]
 #[error("Invalid Kyber key: {reason}")]
 pub struct KyberKeyError {
-    pub reason: String,
+	pub reason: String,
 }
 
 /// Error occurred from trying to decapsulate with [`KyberPrivateKey::decapsulate`].
 #[derive(thiserror::Error, Debug)]
 #[error("Decapsulation failure: {reason}")]
 pub struct KyberDecapsulationError {
-    pub reason: String,
+	pub reason: String,
 }
 
 /// Can be used with [`KyberPrivateKey::decapsulate`] to get the shared secret.
@@ -224,21 +263,21 @@ pub struct KyberDecapsulationError {
 pub struct KyberCiphertext([u8; KYBER_CIPHERTEXT_LEN]);
 
 impl KyberCiphertext {
-    pub fn into_bytes(self) -> [u8; KYBER_CIPHERTEXT_LEN] {
-        self.0
-    }
+	pub fn into_bytes(self) -> [u8; KYBER_CIPHERTEXT_LEN] {
+		self.0
+	}
 
-    /// Get a reference to the underlying bytes.
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_slice()
-    }
+	/// Get a reference to the underlying bytes.
+	pub fn as_bytes(&self) -> &[u8] {
+		self.0.as_slice()
+	}
 }
 
 impl TryFrom<&[u8]> for KyberCiphertext {
-    type Error = ArrayCastingError;
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        Ok(Self(array_cast_slice(value, "KyberCiphertext")?))
-    }
+	type Error = ArrayCastingError;
+	fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+		Ok(Self(array_cast_slice(value, "KyberCiphertext")?))
+	}
 }
 
 /// Shared secret generated from either [`KyberPublicKey::encapsulate`] or [`KyberPrivateKey::decapsulate`].
@@ -247,98 +286,112 @@ impl TryFrom<&[u8]> for KyberCiphertext {
 pub struct KyberSharedSecret([u8; KYBER_SHARED_SECRET_LEN]);
 
 impl KyberSharedSecret {
-    pub fn into_bytes(self) -> [u8; KYBER_SHARED_SECRET_LEN] {
-        self.0
-    }
+	pub fn into_bytes(self) -> [u8; KYBER_SHARED_SECRET_LEN] {
+		self.0
+	}
 
-    pub fn as_bytes(&self) -> &[u8] {
-        self.0.as_slice()
-    }
+	pub fn as_bytes(&self) -> &[u8] {
+		self.0.as_slice()
+	}
 }
 
 /// Denotes a ciphertext and shared secret from [`KyberPublicKey::encapsulate`].
 ///
 /// The ciphertext can be used with [`KyberPrivateKey::decapsulate`] to get the shared secret.
 pub struct KyberEncapsulation {
-    pub ciphertext: KyberCiphertext,
-    pub shared_secret: KyberSharedSecret,
+	pub ciphertext: KyberCiphertext,
+	pub shared_secret: KyberSharedSecret,
 }
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
 pub struct KyberKeyPair {
-    pub public_key: KyberPublicKey,
-    pub private_key: KyberPrivateKey,
+	pub public_key: KyberPublicKey,
+	pub private_key: KyberPrivateKey,
 }
 
 impl KyberKeyPair {
-    /// Generate a keypair.
-    pub fn generate() -> Self {
-        use pqcrypto_kyber::kyber1024_keypair;
-        let (kyber_public_key, kyber_private_key) = kyber1024_keypair();
-        Self {
-            public_key: kyber_public_key.into(),
-            private_key: kyber_private_key.into(),
-        }
-    }
+	/// Generate a keypair.
+	pub fn generate() -> Self {
+		use pqcrypto_kyber::kyber1024_keypair;
+		let (kyber_public_key, kyber_private_key) = kyber1024_keypair();
+		Self {
+			public_key: kyber_public_key.into(),
+			private_key: kyber_private_key.into(),
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::compatibility_test_utils::get_test_data;
-    use super::*;
+	use super::*;
+	use crate::crypto::compatibility_test_utils::get_test_data;
 
-    #[test]
-    fn test_kyber() {
-        let test_data = get_test_data();
-        for i in test_data.kyber_encryption_tests {
-            let shared_secret = KyberSharedSecret(i.shared_secret.as_slice().try_into().unwrap());
-            let ciphertext = KyberCiphertext(i.cipher_text.as_slice().try_into().unwrap());
-            let private_key = KyberPrivateKey::deserialize(i.private_key.as_slice()).unwrap();
-            let public_key = KyberPublicKey::deserialize(i.public_key.as_slice()).unwrap();
-            assert_eq!(shared_secret.0, private_key.decapsulate(&ciphertext).unwrap().0);
+	#[test]
+	fn test_kyber() {
+		let test_data = get_test_data();
+		for i in test_data.kyber_encryption_tests {
+			let shared_secret = KyberSharedSecret(i.shared_secret.as_slice().try_into().unwrap());
+			let ciphertext = KyberCiphertext(i.cipher_text.as_slice().try_into().unwrap());
+			let private_key = KyberPrivateKey::deserialize(i.private_key.as_slice()).unwrap();
+			let public_key = KyberPublicKey::deserialize(i.public_key.as_slice()).unwrap();
+			assert_eq!(
+				shared_secret.0,
+				private_key.decapsulate(&ciphertext).unwrap().0
+			);
 
-            // NOTE: We cannot do compatibility tests for encapsulation with this library, only decapsulation, since we cannot inject randomness.
-            //
-            // As such, we'll just test round-trip. Since we test decapsulation, if round-trip is correct, then encapsulation SHOULD be correct.
-            let encapsulated = public_key.encapsulate();
-            let decapsulated = private_key.decapsulate(&encapsulated.ciphertext);
-            assert_eq!(encapsulated.shared_secret.0, decapsulated.unwrap().0);
+			// NOTE: We cannot do compatibility tests for encapsulation with this library, only decapsulation, since we cannot inject randomness.
+			//
+			// As such, we'll just test round-trip. Since we test decapsulation, if round-trip is correct, then encapsulation SHOULD be correct.
+			let encapsulated = public_key.encapsulate();
+			let decapsulated = private_key.decapsulate(&encapsulated.ciphertext);
+			assert_eq!(encapsulated.shared_secret.0, decapsulated.unwrap().0);
 
-            // Test serialization
-            let serialized_pub = public_key.serialize();
-            let serialized_priv = private_key.serialize();
-            assert_eq!(i.public_key, serialized_pub);
-            assert_eq!(i.private_key, serialized_priv);
+			// Test serialization
+			let serialized_pub = public_key.serialize();
+			let serialized_priv = private_key.serialize();
+			assert_eq!(i.public_key, serialized_pub);
+			assert_eq!(i.private_key, serialized_priv);
 
-            // Test getting the public key
-            assert_eq!(public_key.public_key.as_bytes(), private_key.get_public_key().public_key.as_bytes());
-        }
-    }
+			// Test getting the public key
+			assert_eq!(
+				public_key.public_key.as_bytes(),
+				private_key.get_public_key().public_key.as_bytes()
+			);
+		}
+	}
 
-    #[test]
-    fn test_kyber_encoding_roundtrip() {
-        // Generate some raw unencoded kyber keys
-        let KyberKeyPair { public_key, private_key } = KyberKeyPair::generate();
+	#[test]
+	fn test_kyber_encoding_roundtrip() {
+		// Generate some raw unencoded kyber keys
+		let KyberKeyPair {
+			public_key,
+			private_key,
+		} = KyberKeyPair::generate();
 
-        // Encode the kyber keys
-        let encoded_public_key = public_key.serialize();
-        let encoded_private_key = private_key.serialize();
+		// Encode the kyber keys
+		let encoded_public_key = public_key.serialize();
+		let encoded_private_key = private_key.serialize();
 
-        // Decode the encoded kyber keys which should give us the raw kyber keys back
-        let decoded_public_key = KyberPublicKey::deserialize(encoded_public_key.as_slice()).unwrap();
-        let decoded_private_key = KyberPrivateKey::deserialize(encoded_private_key.as_slice()).unwrap();
+		// Decode the encoded kyber keys which should give us the raw kyber keys back
+		let decoded_public_key =
+			KyberPublicKey::deserialize(encoded_public_key.as_slice()).unwrap();
+		let decoded_private_key =
+			KyberPrivateKey::deserialize(encoded_private_key.as_slice()).unwrap();
 
-        assert_eq!(public_key, decoded_public_key);
-        assert_eq!(private_key, decoded_private_key);
-    }
+		assert_eq!(public_key, decoded_public_key);
+		assert_eq!(private_key, decoded_private_key);
+	}
 
-    #[test]
-    fn test_kyber_encryption_roundtrip() {
-        let key_pair = KyberKeyPair::generate();
-        let encapsulated = key_pair.public_key.encapsulate();
-        let shared_secret_alice = encapsulated.shared_secret;
-        let shared_secret_bob = key_pair.private_key.decapsulate(&encapsulated.ciphertext).unwrap();
-        assert_eq!(shared_secret_alice, shared_secret_bob)
-    }
+	#[test]
+	fn test_kyber_encryption_roundtrip() {
+		let key_pair = KyberKeyPair::generate();
+		let encapsulated = key_pair.public_key.encapsulate();
+		let shared_secret_alice = encapsulated.shared_secret;
+		let shared_secret_bob = key_pair
+			.private_key
+			.decapsulate(&encapsulated.ciphertext)
+			.unwrap();
+		assert_eq!(shared_secret_alice, shared_secret_bob)
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/mod.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/mod.rs
@@ -2,13 +2,12 @@
 //! Contains implementations of cryptographic algorithms and their primitives
 // TODO: Remove the above allowance when starting to implement higher level functions
 
-
-pub use aes::{Aes256Key, AES_256_KEY_SIZE, IV_BYTE_SIZE};
 #[allow(unused_imports)]
 pub use aes::Aes128Key;
 #[cfg(test)]
 pub use aes::Iv;
 pub use aes::PlaintextAndIv;
+pub use aes::{Aes256Key, AES_256_KEY_SIZE, IV_BYTE_SIZE};
 pub use argon2_id::generate_key_from_passphrase;
 pub use hkdf::hkdf;
 pub use sha::sha256;
@@ -29,9 +28,9 @@ pub(crate) mod rsa;
 
 mod tuta_crypt;
 
-pub mod key_encryption;
-pub mod crypto_facade;
-pub mod key;
-pub mod randomizer_facade;
 #[cfg(test)]
 mod compatibility_test_utils;
+pub mod crypto_facade;
+pub mod key;
+pub mod key_encryption;
+pub mod randomizer_facade;

--- a/tuta-sdk/rust/sdk/src/crypto/randomizer_facade.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/randomizer_facade.rs
@@ -1,67 +1,71 @@
-use std::sync::{Arc, Mutex};
 use rand_core::{CryptoRng, CryptoRngCore, Error, RngCore};
+use std::sync::{Arc, Mutex};
 
 /// Provides an interface for generating values from a `CryptoRngCore` in a thread-safe way.
 pub struct RandomizerFacade {
-    source: Arc<Mutex<Box<dyn CryptoRngCore + Send + Sync>>>,
+	source: Arc<Mutex<Box<dyn CryptoRngCore + Send + Sync>>>,
 }
 
 impl RandomizerFacade {
-    /// Instantiate this facade with the given core.
-    pub fn from_core<C: CryptoRngCore + Send + Sync + 'static>(core: C) -> Self {
-        Self { source: Arc::new(Mutex::new(Box::new(core))) }
-    }
+	/// Instantiate this facade with the given core.
+	pub fn from_core<C: CryptoRngCore + Send + Sync + 'static>(core: C) -> Self {
+		Self {
+			source: Arc::new(Mutex::new(Box::new(core))),
+		}
+	}
 
-    /// Create a copy of this facade.
-    ///
-    /// The source will be shared between both instances.
-    ///
-    /// This is useful if you want to make a mutable version of this facade to use in functions that
-    /// directly require a CryptoRngCore.
-    pub(in crate::crypto) fn clone(&self) -> Self {
-        Self { source: self.source.clone() }
-    }
-    
-    /// Generate a random array of a given size.
-    pub fn generate_random_array<const S: usize>(&self) -> [u8; S] {
-        let mut output = [0u8; S];
-        self.fill_slice(&mut output);
-        output
-    }
+	/// Create a copy of this facade.
+	///
+	/// The source will be shared between both instances.
+	///
+	/// This is useful if you want to make a mutable version of this facade to use in functions that
+	/// directly require a CryptoRngCore.
+	pub(in crate::crypto) fn clone(&self) -> Self {
+		Self {
+			source: self.source.clone(),
+		}
+	}
 
-    fn fill_slice(&self, output: &mut [u8]) {
-        let mut source = self.source.lock().expect("how???");
-        source.fill_bytes(output)
-    }
+	/// Generate a random array of a given size.
+	pub fn generate_random_array<const S: usize>(&self) -> [u8; S] {
+		let mut output = [0u8; S];
+		self.fill_slice(&mut output);
+		output
+	}
+
+	fn fill_slice(&self, output: &mut [u8]) {
+		let mut source = self.source.lock().expect("how???");
+		source.fill_bytes(output)
+	}
 }
 
 impl CryptoRng for RandomizerFacade {}
 
 impl RngCore for RandomizerFacade {
-    fn next_u32(&mut self) -> u32 {
-        rand_core::impls::next_u32_via_fill(self)
-    }
+	fn next_u32(&mut self) -> u32 {
+		rand_core::impls::next_u32_via_fill(self)
+	}
 
-    fn next_u64(&mut self) -> u64 {
-        rand_core::impls::next_u64_via_fill(self)
-    }
+	fn next_u64(&mut self) -> u64 {
+		rand_core::impls::next_u64_via_fill(self)
+	}
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.fill_slice(dest)
-    }
+	fn fill_bytes(&mut self, dest: &mut [u8]) {
+		self.fill_slice(dest)
+	}
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_slice(dest);
-        Ok(())
-    }
+	fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+		self.fill_slice(dest);
+		Ok(())
+	}
 }
 
 #[cfg(test)]
 pub mod test_util {
-    use super::*;
+	use super::*;
 
-    /// Used for internal testing using OsRng.
-    pub fn make_thread_rng_facade() -> RandomizerFacade {
-        RandomizerFacade::from_core(rand::rngs::OsRng {})
-    }
+	/// Used for internal testing using OsRng.
+	pub fn make_thread_rng_facade() -> RandomizerFacade {
+		RandomizerFacade::from_core(rand::rngs::OsRng {})
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/rsa.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/rsa.rs
@@ -1,13 +1,13 @@
-use std::ops::Deref;
+use crate::crypto::ecc::EccKeyPair;
+use crate::crypto::randomizer_facade::RandomizerFacade;
+use crate::join_slices;
 use rand_core::impls::{next_u32_via_fill, next_u64_via_fill};
 use rand_core::{CryptoRng, Error, RngCore};
-use rsa::{BigUint, Oaep};
 use rsa::traits::{PrivateKeyParts, PublicKeyParts};
+use rsa::{BigUint, Oaep};
 use sha2::Sha256;
+use std::ops::Deref;
 use zeroize::{ZeroizeOnDrop, Zeroizing};
-use crate::crypto::randomizer_facade::RandomizerFacade;
-use crate::crypto::ecc::EccKeyPair;
-use crate::join_slices;
 
 #[cfg(test)]
 const RSA_KEY_BIT_SIZE: usize = 2048;
@@ -17,55 +17,66 @@ const RSA_KEY_BIT_SIZE: usize = 2048;
 pub struct RSAPublicKey(rsa::RsaPublicKey);
 
 impl RSAPublicKey {
-    pub fn new(public_key: rsa::RsaPublicKey) -> Self {
-        Self(public_key)
-    }
+	pub fn new(public_key: rsa::RsaPublicKey) -> Self {
+		Self(public_key)
+	}
 
-    /// Create a key from a PEM-encoded ASN.1 SPKI
-    pub fn from_public_key_pem(s: &str) -> Result<Self, RSAKeyError> {
-        use rsa as rsa_package;
-        use rsa_package::pkcs8::DecodePublicKey;
-        let new_key = rsa_package::RsaPublicKey::from_public_key_pem(s).map_err(|error| RSAKeyError { reason: error.to_string() })?;
-        Ok(Self(new_key))
-    }
+	/// Create a key from a PEM-encoded ASN.1 SPKI
+	pub fn from_public_key_pem(s: &str) -> Result<Self, RSAKeyError> {
+		use rsa as rsa_package;
+		use rsa_package::pkcs8::DecodePublicKey;
+		let new_key =
+			rsa_package::RsaPublicKey::from_public_key_pem(s).map_err(|error| RSAKeyError {
+				reason: error.to_string(),
+			})?;
+		Ok(Self(new_key))
+	}
 }
 
 const RSA_PUBLIC_EXPONENT: u32 = 65537;
 
 impl RSAPublicKey {
-    /// Instantiate an RSAPublicKey from a modulus.
-    ///
-    /// Returns `Err` if the modulus is the wrong size.
-    pub fn from_components(modulus: &[u8], public_exponent: u32) -> Result<Self, RSAKeyError> {
-        rsa::RsaPublicKey::new(BigUint::from_bytes_be(modulus), public_exponent.into())
-            .map(Self)
-            .map_err(|e| RSAKeyError { reason: format!("rsa public key parse error: {e}") })
-    }
+	/// Instantiate an RSAPublicKey from a modulus.
+	///
+	/// Returns `Err` if the modulus is the wrong size.
+	pub fn from_components(modulus: &[u8], public_exponent: u32) -> Result<Self, RSAKeyError> {
+		rsa::RsaPublicKey::new(BigUint::from_bytes_be(modulus), public_exponent.into())
+			.map(Self)
+			.map_err(|e| RSAKeyError {
+				reason: format!("rsa public key parse error: {e}"),
+			})
+	}
 
-    /// Parse from encoded form.
-    pub fn deserialize(bytes: &[u8]) -> Result<Self, RSAKeyError> {
-        let [modulus] = decode_nibble_arrays(bytes)?;
-        Self::from_components(modulus, RSA_PUBLIC_EXPONENT)
-    }
+	/// Parse from encoded form.
+	pub fn deserialize(bytes: &[u8]) -> Result<Self, RSAKeyError> {
+		let [modulus] = decode_nibble_arrays(bytes)?;
+		Self::from_components(modulus, RSA_PUBLIC_EXPONENT)
+	}
 
-    /// Convert to encoded form.
-    pub fn serialize(&self) -> Vec<u8> {
-        let modulus = Zeroizing::new(self.0.n().to_bytes_be());
-        let encoded = encode_nibble_arrays(&[modulus.as_slice()]).unwrap();
-        encoded
-    }
+	/// Convert to encoded form.
+	pub fn serialize(&self) -> Vec<u8> {
+		let modulus = Zeroizing::new(self.0.n().to_bytes_be());
+		let encoded = encode_nibble_arrays(&[modulus.as_slice()]).unwrap();
+		encoded
+	}
 
-    /// Encrypt with the given RNG provider.
-    ///
-    /// Returns `Err` if an error occurs.
-    pub fn encrypt(&self, randomizer_facade: &RandomizerFacade, data: &[u8]) -> Result<Vec<u8>, RSAEncryptionError> {
-        let padding = Oaep::new::<Sha256>();
-        let mut rng = randomizer_facade.clone();
+	/// Encrypt with the given RNG provider.
+	///
+	/// Returns `Err` if an error occurs.
+	pub fn encrypt(
+		&self,
+		randomizer_facade: &RandomizerFacade,
+		data: &[u8],
+	) -> Result<Vec<u8>, RSAEncryptionError> {
+		let padding = Oaep::new::<Sha256>();
+		let mut rng = randomizer_facade.clone();
 
-        self.0
-            .encrypt(&mut rng, padding, data)
-            .map_err(|e| RSAEncryptionError { reason: format!("encrypt error: {e}") })
-    }
+		self.0
+			.encrypt(&mut rng, padding, data)
+			.map_err(|e| RSAEncryptionError {
+				reason: format!("encrypt error: {e}"),
+			})
+	}
 }
 
 #[derive(Clone, ZeroizeOnDrop, PartialEq)]
@@ -73,141 +84,162 @@ impl RSAPublicKey {
 pub struct RSAPrivateKey(rsa::RsaPrivateKey);
 
 impl RSAPrivateKey {
-    pub fn new(private_key: rsa::RsaPrivateKey) -> Self {
-        Self(private_key)
-    }
-    /// Derives an PKCS1 RSA private key from an ASN.1-DER encoded private key
-    pub fn from_pkcs1_der(private_key: &[u8]) -> Result<Self, RSAKeyError> {
-        use rsa as rsa_package;
-        use rsa_package::pkcs1::DecodeRsaPrivateKey;
+	pub fn new(private_key: rsa::RsaPrivateKey) -> Self {
+		Self(private_key)
+	}
+	/// Derives an PKCS1 RSA private key from an ASN.1-DER encoded private key
+	pub fn from_pkcs1_der(private_key: &[u8]) -> Result<Self, RSAKeyError> {
+		use rsa as rsa_package;
+		use rsa_package::pkcs1::DecodeRsaPrivateKey;
 
-        let derived_key = rsa_package::RsaPrivateKey::from_pkcs1_der(private_key)
-            .map_err(|error| RSAKeyError { reason: error.to_string() })?;
-        Ok(Self(derived_key))
-    }
+		let derived_key =
+			rsa_package::RsaPrivateKey::from_pkcs1_der(private_key).map_err(|error| {
+				RSAKeyError {
+					reason: error.to_string(),
+				}
+			})?;
+		Ok(Self(derived_key))
+	}
 }
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
 pub struct RSAKeyPair {
-    pub public_key: RSAPublicKey,
-    pub private_key: RSAPrivateKey,
+	pub public_key: RSAPublicKey,
+	pub private_key: RSAPrivateKey,
 }
 
 impl RSAKeyPair {
-    /// Generate an RSA keypair.
-    ///
-    /// We do not generate RSA keys anymore, so this is only visible in test code.
-    #[cfg(test)]
-    pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
-        let private_key = rsa::RsaPrivateKey::new(&mut randomizer_facade.clone(), RSA_KEY_BIT_SIZE).unwrap();
-        let public_key = private_key.to_public_key();
-        Self {
-            public_key: RSAPublicKey::new(public_key),
-            private_key: RSAPrivateKey::new(private_key),
-        }
-    }
+	/// Generate an RSA keypair.
+	///
+	/// We do not generate RSA keys anymore, so this is only visible in test code.
+	#[cfg(test)]
+	pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
+		let private_key =
+			rsa::RsaPrivateKey::new(&mut randomizer_facade.clone(), RSA_KEY_BIT_SIZE).unwrap();
+		let public_key = private_key.to_public_key();
+		Self {
+			public_key: RSAPublicKey::new(public_key),
+			private_key: RSAPrivateKey::new(private_key),
+		}
+	}
 }
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
 pub struct RSAEccKeyPair {
-    pub rsa_key_pair: RSAKeyPair,
-    pub ecc_key_pair: EccKeyPair,
+	pub rsa_key_pair: RSAKeyPair,
+	pub ecc_key_pair: EccKeyPair,
 }
 
 impl RSAEccKeyPair {
-    /// Generate an RSA-ECC keypair.
-    ///
-    /// This is only intended to be used for testing, as new RSA keys should not be generated.
-    #[cfg(test)]
-    pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
-        Self {
-            rsa_key_pair: RSAKeyPair::generate(randomizer_facade),
-            ecc_key_pair: EccKeyPair::generate(randomizer_facade),
-        }
-    }
+	/// Generate an RSA-ECC keypair.
+	///
+	/// This is only intended to be used for testing, as new RSA keys should not be generated.
+	#[cfg(test)]
+	pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
+		Self {
+			rsa_key_pair: RSAKeyPair::generate(randomizer_facade),
+			ecc_key_pair: EccKeyPair::generate(randomizer_facade),
+		}
+	}
 }
 
 impl RSAPrivateKey {
-    /// Instantiate an RSAPrivateKey from its components.
-    ///
-    /// Returns `Err` if any components are not correct.
-    pub fn from_components(modulus: &[u8], private_exponent: &[u8], prime_p: &[u8], prime_q: &[u8]) -> Result<Self, RSAKeyError> {
-        rsa::RsaPrivateKey::from_components(
-            BigUint::from_bytes_be(modulus),
-            RSA_PUBLIC_EXPONENT.into(),
-            BigUint::from_bytes_be(private_exponent),
-            vec![BigUint::from_bytes_be(prime_p), BigUint::from_bytes_be(prime_q)],
-        )
-            .and_then(|v| {
-                v.validate()?;
-                Ok(Self(v))
-            })
-            .map_err(|e| RSAKeyError { reason: format!("rsa private key parse error: {e}") })
-    }
+	/// Instantiate an RSAPrivateKey from its components.
+	///
+	/// Returns `Err` if any components are not correct.
+	pub fn from_components(
+		modulus: &[u8],
+		private_exponent: &[u8],
+		prime_p: &[u8],
+		prime_q: &[u8],
+	) -> Result<Self, RSAKeyError> {
+		rsa::RsaPrivateKey::from_components(
+			BigUint::from_bytes_be(modulus),
+			RSA_PUBLIC_EXPONENT.into(),
+			BigUint::from_bytes_be(private_exponent),
+			vec![
+				BigUint::from_bytes_be(prime_p),
+				BigUint::from_bytes_be(prime_q),
+			],
+		)
+		.and_then(|v| {
+			v.validate()?;
+			Ok(Self(v))
+		})
+		.map_err(|e| RSAKeyError {
+			reason: format!("rsa private key parse error: {e}"),
+		})
+	}
 
-    /// Convert to encoded form.
-    pub fn serialize(&self) -> Vec<u8> {
-        let one = BigUint::from(1u32);
-        let crt_coefficient = self.0.crt_coefficient().unwrap();
-        let [prime_p, prime_q] = self.0.primes() else { unreachable!() };
-        let modulus = self.0.n();
-        let private_exponent = self.0.d();
+	/// Convert to encoded form.
+	pub fn serialize(&self) -> Vec<u8> {
+		let one = BigUint::from(1u32);
+		let crt_coefficient = self.0.crt_coefficient().unwrap();
+		let [prime_p, prime_q] = self.0.primes() else {
+			unreachable!()
+		};
+		let modulus = self.0.n();
+		let private_exponent = self.0.d();
 
-        // Note: We have to store p-1 and q-1 to ensure we zeroize them later
-        let p1 = Zeroizing::new(prime_p - &one);
-        let q1 = Zeroizing::new(prime_q - &one);
-        let exponent_p = Zeroizing::new(private_exponent % p1.deref());
-        let exponent_q = Zeroizing::new(private_exponent % q1.deref());
+		// Note: We have to store p-1 and q-1 to ensure we zeroize them later
+		let p1 = Zeroizing::new(prime_p - &one);
+		let q1 = Zeroizing::new(prime_q - &one);
+		let exponent_p = Zeroizing::new(private_exponent % p1.deref());
+		let exponent_q = Zeroizing::new(private_exponent % q1.deref());
 
-        // For efficiently padding to 256 bytes
-        let mut zeroes = Vec::with_capacity(256);
-        let mut resize = |bytes: Vec<u8>| -> Vec<u8> {
-            if bytes.len() < 256 {
-                let bytes = Zeroizing::new(bytes);
-                zeroes.resize(256 - bytes.len(), 0); // resize the same byte array so we don't have to re-allocate
-                let new_val = join_slices!(&zeroes, bytes.as_slice());
-                new_val
-            } else {
-                bytes
-            }
-        };
+		// For efficiently padding to 256 bytes
+		let mut zeroes = Vec::with_capacity(256);
+		let mut resize = |bytes: Vec<u8>| -> Vec<u8> {
+			if bytes.len() < 256 {
+				let bytes = Zeroizing::new(bytes);
+				zeroes.resize(256 - bytes.len(), 0); // resize the same byte array so we don't have to re-allocate
+				let new_val = join_slices!(&zeroes, bytes.as_slice());
+				new_val
+			} else {
+				bytes
+			}
+		};
 
-        let modulus_bytes = Zeroizing::new(modulus.to_bytes_be());
-        let private_exponent_bytes = Zeroizing::new(private_exponent.to_bytes_be());
-        let prime_p_bytes = Zeroizing::new(resize(prime_p.to_bytes_be()));
-        let prime_q_bytes = Zeroizing::new(resize(prime_q.to_bytes_be()));
-        let exponent_p_bytes = Zeroizing::new(resize(exponent_p.to_bytes_be()));
-        let exponent_q_bytes = Zeroizing::new(resize(exponent_q.to_bytes_be()));
-        let crt_coefficient_bytes = Zeroizing::new(resize(crt_coefficient.to_bytes_be()));
+		let modulus_bytes = Zeroizing::new(modulus.to_bytes_be());
+		let private_exponent_bytes = Zeroizing::new(private_exponent.to_bytes_be());
+		let prime_p_bytes = Zeroizing::new(resize(prime_p.to_bytes_be()));
+		let prime_q_bytes = Zeroizing::new(resize(prime_q.to_bytes_be()));
+		let exponent_p_bytes = Zeroizing::new(resize(exponent_p.to_bytes_be()));
+		let exponent_q_bytes = Zeroizing::new(resize(exponent_q.to_bytes_be()));
+		let crt_coefficient_bytes = Zeroizing::new(resize(crt_coefficient.to_bytes_be()));
 
-        encode_nibble_arrays(&[
-            modulus_bytes.as_slice(),
-            private_exponent_bytes.as_slice(),
-            prime_p_bytes.as_slice(),
-            prime_q_bytes.as_slice(),
-            exponent_p_bytes.as_slice(),
-            exponent_q_bytes.as_slice(),
-            crt_coefficient_bytes.as_slice()
-        ]).unwrap()
-    }
+		encode_nibble_arrays(&[
+			modulus_bytes.as_slice(),
+			private_exponent_bytes.as_slice(),
+			prime_p_bytes.as_slice(),
+			prime_q_bytes.as_slice(),
+			exponent_p_bytes.as_slice(),
+			exponent_q_bytes.as_slice(),
+			crt_coefficient_bytes.as_slice(),
+		])
+		.unwrap()
+	}
 
-    /// Parse from encoded form.
-    pub fn deserialize(bytes: &[u8]) -> Result<Self, RSAKeyError> {
-        let [modulus, private_exponent, prime_p, prime_q, _exponent_p, _exponent_q, _crt_coefficient] = decode_nibble_arrays(bytes).unwrap();
-        Self::from_components(modulus, private_exponent, prime_p, prime_q)
-    }
+	/// Parse from encoded form.
+	pub fn deserialize(bytes: &[u8]) -> Result<Self, RSAKeyError> {
+		let [modulus, private_exponent, prime_p, prime_q, _exponent_p, _exponent_q, _crt_coefficient] =
+			decode_nibble_arrays(bytes).unwrap();
+		Self::from_components(modulus, private_exponent, prime_p, prime_q)
+	}
 
-    /// Decrypt the ciphertext.
-    ///
-    /// Returns `Err` if an error occurs.
-    pub fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, RSAEncryptionError> {
-        let padding = Oaep::new::<Sha256>();
-        self.0
-            .decrypt(padding, ciphertext)
-            .map_err(|e| RSAEncryptionError { reason: format!("decrypt error: {e}") })
-    }
+	/// Decrypt the ciphertext.
+	///
+	/// Returns `Err` if an error occurs.
+	pub fn decrypt(&self, ciphertext: &[u8]) -> Result<Vec<u8>, RSAEncryptionError> {
+		let padding = Oaep::new::<Sha256>();
+		self.0
+			.decrypt(padding, ciphertext)
+			.map_err(|e| RSAEncryptionError {
+				reason: format!("decrypt error: {e}"),
+			})
+	}
 }
 
 /// Decode the encoded byte arrays.
@@ -216,30 +248,41 @@ impl RSAPrivateKey {
 ///
 /// Returns `Err` if this is invalid.
 fn decode_nibble_arrays<const SIZE: usize>(arrays: &[u8]) -> Result<[&[u8]; SIZE], RSAKeyError> {
-    let mut result = [[0u8; 0].as_slice(); SIZE];
-    let mut remaining = arrays;
+	let mut result = [[0u8; 0].as_slice(); SIZE];
+	let mut remaining = arrays;
 
-    for (array_index, array_result) in result.iter_mut().enumerate() {
-        if remaining.len() < 2 {
-            return Err(RSAKeyError { reason: format!("invalid encoded RSA key (only got {array_index} array(s), expected {SIZE})") });
-        }
-        let (len_bytes, after) = remaining.split_at(2);
+	for (array_index, array_result) in result.iter_mut().enumerate() {
+		if remaining.len() < 2 {
+			return Err(RSAKeyError {
+				reason: format!(
+					"invalid encoded RSA key (only got {array_index} array(s), expected {SIZE})"
+				),
+			});
+		}
+		let (len_bytes, after) = remaining.split_at(2);
 
-        let length = (u16::from_be_bytes(len_bytes.try_into().unwrap()) as usize) / 2;
-        if after.len() < length {
-            return Err(RSAKeyError { reason: format!("invalid encoded RSA key (size {length} is too large)") });
-        }
-        let (arr, new_remaining) = after.split_at(length);
+		let length = (u16::from_be_bytes(len_bytes.try_into().unwrap()) as usize) / 2;
+		if after.len() < length {
+			return Err(RSAKeyError {
+				reason: format!("invalid encoded RSA key (size {length} is too large)"),
+			});
+		}
+		let (arr, new_remaining) = after.split_at(length);
 
-        *array_result = arr;
-        remaining = new_remaining;
-    }
+		*array_result = arr;
+		remaining = new_remaining;
+	}
 
-    if !remaining.is_empty() {
-        return Err(RSAKeyError { reason: format!("extraneous {} byte(s) detected - incorrect size?", remaining.len()) });
-    }
+	if !remaining.is_empty() {
+		return Err(RSAKeyError {
+			reason: format!(
+				"extraneous {} byte(s) detected - incorrect size?",
+				remaining.len()
+			),
+		});
+	}
 
-    Ok(result)
+	Ok(result)
 }
 
 /// Encode the byte arrays into one.
@@ -248,36 +291,38 @@ fn decode_nibble_arrays<const SIZE: usize>(arrays: &[u8]) -> Result<[&[u8]; SIZE
 ///
 /// Returns `Err` if anything is bigger than a 16-bit integer.
 fn encode_nibble_arrays<const SIZE: usize>(arrays: &[&[u8]; SIZE]) -> Result<Vec<u8>, RSAKeyError> {
-    let mut expected_size = 0usize;
-    for &i in arrays {
-        let len = i.len() * 2;
-        if len > u16::MAX as usize {
-            return Err(RSAKeyError { reason: format!("nibble array length {len} exceeds 16-bit limit") });
-        }
-        expected_size += 2 + i.len();
-    }
+	let mut expected_size = 0usize;
+	for &i in arrays {
+		let len = i.len() * 2;
+		if len > u16::MAX as usize {
+			return Err(RSAKeyError {
+				reason: format!("nibble array length {len} exceeds 16-bit limit"),
+			});
+		}
+		expected_size += 2 + i.len();
+	}
 
-    let mut v = Vec::with_capacity(expected_size);
-    for &i in arrays {
-        v.extend_from_slice(&((i.len() * 2) as u16).to_be_bytes());
-        v.extend_from_slice(i);
-    }
+	let mut v = Vec::with_capacity(expected_size);
+	for &i in arrays {
+		v.extend_from_slice(&((i.len() * 2) as u16).to_be_bytes());
+		v.extend_from_slice(i);
+	}
 
-    Ok(v)
+	Ok(v)
 }
 
 /// Error that occurs when parsing RSA keys.
 #[derive(thiserror::Error, Debug)]
 #[error("RSA error: {reason}")]
 pub struct RSAKeyError {
-    reason: String,
+	reason: String,
 }
 
 /// Error that occurs when using rsa encrypt/decrypt.
 #[derive(thiserror::Error, Debug)]
 #[error("RSA error: {reason}")]
 pub struct RSAEncryptionError {
-    reason: String,
+	reason: String,
 }
 
 /// Used for providing a string of bytes as a random number generator.
@@ -287,72 +332,72 @@ pub struct RSAEncryptionError {
 /// This will panic if not enough bytes have been passed into the random number generator.
 #[derive(ZeroizeOnDrop)]
 pub(crate) struct SeedBufferRng {
-    buff: Vec<u8>,
+	buff: Vec<u8>,
 }
 
 impl SeedBufferRng {
-    pub fn new(buff: Vec<u8>) -> SeedBufferRng {
-        SeedBufferRng { buff }
-    }
+	pub fn new(buff: Vec<u8>) -> SeedBufferRng {
+		SeedBufferRng { buff }
+	}
 }
 
 impl RngCore for SeedBufferRng {
-    fn next_u32(&mut self) -> u32 {
-        next_u32_via_fill(self)
-    }
+	fn next_u32(&mut self) -> u32 {
+		next_u32_via_fill(self)
+	}
 
-    fn next_u64(&mut self) -> u64 {
-        next_u64_via_fill(self)
-    }
+	fn next_u64(&mut self) -> u64 {
+		next_u64_via_fill(self)
+	}
 
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        let (copied, remaining) = self.buff.split_at(dest.len());
-        dest.copy_from_slice(copied);
-        self.buff = remaining.to_owned();
-    }
+	fn fill_bytes(&mut self, dest: &mut [u8]) {
+		let (copied, remaining) = self.buff.split_at(dest.len());
+		dest.copy_from_slice(copied);
+		self.buff = remaining.to_owned();
+	}
 
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
-        self.fill_bytes(dest);
-        Ok(())
-    }
+	fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+		self.fill_bytes(dest);
+		Ok(())
+	}
 }
 
 impl CryptoRng for SeedBufferRng {}
 
 #[cfg(test)]
 mod tests {
-    use crate::crypto::compatibility_test_utils::get_test_data;
-    use super::*;
+	use super::*;
+	use crate::crypto::compatibility_test_utils::get_test_data;
 
-    #[test]
-    fn test_rsa_encryption() {
-        let test_data = get_test_data();
-        for i in test_data.rsa_encryption_tests {
-            let public_key = RSAPublicKey::deserialize(&i.public_key).unwrap();
-            let randomizer = RandomizerFacade::from_core(SeedBufferRng::new(i.seed));
-            let ciphertext = public_key.encrypt(&randomizer, &i.input).unwrap();
-            assert_eq!(i.result, ciphertext);
-        }
-    }
+	#[test]
+	fn test_rsa_encryption() {
+		let test_data = get_test_data();
+		for i in test_data.rsa_encryption_tests {
+			let public_key = RSAPublicKey::deserialize(&i.public_key).unwrap();
+			let randomizer = RandomizerFacade::from_core(SeedBufferRng::new(i.seed));
+			let ciphertext = public_key.encrypt(&randomizer, &i.input).unwrap();
+			assert_eq!(i.result, ciphertext);
+		}
+	}
 
-    #[test]
-    fn test_rsa_decryption() {
-        let test_data = get_test_data();
-        for i in test_data.rsa_encryption_tests {
-            let private_key = RSAPrivateKey::deserialize(&i.private_key).unwrap();
-            let data = private_key.decrypt(&i.result).unwrap();
-            assert_eq!(i.input, data);
-        }
-    }
+	#[test]
+	fn test_rsa_decryption() {
+		let test_data = get_test_data();
+		for i in test_data.rsa_encryption_tests {
+			let private_key = RSAPrivateKey::deserialize(&i.private_key).unwrap();
+			let data = private_key.decrypt(&i.result).unwrap();
+			assert_eq!(i.input, data);
+		}
+	}
 
-    #[test]
-    fn test_rsa_serialize_roundtrip() {
-        let test_data = get_test_data();
-        for i in test_data.rsa_encryption_tests {
-            let public_key = RSAPublicKey::deserialize(&i.public_key).unwrap();
-            assert_eq!(i.public_key, public_key.serialize());
-            let private_key = RSAPrivateKey::deserialize(&i.private_key).unwrap();
-            assert_eq!(i.private_key, private_key.serialize());
-        }
-    }
+	#[test]
+	fn test_rsa_serialize_roundtrip() {
+		let test_data = get_test_data();
+		for i in test_data.rsa_encryption_tests {
+			let public_key = RSAPublicKey::deserialize(&i.public_key).unwrap();
+			assert_eq!(i.public_key, public_key.serialize());
+			let private_key = RSAPrivateKey::deserialize(&i.private_key).unwrap();
+			assert_eq!(i.private_key, private_key.serialize());
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto/sha.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/sha.rs
@@ -3,14 +3,14 @@ use sha2::Digest;
 
 /// Generates a SHA256 hash of `data`
 pub fn sha256(data: &[u8]) -> Vec<u8> {
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(data);
-    hasher.finalize().to_vec()
+	let mut hasher = sha2::Sha256::new();
+	hasher.update(data);
+	hasher.finalize().to_vec()
 }
 
 /// Generates a SHA512 hash of `data`
 pub fn sha512(data: &[u8]) -> Vec<u8> {
-    let mut hasher = sha2::Sha512::new();
-    hasher.update(data);
-    hasher.finalize().to_vec()
+	let mut hasher = sha2::Sha512::new();
+	hasher.update(data);
+	hasher.finalize().to_vec()
 }

--- a/tuta-sdk/rust/sdk/src/crypto/tuta_crypt.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/tuta_crypt.rs
@@ -1,188 +1,211 @@
-use zeroize::{ZeroizeOnDrop, Zeroizing};
-use crate::crypto::aes::{Aes256Key, aes_256_decrypt, aes_256_encrypt, AesDecryptError, AesEncryptError, Iv, PaddingMode};
-use crate::crypto::ecc::{ecc_decapsulate, ecc_encapsulate, EccKeyPair, EccPublicKey, EccSharedSecrets};
+use crate::crypto::aes::{
+	aes_256_decrypt, aes_256_encrypt, Aes256Key, AesDecryptError, AesEncryptError, Iv, PaddingMode,
+};
+use crate::crypto::ecc::{
+	ecc_decapsulate, ecc_encapsulate, EccKeyPair, EccPublicKey, EccSharedSecrets,
+};
 use crate::crypto::hkdf::hkdf;
-use crate::crypto::kyber::{KyberCiphertext, KyberDecapsulationError, KyberKeyPair, KyberPublicKey, KyberSharedSecret};
+use crate::crypto::kyber::{
+	KyberCiphertext, KyberDecapsulationError, KyberKeyPair, KyberPublicKey, KyberSharedSecret,
+};
 use crate::crypto::randomizer_facade::RandomizerFacade;
 use crate::join_slices;
-use crate::util::{ArrayCastingError, decode_byte_arrays, encode_byte_arrays};
+use crate::util::{decode_byte_arrays, encode_byte_arrays, ArrayCastingError};
+use zeroize::{ZeroizeOnDrop, Zeroizing};
 
 /// An encapsulated post quantum message using the Tuta Crypt protocol.
 #[derive(ZeroizeOnDrop)]
 pub struct PQMessage {
-    sender_identity_public_key: EccPublicKey,
-    ephemeral_public_key: EccPublicKey,
-    encapsulation: PQBucketKeyEncapsulation,
+	sender_identity_public_key: EccPublicKey,
+	ephemeral_public_key: EccPublicKey,
+	encapsulation: PQBucketKeyEncapsulation,
 }
 
 impl PQMessage {
-    /// Deserialized from encoded form.
-    ///
-    /// Returns `Err` if invalid.
-    pub fn deserialize(data: &[u8]) -> Result<PQMessage, PQError> {
-        let [
-        sender_identity_pub_key_bytes,
-        ephemeral_pub_key_bytes,
-        kyber_cipher_text_bytes,
-        kek_enc_bucket_key_bytes
-        ] = decode_byte_arrays(data)
-            .map_err(|reason| PQError { reason: format!("Can't deserialize PQBucketKey: {reason}") })?;
+	/// Deserialized from encoded form.
+	///
+	/// Returns `Err` if invalid.
+	pub fn deserialize(data: &[u8]) -> Result<PQMessage, PQError> {
+		let [sender_identity_pub_key_bytes, ephemeral_pub_key_bytes, kyber_cipher_text_bytes, kek_enc_bucket_key_bytes] =
+			decode_byte_arrays(data).map_err(|reason| PQError {
+				reason: format!("Can't deserialize PQBucketKey: {reason}"),
+			})?;
 
-        let sender_identity_public_key = EccPublicKey::from_bytes(sender_identity_pub_key_bytes)?;
-        let ephemeral_public_key = EccPublicKey::from_bytes(ephemeral_pub_key_bytes)?;
-        let kyber_ciphertext = kyber_cipher_text_bytes.try_into()?;
-        let kek_enc_bucket_key = kek_enc_bucket_key_bytes.to_owned();
+		let sender_identity_public_key = EccPublicKey::from_bytes(sender_identity_pub_key_bytes)?;
+		let ephemeral_public_key = EccPublicKey::from_bytes(ephemeral_pub_key_bytes)?;
+		let kyber_ciphertext = kyber_cipher_text_bytes.try_into()?;
+		let kek_enc_bucket_key = kek_enc_bucket_key_bytes.to_owned();
 
-        Ok(Self {
-            sender_identity_public_key,
-            ephemeral_public_key,
-            encapsulation: PQBucketKeyEncapsulation {
-                kyber_ciphertext,
-                kek_enc_bucket_key,
-            },
-        })
-    }
+		Ok(Self {
+			sender_identity_public_key,
+			ephemeral_public_key,
+			encapsulation: PQBucketKeyEncapsulation {
+				kyber_ciphertext,
+				kek_enc_bucket_key,
+			},
+		})
+	}
 
-    /// Serialize into encoded form.
-    pub fn serialize(&self) -> Vec<u8> {
-        encode_byte_arrays(&[
-            self.sender_identity_public_key.as_bytes(),
-            self.ephemeral_public_key.as_bytes(),
-            self.encapsulation.kyber_ciphertext.as_bytes(),
-            self.encapsulation.kek_enc_bucket_key.as_slice()
-        ]).unwrap()
-    }
+	/// Serialize into encoded form.
+	pub fn serialize(&self) -> Vec<u8> {
+		encode_byte_arrays(&[
+			self.sender_identity_public_key.as_bytes(),
+			self.ephemeral_public_key.as_bytes(),
+			self.encapsulation.kyber_ciphertext.as_bytes(),
+			self.encapsulation.kek_enc_bucket_key.as_slice(),
+		])
+		.unwrap()
+	}
 
-    /// Decapsulate the PQ message with the given keys.
-    pub fn decapsulate(&self, recipient_keys: &PQKeyPairs) -> Result<Aes256Key, PQError> {
-        let PQKeyPairs { ecc_keys, kyber_keys } = recipient_keys;
+	/// Decapsulate the PQ message with the given keys.
+	pub fn decapsulate(&self, recipient_keys: &PQKeyPairs) -> Result<Aes256Key, PQError> {
+		let PQKeyPairs {
+			ecc_keys,
+			kyber_keys,
+		} = recipient_keys;
 
-        let ecc_shared_secret = ecc_decapsulate(&self.sender_identity_public_key, &self.ephemeral_public_key, &ecc_keys.private_key);
-        let kyber_shared_secret = kyber_keys.private_key.decapsulate(&self.encapsulation.kyber_ciphertext)?;
+		let ecc_shared_secret = ecc_decapsulate(
+			&self.sender_identity_public_key,
+			&self.ephemeral_public_key,
+			&ecc_keys.private_key,
+		);
+		let kyber_shared_secret = kyber_keys
+			.private_key
+			.decapsulate(&self.encapsulation.kyber_ciphertext)?;
 
-        let kek = derive_pq_kek(
-            &self.sender_identity_public_key,
-            &self.ephemeral_public_key,
-            &ecc_keys.public_key,
-            &kyber_keys.public_key,
-            &self.encapsulation.kyber_ciphertext,
-            &kyber_shared_secret,
-            &ecc_shared_secret,
-            CryptoProtocolVersion::TutaCrypt,
-        );
+		let kek = derive_pq_kek(
+			&self.sender_identity_public_key,
+			&self.ephemeral_public_key,
+			&ecc_keys.public_key,
+			&kyber_keys.public_key,
+			&self.encapsulation.kyber_ciphertext,
+			&kyber_shared_secret,
+			&ecc_shared_secret,
+			CryptoProtocolVersion::TutaCrypt,
+		);
 
-        let bucket_key = aes_256_decrypt(&kek, &self.encapsulation.kek_enc_bucket_key)?.data;
-        Ok(Aes256Key::try_from(bucket_key)?)
-    }
+		let bucket_key = aes_256_decrypt(&kek, &self.encapsulation.kek_enc_bucket_key)?.data;
+		Ok(Aes256Key::try_from(bucket_key)?)
+	}
 
-    /// Construct a `PQMessage` containing an AES key from the given keys.
-    pub fn encapsulate(
-        sender_ecc_keypair: &EccKeyPair,
-        ephemeral_ecc_keypair: &EccKeyPair,
-        recipient_ecc_key: &EccPublicKey,
-        recipient_kyber_key: &KyberPublicKey,
-        bucket_key: &Aes256Key,
-        iv: Iv,
-    ) -> Result<Self, PQError> {
-        let ecc_shared_secret = ecc_encapsulate(&sender_ecc_keypair.private_key, &ephemeral_ecc_keypair.private_key, recipient_ecc_key);
-        let encapsulation = recipient_kyber_key.encapsulate();
+	/// Construct a `PQMessage` containing an AES key from the given keys.
+	pub fn encapsulate(
+		sender_ecc_keypair: &EccKeyPair,
+		ephemeral_ecc_keypair: &EccKeyPair,
+		recipient_ecc_key: &EccPublicKey,
+		recipient_kyber_key: &KyberPublicKey,
+		bucket_key: &Aes256Key,
+		iv: Iv,
+	) -> Result<Self, PQError> {
+		let ecc_shared_secret = ecc_encapsulate(
+			&sender_ecc_keypair.private_key,
+			&ephemeral_ecc_keypair.private_key,
+			recipient_ecc_key,
+		);
+		let encapsulation = recipient_kyber_key.encapsulate();
 
-        let kek = derive_pq_kek(
-            &sender_ecc_keypair.public_key,
-            &ephemeral_ecc_keypair.public_key,
-            recipient_ecc_key,
-            recipient_kyber_key,
-            &encapsulation.ciphertext,
-            &encapsulation.shared_secret,
-            &ecc_shared_secret,
-            CryptoProtocolVersion::TutaCrypt,
-        );
+		let kek = derive_pq_kek(
+			&sender_ecc_keypair.public_key,
+			&ephemeral_ecc_keypair.public_key,
+			recipient_ecc_key,
+			recipient_kyber_key,
+			&encapsulation.ciphertext,
+			&encapsulation.shared_secret,
+			&ecc_shared_secret,
+			CryptoProtocolVersion::TutaCrypt,
+		);
 
-        let kek_enc_bucket_key = aes_256_encrypt(&kek, bucket_key.as_bytes(), &iv, PaddingMode::WithPadding)?;
+		let kek_enc_bucket_key =
+			aes_256_encrypt(&kek, bucket_key.as_bytes(), &iv, PaddingMode::WithPadding)?;
 
-        Ok(Self {
-            sender_identity_public_key: sender_ecc_keypair.public_key.clone(),
-            ephemeral_public_key: ephemeral_ecc_keypair.public_key.clone(),
-            encapsulation: PQBucketKeyEncapsulation {
-                kyber_ciphertext: encapsulation.ciphertext,
-                kek_enc_bucket_key,
-            },
-        })
-    }
+		Ok(Self {
+			sender_identity_public_key: sender_ecc_keypair.public_key.clone(),
+			ephemeral_public_key: ephemeral_ecc_keypair.public_key.clone(),
+			encapsulation: PQBucketKeyEncapsulation {
+				kyber_ciphertext: encapsulation.ciphertext,
+				kek_enc_bucket_key,
+			},
+		})
+	}
 }
 
 #[derive(Copy, Clone)]
 #[repr(u8)]
 enum CryptoProtocolVersion {
-    Rsa = 0,
-    SymmetricEncryption = 1,
-    TutaCrypt = 2,
+	Rsa = 0,
+	SymmetricEncryption = 1,
+	TutaCrypt = 2,
 }
 
 fn derive_pq_kek(
-    sender_identity_public_key: &EccPublicKey,
-    ephemeral_public_key: &EccPublicKey,
-    recipient_ecc_public_key: &EccPublicKey,
-    recipient_kyber_public_key: &KyberPublicKey,
-    kyber_ciphertext: &KyberCiphertext,
-    kyber_shared_secret: &KyberSharedSecret,
-    ecc_shared_secrets: &EccSharedSecrets,
-    crypto_protocol_version: CryptoProtocolVersion,
+	sender_identity_public_key: &EccPublicKey,
+	ephemeral_public_key: &EccPublicKey,
+	recipient_ecc_public_key: &EccPublicKey,
+	recipient_kyber_public_key: &KyberPublicKey,
+	kyber_ciphertext: &KyberCiphertext,
+	kyber_shared_secret: &KyberSharedSecret,
+	ecc_shared_secrets: &EccSharedSecrets,
+	crypto_protocol_version: CryptoProtocolVersion,
 ) -> Aes256Key {
-    let context = Zeroizing::new(join_slices!(
-        sender_identity_public_key.as_bytes(),
-        ephemeral_public_key.as_bytes(),
-        recipient_ecc_public_key.as_bytes(),
-        Zeroizing::new(recipient_kyber_public_key.serialize()).as_slice(),
-        kyber_ciphertext.as_bytes(),
-        &[crypto_protocol_version as u8]
-    ));
+	let context = Zeroizing::new(join_slices!(
+		sender_identity_public_key.as_bytes(),
+		ephemeral_public_key.as_bytes(),
+		recipient_ecc_public_key.as_bytes(),
+		Zeroizing::new(recipient_kyber_public_key.serialize()).as_slice(),
+		kyber_ciphertext.as_bytes(),
+		&[crypto_protocol_version as u8]
+	));
 
-    let input_key_material = Zeroizing::new(join_slices!(
-        ecc_shared_secrets.ephemeral_shared_secret.as_bytes(),
-        ecc_shared_secrets.auth_shared_secret.as_bytes(),
-        kyber_shared_secret.as_bytes()
-    ));
+	let input_key_material = Zeroizing::new(join_slices!(
+		ecc_shared_secrets.ephemeral_shared_secret.as_bytes(),
+		ecc_shared_secrets.auth_shared_secret.as_bytes(),
+		kyber_shared_secret.as_bytes()
+	));
 
-    let kek_bytes = hkdf(&context, input_key_material.as_slice(), b"kek", 32);
-    Aes256Key::try_from(kek_bytes).unwrap()
+	let kek_bytes = hkdf(&context, input_key_material.as_slice(), b"kek", 32);
+	Aes256Key::try_from(kek_bytes).unwrap()
 }
 
 #[derive(Clone, PartialEq)]
 #[cfg_attr(test, derive(Debug))] // only allow Debug in tests because this prints the key!
 pub struct PQKeyPairs {
-    pub ecc_keys: EccKeyPair,
-    pub kyber_keys: KyberKeyPair,
+	pub ecc_keys: EccKeyPair,
+	pub kyber_keys: KyberKeyPair,
 }
 
 impl PQKeyPairs {
-    /// Generate a keypair with the given random number generator.
-    pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
-        let ecc_keys = EccKeyPair::generate(randomizer_facade);
-        let kyber_keys = KyberKeyPair::generate();
-        Self { ecc_keys, kyber_keys }
-    }
+	/// Generate a keypair with the given random number generator.
+	pub fn generate(randomizer_facade: &RandomizerFacade) -> Self {
+		let ecc_keys = EccKeyPair::generate(randomizer_facade);
+		let kyber_keys = KyberKeyPair::generate();
+		Self {
+			ecc_keys,
+			kyber_keys,
+		}
+	}
 }
 
 #[derive(ZeroizeOnDrop)]
 pub struct PQBucketKeyEncapsulation {
-    kyber_ciphertext: KyberCiphertext,
-    kek_enc_bucket_key: Vec<u8>,
+	kyber_ciphertext: KyberCiphertext,
+	kek_enc_bucket_key: Vec<u8>,
 }
 
 /// Error that occurs when parsing RSA keys.
 #[derive(thiserror::Error, Debug)]
 #[error("PQ error: {reason}")]
 pub struct PQError {
-    reason: String,
+	reason: String,
 }
 
 trait PQErrorType: ToString {}
 
 impl<T: PQErrorType> From<T> for PQError {
-    fn from(reason: T) -> Self {
-        Self { reason: reason.to_string() }
-    }
+	fn from(reason: T) -> Self {
+		Self {
+			reason: reason.to_string(),
+		}
+	}
 }
 
 impl PQErrorType for ArrayCastingError {}
@@ -193,85 +216,98 @@ impl PQErrorType for AesDecryptError {}
 
 impl PQErrorType for AesEncryptError {}
 
-
 #[cfg(test)]
 mod tests {
-    use crate::crypto::compatibility_test_utils::{get_test_data, PQCryptEncryptionTest};
-    use crate::crypto::ecc::EccPrivateKey;
-    use crate::crypto::kyber::KyberPrivateKey;
-    use super::*;
+	use super::*;
+	use crate::crypto::compatibility_test_utils::{get_test_data, PQCryptEncryptionTest};
+	use crate::crypto::ecc::EccPrivateKey;
+	use crate::crypto::kyber::KyberPrivateKey;
 
-    #[test]
-    fn test_bucket_key_serialize_roundtrip() {
-        let tests = get_test_data();
-        for i in tests.pqcrypt_encryption_tests {
-            let pq_message = PQMessage::deserialize(&i.pq_message).unwrap();
-            let serialized = pq_message.serialize();
-            assert_eq!(i.pq_message, serialized);
-        }
-    }
+	#[test]
+	fn test_bucket_key_serialize_roundtrip() {
+		let tests = get_test_data();
+		for i in tests.pqcrypt_encryption_tests {
+			let pq_message = PQMessage::deserialize(&i.pq_message).unwrap();
+			let serialized = pq_message.serialize();
+			assert_eq!(i.pq_message, serialized);
+		}
+	}
 
-    #[test]
-    fn test_bucket_key_serialize_decapsulate() {
-        let tests = get_test_data();
-        for i in tests.pqcrypt_encryption_tests {
-            let pq_message = PQMessage::deserialize(&i.pq_message).unwrap();
-            let recipient_keys = get_recipient_keys(&i);
-            let key = pq_message.decapsulate(&recipient_keys).unwrap();
-            assert_eq!(i.bucket_key, key.as_bytes());
-        }
-    }
+	#[test]
+	fn test_bucket_key_serialize_decapsulate() {
+		let tests = get_test_data();
+		for i in tests.pqcrypt_encryption_tests {
+			let pq_message = PQMessage::deserialize(&i.pq_message).unwrap();
+			let recipient_keys = get_recipient_keys(&i);
+			let key = pq_message.decapsulate(&recipient_keys).unwrap();
+			assert_eq!(i.bucket_key, key.as_bytes());
+		}
+	}
 
-    #[test]
-    fn test_bucket_key_serialize_encapsulate_roundtrip() {
-        let tests = get_test_data();
-        for i in tests.pqcrypt_encryption_tests {
-            let recipient_keys = get_recipient_keys(&i);
-            let PQKeyPairs { ecc_keys, kyber_keys } = &recipient_keys;
+	#[test]
+	fn test_bucket_key_serialize_encapsulate_roundtrip() {
+		let tests = get_test_data();
+		for i in tests.pqcrypt_encryption_tests {
+			let recipient_keys = get_recipient_keys(&i);
+			let PQKeyPairs {
+				ecc_keys,
+				kyber_keys,
+			} = &recipient_keys;
 
-            // Note that the test data uses sender keys as recipient keys, so we are basically just simulating sending mail to ourselves.
-            let sender_ecc_keypair = ecc_keys;
-            let ephemeral_ecc_keypair = EccKeyPair {
-                private_key: EccPrivateKey::from_bytes(&i.epheremal_private_x25519_key).unwrap(),
-                public_key: EccPublicKey::from_bytes(&i.epheremal_public_x25519_key).unwrap(),
-            };
+			// Note that the test data uses sender keys as recipient keys, so we are basically just simulating sending mail to ourselves.
+			let sender_ecc_keypair = ecc_keys;
+			let ephemeral_ecc_keypair = EccKeyPair {
+				private_key: EccPrivateKey::from_bytes(&i.epheremal_private_x25519_key).unwrap(),
+				public_key: EccPublicKey::from_bytes(&i.epheremal_public_x25519_key).unwrap(),
+			};
 
-            let bucket_key = Aes256Key::try_from(i.bucket_key).unwrap();
-            let iv = Iv::from_bytes(&i.seed[i.seed.len() - 16..]).unwrap();
+			let bucket_key = Aes256Key::try_from(i.bucket_key).unwrap();
+			let iv = Iv::from_bytes(&i.seed[i.seed.len() - 16..]).unwrap();
 
-            let encapsulation = PQMessage::encapsulate(
-                sender_ecc_keypair,
-                &ephemeral_ecc_keypair,
-                &ecc_keys.public_key,
-                &kyber_keys.public_key,
-                &bucket_key,
-                iv,
-            ).unwrap();
+			let encapsulation = PQMessage::encapsulate(
+				sender_ecc_keypair,
+				&ephemeral_ecc_keypair,
+				&ecc_keys.public_key,
+				&kyber_keys.public_key,
+				&bucket_key,
+				iv,
+			)
+			.unwrap();
 
-            // NOTE: This will generally not match the test data, because we cannot inject randomness into Kyber.
-            //
-            // However, since we can test decapsulation separately, we can prove that encapsulation is accurate if we can decapsulate it as well.
-            //
-            // assert_eq!(i.pq_message, encapsulation.serialize());
+			// NOTE: This will generally not match the test data, because we cannot inject randomness into Kyber.
+			//
+			// However, since we can test decapsulation separately, we can prove that encapsulation is accurate if we can decapsulate it as well.
+			//
+			// assert_eq!(i.pq_message, encapsulation.serialize());
 
-            let decapsulation = encapsulation.decapsulate(&recipient_keys).unwrap();
-            assert_eq!(bucket_key.as_bytes(), decapsulation.as_bytes());
+			let decapsulation = encapsulation.decapsulate(&recipient_keys).unwrap();
+			assert_eq!(bucket_key.as_bytes(), decapsulation.as_bytes());
 
-            // Should be able to serialize/deserialize and still decapsulate it.
-            let reloaded = PQMessage::deserialize(&encapsulation.serialize()).unwrap();
-            assert_eq!(bucket_key.as_bytes(), reloaded.decapsulate(&recipient_keys).unwrap().as_bytes());
-        }
-    }
+			// Should be able to serialize/deserialize and still decapsulate it.
+			let reloaded = PQMessage::deserialize(&encapsulation.serialize()).unwrap();
+			assert_eq!(
+				bucket_key.as_bytes(),
+				reloaded.decapsulate(&recipient_keys).unwrap().as_bytes()
+			);
+		}
+	}
 
-    fn get_recipient_keys(test: &PQCryptEncryptionTest) -> PQKeyPairs {
-        let ecc_private = EccPrivateKey::from_bytes(test.private_x25519_key.as_slice()).unwrap();
-        let ecc_public = EccPublicKey::from_bytes(test.public_x25519_key.as_slice()).unwrap();
-        let kyber_private = KyberPrivateKey::deserialize(test.private_kyber_key.as_slice()).unwrap();
-        let kyber_public = KyberPublicKey::deserialize(test.public_kyber_key.as_slice()).unwrap();
+	fn get_recipient_keys(test: &PQCryptEncryptionTest) -> PQKeyPairs {
+		let ecc_private = EccPrivateKey::from_bytes(test.private_x25519_key.as_slice()).unwrap();
+		let ecc_public = EccPublicKey::from_bytes(test.public_x25519_key.as_slice()).unwrap();
+		let kyber_private =
+			KyberPrivateKey::deserialize(test.private_kyber_key.as_slice()).unwrap();
+		let kyber_public = KyberPublicKey::deserialize(test.public_kyber_key.as_slice()).unwrap();
 
-        PQKeyPairs {
-            ecc_keys: EccKeyPair { public_key: ecc_public, private_key: ecc_private },
-            kyber_keys: KyberKeyPair { public_key: kyber_public, private_key: kyber_private },
-        }
-    }
+		PQKeyPairs {
+			ecc_keys: EccKeyPair {
+				public_key: ecc_public,
+				private_key: ecc_private,
+			},
+			kyber_keys: KyberKeyPair {
+				public_key: kyber_public,
+				private_key: kyber_private,
+			},
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
@@ -1,172 +1,194 @@
-use std::sync::Arc;
-use serde::Deserialize;
-use crate::entity_client::IdType;
-#[mockall_double::double]
-use crate::entity_client::EntityClient;
-use crate::ApiCallError;
 #[mockall_double::double]
 use crate::crypto::crypto_facade::CryptoFacade;
-use crate::entities::Entity;
 use crate::entities::entity_facade::EntityFacade;
+use crate::entities::Entity;
+#[mockall_double::double]
+use crate::entity_client::EntityClient;
+use crate::entity_client::IdType;
 use crate::instance_mapper::InstanceMapper;
-
+use crate::ApiCallError;
+use serde::Deserialize;
+use std::sync::Arc;
 
 // A high level interface to manipulate encrypted entities/instances via the REST API
 pub struct CryptoEntityClient {
-    entity_client: Arc<EntityClient>,
-    entity_facade: Arc<EntityFacade>,
-    crypto_facade: Arc<CryptoFacade>,
-    instance_mapper: Arc<InstanceMapper>,
+	entity_client: Arc<EntityClient>,
+	entity_facade: Arc<EntityFacade>,
+	crypto_facade: Arc<CryptoFacade>,
+	instance_mapper: Arc<InstanceMapper>,
 }
 
 #[cfg_attr(test, mockall::automock)]
 impl CryptoEntityClient {
-    pub fn new(
-        entity_client: Arc<EntityClient>,
-        entity_facade: Arc<EntityFacade>,
-        crypto_facade: Arc<CryptoFacade>,
-        instance_mapper: Arc<InstanceMapper>,
-    ) -> Self {
-        CryptoEntityClient { entity_client, entity_facade, crypto_facade, instance_mapper }
-    }
-    pub async fn load<T: Entity + Deserialize<'static>, ID: IdType>(
-        &self,
-        id: &ID,
-    ) -> Result<T, ApiCallError> {
-        let type_ref = T::type_ref();
-        let type_model = self.entity_client.get_type_model(&type_ref)?;
-        let mut parsed_entity = self.entity_client.load(&type_ref, id).await?;
+	pub fn new(
+		entity_client: Arc<EntityClient>,
+		entity_facade: Arc<EntityFacade>,
+		crypto_facade: Arc<CryptoFacade>,
+		instance_mapper: Arc<InstanceMapper>,
+	) -> Self {
+		CryptoEntityClient {
+			entity_client,
+			entity_facade,
+			crypto_facade,
+			instance_mapper,
+		}
+	}
+	pub async fn load<T: Entity + Deserialize<'static>, ID: IdType>(
+		&self,
+		id: &ID,
+	) -> Result<T, ApiCallError> {
+		let type_ref = T::type_ref();
+		let type_model = self.entity_client.get_type_model(&type_ref)?;
+		let mut parsed_entity = self.entity_client.load(&type_ref, id).await?;
 
-        if type_model.marked_encrypted() {
-            let possible_session_key = self.crypto_facade
-                .resolve_session_key(&mut parsed_entity, type_model)
-                .await
-                .map_err(|error|
-                    ApiCallError::InternalSdkError {
-                        error_message: format!(
-                            "Failed to resolve session key for entity '{}' with ID: {}; {}",
-                            type_model.name,
-                            id,
-                            error
-                        )
-                    }
-                )?;
-            match possible_session_key {
-                Some(session_key) => {
-                    let decrypted_entity = self.entity_facade.decrypt_and_map(type_model, parsed_entity, session_key)?;
-                    let typed_entity = self.instance_mapper.parse_entity::<T>(decrypted_entity)
-                        .map_err(|e|
-                            ApiCallError::InternalSdkError {
-                                error_message: format!(
-                                    "Failed to parse encrypted entity into proper types: {}",
-                                    e
-                                )
-                            }
-                        )?;
-                    Ok(typed_entity)
-                }
-                // `resolve_session_key()` only returns none if the entity is unencrypted, so
-                // no need to handle it
-                None => { unreachable!() }
-            }
-        } else {
-            let typed_entity = self.instance_mapper.parse_entity::<T>(parsed_entity)
-                .map_err(|error|
-                    ApiCallError::InternalSdkError {
-                        error_message: format!(
-                            "Failed to parse unencrypted entity into proper types: {}",
-                            error
-                        )
-                    }
-                )?;
-            Ok(typed_entity)
-        }
-    }
+		if type_model.marked_encrypted() {
+			let possible_session_key = self
+				.crypto_facade
+				.resolve_session_key(&mut parsed_entity, type_model)
+				.await
+				.map_err(|error| ApiCallError::InternalSdkError {
+					error_message: format!(
+						"Failed to resolve session key for entity '{}' with ID: {}; {}",
+						type_model.name, id, error
+					),
+				})?;
+			match possible_session_key {
+				Some(session_key) => {
+					let decrypted_entity = self.entity_facade.decrypt_and_map(
+						type_model,
+						parsed_entity,
+						session_key,
+					)?;
+					let typed_entity = self
+						.instance_mapper
+						.parse_entity::<T>(decrypted_entity)
+						.map_err(|e| ApiCallError::InternalSdkError {
+							error_message: format!(
+								"Failed to parse encrypted entity into proper types: {}",
+								e
+							),
+						})?;
+					Ok(typed_entity)
+				},
+				// `resolve_session_key()` only returns none if the entity is unencrypted, so
+				// no need to handle it
+				None => {
+					unreachable!()
+				},
+			}
+		} else {
+			let typed_entity = self
+				.instance_mapper
+				.parse_entity::<T>(parsed_entity)
+				.map_err(|error| ApiCallError::InternalSdkError {
+					error_message: format!(
+						"Failed to parse unencrypted entity into proper types: {}",
+						error
+					),
+				})?;
+			Ok(typed_entity)
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use rand::random;
-    use crate::crypto::{Aes256Key, Iv};
-    use crate::crypto::crypto_facade::{MockCryptoFacade, ResolvedSessionKey};
-    use crate::crypto::key::GenericAesKey;
-    use crate::crypto_entity_client::CryptoEntityClient;
-    use crate::date::DateTime;
-    use crate::entities::entity_facade::EntityFacade;
-    use crate::entities::tutanota::Mail;
-    use crate::util::entity_test_utils::generate_email_entity;
-    use crate::entity_client::MockEntityClient;
-    use crate::metamodel::TypeModel;
-    use crate::type_model_provider::{init_type_model_provider, TypeModelProvider};
-    use crate::{IdTuple, TypeRef};
-    use crate::instance_mapper::InstanceMapper;
-    use crate::util::test_utils::leak;
+	use crate::crypto::crypto_facade::{MockCryptoFacade, ResolvedSessionKey};
+	use crate::crypto::key::GenericAesKey;
+	use crate::crypto::{Aes256Key, Iv};
+	use crate::crypto_entity_client::CryptoEntityClient;
+	use crate::date::DateTime;
+	use crate::entities::entity_facade::EntityFacade;
+	use crate::entities::tutanota::Mail;
+	use crate::entity_client::MockEntityClient;
+	use crate::instance_mapper::InstanceMapper;
+	use crate::metamodel::TypeModel;
+	use crate::type_model_provider::{init_type_model_provider, TypeModelProvider};
+	use crate::util::entity_test_utils::generate_email_entity;
+	use crate::util::test_utils::leak;
+	use crate::{IdTuple, TypeRef};
+	use rand::random;
+	use std::sync::Arc;
 
-    #[tokio::test]
-    async fn can_load_mail() {
-        // Generate an encrypted type to feed into a mock of the entity client
-        let sk = GenericAesKey::Aes256(Aes256Key::from_bytes(&random::<[u8; 32]>()).unwrap());
-        let iv = Iv::from_bytes(&random::<[u8; 16]>()).unwrap();
-        let is_confidential = false;
-        const SUBJECT: &str = "Subject";
-        const SENDER_NAME: &str = "Sender";
-        const RECIPIENT_NAME: &str = "Recipient";
-        let (encrypted_mail, ..) = generate_email_entity(
-            &sk,
-            &iv,
-            is_confidential,
-            SUBJECT.to_owned(),
-            SENDER_NAME.to_owned(),
-            RECIPIENT_NAME.to_owned(),
-        );
+	#[tokio::test]
+	async fn can_load_mail() {
+		// Generate an encrypted type to feed into a mock of the entity client
+		let sk = GenericAesKey::Aes256(Aes256Key::from_bytes(&random::<[u8; 32]>()).unwrap());
+		let iv = Iv::from_bytes(&random::<[u8; 16]>()).unwrap();
+		let is_confidential = false;
+		const SUBJECT: &str = "Subject";
+		const SENDER_NAME: &str = "Sender";
+		const RECIPIENT_NAME: &str = "Recipient";
+		let (encrypted_mail, ..) = generate_email_entity(
+			&sk,
+			&iv,
+			is_confidential,
+			SUBJECT.to_owned(),
+			SENDER_NAME.to_owned(),
+			RECIPIENT_NAME.to_owned(),
+		);
 
-        // We cause a deliberate memory leak to convert the mail type's lifetime to static because
-        // the callback to `returning` requires returned references to have a static lifetime
-        let my_favorite_leak: &'static TypeModelProvider = leak(init_type_model_provider());
+		// We cause a deliberate memory leak to convert the mail type's lifetime to static because
+		// the callback to `returning` requires returned references to have a static lifetime
+		let my_favorite_leak: &'static TypeModelProvider = leak(init_type_model_provider());
 
-        let raw_mail_id = encrypted_mail.get("_id").unwrap().assert_tuple_id();
-        let mail_id = IdTuple::new(
-            raw_mail_id.list_id.clone(),
-            raw_mail_id.element_id.clone(),
-        );
-        let mail_type_ref = TypeRef { app: "tutanota", type_: "Mail" };
-        let mail_type_model: &'static TypeModel = my_favorite_leak
-            .get_type_model(mail_type_ref.app, mail_type_ref.type_)
-            .expect("Error in type_model_provider");
+		let raw_mail_id = encrypted_mail.get("_id").unwrap().assert_tuple_id();
+		let mail_id = IdTuple::new(raw_mail_id.list_id.clone(), raw_mail_id.element_id.clone());
+		let mail_type_ref = TypeRef {
+			app: "tutanota",
+			type_: "Mail",
+		};
+		let mail_type_model: &'static TypeModel = my_favorite_leak
+			.get_type_model(mail_type_ref.app, mail_type_ref.type_)
+			.expect("Error in type_model_provider");
 
-        // Set up the mock of the plain unencrypted entity client
-        let mut mock_entity_client = MockEntityClient::default();
-        mock_entity_client.expect_get_type_model().returning(|_| Ok(mail_type_model));
-        mock_entity_client.expect_load().returning(move |_, _: &IdTuple| Ok(encrypted_mail.clone()));
+		// Set up the mock of the plain unencrypted entity client
+		let mut mock_entity_client = MockEntityClient::default();
+		mock_entity_client
+			.expect_get_type_model()
+			.returning(|_| Ok(mail_type_model));
+		mock_entity_client
+			.expect_load()
+			.returning(move |_, _: &IdTuple| Ok(encrypted_mail.clone()));
 
-        // Set up the mock of the crypto facade
-        let mut mock_crypto_facade = MockCryptoFacade::default();
-        mock_crypto_facade.expect_resolve_session_key().returning(move |_, _| Ok(Some(ResolvedSessionKey { session_key: sk.clone(), owner_enc_session_key: vec![1, 2, 3]})));
+		// Set up the mock of the crypto facade
+		let mut mock_crypto_facade = MockCryptoFacade::default();
+		mock_crypto_facade
+			.expect_resolve_session_key()
+			.returning(move |_, _| {
+				Ok(Some(ResolvedSessionKey {
+					session_key: sk.clone(),
+					owner_enc_session_key: vec![1, 2, 3],
+				}))
+			});
 
-        // TODO: it would be nice to mock this
-        let type_model_provider = Arc::new(init_type_model_provider());
+		// TODO: it would be nice to mock this
+		let type_model_provider = Arc::new(init_type_model_provider());
 
-        // Use the real `EntityFacade` as it contains the actual decryption logic
-        let entity_facade = EntityFacade::new(Arc::clone(&type_model_provider));
+		// Use the real `EntityFacade` as it contains the actual decryption logic
+		let entity_facade = EntityFacade::new(Arc::clone(&type_model_provider));
 
-        let crypto_entity_client = CryptoEntityClient::new(
-            Arc::new(mock_entity_client),
-            Arc::new(entity_facade),
-            Arc::new(mock_crypto_facade),
-            Arc::new(InstanceMapper::new()),
-        );
+		let crypto_entity_client = CryptoEntityClient::new(
+			Arc::new(mock_entity_client),
+			Arc::new(entity_facade),
+			Arc::new(mock_crypto_facade),
+			Arc::new(InstanceMapper::new()),
+		);
 
-        let result: Mail = crypto_entity_client.load(&mail_id)
-            .await
-            .unwrap();
+		let result: Mail = crypto_entity_client.load(&mail_id).await.unwrap();
 
-        assert_eq!(DateTime::from_millis(1470039025474), result.receivedDate);
-        assert_eq!(is_confidential, result.confidential);
-        assert_eq!(SUBJECT.to_owned(), result.subject);
-        assert_eq!(SENDER_NAME.to_owned(), result.sender.name);
-        assert_eq!("hello@tutao.de".to_owned(), result.sender.address);
-        assert_eq!(RECIPIENT_NAME.to_owned(), result.firstRecipient.clone().unwrap().name);
-        assert_eq!("support@yahoo.com".to_owned(), result.firstRecipient.clone().unwrap().address);
-    }
+		assert_eq!(DateTime::from_millis(1470039025474), result.receivedDate);
+		assert_eq!(is_confidential, result.confidential);
+		assert_eq!(SUBJECT.to_owned(), result.subject);
+		assert_eq!(SENDER_NAME.to_owned(), result.sender.name);
+		assert_eq!("hello@tutao.de".to_owned(), result.sender.address);
+		assert_eq!(
+			RECIPIENT_NAME.to_owned(),
+			result.firstRecipient.clone().unwrap().name
+		);
+		assert_eq!(
+			"support@yahoo.com".to_owned(),
+			result.firstRecipient.clone().unwrap().address
+		);
+	}
 }

--- a/tuta-sdk/rust/sdk/src/custom_id.rs
+++ b/tuta-sdk/rust/sdk/src/custom_id.rs
@@ -1,7 +1,7 @@
-use std::fmt::{Debug, Display, Formatter};
 use base64::Engine;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Debug, Display, Formatter};
 
 /// An ID that uses arbitrary data encoded in base64
 #[derive(Clone, Default, PartialEq, PartialOrd)]
@@ -9,69 +9,81 @@ use serde::de::{Error, Visitor};
 pub struct CustomId(pub String);
 
 impl CustomId {
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
 
-    /// Create a CustomId from an arbitrary (unencoded) string
-    pub fn from_custom_string(custom_string: &str) -> Self {
-        Self(base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(custom_string))
-    }
+	/// Create a CustomId from an arbitrary (unencoded) string
+	pub fn from_custom_string(custom_string: &str) -> Self {
+		Self(base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(custom_string))
+	}
 
-    /// Generates and returns a random `CustomId`
-    #[cfg(test)]
-    pub fn test_random() -> Self {
-        use crate::util::test_utils::generate_random_string;
-        Self(generate_random_string::<9>())
-    }
+	/// Generates and returns a random `CustomId`
+	#[cfg(test)]
+	pub fn test_random() -> Self {
+		use crate::util::test_utils::generate_random_string;
+		Self(generate_random_string::<9>())
+	}
 }
 
 impl From<CustomId> for String {
-    fn from(value: CustomId) -> Self {
-        value.0
-    }
+	fn from(value: CustomId) -> Self {
+		value.0
+	}
 }
 
 impl Display for CustomId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
 }
 
 impl Debug for CustomId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Custom ID: \"{self}\"")
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "Custom ID: \"{self}\"")
+	}
 }
 
 uniffi::custom_newtype!(CustomId, String);
 
 impl Serialize for CustomId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-        serializer.serialize_newtype_struct("CustomId", &self.0)
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_newtype_struct("CustomId", &self.0)
+	}
 }
 
 impl<'de> Deserialize<'de> for CustomId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-        deserializer.deserialize_string(IdVisitor)
-    }
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_string(IdVisitor)
+	}
 }
 
 struct IdVisitor;
 
 impl Visitor<'_> for IdVisitor {
-    type Value = CustomId;
+	type Value = CustomId;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("a string")
-    }
+	fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+		formatter.write_str("a string")
+	}
 
-    fn visit_string<E>(self, s: String) -> Result<Self::Value, E> where E: Error {
-        Ok(CustomId(s))
-    }
+	fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(CustomId(s))
+	}
 
-    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E> where E: Error {
-        Ok(CustomId(s.to_owned()))
-    }
+	fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(CustomId(s.to_owned()))
+	}
 }

--- a/tuta-sdk/rust/sdk/src/date.rs
+++ b/tuta-sdk/rust/sdk/src/date.rs
@@ -1,64 +1,76 @@
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::Formatter;
 use std::time::{Duration, SystemTime};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde::de::{Error, Visitor};
 
 /// A wrapper around `SystemTime` so we can change how it is serialised by serde.
 #[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct DateTime(SystemTime);
 
 impl DateTime {
-    #[must_use]
-    pub fn new(time: SystemTime) -> Self {
-        Self(time)
-    }
+	#[must_use]
+	pub fn new(time: SystemTime) -> Self {
+		Self(time)
+	}
 
-    #[must_use]
-    pub fn from_millis(millis: u64) -> Self {
-        Self(SystemTime::UNIX_EPOCH + Duration::from_millis(millis))
-    }
+	#[must_use]
+	pub fn from_millis(millis: u64) -> Self {
+		Self(SystemTime::UNIX_EPOCH + Duration::from_millis(millis))
+	}
 
-    #[must_use]
-    pub fn get_time(self) -> SystemTime {
-        self.0
-    }
+	#[must_use]
+	pub fn get_time(self) -> SystemTime {
+		self.0
+	}
 
-    #[must_use]
-    pub fn as_millis(self) -> u64 {
-        self.0.duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis() as u64
-    }
+	#[must_use]
+	pub fn as_millis(self) -> u64 {
+		self.0
+			.duration_since(SystemTime::UNIX_EPOCH)
+			.unwrap()
+			.as_millis() as u64
+	}
 }
 
 uniffi::custom_newtype!(DateTime, SystemTime);
 
 impl Default for DateTime {
-    fn default() -> Self {
-        Self(SystemTime::UNIX_EPOCH)
-    }
+	fn default() -> Self {
+		Self(SystemTime::UNIX_EPOCH)
+	}
 }
 
 impl Serialize for DateTime {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-        serializer.serialize_newtype_struct("Date", &self.as_millis())
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_newtype_struct("Date", &self.as_millis())
+	}
 }
 
 impl<'de> Deserialize<'de> for DateTime {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-        deserializer.deserialize_u64(DateVisitor)
-    }
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_u64(DateVisitor)
+	}
 }
 
 struct DateVisitor;
 
 impl Visitor<'_> for DateVisitor {
-    type Value = DateTime;
+	type Value = DateTime;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("expecting an u64")
-    }
+	fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+		formatter.write_str("expecting an u64")
+	}
 
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
-        Ok(DateTime::from_millis(v))
-    }
+	fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(DateTime::from_millis(v))
+	}
 }

--- a/tuta-sdk/rust/sdk/src/element_value.rs
+++ b/tuta-sdk/rust/sdk/src/element_value.rs
@@ -1,123 +1,123 @@
-use std::collections::HashMap;
-use serde::{Deserialize, Serialize};
 use crate::custom_id::CustomId;
 use crate::date::DateTime;
 use crate::generated_id::GeneratedId;
 use crate::IdTuple;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Primitive value types used by entity/instance types
 #[derive(uniffi::Enum, Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub enum ElementValue {
-    Null,
-    String(String),
-    Number(i64),
-    Bytes(Vec<u8>),
-    Date(DateTime),
-    Bool(bool),
-    // Names are prefixed with 'Id' to avoid name collision in Kotlin
-    IdGeneratedId(GeneratedId),
-    IdCustomId(CustomId),
-    IdTupleId(IdTuple),
-    Dict(HashMap<String, ElementValue>),
-    Array(Vec<ElementValue>),
+	Null,
+	String(String),
+	Number(i64),
+	Bytes(Vec<u8>),
+	Date(DateTime),
+	Bool(bool),
+	// Names are prefixed with 'Id' to avoid name collision in Kotlin
+	IdGeneratedId(GeneratedId),
+	IdCustomId(CustomId),
+	IdTupleId(IdTuple),
+	Dict(HashMap<String, ElementValue>),
+	Array(Vec<ElementValue>),
 }
 
 pub type ParsedEntity = HashMap<String, ElementValue>;
 
 impl ElementValue {
-    pub fn assert_number(&self) -> i64 {
-        match self {
-            ElementValue::Number(number) => *number,
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_number(&self) -> i64 {
+		match self {
+			ElementValue::Number(number) => *number,
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_string(&self) -> String {
-        self.assert_str().to_string()
-    }
+	pub fn assert_string(&self) -> String {
+		self.assert_str().to_string()
+	}
 
-    pub fn assert_array(&self) -> Vec<ElementValue> {
-        match self {
-            ElementValue::Array(value) => value.clone(),
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_array(&self) -> Vec<ElementValue> {
+		match self {
+			ElementValue::Array(value) => value.clone(),
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_bytes(&self) -> Vec<u8> {
-        match self {
-            ElementValue::Bytes(value) => value.clone(),
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_bytes(&self) -> Vec<u8> {
+		match self {
+			ElementValue::Bytes(value) => value.clone(),
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_dict(&self) -> HashMap<String, ElementValue> {
-        match self {
-            ElementValue::Dict(value) => value.clone(),
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_dict(&self) -> HashMap<String, ElementValue> {
+		match self {
+			ElementValue::Dict(value) => value.clone(),
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_array_ref(&self) -> &Vec<ElementValue> {
-        match self {
-            ElementValue::Array(value) => value,
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_array_ref(&self) -> &Vec<ElementValue> {
+		match self {
+			ElementValue::Array(value) => value,
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_dict_ref(&self) -> &HashMap<String, ElementValue> {
-        match self {
-            ElementValue::Dict(value) => value,
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_dict_ref(&self) -> &HashMap<String, ElementValue> {
+		match self {
+			ElementValue::Dict(value) => value,
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_str(&self) -> &str {
-        match self {
-            ElementValue::String(value) => value,
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_str(&self) -> &str {
+		match self {
+			ElementValue::String(value) => value,
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_generated_id(&self) -> &GeneratedId {
-        match self {
-            ElementValue::IdGeneratedId(value) => value,
-            _ => panic!("Invalid type"),
-        }
-    }
-    pub fn assert_tuple_id(&self) -> &IdTuple {
-        match self {
-            ElementValue::IdTupleId(value) => value,
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_generated_id(&self) -> &GeneratedId {
+		match self {
+			ElementValue::IdGeneratedId(value) => value,
+			_ => panic!("Invalid type"),
+		}
+	}
+	pub fn assert_tuple_id(&self) -> &IdTuple {
+		match self {
+			ElementValue::IdTupleId(value) => value,
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_date(&self) -> &DateTime {
-        match self {
-            ElementValue::Date(value) => value,
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_date(&self) -> &DateTime {
+		match self {
+			ElementValue::Date(value) => value,
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub fn assert_bool(&self) -> bool {
-        match self {
-            ElementValue::Bool(value) => *value,
-            _ => panic!("Invalid type"),
-        }
-    }
+	pub fn assert_bool(&self) -> bool {
+		match self {
+			ElementValue::Bool(value) => *value,
+			_ => panic!("Invalid type"),
+		}
+	}
 
-    pub(crate) fn type_variant_name(&self) -> &'static str {
-        match self {
-            Self::Null => "Null",
-            Self::String(_) => "String",
-            Self::Number(_) => "Number",
-            Self::Bytes(_) => "Bytes",
-            Self::Date(_) => "Date",
-            Self::Bool(_) => "Bool",
-            Self::IdGeneratedId(_) => "IdGeneratedId",
-            Self::IdCustomId(_) => "IdCustomId",
-            Self::IdTupleId(_) => "IdTupleId",
-            Self::Dict(_) => "Dict",
-            Self::Array(_) => "Array",
-        }
-    }
+	pub(crate) fn type_variant_name(&self) -> &'static str {
+		match self {
+			Self::Null => "Null",
+			Self::String(_) => "String",
+			Self::Number(_) => "Number",
+			Self::Bytes(_) => "Bytes",
+			Self::Date(_) => "Date",
+			Self::Bool(_) => "Bool",
+			Self::IdGeneratedId(_) => "IdGeneratedId",
+			Self::IdCustomId(_) => "IdCustomId",
+			Self::IdTupleId(_) => "IdTupleId",
+			Self::Dict(_) => "Dict",
+			Self::Array(_) => "Array",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/accounting.rs
+++ b/tuta-sdk/rust/sdk/src/entities/accounting.rs
@@ -1,47 +1,46 @@
 #![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerAccountPosting {
-    pub _id: CustomId,
-    pub amount: i64,
-    pub invoiceNumber: Option<String>,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub valueDate: DateTime,
+	pub _id: CustomId,
+	pub amount: i64,
+	pub invoiceNumber: Option<String>,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub valueDate: DateTime,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerAccountPosting {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "accounting",
-            type_: "CustomerAccountPosting",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "accounting",
+			type_: "CustomerAccountPosting",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerAccountReturn {
-    pub _format: i64,
-    pub _ownerGroup: Option<GeneratedId>,
-    #[serde(with = "serde_bytes")]
-    pub _ownerPublicEncSessionKey: Option<Vec<u8>>,
-    pub _publicCryptoProtocolVersion: Option<i64>,
-    pub balance: i64,
-    pub outstandingBookingsPrice: i64,
-    pub postings: Vec<CustomerAccountPosting>,
+	pub _format: i64,
+	pub _ownerGroup: Option<GeneratedId>,
+	#[serde(with = "serde_bytes")]
+	pub _ownerPublicEncSessionKey: Option<Vec<u8>>,
+	pub _publicCryptoProtocolVersion: Option<i64>,
+	pub balance: i64,
+	pub outstandingBookingsPrice: i64,
+	pub postings: Vec<CustomerAccountPosting>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerAccountReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "accounting",
-            type_: "CustomerAccountReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "accounting",
+			type_: "CustomerAccountReturn",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/base.rs
+++ b/tuta-sdk/rust/sdk/src/entities/base.rs
@@ -1,19 +1,19 @@
 #![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PersistenceResourcePostReturn {
-    pub _format: i64,
-    pub generatedId: Option<GeneratedId>,
-    pub permissionListId: GeneratedId,
+	pub _format: i64,
+	pub generatedId: Option<GeneratedId>,
+	pub permissionListId: GeneratedId,
 }
 
 impl Entity for PersistenceResourcePostReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "base",
-            type_: "PersistenceResourcePostReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "base",
+			type_: "PersistenceResourcePostReturn",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
+++ b/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
@@ -5,442 +5,600 @@ use std::fmt::format;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use crate::ApiCallError;
 use crate::crypto::crypto_facade::ResolvedSessionKey;
-use crate::crypto::{IV_BYTE_SIZE, PlaintextAndIv};
-use crate::date::DateTime;
 use crate::crypto::key::GenericAesKey;
-use crate::element_value::{ElementValue, ParsedEntity};
+use crate::crypto::{PlaintextAndIv, IV_BYTE_SIZE};
+use crate::date::DateTime;
 use crate::element_value::ElementValue::Bool;
+use crate::element_value::{ElementValue, ParsedEntity};
 use crate::entities::Errors;
-use crate::metamodel::{AssociationType, Cardinality, ModelAssociation, ModelValue, TypeModel, ValueType};
+use crate::metamodel::{
+	AssociationType, Cardinality, ModelAssociation, ModelValue, TypeModel, ValueType,
+};
 use crate::type_model_provider::TypeModelProvider;
 use crate::util::array_cast_slice;
+use crate::ApiCallError;
 
 /// Provides high level functions to handle encryption/decryption of entities
 #[derive(uniffi::Object)]
 pub struct EntityFacade {
-    type_model_provider: Arc<TypeModelProvider>,
+	type_model_provider: Arc<TypeModelProvider>,
 }
 
 /// Value after it has been processed
 struct MappedValue {
-    /// The actual decrypted value that will be written to the field
-    value: ElementValue,
-    /// IV that was used for encryption or empty value if the field was default-encrypted (empty)
-    iv: Option<Vec<u8>>,
-    /// Expected encryption errors
-    error: Option<String>,
+	/// The actual decrypted value that will be written to the field
+	value: ElementValue,
+	/// IV that was used for encryption or empty value if the field was default-encrypted (empty)
+	iv: Option<Vec<u8>>,
+	/// Expected encryption errors
+	error: Option<String>,
 }
 
 #[cfg_attr(test, mockall::automock)]
 impl EntityFacade {
-    pub fn new(type_model_provider: Arc<TypeModelProvider>) -> Self {
-        EntityFacade {
-            type_model_provider
-        }
-    }
-    pub fn decrypt_and_map(&self, type_model: &TypeModel, mut entity: ParsedEntity, resolved_session_key: ResolvedSessionKey) -> Result<ParsedEntity, ApiCallError> {
-        let mut mapped_decrypted = self.decrypt_and_map_inner(type_model, entity, &resolved_session_key.session_key)?;
-        mapped_decrypted.insert("_ownerEncSessionKey".to_owned(), ElementValue::Bytes(resolved_session_key.owner_enc_session_key.clone()));
-        Ok(mapped_decrypted)
-    }
+	pub fn new(type_model_provider: Arc<TypeModelProvider>) -> Self {
+		EntityFacade {
+			type_model_provider,
+		}
+	}
+	pub fn decrypt_and_map(
+		&self,
+		type_model: &TypeModel,
+		mut entity: ParsedEntity,
+		resolved_session_key: ResolvedSessionKey,
+	) -> Result<ParsedEntity, ApiCallError> {
+		let mut mapped_decrypted =
+			self.decrypt_and_map_inner(type_model, entity, &resolved_session_key.session_key)?;
+		mapped_decrypted.insert(
+			"_ownerEncSessionKey".to_owned(),
+			ElementValue::Bytes(resolved_session_key.owner_enc_session_key.clone()),
+		);
+		Ok(mapped_decrypted)
+	}
 
-    fn decrypt_and_map_inner(&self, type_model: &TypeModel, mut entity: ParsedEntity, session_key: &GenericAesKey) -> Result<ParsedEntity, ApiCallError> {
-        let mut mapped_decrypted: HashMap<String, ElementValue> = Default::default();
-        let mut mapped_errors: Errors = Default::default();
-        let mut mapped_ivs: HashMap<String, ElementValue> = Default::default();
+	fn decrypt_and_map_inner(
+		&self,
+		type_model: &TypeModel,
+		mut entity: ParsedEntity,
+		session_key: &GenericAesKey,
+	) -> Result<ParsedEntity, ApiCallError> {
+		let mut mapped_decrypted: HashMap<String, ElementValue> = Default::default();
+		let mut mapped_errors: Errors = Default::default();
+		let mut mapped_ivs: HashMap<String, ElementValue> = Default::default();
 
-        for (&key, model_value) in &type_model.values {
-            let stored_element = entity.remove(key).unwrap_or(ElementValue::Null);
-            let MappedValue {value, iv, error } = self.map_value(stored_element, session_key, key, model_value)?;
+		for (&key, model_value) in &type_model.values {
+			let stored_element = entity.remove(key).unwrap_or(ElementValue::Null);
+			let MappedValue { value, iv, error } =
+				self.map_value(stored_element, session_key, key, model_value)?;
 
-            mapped_decrypted.insert(key.to_string(), value);
-            if let Some(error) = error {
-                mapped_errors.insert(key.to_string(), ElementValue::String(error));
-            }
-            if let Some(iv) = iv {
-                mapped_ivs.insert(key.to_string(), ElementValue::Bytes(iv.clone()));
-            }
-        }
+			mapped_decrypted.insert(key.to_string(), value);
+			if let Some(error) = error {
+				mapped_errors.insert(key.to_string(), ElementValue::String(error));
+			}
+			if let Some(iv) = iv {
+				mapped_ivs.insert(key.to_string(), ElementValue::Bytes(iv.clone()));
+			}
+		}
 
-        for (&association_name, association_model) in &type_model.associations {
-            let association_entry = entity.remove(association_name).unwrap_or(ElementValue::Null);
-            let (mapped_association, errors) = self.map_associations(type_model, association_entry, session_key, association_name, association_model)?;
+		for (&association_name, association_model) in &type_model.associations {
+			let association_entry = entity
+				.remove(association_name)
+				.unwrap_or(ElementValue::Null);
+			let (mapped_association, errors) = self.map_associations(
+				type_model,
+				association_entry,
+				session_key,
+				association_name,
+				association_model,
+			)?;
 
-            mapped_decrypted.insert(association_name.to_string(), mapped_association);
-            if !errors.is_empty() {
-                mapped_errors.insert(association_name.to_string(), ElementValue::Dict(errors));
-            }
-        }
+			mapped_decrypted.insert(association_name.to_string(), mapped_association);
+			if !errors.is_empty() {
+				mapped_errors.insert(association_name.to_string(), ElementValue::Dict(errors));
+			}
+		}
 
-        if type_model.is_encrypted() {
-            // Only top-level types are expected to have `_errors` in the end but it is removed
-            // from the aggregates by `extract_errors()`.
-            mapped_decrypted.insert("_errors".to_string(), ElementValue::Dict(mapped_errors));
-            mapped_decrypted.insert("_finalIvs".to_string(), ElementValue::Dict(mapped_ivs));
-        }
+		if type_model.is_encrypted() {
+			// Only top-level types are expected to have `_errors` in the end but it is removed
+			// from the aggregates by `extract_errors()`.
+			mapped_decrypted.insert("_errors".to_string(), ElementValue::Dict(mapped_errors));
+			mapped_decrypted.insert("_finalIvs".to_string(), ElementValue::Dict(mapped_ivs));
+		}
 
-        Ok(mapped_decrypted)
-    }
+		Ok(mapped_decrypted)
+	}
 
-    fn map_associations(&self, type_model: &TypeModel, association_data: ElementValue, session_key: &GenericAesKey, association_name: &str, association_model: &ModelAssociation) -> Result<(ElementValue, Errors), ApiCallError> {
-        let mut errors: Errors = Default::default();
-        let dependency = match association_model.dependency {
-            Some(dep) => dep,
-            None => type_model.app
-        };
+	fn map_associations(
+		&self,
+		type_model: &TypeModel,
+		association_data: ElementValue,
+		session_key: &GenericAesKey,
+		association_name: &str,
+		association_model: &ModelAssociation,
+	) -> Result<(ElementValue, Errors), ApiCallError> {
+		let mut errors: Errors = Default::default();
+		let dependency = match association_model.dependency {
+			Some(dep) => dep,
+			None => type_model.app,
+		};
 
-        let Some(aggregate_type_model) = self.type_model_provider.get_type_model(dependency, association_model.ref_type) else {
-            panic!("Undefined type_model {}", association_model.ref_type)
-        };
+		let Some(aggregate_type_model) = self
+			.type_model_provider
+			.get_type_model(dependency, association_model.ref_type)
+		else {
+			panic!("Undefined type_model {}", association_model.ref_type)
+		};
 
-        return if let AssociationType::Aggregation = association_model.association_type {
-            match (association_data, association_model.cardinality.borrow()) {
-                (ElementValue::Null, Cardinality::ZeroOrOne) => Ok((ElementValue::Null, errors)),
-                (ElementValue::Null, Cardinality::One) => Err(ApiCallError::InternalSdkError { error_message: format!("Value {association_name} with cardinality ONE can't be null") }),
-                (ElementValue::Array(arr), Cardinality::Any) => {
-                    let mut aggregate_vec: Vec<ElementValue> = Vec::with_capacity(arr.len());
-                    for (index, aggregate) in arr.into_iter().enumerate() {
-                        match aggregate {
-                            ElementValue::Dict(entity) => {
-                                let mut decrypted_aggregate = self.decrypt_and_map_inner(aggregate_type_model, entity, session_key)?;
+		return if let AssociationType::Aggregation = association_model.association_type {
+			match (association_data, association_model.cardinality.borrow()) {
+				(ElementValue::Null, Cardinality::ZeroOrOne) => Ok((ElementValue::Null, errors)),
+				(ElementValue::Null, Cardinality::One) => Err(ApiCallError::InternalSdkError {
+					error_message: format!(
+						"Value {association_name} with cardinality ONE can't be null"
+					),
+				}),
+				(ElementValue::Array(arr), Cardinality::Any) => {
+					let mut aggregate_vec: Vec<ElementValue> = Vec::with_capacity(arr.len());
+					for (index, aggregate) in arr.into_iter().enumerate() {
+						match aggregate {
+							ElementValue::Dict(entity) => {
+								let mut decrypted_aggregate = self.decrypt_and_map_inner(
+									aggregate_type_model,
+									entity,
+									session_key,
+								)?;
 
-                                // Errors should be grouped inside the top-most object, so they should be
-                                // extracted and removed from aggregates
-                                if decrypted_aggregate.contains_key("_errors") {
-                                    let error_key = &format!("{}_{}", association_name, index);
-                                    self.extract_errors(error_key, &mut errors, &mut decrypted_aggregate);
-                                }
+								// Errors should be grouped inside the top-most object, so they should be
+								// extracted and removed from aggregates
+								if decrypted_aggregate.contains_key("_errors") {
+									let error_key = &format!("{}_{}", association_name, index);
+									self.extract_errors(
+										error_key,
+										&mut errors,
+										&mut decrypted_aggregate,
+									);
+								}
 
-                                aggregate_vec.push(ElementValue::Dict(decrypted_aggregate));
-                            }
-                            _ => return Err(ApiCallError::InternalSdkError { error_message: format!("Invalid aggregate format. {} isn't a dict", association_name) })
-                        }
-                    };
+								aggregate_vec.push(ElementValue::Dict(decrypted_aggregate));
+							},
+							_ => {
+								return Err(ApiCallError::InternalSdkError {
+									error_message: format!(
+										"Invalid aggregate format. {} isn't a dict",
+										association_name
+									),
+								})
+							},
+						}
+					}
 
-                    Ok((ElementValue::Array(aggregate_vec), errors))
-                }
-                (ElementValue::Dict(dict), Cardinality::One | Cardinality::ZeroOrOne) => {
-                    let decrypted_aggregate = self.decrypt_and_map_inner(aggregate_type_model, dict, session_key);
-                    match decrypted_aggregate {
-                        Ok(mut dec_aggregate) => {
-                            self.extract_errors(association_name, &mut errors, &mut dec_aggregate);
-                            Ok((ElementValue::Dict(dec_aggregate), errors))
-                        }
-                        Err(_) => {
-                            return Err(ApiCallError::InternalSdkError { error_message: format!("Failed to decrypt association {association_name}") });
-                        }
-                    }
-                }
-                _ => Err(ApiCallError::InternalSdkError { error_message: format!("Invalid association {association_name}") })
-            }
-        } else {
-            Ok((association_data, errors))
-        };
-    }
+					Ok((ElementValue::Array(aggregate_vec), errors))
+				},
+				(ElementValue::Dict(dict), Cardinality::One | Cardinality::ZeroOrOne) => {
+					let decrypted_aggregate =
+						self.decrypt_and_map_inner(aggregate_type_model, dict, session_key);
+					match decrypted_aggregate {
+						Ok(mut dec_aggregate) => {
+							self.extract_errors(association_name, &mut errors, &mut dec_aggregate);
+							Ok((ElementValue::Dict(dec_aggregate), errors))
+						},
+						Err(_) => {
+							return Err(ApiCallError::InternalSdkError {
+								error_message: format!(
+									"Failed to decrypt association {association_name}"
+								),
+							});
+						},
+					}
+				},
+				_ => Err(ApiCallError::InternalSdkError {
+					error_message: format!("Invalid association {association_name}"),
+				}),
+			}
+		} else {
+			Ok((association_data, errors))
+		};
+	}
 
-    fn extract_errors(&self, association_name: &str, errors: &mut Errors, dec_aggregate: &mut ParsedEntity) {
-        if let Some(ElementValue::Dict(err_dict)) = dec_aggregate.remove("_errors") {
-            if !err_dict.is_empty() {
-                errors.insert(association_name.to_string(), ElementValue::Dict(err_dict));
-            }
-        }
-    }
+	fn extract_errors(
+		&self,
+		association_name: &str,
+		errors: &mut Errors,
+		dec_aggregate: &mut ParsedEntity,
+	) {
+		if let Some(ElementValue::Dict(err_dict)) = dec_aggregate.remove("_errors") {
+			if !err_dict.is_empty() {
+				errors.insert(association_name.to_string(), ElementValue::Dict(err_dict));
+			}
+		}
+	}
 
-    fn map_value(&self, value: ElementValue, session_key: &GenericAesKey, key: &str, model_value: &ModelValue) -> Result<MappedValue, ApiCallError> {
-        match (&model_value.cardinality, &model_value.encrypted, value) {
-            (Cardinality::One | Cardinality::ZeroOrOne, true, ElementValue::String(s)) if s.is_empty() => {
-                // If the value is default-encrypted (empty string) then return default value and
-                // empty IV. When re-encrypting we should put the empty value back to not increase
-                // used storage.
-                let value = self.resolve_default_value(&model_value.value_type);
-                Ok(MappedValue {
-                    value,
-                    iv: Some(Vec::new()),
-                    error: None,
-                })
-            }
-            (Cardinality::ZeroOrOne, _, ElementValue::Null) => {
-                // If it's null, and it's permissible then we keep it as such
-                Ok(MappedValue {value: ElementValue::Null, iv: None, error: None})
-            },
-            (Cardinality::One | Cardinality::ZeroOrOne, true, ElementValue::Bytes(bytes)) => {
-                // If it's a proper encrypted value then we need to decrypt it, parse it and
-                // possibly record the IV.
-                let PlaintextAndIv { data: plaintext, iv } = session_key.decrypt_data_and_iv(bytes.as_slice())
-                    .map_err(|e| ApiCallError::InternalSdkError { error_message: e.to_string() })?;
+	fn map_value(
+		&self,
+		value: ElementValue,
+		session_key: &GenericAesKey,
+		key: &str,
+		model_value: &ModelValue,
+	) -> Result<MappedValue, ApiCallError> {
+		match (&model_value.cardinality, &model_value.encrypted, value) {
+			(Cardinality::One | Cardinality::ZeroOrOne, true, ElementValue::String(s))
+				if s.is_empty() =>
+			{
+				// If the value is default-encrypted (empty string) then return default value and
+				// empty IV. When re-encrypting we should put the empty value back to not increase
+				// used storage.
+				let value = self.resolve_default_value(&model_value.value_type);
+				Ok(MappedValue {
+					value,
+					iv: Some(Vec::new()),
+					error: None,
+				})
+			},
+			(Cardinality::ZeroOrOne, _, ElementValue::Null) => {
+				// If it's null, and it's permissible then we keep it as such
+				Ok(MappedValue {
+					value: ElementValue::Null,
+					iv: None,
+					error: None,
+				})
+			},
+			(Cardinality::One | Cardinality::ZeroOrOne, true, ElementValue::Bytes(bytes)) => {
+				// If it's a proper encrypted value then we need to decrypt it, parse it and
+				// possibly record the IV.
+				let PlaintextAndIv {
+					data: plaintext,
+					iv,
+				} = session_key
+					.decrypt_data_and_iv(bytes.as_slice())
+					.map_err(|e| ApiCallError::InternalSdkError {
+						error_message: e.to_string(),
+					})?;
 
-                match self.parse_decrypted_value(model_value.value_type.clone(), plaintext) {
-                    Ok(value) => {
-                        // We want to ensure we use the same IV for final encrypted values, as this
-                        // will guarantee we get the same value back when we encrypt it.
-                        let iv = if model_value.is_final { Some(iv.to_vec()) } else { None };
-                        Ok(MappedValue {value, iv, error: None})
-                    },
-                    Err(err) => {
-                        Ok(MappedValue {
-                            value: self.resolve_default_value(&model_value.value_type),
-                            iv: None,
-                            error: Some(format!("Failed to decrypt {key}. {err}")),
-                        })
-                    }
-                }
-            },
-            (Cardinality::One | Cardinality::ZeroOrOne, false, value) => {
-                Ok(MappedValue { value, iv: None, error: None })
-            },
-            _ => Err(ApiCallError::internal(format!("Invalid value/cardinality combination for key `{key}`")))
-        }
-    }
+				match self.parse_decrypted_value(model_value.value_type.clone(), plaintext) {
+					Ok(value) => {
+						// We want to ensure we use the same IV for final encrypted values, as this
+						// will guarantee we get the same value back when we encrypt it.
+						let iv = if model_value.is_final {
+							Some(iv.to_vec())
+						} else {
+							None
+						};
+						Ok(MappedValue {
+							value,
+							iv,
+							error: None,
+						})
+					},
+					Err(err) => Ok(MappedValue {
+						value: self.resolve_default_value(&model_value.value_type),
+						iv: None,
+						error: Some(format!("Failed to decrypt {key}. {err}")),
+					}),
+				}
+			},
+			(Cardinality::One | Cardinality::ZeroOrOne, false, value) => Ok(MappedValue {
+				value,
+				iv: None,
+				error: None,
+			}),
+			_ => Err(ApiCallError::internal(format!(
+				"Invalid value/cardinality combination for key `{key}`"
+			))),
+		}
+	}
 
-    fn resolve_default_value(&self, value_type: &ValueType) -> ElementValue {
-        match value_type {
-            ValueType::String => ElementValue::String(String::new()),
-            ValueType::Number => ElementValue::Number(0),
-            ValueType::Bytes => ElementValue::Bytes(Vec::new()),
-            ValueType::Date => ElementValue::Date(DateTime::new(SystemTime::UNIX_EPOCH)),
-            ValueType::Boolean => Bool(false),
-            ValueType::CompressedString => ElementValue::String(String::new()),
-            v => unreachable!("Invalid type {v:?}")
-        }
-    }
+	fn resolve_default_value(&self, value_type: &ValueType) -> ElementValue {
+		match value_type {
+			ValueType::String => ElementValue::String(String::new()),
+			ValueType::Number => ElementValue::Number(0),
+			ValueType::Bytes => ElementValue::Bytes(Vec::new()),
+			ValueType::Date => ElementValue::Date(DateTime::new(SystemTime::UNIX_EPOCH)),
+			ValueType::Boolean => Bool(false),
+			ValueType::CompressedString => ElementValue::String(String::new()),
+			v => unreachable!("Invalid type {v:?}"),
+		}
+	}
 
-    fn parse_decrypted_value(&self, value_type: ValueType, bytes: Vec<u8>) -> Result<ElementValue, ApiCallError> {
-        return match value_type {
-            ValueType::String => {
-                let string = String::from_utf8(bytes)
-                    .map_err(|e| ApiCallError::internal_with_err(e, "Invalid string"))?;
-                Ok(ElementValue::String(string))
-            },
-            ValueType::Number => {
-                if bytes.is_empty() {
-                    Ok(ElementValue::Null)
-                } else {
-                    // Encrypted numbers are encrypted strings.
-                    let string = String::from_utf8(bytes)
-                        .map_err(|e| ApiCallError::internal_with_err(e, "Invalid string"))?;
-                    let number = string.parse()
-                        .map_err(|e| ApiCallError::internal_with_err(e, "Invalid number"))?;
+	fn parse_decrypted_value(
+		&self,
+		value_type: ValueType,
+		bytes: Vec<u8>,
+	) -> Result<ElementValue, ApiCallError> {
+		return match value_type {
+			ValueType::String => {
+				let string = String::from_utf8(bytes)
+					.map_err(|e| ApiCallError::internal_with_err(e, "Invalid string"))?;
+				Ok(ElementValue::String(string))
+			},
+			ValueType::Number => {
+				if bytes.is_empty() {
+					Ok(ElementValue::Null)
+				} else {
+					// Encrypted numbers are encrypted strings.
+					let string = String::from_utf8(bytes)
+						.map_err(|e| ApiCallError::internal_with_err(e, "Invalid string"))?;
+					let number = string
+						.parse()
+						.map_err(|e| ApiCallError::internal_with_err(e, "Invalid number"))?;
 
-                    Ok(ElementValue::Number(number))
-                }
-            }
-            ValueType::Bytes => Ok(ElementValue::Bytes(bytes.clone())),
-            ValueType::Date => {
-                let bytes = array_cast_slice(bytes.as_slice(), "u64")
-                    .map_err(|e| ApiCallError::internal_with_err(e, "Invalid date bytes"))?;
-                Ok(ElementValue::Date(DateTime::from_millis(u64::from_be_bytes(bytes))))
-            }
-            ValueType::Boolean => {
-                let value = match bytes.as_slice() {
-                    b"0" => false,
-                    b"1" => true,
-                    _ => return Err(ApiCallError::InternalSdkError { error_message: "Failed to parse boolean bytes".to_owned() })
-                };
-                Ok(Bool(value))
-            }
-            ValueType::CompressedString => unimplemented!("compressed string"),
-            v => unreachable!("Can't parse {v:?} into ElementValue")
-        };
-    }
+					Ok(ElementValue::Number(number))
+				}
+			},
+			ValueType::Bytes => Ok(ElementValue::Bytes(bytes.clone())),
+			ValueType::Date => {
+				let bytes = array_cast_slice(bytes.as_slice(), "u64")
+					.map_err(|e| ApiCallError::internal_with_err(e, "Invalid date bytes"))?;
+				Ok(ElementValue::Date(DateTime::from_millis(
+					u64::from_be_bytes(bytes),
+				)))
+			},
+			ValueType::Boolean => {
+				let value = match bytes.as_slice() {
+					b"0" => false,
+					b"1" => true,
+					_ => {
+						return Err(ApiCallError::InternalSdkError {
+							error_message: "Failed to parse boolean bytes".to_owned(),
+						})
+					},
+				};
+				Ok(Bool(value))
+			},
+			ValueType::CompressedString => unimplemented!("compressed string"),
+			v => unreachable!("Can't parse {v:?} into ElementValue"),
+		};
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::time::SystemTime;
+	use std::sync::Arc;
+	use std::time::SystemTime;
 
-    use rand::random;
-    use crate::crypto::{Aes256Key, Iv, IV_BYTE_SIZE};
+	use crate::crypto::{Aes256Key, Iv, IV_BYTE_SIZE};
+	use rand::random;
 
-    use crate::crypto::key::GenericAesKey;
-    use crate::date::DateTime;
-    use crate::element_value::{ElementValue, ParsedEntity};
-    use crate::entities::entity_facade::EntityFacade;
-    use crate::type_model_provider::init_type_model_provider;
-    use crate::{collection, IdTuple, TypeRef};
-    use crate::crypto::crypto_facade::ResolvedSessionKey;
-    use crate::entities::Entity;
-    use crate::entities::tutanota::Mail;
-    use crate::generated_id::GeneratedId;
-    use crate::instance_mapper::InstanceMapper;
-    use crate::json_element::{JsonElement, RawEntity};
-    use crate::json_serializer::JsonSerializer;
+	use crate::crypto::crypto_facade::ResolvedSessionKey;
+	use crate::crypto::key::GenericAesKey;
+	use crate::date::DateTime;
+	use crate::element_value::{ElementValue, ParsedEntity};
+	use crate::entities::entity_facade::EntityFacade;
+	use crate::entities::tutanota::Mail;
+	use crate::entities::Entity;
+	use crate::generated_id::GeneratedId;
+	use crate::instance_mapper::InstanceMapper;
+	use crate::json_element::{JsonElement, RawEntity};
+	use crate::json_serializer::JsonSerializer;
+	use crate::type_model_provider::init_type_model_provider;
+	use crate::{collection, IdTuple, TypeRef};
 
-    #[test]
-    fn test_decrypt_mail() {
-        let sk = GenericAesKey::Aes256(Aes256Key::from_bytes(vec![83, 168, 168, 203, 48, 91, 246, 102, 175, 252, 39, 110, 36, 141, 4, 216, 135, 201, 226, 134, 182, 175, 15, 152, 117, 216, 81, 1, 120, 134, 116, 143].as_slice()).unwrap());
-        let owner_enc_session_key = vec![0, 1, 2];
-        let iv = Iv::from_bytes(&random::<[u8; 16]>()).unwrap();
-        let type_model_provider = Arc::new(init_type_model_provider());
-        let raw_entity: RawEntity = make_json_entity();
-        let json_serializer = JsonSerializer::new(type_model_provider.clone());
-        let encrypted_mail: ParsedEntity = json_serializer.parse(&Mail::type_ref(), raw_entity).unwrap();
+	#[test]
+	fn test_decrypt_mail() {
+		let sk = GenericAesKey::Aes256(
+			Aes256Key::from_bytes(
+				vec![
+					83, 168, 168, 203, 48, 91, 246, 102, 175, 252, 39, 110, 36, 141, 4, 216, 135,
+					201, 226, 134, 182, 175, 15, 152, 117, 216, 81, 1, 120, 134, 116, 143,
+				]
+				.as_slice(),
+			)
+			.unwrap(),
+		);
+		let owner_enc_session_key = vec![0, 1, 2];
+		let iv = Iv::from_bytes(&random::<[u8; 16]>()).unwrap();
+		let type_model_provider = Arc::new(init_type_model_provider());
+		let raw_entity: RawEntity = make_json_entity();
+		let json_serializer = JsonSerializer::new(type_model_provider.clone());
+		let encrypted_mail: ParsedEntity = json_serializer
+			.parse(&Mail::type_ref(), raw_entity)
+			.unwrap();
 
-        let entity_facade = EntityFacade::new(Arc::clone(&type_model_provider));
-        let type_ref = Mail::type_ref();
-        let type_model = type_model_provider.get_type_model(type_ref.app, type_ref.type_)
-            .unwrap();
+		let entity_facade = EntityFacade::new(Arc::clone(&type_model_provider));
+		let type_ref = Mail::type_ref();
+		let type_model = type_model_provider
+			.get_type_model(type_ref.app, type_ref.type_)
+			.unwrap();
 
-        let decrypted_mail = entity_facade.decrypt_and_map(type_model, encrypted_mail, ResolvedSessionKey { session_key: sk, owner_enc_session_key }).unwrap();
-        let instance_mapper = InstanceMapper::new();
-        let mail: Mail = instance_mapper.parse_entity(decrypted_mail.clone()).unwrap();
+		let decrypted_mail = entity_facade
+			.decrypt_and_map(
+				type_model,
+				encrypted_mail,
+				ResolvedSessionKey {
+					session_key: sk,
+					owner_enc_session_key,
+				},
+			)
+			.unwrap();
+		let instance_mapper = InstanceMapper::new();
+		let mail: Mail = instance_mapper
+			.parse_entity(decrypted_mail.clone())
+			.unwrap();
 
-        assert_eq!(&DateTime::from_millis(1720612041643), decrypted_mail.get("receivedDate").unwrap().assert_date());
-        assert!(decrypted_mail.get("confidential").unwrap().assert_bool());
-        assert_eq!("Html email features", decrypted_mail.get("subject").unwrap().assert_str());
-        assert_eq!("Matthias", decrypted_mail.get("sender").unwrap().assert_dict().get("name").unwrap().assert_str());
-        assert_eq!("map-free@tutanota.de", decrypted_mail.get("sender").unwrap().assert_dict().get("address").unwrap().assert_str());
-        assert!(decrypted_mail.get("attachments").unwrap().assert_array().is_empty());
-        assert_eq!(
-            decrypted_mail
-                .get("_finalIvs")
-                .expect("has_final_ivs")
-                .assert_dict()
-                .get("subject")
-                .expect("has_subject")
-                .assert_bytes(),
-            vec![0x54, 0x58, 0x02, 0x8b, 0x82, 0xca, 0xb8, 0xa2, 0xd2, 0x01, 0x94, 0xa5, 0x0f, 0x53, 0x72, 0x06],
-        );
-        assert_eq!(
-            decrypted_mail
-                .get("sender")
-                .expect("has sender")
-                .assert_dict()
-                .get("_finalIvs")
-                .expect("has _finalIvs")
-                .assert_dict()
-            .len(),
-            1,
-        );
-    }
+		assert_eq!(
+			&DateTime::from_millis(1720612041643),
+			decrypted_mail.get("receivedDate").unwrap().assert_date()
+		);
+		assert!(decrypted_mail.get("confidential").unwrap().assert_bool());
+		assert_eq!(
+			"Html email features",
+			decrypted_mail.get("subject").unwrap().assert_str()
+		);
+		assert_eq!(
+			"Matthias",
+			decrypted_mail
+				.get("sender")
+				.unwrap()
+				.assert_dict()
+				.get("name")
+				.unwrap()
+				.assert_str()
+		);
+		assert_eq!(
+			"map-free@tutanota.de",
+			decrypted_mail
+				.get("sender")
+				.unwrap()
+				.assert_dict()
+				.get("address")
+				.unwrap()
+				.assert_str()
+		);
+		assert!(decrypted_mail
+			.get("attachments")
+			.unwrap()
+			.assert_array()
+			.is_empty());
+		assert_eq!(
+			decrypted_mail
+				.get("_finalIvs")
+				.expect("has_final_ivs")
+				.assert_dict()
+				.get("subject")
+				.expect("has_subject")
+				.assert_bytes(),
+			vec![
+				0x54, 0x58, 0x02, 0x8b, 0x82, 0xca, 0xb8, 0xa2, 0xd2, 0x01, 0x94, 0xa5, 0x0f, 0x53,
+				0x72, 0x06
+			],
+		);
+		assert_eq!(
+			decrypted_mail
+				.get("sender")
+				.expect("has sender")
+				.assert_dict()
+				.get("_finalIvs")
+				.expect("has _finalIvs")
+				.assert_dict()
+				.len(),
+			1,
+		);
+	}
 
-    fn make_json_entity() -> RawEntity {
-        collection! {
-            "sentDate"=> JsonElement::Null,
-            "_ownerEncSessionKey"=> JsonElement::String(
-                "AbK4PO4dConOew4jXt7UcmL9I73z1NA14EgbpBEw8J9ipgjD3i92SakgAv7SFXOE59VlWQ5dw3whqqSzkwoQavWWkDeJep1JzdP4ZyzNFMO7".to_string(),
-            ),
-            "method"=> JsonElement::String(
-                "AROQNb+N33nEk9+C+fCuy0vPwMWzqDcnZP48St2Jm1obAvKux3xZwnq1mdqpZmcUQEUL3USwYoJ80Ef8gmqmFgk=".to_string(),
-            ),
-            "bucketKey"=> JsonElement::Null,
-            "conversationEntry"=> JsonElement::Array(
-                vec![
-                    JsonElement::String(
-                        "O1RT2Dj--3-0".to_string(),
-                    ),
-                    JsonElement::String(
-                        "O1RT2Dj--7-0".to_string(),
-                    ),
-                ],
-            ),
-            "_permissions"=> JsonElement::String(
-                "O1RT2Dj--g-0".to_string(),
-            ),
-            "mailDetailsDraft"=> JsonElement::Null,
-            "sender"=> JsonElement::Dict(
-                collection! {
-                    "address"=> JsonElement::String(
-                        "map-free@tutanota.de".to_string(),
-                    ),
-                    "contact"=> JsonElement::Null,
-                    "_id"=> JsonElement::String(
-                        "0y7Pgw".to_string(),
-                    ),
-                    "name"=> JsonElement::String(
-                        "AQLHPJe+eDYk6eRtBsmtpNBGllFzNvfb7gUuMjxsiJGinYAStt4nHO4L1PLChTZL63ifyZd87IqJ7DpVNFkpPNQ=".to_string(),
-                    ),
-                },
-            ),
-            "subject"=> JsonElement::String(
-                "AVRYAouCyrii0gGUpQ9TcgbBdzQiFUc8n0I32fO5pA0wk+0i6vNke8uML5vPy09NQEzUiozrSYDl3bEzHCdrD9rjQgvrJhaygZiAF5bv8eX/".to_string(),
-            ),
-            "movedTime"=> JsonElement::String(
-                "1720612041643".to_string(),
-            ),
-            "state"=> JsonElement::String(
-                "2".to_string(),
-            ),
-            "_ownerKeyVersion"=> JsonElement::String(
-                "0".to_string(),
-            ),
-            "replyTos"=> JsonElement::Array(
-                vec![],
-            ),
-            "unread"=> JsonElement::String(
-                "0".to_string(),
-            ),
-            "body"=> JsonElement::Null,
-            "authStatus"=> JsonElement::Null,
-            "firstRecipient"=> JsonElement::Dict(
-                collection! {
-                    "address"=> JsonElement::String(
-                        "bed-free@tutanota.de".to_string(),
-                    ),
-                    "_id"=> JsonElement::String(
-                        "yPeInQ".to_string(),
-                    ),
-                    "name"=> JsonElement::String(
-                        "AcCA59dQjq0y32zLYtBYvZZ84DXe3ftn4fBplPt9KAkdRBauIaKN2jiSqNa7wvcb5TTyeLz7tdTt9sKyM9Y+tx0=".to_string(),
-                    ),
-                    "contact"=> JsonElement::Null,
-                },
-            ),
-            "differentEnvelopeSender"=> JsonElement::Null,
-            "listUnsubscribe"=> JsonElement::String(
-                "".to_string(),
-            ),
-            "attachments"=> JsonElement::Array(
-                vec![],
-            ),
-            "_id"=> JsonElement::Array(
-                vec![
-                    JsonElement::String(
-                        "O1RT1m6-0R-0".to_string(),
-                    ),
-                    JsonElement::String(
-                        "O1RT2Dj----0".to_string(),
-                    ),
-                ],
-            ),
-            "confidential"=> JsonElement::String(
-                "AWv1okmvm7ItO37ubnKytr0kPscHFvpjzzs7P6CeiL8F3H8GWj/lpk20ewECiAg3wfj7sCyajaw1ShWU0D+Qncg=".to_string(),
-            ),
-            "headers"=> JsonElement::Null,
-            "receivedDate"=> JsonElement::String(
-                "1720612041643".to_string(),
-            ),
-            "_ownerGroup"=> JsonElement::String(
-                "O1RT1m4-0s-0".to_string(),
-            ),
-            "replyType"=> JsonElement::String(
-                "".to_string(),
-            ),
-            "phishingStatus"=> JsonElement::String(
-                "0".to_string(),
-            ),
-            "_format"=> JsonElement::String(
-                "0".to_string(),
-            ),
-            "recipientCount"=> JsonElement::String(
-                "1".to_string(),
-            ),
-            "encryptionAuthStatus"=> JsonElement::String(
-                "AfrN1BgMCYxVksEHHVYnJCMrBK+59cgsu2S84Vvc57YbwV3NvuzFMXq8fMkTZB7vtLBiZdc2ZwLKrxTGwPWqk7w=".to_string(),
-            ),
-            "mailDetails"=> JsonElement::Array(
-                vec![
-                    JsonElement::String(
-                        "O1RT1m5-0--0".to_string(),
-                    ),
-                    JsonElement::String(
-                        "O1RT2Dk----0".to_string(),
-                    ),
-                ],
-            ),
-            "sets"=> JsonElement::Array(vec![]),
-        }
-    }
+	fn make_json_entity() -> RawEntity {
+		collection! {
+			"sentDate"=> JsonElement::Null,
+			"_ownerEncSessionKey"=> JsonElement::String(
+				"AbK4PO4dConOew4jXt7UcmL9I73z1NA14EgbpBEw8J9ipgjD3i92SakgAv7SFXOE59VlWQ5dw3whqqSzkwoQavWWkDeJep1JzdP4ZyzNFMO7".to_string(),
+			),
+			"method"=> JsonElement::String(
+				"AROQNb+N33nEk9+C+fCuy0vPwMWzqDcnZP48St2Jm1obAvKux3xZwnq1mdqpZmcUQEUL3USwYoJ80Ef8gmqmFgk=".to_string(),
+			),
+			"bucketKey"=> JsonElement::Null,
+			"conversationEntry"=> JsonElement::Array(
+				vec![
+					JsonElement::String(
+						"O1RT2Dj--3-0".to_string(),
+					),
+					JsonElement::String(
+						"O1RT2Dj--7-0".to_string(),
+					),
+				],
+			),
+			"_permissions"=> JsonElement::String(
+				"O1RT2Dj--g-0".to_string(),
+			),
+			"mailDetailsDraft"=> JsonElement::Null,
+			"sender"=> JsonElement::Dict(
+				collection! {
+					"address"=> JsonElement::String(
+						"map-free@tutanota.de".to_string(),
+					),
+					"contact"=> JsonElement::Null,
+					"_id"=> JsonElement::String(
+						"0y7Pgw".to_string(),
+					),
+					"name"=> JsonElement::String(
+						"AQLHPJe+eDYk6eRtBsmtpNBGllFzNvfb7gUuMjxsiJGinYAStt4nHO4L1PLChTZL63ifyZd87IqJ7DpVNFkpPNQ=".to_string(),
+					),
+				},
+			),
+			"subject"=> JsonElement::String(
+				"AVRYAouCyrii0gGUpQ9TcgbBdzQiFUc8n0I32fO5pA0wk+0i6vNke8uML5vPy09NQEzUiozrSYDl3bEzHCdrD9rjQgvrJhaygZiAF5bv8eX/".to_string(),
+			),
+			"movedTime"=> JsonElement::String(
+				"1720612041643".to_string(),
+			),
+			"state"=> JsonElement::String(
+				"2".to_string(),
+			),
+			"_ownerKeyVersion"=> JsonElement::String(
+				"0".to_string(),
+			),
+			"replyTos"=> JsonElement::Array(
+				vec![],
+			),
+			"unread"=> JsonElement::String(
+				"0".to_string(),
+			),
+			"body"=> JsonElement::Null,
+			"authStatus"=> JsonElement::Null,
+			"firstRecipient"=> JsonElement::Dict(
+				collection! {
+					"address"=> JsonElement::String(
+						"bed-free@tutanota.de".to_string(),
+					),
+					"_id"=> JsonElement::String(
+						"yPeInQ".to_string(),
+					),
+					"name"=> JsonElement::String(
+						"AcCA59dQjq0y32zLYtBYvZZ84DXe3ftn4fBplPt9KAkdRBauIaKN2jiSqNa7wvcb5TTyeLz7tdTt9sKyM9Y+tx0=".to_string(),
+					),
+					"contact"=> JsonElement::Null,
+				},
+			),
+			"differentEnvelopeSender"=> JsonElement::Null,
+			"listUnsubscribe"=> JsonElement::String(
+				"".to_string(),
+			),
+			"attachments"=> JsonElement::Array(
+				vec![],
+			),
+			"_id"=> JsonElement::Array(
+				vec![
+					JsonElement::String(
+						"O1RT1m6-0R-0".to_string(),
+					),
+					JsonElement::String(
+						"O1RT2Dj----0".to_string(),
+					),
+				],
+			),
+			"confidential"=> JsonElement::String(
+				"AWv1okmvm7ItO37ubnKytr0kPscHFvpjzzs7P6CeiL8F3H8GWj/lpk20ewECiAg3wfj7sCyajaw1ShWU0D+Qncg=".to_string(),
+			),
+			"headers"=> JsonElement::Null,
+			"receivedDate"=> JsonElement::String(
+				"1720612041643".to_string(),
+			),
+			"_ownerGroup"=> JsonElement::String(
+				"O1RT1m4-0s-0".to_string(),
+			),
+			"replyType"=> JsonElement::String(
+				"".to_string(),
+			),
+			"phishingStatus"=> JsonElement::String(
+				"0".to_string(),
+			),
+			"_format"=> JsonElement::String(
+				"0".to_string(),
+			),
+			"recipientCount"=> JsonElement::String(
+				"1".to_string(),
+			),
+			"encryptionAuthStatus"=> JsonElement::String(
+				"AfrN1BgMCYxVksEHHVYnJCMrBK+59cgsu2S84Vvc57YbwV3NvuzFMXq8fMkTZB7vtLBiZdc2ZwLKrxTGwPWqk7w=".to_string(),
+			),
+			"mailDetails"=> JsonElement::Array(
+				vec![
+					JsonElement::String(
+						"O1RT1m5-0--0".to_string(),
+					),
+					JsonElement::String(
+						"O1RT2Dk----0".to_string(),
+					),
+				],
+			),
+		"sets"=> JsonElement::Array(vec![]),}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/gossip.rs
+++ b/tuta-sdk/rust/sdk/src/entities/gossip.rs
@@ -1,4 +1,1 @@
-#![allow(non_snake_case, unused_imports)]
-use super::*;
-use serde::{Serialize, Deserialize};
 

--- a/tuta-sdk/rust/sdk/src/entities/mod.rs
+++ b/tuta-sdk/rust/sdk/src/entities/mod.rs
@@ -1,27 +1,27 @@
-use std::collections::HashMap;
-use serde::{Deserialize, Serialize};
 pub use crate::IdTuple;
 use crate::TypeRef;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub(crate) mod accounting;
 pub(crate) mod base;
+pub(crate) mod entity_facade;
 pub(crate) mod gossip;
 pub(crate) mod monitor;
 pub(crate) mod storage;
 pub(crate) mod sys;
 pub(crate) mod tutanota;
 pub(crate) mod usage;
-pub(crate) mod entity_facade;
 
-use crate::date::DateTime;
-use crate::generated_id::GeneratedId;
 use crate::custom_id::CustomId;
+use crate::date::DateTime;
 use crate::element_value::ElementValue;
+use crate::generated_id::GeneratedId;
 
 /// `'static` on trait bound is fine here because Entity does not contain any non-static references.
 /// See https://doc.rust-lang.org/rust-by-example/scope/lifetime/static_lifetime.html#trait-bound
 pub trait Entity: 'static {
-    fn type_ref() -> TypeRef;
+	fn type_ref() -> TypeRef;
 }
 
 /// A wrapper for the value in _finalIvs map on entities.
@@ -31,12 +31,8 @@ pub trait Entity: 'static {
 /// FinalIv holds such an IV for a specific field.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(transparent)]
-pub struct FinalIv(
-    #[serde(with = "serde_bytes")]
-    Vec<u8>
-);
+pub struct FinalIv(#[serde(with = "serde_bytes")] Vec<u8>);
 
 uniffi::custom_newtype!(FinalIv, Vec<u8>);
 
 type Errors = HashMap<String, ElementValue>;
-

--- a/tuta-sdk/rust/sdk/src/entities/monitor.rs
+++ b/tuta-sdk/rust/sdk/src/entities/monitor.rs
@@ -1,153 +1,146 @@
 #![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ApprovalMail {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub date: Option<DateTime>,
-    pub range: Option<String>,
-    pub text: String,
-    pub customer: Option<GeneratedId>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub date: Option<DateTime>,
+	pub range: Option<String>,
+	pub text: String,
+	pub customer: Option<GeneratedId>,
 }
 
 impl Entity for ApprovalMail {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "ApprovalMail",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "ApprovalMail",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CounterValue {
-    pub _id: CustomId,
-    pub counterId: GeneratedId,
-    pub value: i64,
+	pub _id: CustomId,
+	pub counterId: GeneratedId,
+	pub value: i64,
 }
 
 impl Entity for CounterValue {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "CounterValue",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "CounterValue",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ErrorReportData {
-    pub _id: CustomId,
-    pub additionalInfo: String,
-    pub appVersion: String,
-    pub clientType: i64,
-    pub errorClass: String,
-    pub errorMessage: Option<String>,
-    pub stackTrace: String,
-    pub time: DateTime,
-    pub userId: Option<String>,
-    pub userMessage: Option<String>,
+	pub _id: CustomId,
+	pub additionalInfo: String,
+	pub appVersion: String,
+	pub clientType: i64,
+	pub errorClass: String,
+	pub errorMessage: Option<String>,
+	pub stackTrace: String,
+	pub time: DateTime,
+	pub userId: Option<String>,
+	pub userMessage: Option<String>,
 }
 
 impl Entity for ErrorReportData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "ErrorReportData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "ErrorReportData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ErrorReportFile {
-    pub _id: CustomId,
-    pub content: String,
-    pub name: String,
+	pub _id: CustomId,
+	pub content: String,
+	pub name: String,
 }
 
 impl Entity for ErrorReportFile {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "ErrorReportFile",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "ErrorReportFile",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReadCounterData {
-    pub _format: i64,
-    pub columnName: Option<GeneratedId>,
-    pub counterType: i64,
-    pub rowName: String,
+	pub _format: i64,
+	pub columnName: Option<GeneratedId>,
+	pub counterType: i64,
+	pub rowName: String,
 }
 
 impl Entity for ReadCounterData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "ReadCounterData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "ReadCounterData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReadCounterReturn {
-    pub _format: i64,
-    pub value: Option<i64>,
-    pub counterValues: Vec<CounterValue>,
+	pub _format: i64,
+	pub value: Option<i64>,
+	pub counterValues: Vec<CounterValue>,
 }
 
 impl Entity for ReadCounterReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "ReadCounterReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "ReadCounterReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReportErrorIn {
-    pub _format: i64,
-    pub data: ErrorReportData,
-    pub files: Vec<ErrorReportFile>,
+	pub _format: i64,
+	pub data: ErrorReportData,
+	pub files: Vec<ErrorReportFile>,
 }
 
 impl Entity for ReportErrorIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "ReportErrorIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "ReportErrorIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WriteCounterData {
-    pub _format: i64,
-    pub column: GeneratedId,
-    pub counterType: Option<i64>,
-    pub row: String,
-    pub value: i64,
+	pub _format: i64,
+	pub column: GeneratedId,
+	pub counterType: Option<i64>,
+	pub row: String,
+	pub value: i64,
 }
 
 impl Entity for WriteCounterData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "monitor",
-            type_: "WriteCounterData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "monitor",
+			type_: "WriteCounterData",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/storage.rs
+++ b/tuta-sdk/rust/sdk/src/entities/storage.rs
@@ -1,227 +1,215 @@
 #![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobAccessTokenPostIn {
-    pub _format: i64,
-    pub archiveDataType: Option<i64>,
-    pub read: Option<BlobReadData>,
-    pub write: Option<BlobWriteData>,
+	pub _format: i64,
+	pub archiveDataType: Option<i64>,
+	pub read: Option<BlobReadData>,
+	pub write: Option<BlobWriteData>,
 }
 
 impl Entity for BlobAccessTokenPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobAccessTokenPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobAccessTokenPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobAccessTokenPostOut {
-    pub _format: i64,
-    pub blobAccessInfo: BlobServerAccessInfo,
+	pub _format: i64,
+	pub blobAccessInfo: BlobServerAccessInfo,
 }
 
 impl Entity for BlobAccessTokenPostOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobAccessTokenPostOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobAccessTokenPostOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobArchiveRef {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub archive: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub archive: GeneratedId,
 }
 
 impl Entity for BlobArchiveRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobArchiveRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobArchiveRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobGetIn {
-    pub _format: i64,
-    pub archiveId: GeneratedId,
-    pub blobId: Option<GeneratedId>,
-    pub blobIds: Vec<BlobId>,
+	pub _format: i64,
+	pub archiveId: GeneratedId,
+	pub blobId: Option<GeneratedId>,
+	pub blobIds: Vec<BlobId>,
 }
 
 impl Entity for BlobGetIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobGetIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobGetIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobId {
-    pub _id: CustomId,
-    pub blobId: GeneratedId,
+	pub _id: CustomId,
+	pub blobId: GeneratedId,
 }
 
 impl Entity for BlobId {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobId",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobId",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobPostOut {
-    pub _format: i64,
-    pub blobReferenceToken: String,
+	pub _format: i64,
+	pub blobReferenceToken: String,
 }
 
 impl Entity for BlobPostOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobPostOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobPostOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobReadData {
-    pub _id: CustomId,
-    pub archiveId: GeneratedId,
-    pub instanceListId: Option<GeneratedId>,
-    pub instanceIds: Vec<InstanceId>,
+	pub _id: CustomId,
+	pub archiveId: GeneratedId,
+	pub instanceListId: Option<GeneratedId>,
+	pub instanceIds: Vec<InstanceId>,
 }
 
 impl Entity for BlobReadData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobReadData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobReadData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobReferenceDeleteIn {
-    pub _format: i64,
-    pub archiveDataType: i64,
-    pub instanceId: GeneratedId,
-    pub instanceListId: Option<GeneratedId>,
-    pub blobs: Vec<sys::Blob>,
+	pub _format: i64,
+	pub archiveDataType: i64,
+	pub instanceId: GeneratedId,
+	pub instanceListId: Option<GeneratedId>,
+	pub blobs: Vec<sys::Blob>,
 }
 
 impl Entity for BlobReferenceDeleteIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobReferenceDeleteIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobReferenceDeleteIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobReferencePutIn {
-    pub _format: i64,
-    pub archiveDataType: i64,
-    pub instanceId: GeneratedId,
-    pub instanceListId: Option<GeneratedId>,
-    pub referenceTokens: Vec<sys::BlobReferenceTokenWrapper>,
+	pub _format: i64,
+	pub archiveDataType: i64,
+	pub instanceId: GeneratedId,
+	pub instanceListId: Option<GeneratedId>,
+	pub referenceTokens: Vec<sys::BlobReferenceTokenWrapper>,
 }
 
 impl Entity for BlobReferencePutIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobReferencePutIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobReferencePutIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobServerAccessInfo {
-    pub _id: CustomId,
-    pub blobAccessToken: String,
-    pub expires: DateTime,
-    pub servers: Vec<BlobServerUrl>,
+	pub _id: CustomId,
+	pub blobAccessToken: String,
+	pub expires: DateTime,
+	pub servers: Vec<BlobServerUrl>,
 }
 
 impl Entity for BlobServerAccessInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobServerAccessInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobServerAccessInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobServerUrl {
-    pub _id: CustomId,
-    pub url: String,
+	pub _id: CustomId,
+	pub url: String,
 }
 
 impl Entity for BlobServerUrl {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobServerUrl",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobServerUrl",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobWriteData {
-    pub _id: CustomId,
-    pub archiveOwnerGroup: GeneratedId,
+	pub _id: CustomId,
+	pub archiveOwnerGroup: GeneratedId,
 }
 
 impl Entity for BlobWriteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "BlobWriteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "BlobWriteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InstanceId {
-    pub _id: CustomId,
-    pub instanceId: Option<GeneratedId>,
+	pub _id: CustomId,
+	pub instanceId: Option<GeneratedId>,
 }
 
 impl Entity for InstanceId {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "storage",
-            type_: "InstanceId",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "storage",
+			type_: "InstanceId",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/sys.rs
+++ b/tuta-sdk/rust/sdk/src/entities/sys.rs
@@ -1,4453 +1,4236 @@
 #![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AccountingInfo {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _modified: DateTime,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub invoiceAddress: String,
-    pub invoiceCountry: Option<String>,
-    pub invoiceName: String,
-    pub invoiceVatIdNo: String,
-    pub lastInvoiceNbrOfSentSms: i64,
-    pub lastInvoiceTimestamp: Option<DateTime>,
-    pub paymentAccountIdentifier: Option<String>,
-    pub paymentInterval: i64,
-    pub paymentMethod: Option<i64>,
-    pub paymentMethodInfo: Option<String>,
-    pub paymentProviderCustomerId: Option<String>,
-    pub paypalBillingAgreement: Option<String>,
-    pub secondCountryInfo: i64,
-    pub appStoreSubscription: Option<IdTuple>,
-    pub invoiceInfo: Option<GeneratedId>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _modified: DateTime,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub invoiceAddress: String,
+	pub invoiceCountry: Option<String>,
+	pub invoiceName: String,
+	pub invoiceVatIdNo: String,
+	pub lastInvoiceNbrOfSentSms: i64,
+	pub lastInvoiceTimestamp: Option<DateTime>,
+	pub paymentAccountIdentifier: Option<String>,
+	pub paymentInterval: i64,
+	pub paymentMethod: Option<i64>,
+	pub paymentMethodInfo: Option<String>,
+	pub paymentProviderCustomerId: Option<String>,
+	pub paypalBillingAgreement: Option<String>,
+	pub secondCountryInfo: i64,
+	pub appStoreSubscription: Option<IdTuple>,
+	pub invoiceInfo: Option<GeneratedId>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AccountingInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AccountingInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AccountingInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AdminGroupKeyRotationPostIn {
-    pub _format: i64,
-    pub adminGroupKeyData: GroupKeyRotationData,
-    pub userGroupKeyData: UserGroupKeyRotationData,
+	pub _format: i64,
+	pub adminGroupKeyData: GroupKeyRotationData,
+	pub userGroupKeyData: UserGroupKeyRotationData,
 }
 
 impl Entity for AdminGroupKeyRotationPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AdminGroupKeyRotationPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AdminGroupKeyRotationPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AdministratedGroupsRef {
-    pub _id: CustomId,
-    pub items: GeneratedId,
+	pub _id: CustomId,
+	pub items: GeneratedId,
 }
 
 impl Entity for AdministratedGroupsRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AdministratedGroupsRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AdministratedGroupsRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AlarmInfo {
-    pub _id: CustomId,
-    pub alarmIdentifier: String,
-    pub trigger: String,
-    pub calendarRef: CalendarEventRef,
+	pub _id: CustomId,
+	pub alarmIdentifier: String,
+	pub trigger: String,
+	pub calendarRef: CalendarEventRef,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AlarmInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AlarmInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AlarmInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AlarmNotification {
-    pub _id: CustomId,
-    pub eventEnd: DateTime,
-    pub eventStart: DateTime,
-    pub operation: i64,
-    pub summary: String,
-    pub alarmInfo: AlarmInfo,
-    pub notificationSessionKeys: Vec<NotificationSessionKey>,
-    pub repeatRule: Option<RepeatRule>,
-    pub user: GeneratedId,
+	pub _id: CustomId,
+	pub eventEnd: DateTime,
+	pub eventStart: DateTime,
+	pub operation: i64,
+	pub summary: String,
+	pub alarmInfo: AlarmInfo,
+	pub notificationSessionKeys: Vec<NotificationSessionKey>,
+	pub repeatRule: Option<RepeatRule>,
+	pub user: GeneratedId,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AlarmNotification {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AlarmNotification",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AlarmNotification",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AlarmServicePost {
-    pub _format: i64,
-    pub alarmNotifications: Vec<AlarmNotification>,
+	pub _format: i64,
+	pub alarmNotifications: Vec<AlarmNotification>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AlarmServicePost {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AlarmServicePost",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AlarmServicePost",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ArchiveRef {
-    pub _id: CustomId,
-    pub archiveId: GeneratedId,
+	pub _id: CustomId,
+	pub archiveId: GeneratedId,
 }
 
 impl Entity for ArchiveRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ArchiveRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ArchiveRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ArchiveType {
-    pub _id: CustomId,
-    pub active: ArchiveRef,
-    pub inactive: Vec<ArchiveRef>,
-    #[serde(rename = "type")]
-    pub r#type: TypeInfo,
+	pub _id: CustomId,
+	pub active: ArchiveRef,
+	pub inactive: Vec<ArchiveRef>,
+	#[serde(rename = "type")]
+	pub r#type: TypeInfo,
 }
 
 impl Entity for ArchiveType {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ArchiveType",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ArchiveType",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AuditLogEntry {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub action: String,
-    pub actorIpAddress: Option<String>,
-    pub actorMailAddress: String,
-    pub date: DateTime,
-    pub modifiedEntity: String,
-    pub groupInfo: Option<IdTuple>,
-    pub modifiedGroupInfo: Option<IdTuple>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub action: String,
+	pub actorIpAddress: Option<String>,
+	pub actorMailAddress: String,
+	pub date: DateTime,
+	pub modifiedEntity: String,
+	pub groupInfo: Option<IdTuple>,
+	pub modifiedGroupInfo: Option<IdTuple>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AuditLogEntry {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AuditLogEntry",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AuditLogEntry",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AuditLogRef {
-    pub _id: CustomId,
-    pub items: GeneratedId,
+	pub _id: CustomId,
+	pub items: GeneratedId,
 }
 
 impl Entity for AuditLogRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AuditLogRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AuditLogRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AuthenticatedDevice {
-    pub _id: CustomId,
-    pub authType: i64,
-    #[serde(with = "serde_bytes")]
-    pub deviceKey: Vec<u8>,
-    pub deviceToken: String,
+	pub _id: CustomId,
+	pub authType: i64,
+	#[serde(with = "serde_bytes")]
+	pub deviceKey: Vec<u8>,
+	pub deviceToken: String,
 }
 
 impl Entity for AuthenticatedDevice {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AuthenticatedDevice",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AuthenticatedDevice",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Authentication {
-    pub _id: CustomId,
-    pub accessToken: Option<String>,
-    pub authVerifier: Option<String>,
-    pub externalAuthToken: Option<String>,
-    pub userId: GeneratedId,
+	pub _id: CustomId,
+	pub accessToken: Option<String>,
+	pub authVerifier: Option<String>,
+	pub externalAuthToken: Option<String>,
+	pub userId: GeneratedId,
 }
 
 impl Entity for Authentication {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Authentication",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Authentication",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AutoLoginDataDelete {
-    pub _format: i64,
-    pub deviceToken: String,
+	pub _format: i64,
+	pub deviceToken: String,
 }
 
 impl Entity for AutoLoginDataDelete {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AutoLoginDataDelete",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AutoLoginDataDelete",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AutoLoginDataGet {
-    pub _format: i64,
-    pub deviceToken: String,
-    pub userId: GeneratedId,
+	pub _format: i64,
+	pub deviceToken: String,
+	pub userId: GeneratedId,
 }
 
 impl Entity for AutoLoginDataGet {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AutoLoginDataGet",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AutoLoginDataGet",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AutoLoginDataReturn {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub deviceKey: Vec<u8>,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub deviceKey: Vec<u8>,
 }
 
 impl Entity for AutoLoginDataReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AutoLoginDataReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AutoLoginDataReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AutoLoginPostReturn {
-    pub _format: i64,
-    pub deviceToken: String,
+	pub _format: i64,
+	pub deviceToken: String,
 }
 
 impl Entity for AutoLoginPostReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "AutoLoginPostReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AutoLoginPostReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Blob {
-    pub _id: CustomId,
-    pub archiveId: GeneratedId,
-    pub blobId: GeneratedId,
-    pub size: i64,
+	pub _id: CustomId,
+	pub archiveId: GeneratedId,
+	pub blobId: GeneratedId,
+	pub size: i64,
 }
 
 impl Entity for Blob {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Blob",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Blob",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BlobReferenceTokenWrapper {
-    pub _id: CustomId,
-    pub blobReferenceToken: String,
+	pub _id: CustomId,
+	pub blobReferenceToken: String,
 }
 
 impl Entity for BlobReferenceTokenWrapper {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BlobReferenceTokenWrapper",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BlobReferenceTokenWrapper",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Booking {
-    pub _area: i64,
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _owner: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub bonusMonth: i64,
-    pub createDate: DateTime,
-    pub endDate: Option<DateTime>,
-    pub paymentInterval: i64,
-    pub paymentMonths: i64,
-    pub items: Vec<BookingItem>,
+	pub _area: i64,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _owner: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub bonusMonth: i64,
+	pub createDate: DateTime,
+	pub endDate: Option<DateTime>,
+	pub paymentInterval: i64,
+	pub paymentMonths: i64,
+	pub items: Vec<BookingItem>,
 }
 
 impl Entity for Booking {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Booking",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Booking",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BookingItem {
-    pub _id: CustomId,
-    pub currentCount: i64,
-    pub currentInvoicedCount: i64,
-    pub featureType: i64,
-    pub maxCount: i64,
-    pub price: i64,
-    pub priceType: i64,
-    pub totalInvoicedCount: i64,
+	pub _id: CustomId,
+	pub currentCount: i64,
+	pub currentInvoicedCount: i64,
+	pub featureType: i64,
+	pub maxCount: i64,
+	pub price: i64,
+	pub priceType: i64,
+	pub totalInvoicedCount: i64,
 }
 
 impl Entity for BookingItem {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BookingItem",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BookingItem",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BookingsRef {
-    pub _id: CustomId,
-    pub items: GeneratedId,
+	pub _id: CustomId,
+	pub items: GeneratedId,
 }
 
 impl Entity for BookingsRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BookingsRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BookingsRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BootstrapFeature {
-    pub _id: CustomId,
-    pub feature: i64,
+	pub _id: CustomId,
+	pub feature: i64,
 }
 
 impl Entity for BootstrapFeature {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BootstrapFeature",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BootstrapFeature",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Braintree3ds2Request {
-    pub _id: CustomId,
-    pub bin: String,
-    pub clientToken: String,
-    pub nonce: String,
+	pub _id: CustomId,
+	pub bin: String,
+	pub clientToken: String,
+	pub nonce: String,
 }
 
 impl Entity for Braintree3ds2Request {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Braintree3ds2Request",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Braintree3ds2Request",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Braintree3ds2Response {
-    pub _id: CustomId,
-    pub clientToken: String,
-    pub nonce: String,
+	pub _id: CustomId,
+	pub clientToken: String,
+	pub nonce: String,
 }
 
 impl Entity for Braintree3ds2Response {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Braintree3ds2Response",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Braintree3ds2Response",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BrandingDomainData {
-    pub _format: i64,
-    pub domain: String,
-    #[serde(with = "serde_bytes")]
-    pub sessionEncPemCertificateChain: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub sessionEncPemPrivateKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub systemAdminPubEncSessionKey: Vec<u8>,
-    pub systemAdminPubKeyVersion: i64,
-    pub systemAdminPublicProtocolVersion: i64,
+	pub _format: i64,
+	pub domain: String,
+	#[serde(with = "serde_bytes")]
+	pub sessionEncPemCertificateChain: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub sessionEncPemPrivateKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub systemAdminPubEncSessionKey: Vec<u8>,
+	pub systemAdminPubKeyVersion: i64,
+	pub systemAdminPublicProtocolVersion: i64,
 }
 
 impl Entity for BrandingDomainData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BrandingDomainData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BrandingDomainData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BrandingDomainDeleteData {
-    pub _format: i64,
-    pub domain: String,
+	pub _format: i64,
+	pub domain: String,
 }
 
 impl Entity for BrandingDomainDeleteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BrandingDomainDeleteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BrandingDomainDeleteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BrandingDomainGetReturn {
-    pub _format: i64,
-    pub certificateInfo: Option<CertificateInfo>,
+	pub _format: i64,
+	pub certificateInfo: Option<CertificateInfo>,
 }
 
 impl Entity for BrandingDomainGetReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BrandingDomainGetReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BrandingDomainGetReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Bucket {
-    pub _id: CustomId,
-    pub bucketPermissions: GeneratedId,
+	pub _id: CustomId,
+	pub bucketPermissions: GeneratedId,
 }
 
 impl Entity for Bucket {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Bucket",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Bucket",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BucketKey {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub groupEncBucketKey: Option<Vec<u8>>,
-    pub protocolVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubEncBucketKey: Option<Vec<u8>>,
-    pub recipientKeyVersion: i64,
-    pub senderKeyVersion: Option<i64>,
-    pub bucketEncSessionKeys: Vec<InstanceSessionKey>,
-    pub keyGroup: Option<GeneratedId>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub groupEncBucketKey: Option<Vec<u8>>,
+	pub protocolVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubEncBucketKey: Option<Vec<u8>>,
+	pub recipientKeyVersion: i64,
+	pub senderKeyVersion: Option<i64>,
+	pub bucketEncSessionKeys: Vec<InstanceSessionKey>,
+	pub keyGroup: Option<GeneratedId>,
 }
 
 impl Entity for BucketKey {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BucketKey",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BucketKey",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct BucketPermission {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncBucketKey: Option<Vec<u8>>,
-    pub ownerKeyVersion: Option<i64>,
-    pub protocolVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubEncBucketKey: Option<Vec<u8>>,
-    pub pubKeyVersion: Option<i64>,
-    pub senderKeyVersion: Option<i64>,
-    #[serde(with = "serde_bytes")]
-    pub symEncBucketKey: Option<Vec<u8>>,
-    pub symKeyVersion: Option<i64>,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub group: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncBucketKey: Option<Vec<u8>>,
+	pub ownerKeyVersion: Option<i64>,
+	pub protocolVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubEncBucketKey: Option<Vec<u8>>,
+	pub pubKeyVersion: Option<i64>,
+	pub senderKeyVersion: Option<i64>,
+	#[serde(with = "serde_bytes")]
+	pub symEncBucketKey: Option<Vec<u8>>,
+	pub symKeyVersion: Option<i64>,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub group: GeneratedId,
 }
 
 impl Entity for BucketPermission {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "BucketPermission",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "BucketPermission",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarEventRef {
-    pub _id: CustomId,
-    pub elementId: CustomId,
-    pub listId: GeneratedId,
+	pub _id: CustomId,
+	pub elementId: CustomId,
+	pub listId: GeneratedId,
 }
 
 impl Entity for CalendarEventRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CalendarEventRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CalendarEventRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CertificateInfo {
-    pub _id: CustomId,
-    pub expiryDate: Option<DateTime>,
-    pub state: i64,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub certificate: Option<GeneratedId>,
+	pub _id: CustomId,
+	pub expiryDate: Option<DateTime>,
+	pub state: i64,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub certificate: Option<GeneratedId>,
 }
 
 impl Entity for CertificateInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CertificateInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CertificateInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Challenge {
-    pub _id: CustomId,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub otp: Option<OtpChallenge>,
-    pub u2f: Option<U2fChallenge>,
+	pub _id: CustomId,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub otp: Option<OtpChallenge>,
+	pub u2f: Option<U2fChallenge>,
 }
 
 impl Entity for Challenge {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Challenge",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Challenge",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ChangeKdfPostIn {
-    pub _format: i64,
-    pub kdfVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub oldVerifier: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub pwEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub salt: Vec<u8>,
-    pub userGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub verifier: Vec<u8>,
+	pub _format: i64,
+	pub kdfVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub oldVerifier: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub pwEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub salt: Vec<u8>,
+	pub userGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub verifier: Vec<u8>,
 }
 
 impl Entity for ChangeKdfPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ChangeKdfPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ChangeKdfPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ChangePasswordPostIn {
-    pub _format: i64,
-    pub code: Option<String>,
-    pub kdfVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub oldVerifier: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub pwEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub recoverCodeVerifier: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub salt: Vec<u8>,
-    pub userGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub verifier: Vec<u8>,
+	pub _format: i64,
+	pub code: Option<String>,
+	pub kdfVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub oldVerifier: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub pwEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub recoverCodeVerifier: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub salt: Vec<u8>,
+	pub userGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub verifier: Vec<u8>,
 }
 
 impl Entity for ChangePasswordPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ChangePasswordPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ChangePasswordPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Chat {
-    pub _id: CustomId,
-    pub recipient: GeneratedId,
-    pub sender: GeneratedId,
-    pub text: String,
+	pub _id: CustomId,
+	pub recipient: GeneratedId,
+	pub sender: GeneratedId,
+	pub text: String,
 }
 
 impl Entity for Chat {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Chat",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Chat",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CloseSessionServicePost {
-    pub _format: i64,
-    pub accessToken: String,
-    pub sessionId: IdTuple,
+	pub _format: i64,
+	pub accessToken: String,
+	pub sessionId: IdTuple,
 }
 
 impl Entity for CloseSessionServicePost {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CloseSessionServicePost",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CloseSessionServicePost",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateCustomerServerPropertiesData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub adminGroupEncSessionKey: Vec<u8>,
-    pub adminGroupKeyVersion: i64,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub adminGroupEncSessionKey: Vec<u8>,
+	pub adminGroupKeyVersion: i64,
 }
 
 impl Entity for CreateCustomerServerPropertiesData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CreateCustomerServerPropertiesData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CreateCustomerServerPropertiesData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateCustomerServerPropertiesReturn {
-    pub _format: i64,
-    pub id: GeneratedId,
+	pub _format: i64,
+	pub id: GeneratedId,
 }
 
 impl Entity for CreateCustomerServerPropertiesReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CreateCustomerServerPropertiesReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CreateCustomerServerPropertiesReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateSessionData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub accessKey: Option<Vec<u8>>,
-    pub authToken: Option<String>,
-    pub authVerifier: Option<String>,
-    pub clientIdentifier: String,
-    pub mailAddress: Option<String>,
-    pub recoverCodeVerifier: Option<String>,
-    pub user: Option<GeneratedId>,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub accessKey: Option<Vec<u8>>,
+	pub authToken: Option<String>,
+	pub authVerifier: Option<String>,
+	pub clientIdentifier: String,
+	pub mailAddress: Option<String>,
+	pub recoverCodeVerifier: Option<String>,
+	pub user: Option<GeneratedId>,
 }
 
 impl Entity for CreateSessionData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CreateSessionData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CreateSessionData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateSessionReturn {
-    pub _format: i64,
-    pub accessToken: String,
-    pub challenges: Vec<Challenge>,
-    pub user: GeneratedId,
+	pub _format: i64,
+	pub accessToken: String,
+	pub challenges: Vec<Challenge>,
+	pub user: GeneratedId,
 }
 
 impl Entity for CreateSessionReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CreateSessionReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CreateSessionReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreditCard {
-    pub _id: CustomId,
-    pub cardHolderName: String,
-    pub cvv: String,
-    pub expirationMonth: String,
-    pub expirationYear: String,
-    pub number: String,
+	pub _id: CustomId,
+	pub cardHolderName: String,
+	pub cvv: String,
+	pub expirationMonth: String,
+	pub expirationYear: String,
+	pub number: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreditCard {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CreditCard",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CreditCard",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomDomainCheckGetIn {
-    pub _format: i64,
-    pub domain: String,
-    pub customer: Option<GeneratedId>,
+	pub _format: i64,
+	pub domain: String,
+	pub customer: Option<GeneratedId>,
 }
 
 impl Entity for CustomDomainCheckGetIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomDomainCheckGetIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomDomainCheckGetIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomDomainCheckGetOut {
-    pub _format: i64,
-    pub checkResult: i64,
-    pub invalidRecords: Vec<DnsRecord>,
-    pub missingRecords: Vec<DnsRecord>,
-    pub requiredRecords: Vec<DnsRecord>,
+	pub _format: i64,
+	pub checkResult: i64,
+	pub invalidRecords: Vec<DnsRecord>,
+	pub missingRecords: Vec<DnsRecord>,
+	pub requiredRecords: Vec<DnsRecord>,
 }
 
 impl Entity for CustomDomainCheckGetOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomDomainCheckGetOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomDomainCheckGetOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomDomainData {
-    pub _format: i64,
-    pub domain: String,
-    pub catchAllMailGroup: Option<GeneratedId>,
+	pub _format: i64,
+	pub domain: String,
+	pub catchAllMailGroup: Option<GeneratedId>,
 }
 
 impl Entity for CustomDomainData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomDomainData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomDomainData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomDomainReturn {
-    pub _format: i64,
-    pub validationResult: i64,
-    pub invalidDnsRecords: Vec<StringWrapper>,
+	pub _format: i64,
+	pub validationResult: i64,
+	pub invalidDnsRecords: Vec<StringWrapper>,
 }
 
 impl Entity for CustomDomainReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomDomainReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomDomainReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Customer {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub approvalStatus: i64,
-    pub businessUse: bool,
-    pub orderProcessingAgreementNeeded: bool,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub adminGroup: GeneratedId,
-    pub adminGroups: GeneratedId,
-    pub auditLog: Option<AuditLogRef>,
-    pub customerGroup: GeneratedId,
-    pub customerGroups: GeneratedId,
-    pub customerInfo: IdTuple,
-    pub customizations: Vec<Feature>,
-    pub orderProcessingAgreement: Option<IdTuple>,
-    pub properties: Option<GeneratedId>,
-    pub referralCode: Option<GeneratedId>,
-    pub rejectedSenders: Option<RejectedSendersRef>,
-    pub serverProperties: Option<GeneratedId>,
-    pub teamGroups: GeneratedId,
-    pub userAreaGroups: Option<UserAreaGroups>,
-    pub userGroups: GeneratedId,
-    pub whitelabelChildren: Option<WhitelabelChildrenRef>,
-    pub whitelabelParent: Option<WhitelabelParent>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub approvalStatus: i64,
+	pub businessUse: bool,
+	pub orderProcessingAgreementNeeded: bool,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub adminGroup: GeneratedId,
+	pub adminGroups: GeneratedId,
+	pub auditLog: Option<AuditLogRef>,
+	pub customerGroup: GeneratedId,
+	pub customerGroups: GeneratedId,
+	pub customerInfo: IdTuple,
+	pub customizations: Vec<Feature>,
+	pub orderProcessingAgreement: Option<IdTuple>,
+	pub properties: Option<GeneratedId>,
+	pub referralCode: Option<GeneratedId>,
+	pub rejectedSenders: Option<RejectedSendersRef>,
+	pub serverProperties: Option<GeneratedId>,
+	pub teamGroups: GeneratedId,
+	pub userAreaGroups: Option<UserAreaGroups>,
+	pub userGroups: GeneratedId,
+	pub whitelabelChildren: Option<WhitelabelChildrenRef>,
+	pub whitelabelParent: Option<WhitelabelParent>,
 }
 
 impl Entity for Customer {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Customer",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Customer",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerAccountTerminationPostIn {
-    pub _format: i64,
-    pub terminationDate: Option<DateTime>,
-    pub surveyData: Option<SurveyData>,
+	pub _format: i64,
+	pub terminationDate: Option<DateTime>,
+	pub surveyData: Option<SurveyData>,
 }
 
 impl Entity for CustomerAccountTerminationPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomerAccountTerminationPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomerAccountTerminationPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerAccountTerminationPostOut {
-    pub _format: i64,
-    pub terminationRequest: IdTuple,
+	pub _format: i64,
+	pub terminationRequest: IdTuple,
 }
 
 impl Entity for CustomerAccountTerminationPostOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomerAccountTerminationPostOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomerAccountTerminationPostOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerAccountTerminationRequest {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub terminationDate: DateTime,
-    pub terminationRequestDate: DateTime,
-    pub customer: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub terminationDate: DateTime,
+	pub terminationRequestDate: DateTime,
+	pub customer: GeneratedId,
 }
 
 impl Entity for CustomerAccountTerminationRequest {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomerAccountTerminationRequest",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomerAccountTerminationRequest",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerInfo {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub activationTime: Option<DateTime>,
-    pub company: Option<String>,
-    pub creationTime: DateTime,
-    pub deletionReason: Option<String>,
-    pub deletionTime: Option<DateTime>,
-    pub domain: String,
-    pub erased: bool,
-    pub includedEmailAliases: i64,
-    pub includedStorageCapacity: i64,
-    pub perUserAliasCount: i64,
-    pub perUserStorageCapacity: i64,
-    pub plan: i64,
-    pub promotionEmailAliases: i64,
-    pub promotionStorageCapacity: i64,
-    pub registrationMailAddress: String,
-    pub source: String,
-    pub testEndTime: Option<DateTime>,
-    pub usedSharedEmailAliases: i64,
-    pub accountingInfo: GeneratedId,
-    pub bookings: Option<BookingsRef>,
-    pub customPlan: Option<PlanConfiguration>,
-    pub customer: GeneratedId,
-    pub domainInfos: Vec<DomainInfo>,
-    pub giftCards: Option<GiftCardsRef>,
-    pub referredBy: Option<GeneratedId>,
-    pub supportInfo: Option<GeneratedId>,
-    pub takeoverCustomer: Option<GeneratedId>,
-    pub terminationRequest: Option<IdTuple>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub activationTime: Option<DateTime>,
+	pub company: Option<String>,
+	pub creationTime: DateTime,
+	pub deletionReason: Option<String>,
+	pub deletionTime: Option<DateTime>,
+	pub domain: String,
+	pub erased: bool,
+	pub includedEmailAliases: i64,
+	pub includedStorageCapacity: i64,
+	pub perUserAliasCount: i64,
+	pub perUserStorageCapacity: i64,
+	pub plan: i64,
+	pub promotionEmailAliases: i64,
+	pub promotionStorageCapacity: i64,
+	pub registrationMailAddress: String,
+	pub source: String,
+	pub testEndTime: Option<DateTime>,
+	pub usedSharedEmailAliases: i64,
+	pub accountingInfo: GeneratedId,
+	pub bookings: Option<BookingsRef>,
+	pub customPlan: Option<PlanConfiguration>,
+	pub customer: GeneratedId,
+	pub domainInfos: Vec<DomainInfo>,
+	pub giftCards: Option<GiftCardsRef>,
+	pub referredBy: Option<GeneratedId>,
+	pub supportInfo: Option<GeneratedId>,
+	pub takeoverCustomer: Option<GeneratedId>,
+	pub terminationRequest: Option<IdTuple>,
 }
 
 impl Entity for CustomerInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomerInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomerInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerProperties {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub externalUserWelcomeMessage: String,
-    pub lastUpgradeReminder: Option<DateTime>,
-    pub usageDataOptedOut: bool,
-    pub bigLogo: Option<File>,
-    pub notificationMailTemplates: Vec<NotificationMailTemplate>,
-    pub smallLogo: Option<File>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub externalUserWelcomeMessage: String,
+	pub lastUpgradeReminder: Option<DateTime>,
+	pub usageDataOptedOut: bool,
+	pub bigLogo: Option<File>,
+	pub notificationMailTemplates: Vec<NotificationMailTemplate>,
+	pub smallLogo: Option<File>,
 }
 
 impl Entity for CustomerProperties {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomerProperties",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomerProperties",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerServerProperties {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub requirePasswordUpdateAfterReset: bool,
-    pub saveEncryptedIpAddressInSession: bool,
-    pub whitelabelCode: String,
-    pub emailSenderList: Vec<EmailSenderListElement>,
-    pub whitelabelRegistrationDomains: Vec<StringWrapper>,
-    pub whitelistedDomains: Option<DomainsRef>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub requirePasswordUpdateAfterReset: bool,
+	pub saveEncryptedIpAddressInSession: bool,
+	pub whitelabelCode: String,
+	pub emailSenderList: Vec<EmailSenderListElement>,
+	pub whitelabelRegistrationDomains: Vec<StringWrapper>,
+	pub whitelistedDomains: Option<DomainsRef>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerServerProperties {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "CustomerServerProperties",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "CustomerServerProperties",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DateWrapper {
-    pub _id: CustomId,
-    pub date: DateTime,
+	pub _id: CustomId,
+	pub date: DateTime,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DateWrapper {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DateWrapper",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DateWrapper",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DebitServicePutData {
-    pub _format: i64,
-    pub invoice: Option<IdTuple>,
+	pub _format: i64,
+	pub invoice: Option<IdTuple>,
 }
 
 impl Entity for DebitServicePutData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DebitServicePutData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DebitServicePutData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DeleteCustomerData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub authVerifier: Option<Vec<u8>>,
-    pub reason: Option<String>,
-    pub takeoverMailAddress: Option<String>,
-    pub undelete: bool,
-    pub customer: GeneratedId,
-    pub surveyData: Option<SurveyData>,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub authVerifier: Option<Vec<u8>>,
+	pub reason: Option<String>,
+	pub takeoverMailAddress: Option<String>,
+	pub undelete: bool,
+	pub customer: GeneratedId,
+	pub surveyData: Option<SurveyData>,
 }
 
 impl Entity for DeleteCustomerData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DeleteCustomerData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DeleteCustomerData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DnsRecord {
-    pub _id: CustomId,
-    pub subdomain: Option<String>,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub value: String,
+	pub _id: CustomId,
+	pub subdomain: Option<String>,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub value: String,
 }
 
 impl Entity for DnsRecord {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DnsRecord",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DnsRecord",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DomainInfo {
-    pub _id: CustomId,
-    pub domain: String,
-    pub validatedMxRecord: bool,
-    pub catchAllMailGroup: Option<GeneratedId>,
-    pub whitelabelConfig: Option<GeneratedId>,
+	pub _id: CustomId,
+	pub domain: String,
+	pub validatedMxRecord: bool,
+	pub catchAllMailGroup: Option<GeneratedId>,
+	pub whitelabelConfig: Option<GeneratedId>,
 }
 
 impl Entity for DomainInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DomainInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DomainInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DomainMailAddressAvailabilityData {
-    pub _format: i64,
-    pub mailAddress: String,
+	pub _format: i64,
+	pub mailAddress: String,
 }
 
 impl Entity for DomainMailAddressAvailabilityData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DomainMailAddressAvailabilityData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DomainMailAddressAvailabilityData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DomainMailAddressAvailabilityReturn {
-    pub _format: i64,
-    pub available: bool,
+	pub _format: i64,
+	pub available: bool,
 }
 
 impl Entity for DomainMailAddressAvailabilityReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DomainMailAddressAvailabilityReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DomainMailAddressAvailabilityReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DomainsRef {
-    pub _id: CustomId,
-    pub items: GeneratedId,
+	pub _id: CustomId,
+	pub items: GeneratedId,
 }
 
 impl Entity for DomainsRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "DomainsRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "DomainsRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EmailSenderListElement {
-    pub _id: CustomId,
-    pub field: i64,
-    pub hashedValue: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub value: String,
+	pub _id: CustomId,
+	pub field: i64,
+	pub hashedValue: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub value: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EmailSenderListElement {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "EmailSenderListElement",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "EmailSenderListElement",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EntityEventBatch {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub events: Vec<EntityUpdate>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub events: Vec<EntityUpdate>,
 }
 
 impl Entity for EntityEventBatch {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "EntityEventBatch",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "EntityEventBatch",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EntityUpdate {
-    pub _id: CustomId,
-    pub application: String,
-    pub instanceId: String,
-    pub instanceListId: String,
-    pub operation: i64,
-    #[serde(rename = "type")]
-    pub r#type: String,
+	pub _id: CustomId,
+	pub application: String,
+	pub instanceId: String,
+	pub instanceListId: String,
+	pub operation: i64,
+	#[serde(rename = "type")]
+	pub r#type: String,
 }
 
 impl Entity for EntityUpdate {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "EntityUpdate",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "EntityUpdate",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SysException {
-    pub _id: CustomId,
-    pub msg: String,
-    #[serde(rename = "type")]
-    pub r#type: String,
+	pub _id: CustomId,
+	pub msg: String,
+	#[serde(rename = "type")]
+	pub r#type: String,
 }
 
 impl Entity for SysException {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SysException",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SysException",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ExternalPropertiesReturn {
-    pub _format: i64,
-    pub accountType: i64,
-    pub message: String,
-    pub bigLogo: Option<File>,
-    pub smallLogo: Option<File>,
+	pub _format: i64,
+	pub accountType: i64,
+	pub message: String,
+	pub bigLogo: Option<File>,
+	pub smallLogo: Option<File>,
 }
 
 impl Entity for ExternalPropertiesReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ExternalPropertiesReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ExternalPropertiesReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ExternalUserReference {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub user: GeneratedId,
-    pub userGroup: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub user: GeneratedId,
+	pub userGroup: GeneratedId,
 }
 
 impl Entity for ExternalUserReference {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ExternalUserReference",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ExternalUserReference",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Feature {
-    pub _id: CustomId,
-    pub feature: i64,
+	pub _id: CustomId,
+	pub feature: i64,
 }
 
 impl Entity for Feature {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Feature",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Feature",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct File {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub data: Vec<u8>,
-    pub mimeType: String,
-    pub name: String,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub data: Vec<u8>,
+	pub mimeType: String,
+	pub name: String,
 }
 
 impl Entity for File {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "File",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "File",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GeneratedIdWrapper {
-    pub _id: CustomId,
-    pub value: GeneratedId,
+	pub _id: CustomId,
+	pub value: GeneratedId,
 }
 
 impl Entity for GeneratedIdWrapper {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GeneratedIdWrapper",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GeneratedIdWrapper",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCard {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub message: String,
-    pub migrated: bool,
-    pub orderDate: DateTime,
-    pub status: i64,
-    pub value: i64,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub message: String,
+	pub migrated: bool,
+	pub orderDate: DateTime,
+	pub status: i64,
+	pub value: i64,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCard {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCard",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCard",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardCreateData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub keyHash: Vec<u8>,
-    pub message: String,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncSessionKey: Vec<u8>,
-    pub ownerKeyVersion: i64,
-    pub value: i64,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub keyHash: Vec<u8>,
+	pub message: String,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncSessionKey: Vec<u8>,
+	pub ownerKeyVersion: i64,
+	pub value: i64,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCardCreateData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardCreateData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardCreateData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardCreateReturn {
-    pub _format: i64,
-    pub giftCard: IdTuple,
+	pub _format: i64,
+	pub giftCard: IdTuple,
 }
 
 impl Entity for GiftCardCreateReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardCreateReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardCreateReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardDeleteData {
-    pub _format: i64,
-    pub giftCard: IdTuple,
+	pub _format: i64,
+	pub giftCard: IdTuple,
 }
 
 impl Entity for GiftCardDeleteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardDeleteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardDeleteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardGetReturn {
-    pub _format: i64,
-    pub maxPerPeriod: i64,
-    pub period: i64,
-    pub options: Vec<GiftCardOption>,
+	pub _format: i64,
+	pub maxPerPeriod: i64,
+	pub period: i64,
+	pub options: Vec<GiftCardOption>,
 }
 
 impl Entity for GiftCardGetReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardGetReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardGetReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardOption {
-    pub _id: CustomId,
-    pub value: i64,
+	pub _id: CustomId,
+	pub value: i64,
 }
 
 impl Entity for GiftCardOption {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardOption",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardOption",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardRedeemData {
-    pub _format: i64,
-    pub countryCode: String,
-    #[serde(with = "serde_bytes")]
-    pub keyHash: Vec<u8>,
-    pub giftCardInfo: GeneratedId,
+	pub _format: i64,
+	pub countryCode: String,
+	#[serde(with = "serde_bytes")]
+	pub keyHash: Vec<u8>,
+	pub giftCardInfo: GeneratedId,
 }
 
 impl Entity for GiftCardRedeemData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardRedeemData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardRedeemData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardRedeemGetReturn {
-    pub _format: i64,
-    pub message: String,
-    pub value: i64,
-    pub giftCard: IdTuple,
+	pub _format: i64,
+	pub message: String,
+	pub value: i64,
+	pub giftCard: IdTuple,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCardRedeemGetReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardRedeemGetReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardRedeemGetReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GiftCardsRef {
-    pub _id: CustomId,
-    pub items: GeneratedId,
+	pub _id: CustomId,
+	pub items: GeneratedId,
 }
 
 impl Entity for GiftCardsRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GiftCardsRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GiftCardsRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Group {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub adminGroupEncGKey: Option<Vec<u8>>,
-    pub adminGroupKeyVersion: Option<i64>,
-    pub enabled: bool,
-    pub external: bool,
-    pub groupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubAdminGroupEncGKey: Option<Vec<u8>>,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub admin: Option<GeneratedId>,
-    pub administratedGroups: Option<AdministratedGroupsRef>,
-    pub archives: Vec<ArchiveType>,
-    pub currentKeys: Option<KeyPair>,
-    pub customer: Option<GeneratedId>,
-    pub formerGroupKeys: Option<GroupKeysRef>,
-    pub groupInfo: IdTuple,
-    pub invitations: GeneratedId,
-    pub members: GeneratedId,
-    pub storageCounter: Option<GeneratedId>,
-    pub user: Option<GeneratedId>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub adminGroupEncGKey: Option<Vec<u8>>,
+	pub adminGroupKeyVersion: Option<i64>,
+	pub enabled: bool,
+	pub external: bool,
+	pub groupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubAdminGroupEncGKey: Option<Vec<u8>>,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub admin: Option<GeneratedId>,
+	pub administratedGroups: Option<AdministratedGroupsRef>,
+	pub archives: Vec<ArchiveType>,
+	pub currentKeys: Option<KeyPair>,
+	pub customer: Option<GeneratedId>,
+	pub formerGroupKeys: Option<GroupKeysRef>,
+	pub groupInfo: IdTuple,
+	pub invitations: GeneratedId,
+	pub members: GeneratedId,
+	pub storageCounter: Option<GeneratedId>,
+	pub user: Option<GeneratedId>,
 }
 
 impl Entity for Group {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Group",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Group",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupInfo {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _listEncSessionKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub created: DateTime,
-    pub deleted: Option<DateTime>,
-    pub groupType: Option<i64>,
-    pub mailAddress: Option<String>,
-    pub name: String,
-    pub group: GeneratedId,
-    pub localAdmin: Option<GeneratedId>,
-    pub mailAddressAliases: Vec<MailAddressAlias>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _listEncSessionKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub created: DateTime,
+	pub deleted: Option<DateTime>,
+	pub groupType: Option<i64>,
+	pub mailAddress: Option<String>,
+	pub name: String,
+	pub group: GeneratedId,
+	pub localAdmin: Option<GeneratedId>,
+	pub mailAddressAliases: Vec<MailAddressAlias>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKey {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub adminGroupEncGKey: Option<Vec<u8>>,
-    pub adminGroupKeyVersion: Option<i64>,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncGKey: Vec<u8>,
-    pub ownerKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubAdminGroupEncGKey: Option<Vec<u8>>,
-    pub keyPair: Option<KeyPair>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub adminGroupEncGKey: Option<Vec<u8>>,
+	pub adminGroupKeyVersion: Option<i64>,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncGKey: Vec<u8>,
+	pub ownerKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubAdminGroupEncGKey: Option<Vec<u8>>,
+	pub keyPair: Option<KeyPair>,
 }
 
 impl Entity for GroupKey {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKey",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKey",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKeyRotationData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub adminGroupEncGroupKey: Option<Vec<u8>>,
-    pub adminGroupKeyVersion: Option<i64>,
-    #[serde(with = "serde_bytes")]
-    pub groupEncPreviousGroupKey: Vec<u8>,
-    pub groupKeyVersion: i64,
-    pub group: GeneratedId,
-    pub groupKeyUpdatesForMembers: Vec<GroupKeyUpdateData>,
-    pub groupMembershipUpdateData: Vec<GroupMembershipUpdateData>,
-    pub keyPair: Option<KeyPair>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub adminGroupEncGroupKey: Option<Vec<u8>>,
+	pub adminGroupKeyVersion: Option<i64>,
+	#[serde(with = "serde_bytes")]
+	pub groupEncPreviousGroupKey: Vec<u8>,
+	pub groupKeyVersion: i64,
+	pub group: GeneratedId,
+	pub groupKeyUpdatesForMembers: Vec<GroupKeyUpdateData>,
+	pub groupMembershipUpdateData: Vec<GroupMembershipUpdateData>,
+	pub keyPair: Option<KeyPair>,
 }
 
 impl Entity for GroupKeyRotationData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKeyRotationData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKeyRotationData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKeyRotationInfoGetOut {
-    pub _format: i64,
-    pub userOrAdminGroupKeyRotationScheduled: bool,
-    pub groupKeyUpdates: Vec<IdTuple>,
+	pub _format: i64,
+	pub userOrAdminGroupKeyRotationScheduled: bool,
+	pub groupKeyUpdates: Vec<IdTuple>,
 }
 
 impl Entity for GroupKeyRotationInfoGetOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKeyRotationInfoGetOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKeyRotationInfoGetOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKeyRotationPostIn {
-    pub _format: i64,
-    pub groupKeyUpdates: Vec<GroupKeyRotationData>,
+	pub _format: i64,
+	pub groupKeyUpdates: Vec<GroupKeyRotationData>,
 }
 
 impl Entity for GroupKeyRotationPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKeyRotationPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKeyRotationPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKeyUpdate {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub groupKey: Vec<u8>,
-    pub groupKeyVersion: i64,
-    pub bucketKey: BucketKey,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub groupKey: Vec<u8>,
+	pub groupKeyVersion: i64,
+	pub bucketKey: BucketKey,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupKeyUpdate {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKeyUpdate",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKeyUpdate",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKeyUpdateData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub bucketKeyEncSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub sessionKeyEncGroupKey: Vec<u8>,
-    pub sessionKeyEncGroupKeyVersion: i64,
-    pub pubEncBucketKeyData: PubEncKeyData,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub bucketKeyEncSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub sessionKeyEncGroupKey: Vec<u8>,
+	pub sessionKeyEncGroupKeyVersion: i64,
+	pub pubEncBucketKeyData: PubEncKeyData,
 }
 
 impl Entity for GroupKeyUpdateData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKeyUpdateData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKeyUpdateData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKeyUpdatesRef {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for GroupKeyUpdatesRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKeyUpdatesRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKeyUpdatesRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupKeysRef {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for GroupKeysRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupKeysRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupKeysRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupMember {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub capability: Option<i64>,
-    pub group: GeneratedId,
-    pub user: GeneratedId,
-    pub userGroupInfo: IdTuple,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub capability: Option<i64>,
+	pub group: GeneratedId,
+	pub user: GeneratedId,
+	pub userGroupInfo: IdTuple,
 }
 
 impl Entity for GroupMember {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupMember",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupMember",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupMembership {
-    pub _id: CustomId,
-    pub admin: bool,
-    pub capability: Option<i64>,
-    pub groupKeyVersion: i64,
-    pub groupType: Option<i64>,
-    #[serde(with = "serde_bytes")]
-    pub symEncGKey: Vec<u8>,
-    pub symKeyVersion: i64,
-    pub group: GeneratedId,
-    pub groupInfo: IdTuple,
-    pub groupMember: IdTuple,
+	pub _id: CustomId,
+	pub admin: bool,
+	pub capability: Option<i64>,
+	pub groupKeyVersion: i64,
+	pub groupType: Option<i64>,
+	#[serde(with = "serde_bytes")]
+	pub symEncGKey: Vec<u8>,
+	pub symKeyVersion: i64,
+	pub group: GeneratedId,
+	pub groupInfo: IdTuple,
+	pub groupMember: IdTuple,
 }
 
 impl Entity for GroupMembership {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupMembership",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupMembership",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupMembershipKeyData {
-    pub _id: CustomId,
-    pub groupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub symEncGKey: Vec<u8>,
-    pub symKeyVersion: i64,
-    pub group: GeneratedId,
+	pub _id: CustomId,
+	pub groupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub symEncGKey: Vec<u8>,
+	pub symKeyVersion: i64,
+	pub group: GeneratedId,
 }
 
 impl Entity for GroupMembershipKeyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupMembershipKeyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupMembershipKeyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupMembershipUpdateData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub userEncGroupKey: Vec<u8>,
-    pub userKeyVersion: i64,
-    pub userId: GeneratedId,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub userEncGroupKey: Vec<u8>,
+	pub userKeyVersion: i64,
+	pub userId: GeneratedId,
 }
 
 impl Entity for GroupMembershipUpdateData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupMembershipUpdateData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupMembershipUpdateData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupRoot {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub externalGroupInfos: GeneratedId,
-    pub externalUserAreaGroupInfos: Option<UserAreaGroups>,
-    pub externalUserReferences: GeneratedId,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub externalGroupInfos: GeneratedId,
+	pub externalUserAreaGroupInfos: Option<UserAreaGroups>,
+	pub externalUserReferences: GeneratedId,
 }
 
 impl Entity for GroupRoot {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "GroupRoot",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "GroupRoot",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct IdTupleWrapper {
-    pub _id: CustomId,
-    pub listElementId: GeneratedId,
-    pub listId: GeneratedId,
+	pub _id: CustomId,
+	pub listElementId: GeneratedId,
+	pub listId: GeneratedId,
 }
 
 impl Entity for IdTupleWrapper {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "IdTupleWrapper",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "IdTupleWrapper",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InstanceSessionKey {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub encryptionAuthStatus: Option<Vec<u8>>,
-    pub instanceId: GeneratedId,
-    pub instanceList: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub symEncSessionKey: Vec<u8>,
-    pub symKeyVersion: i64,
-    pub typeInfo: TypeInfo,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub encryptionAuthStatus: Option<Vec<u8>>,
+	pub instanceId: GeneratedId,
+	pub instanceList: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub symEncSessionKey: Vec<u8>,
+	pub symKeyVersion: i64,
+	pub typeInfo: TypeInfo,
 }
 
 impl Entity for InstanceSessionKey {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "InstanceSessionKey",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "InstanceSessionKey",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Invoice {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub address: String,
-    pub adminUser: Option<String>,
-    pub business: bool,
-    pub country: String,
-    pub date: DateTime,
-    pub grandTotal: i64,
-    pub paymentMethod: i64,
-    pub reason: Option<String>,
-    pub subTotal: i64,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub vat: i64,
-    pub vatIdNumber: Option<String>,
-    pub vatRate: i64,
-    pub bookings: Vec<IdTuple>,
-    pub customer: GeneratedId,
-    pub items: Vec<InvoiceItem>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub address: String,
+	pub adminUser: Option<String>,
+	pub business: bool,
+	pub country: String,
+	pub date: DateTime,
+	pub grandTotal: i64,
+	pub paymentMethod: i64,
+	pub reason: Option<String>,
+	pub subTotal: i64,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub vat: i64,
+	pub vatIdNumber: Option<String>,
+	pub vatRate: i64,
+	pub bookings: Vec<IdTuple>,
+	pub customer: GeneratedId,
+	pub items: Vec<InvoiceItem>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Invoice {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Invoice",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Invoice",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InvoiceDataGetIn {
-    pub _format: i64,
-    pub invoiceNumber: String,
+	pub _format: i64,
+	pub invoiceNumber: String,
 }
 
 impl Entity for InvoiceDataGetIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "InvoiceDataGetIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "InvoiceDataGetIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InvoiceDataGetOut {
-    pub _format: i64,
-    pub address: String,
-    pub country: String,
-    pub date: DateTime,
-    pub grandTotal: i64,
-    pub invoiceId: GeneratedId,
-    pub invoiceType: i64,
-    pub paymentMethod: i64,
-    pub subTotal: i64,
-    pub vat: i64,
-    pub vatIdNumber: Option<String>,
-    pub vatRate: i64,
-    pub vatType: i64,
-    pub items: Vec<InvoiceDataItem>,
+	pub _format: i64,
+	pub address: String,
+	pub country: String,
+	pub date: DateTime,
+	pub grandTotal: i64,
+	pub invoiceId: GeneratedId,
+	pub invoiceType: i64,
+	pub paymentMethod: i64,
+	pub subTotal: i64,
+	pub vat: i64,
+	pub vatIdNumber: Option<String>,
+	pub vatRate: i64,
+	pub vatType: i64,
+	pub items: Vec<InvoiceDataItem>,
 }
 
 impl Entity for InvoiceDataGetOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "InvoiceDataGetOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "InvoiceDataGetOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InvoiceDataItem {
-    pub _id: CustomId,
-    pub amount: i64,
-    pub endDate: Option<DateTime>,
-    pub itemType: i64,
-    pub singlePrice: Option<i64>,
-    pub startDate: Option<DateTime>,
-    pub totalPrice: i64,
+	pub _id: CustomId,
+	pub amount: i64,
+	pub endDate: Option<DateTime>,
+	pub itemType: i64,
+	pub singlePrice: Option<i64>,
+	pub startDate: Option<DateTime>,
+	pub totalPrice: i64,
 }
 
 impl Entity for InvoiceDataItem {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "InvoiceDataItem",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "InvoiceDataItem",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InvoiceInfo {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub discountPercentage: Option<i64>,
-    pub extendedPeriodOfPaymentDays: i64,
-    pub persistentPaymentPeriodExtension: bool,
-    pub publishInvoices: bool,
-    pub reminderState: i64,
-    pub specialPriceBrandingPerUser: Option<i64>,
-    pub specialPriceBusinessPerUser: Option<i64>,
-    pub specialPriceContactFormSingle: Option<i64>,
-    pub specialPriceSharedGroupSingle: Option<i64>,
-    pub specialPriceSharingPerUser: Option<i64>,
-    pub specialPriceUserSingle: Option<i64>,
-    pub specialPriceUserTotal: Option<i64>,
-    pub invoices: GeneratedId,
-    pub paymentErrorInfo: Option<PaymentErrorInfo>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub discountPercentage: Option<i64>,
+	pub extendedPeriodOfPaymentDays: i64,
+	pub persistentPaymentPeriodExtension: bool,
+	pub publishInvoices: bool,
+	pub reminderState: i64,
+	pub specialPriceBrandingPerUser: Option<i64>,
+	pub specialPriceBusinessPerUser: Option<i64>,
+	pub specialPriceContactFormSingle: Option<i64>,
+	pub specialPriceSharedGroupSingle: Option<i64>,
+	pub specialPriceSharingPerUser: Option<i64>,
+	pub specialPriceUserSingle: Option<i64>,
+	pub specialPriceUserTotal: Option<i64>,
+	pub invoices: GeneratedId,
+	pub paymentErrorInfo: Option<PaymentErrorInfo>,
 }
 
 impl Entity for InvoiceInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "InvoiceInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "InvoiceInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InvoiceItem {
-    pub _id: CustomId,
-    pub amount: i64,
-    pub endDate: Option<DateTime>,
-    pub singlePrice: Option<i64>,
-    pub singleType: bool,
-    pub startDate: Option<DateTime>,
-    pub totalPrice: i64,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub amount: i64,
+	pub endDate: Option<DateTime>,
+	pub singlePrice: Option<i64>,
+	pub singleType: bool,
+	pub startDate: Option<DateTime>,
+	pub totalPrice: i64,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for InvoiceItem {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "InvoiceItem",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "InvoiceItem",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct KeyPair {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub pubEccKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub pubKyberKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub pubRsaKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub symEncPrivEccKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub symEncPrivKyberKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub symEncPrivRsaKey: Option<Vec<u8>>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub pubEccKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub pubKyberKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub pubRsaKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub symEncPrivEccKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub symEncPrivKyberKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub symEncPrivRsaKey: Option<Vec<u8>>,
 }
 
 impl Entity for KeyPair {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "KeyPair",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "KeyPair",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct KeyRotation {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub groupKeyRotationType: i64,
-    pub targetKeyVersion: i64,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub groupKeyRotationType: i64,
+	pub targetKeyVersion: i64,
 }
 
 impl Entity for KeyRotation {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "KeyRotation",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "KeyRotation",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct KeyRotationsRef {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for KeyRotationsRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "KeyRotationsRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "KeyRotationsRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct LocationServiceGetReturn {
-    pub _format: i64,
-    pub country: String,
+	pub _format: i64,
+	pub country: String,
 }
 
 impl Entity for LocationServiceGetReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "LocationServiceGetReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "LocationServiceGetReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Login {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub time: DateTime,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub time: DateTime,
 }
 
 impl Entity for Login {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Login",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Login",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressAlias {
-    pub _id: CustomId,
-    pub enabled: bool,
-    pub mailAddress: String,
+	pub _id: CustomId,
+	pub enabled: bool,
+	pub mailAddress: String,
 }
 
 impl Entity for MailAddressAlias {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MailAddressAlias",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MailAddressAlias",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressAliasGetIn {
-    pub _format: i64,
-    pub targetGroup: GeneratedId,
+	pub _format: i64,
+	pub targetGroup: GeneratedId,
 }
 
 impl Entity for MailAddressAliasGetIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MailAddressAliasGetIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MailAddressAliasGetIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressAliasServiceData {
-    pub _format: i64,
-    pub mailAddress: String,
-    pub group: GeneratedId,
+	pub _format: i64,
+	pub mailAddress: String,
+	pub group: GeneratedId,
 }
 
 impl Entity for MailAddressAliasServiceData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MailAddressAliasServiceData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MailAddressAliasServiceData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressAliasServiceDataDelete {
-    pub _format: i64,
-    pub mailAddress: String,
-    pub restore: bool,
-    pub group: GeneratedId,
+	pub _format: i64,
+	pub mailAddress: String,
+	pub restore: bool,
+	pub group: GeneratedId,
 }
 
 impl Entity for MailAddressAliasServiceDataDelete {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MailAddressAliasServiceDataDelete",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MailAddressAliasServiceDataDelete",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressAliasServiceReturn {
-    pub _format: i64,
-    pub enabledAliases: i64,
-    pub nbrOfFreeAliases: i64,
-    pub totalAliases: i64,
-    pub usedAliases: i64,
+	pub _format: i64,
+	pub enabledAliases: i64,
+	pub nbrOfFreeAliases: i64,
+	pub totalAliases: i64,
+	pub usedAliases: i64,
 }
 
 impl Entity for MailAddressAliasServiceReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MailAddressAliasServiceReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MailAddressAliasServiceReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressAvailability {
-    pub _id: CustomId,
-    pub available: bool,
-    pub mailAddress: String,
+	pub _id: CustomId,
+	pub available: bool,
+	pub mailAddress: String,
 }
 
 impl Entity for MailAddressAvailability {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MailAddressAvailability",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MailAddressAvailability",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressToGroup {
-    pub _format: i64,
-    pub _id: CustomId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub internalGroup: Option<GeneratedId>,
+	pub _format: i64,
+	pub _id: CustomId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub internalGroup: Option<GeneratedId>,
 }
 
 impl Entity for MailAddressToGroup {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MailAddressToGroup",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MailAddressToGroup",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MembershipAddData {
-    pub _format: i64,
-    pub groupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub symEncGKey: Vec<u8>,
-    pub symKeyVersion: i64,
-    pub group: GeneratedId,
-    pub user: GeneratedId,
+	pub _format: i64,
+	pub groupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub symEncGKey: Vec<u8>,
+	pub symKeyVersion: i64,
+	pub group: GeneratedId,
+	pub user: GeneratedId,
 }
 
 impl Entity for MembershipAddData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MembershipAddData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MembershipAddData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MembershipPutIn {
-    pub _format: i64,
-    pub groupKeyUpdates: Vec<GroupMembershipKeyData>,
+	pub _format: i64,
+	pub groupKeyUpdates: Vec<GroupMembershipKeyData>,
 }
 
 impl Entity for MembershipPutIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MembershipPutIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MembershipPutIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MembershipRemoveData {
-    pub _format: i64,
-    pub group: GeneratedId,
-    pub user: GeneratedId,
+	pub _format: i64,
+	pub group: GeneratedId,
+	pub user: GeneratedId,
 }
 
 impl Entity for MembershipRemoveData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MembershipRemoveData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MembershipRemoveData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MissedNotification {
-    pub _format: i64,
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub changeTime: DateTime,
-    pub confirmationId: GeneratedId,
-    pub lastProcessedNotificationId: Option<GeneratedId>,
-    pub alarmNotifications: Vec<AlarmNotification>,
-    pub notificationInfos: Vec<NotificationInfo>,
+	pub _format: i64,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub changeTime: DateTime,
+	pub confirmationId: GeneratedId,
+	pub lastProcessedNotificationId: Option<GeneratedId>,
+	pub alarmNotifications: Vec<AlarmNotification>,
+	pub notificationInfos: Vec<NotificationInfo>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MissedNotification {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MissedNotification",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MissedNotification",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MultipleMailAddressAvailabilityData {
-    pub _format: i64,
-    pub mailAddresses: Vec<StringWrapper>,
+	pub _format: i64,
+	pub mailAddresses: Vec<StringWrapper>,
 }
 
 impl Entity for MultipleMailAddressAvailabilityData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MultipleMailAddressAvailabilityData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MultipleMailAddressAvailabilityData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MultipleMailAddressAvailabilityReturn {
-    pub _format: i64,
-    pub availabilities: Vec<MailAddressAvailability>,
+	pub _format: i64,
+	pub availabilities: Vec<MailAddressAvailability>,
 }
 
 impl Entity for MultipleMailAddressAvailabilityReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "MultipleMailAddressAvailabilityReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "MultipleMailAddressAvailabilityReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NotificationInfo {
-    pub _id: CustomId,
-    pub mailAddress: String,
-    pub userId: GeneratedId,
-    pub mailId: Option<IdTupleWrapper>,
+	pub _id: CustomId,
+	pub mailAddress: String,
+	pub userId: GeneratedId,
+	pub mailId: Option<IdTupleWrapper>,
 }
 
 impl Entity for NotificationInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "NotificationInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "NotificationInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NotificationMailTemplate {
-    pub _id: CustomId,
-    pub body: String,
-    pub language: String,
-    pub subject: String,
+	pub _id: CustomId,
+	pub body: String,
+	pub language: String,
+	pub subject: String,
 }
 
 impl Entity for NotificationMailTemplate {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "NotificationMailTemplate",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "NotificationMailTemplate",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NotificationSessionKey {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub pushIdentifierSessionEncSessionKey: Vec<u8>,
-    pub pushIdentifier: IdTuple,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub pushIdentifierSessionEncSessionKey: Vec<u8>,
+	pub pushIdentifier: IdTuple,
 }
 
 impl Entity for NotificationSessionKey {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "NotificationSessionKey",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "NotificationSessionKey",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct OrderProcessingAgreement {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub customerAddress: String,
-    pub signatureDate: DateTime,
-    pub version: String,
-    pub customer: GeneratedId,
-    pub signerUserGroupInfo: IdTuple,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub customerAddress: String,
+	pub signatureDate: DateTime,
+	pub version: String,
+	pub customer: GeneratedId,
+	pub signerUserGroupInfo: IdTuple,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for OrderProcessingAgreement {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "OrderProcessingAgreement",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "OrderProcessingAgreement",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct OtpChallenge {
-    pub _id: CustomId,
-    pub secondFactors: Vec<IdTuple>,
+	pub _id: CustomId,
+	pub secondFactors: Vec<IdTuple>,
 }
 
 impl Entity for OtpChallenge {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "OtpChallenge",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "OtpChallenge",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentDataServiceGetData {
-    pub _format: i64,
-    pub clientType: Option<i64>,
+	pub _format: i64,
+	pub clientType: Option<i64>,
 }
 
 impl Entity for PaymentDataServiceGetData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PaymentDataServiceGetData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PaymentDataServiceGetData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentDataServiceGetReturn {
-    pub _format: i64,
-    pub loginUrl: String,
+	pub _format: i64,
+	pub loginUrl: String,
 }
 
 impl Entity for PaymentDataServiceGetReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PaymentDataServiceGetReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PaymentDataServiceGetReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentDataServicePostData {
-    pub _format: i64,
-    pub braintree3dsResponse: Braintree3ds2Response,
+	pub _format: i64,
+	pub braintree3dsResponse: Braintree3ds2Response,
 }
 
 impl Entity for PaymentDataServicePostData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PaymentDataServicePostData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PaymentDataServicePostData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentDataServicePutData {
-    pub _format: i64,
-    pub confirmedCountry: Option<String>,
-    pub invoiceAddress: String,
-    pub invoiceCountry: String,
-    pub invoiceName: String,
-    pub invoiceVatIdNo: String,
-    pub paymentInterval: i64,
-    pub paymentMethod: i64,
-    pub paymentMethodInfo: Option<String>,
-    pub paymentToken: Option<String>,
-    pub creditCard: Option<CreditCard>,
+	pub _format: i64,
+	pub confirmedCountry: Option<String>,
+	pub invoiceAddress: String,
+	pub invoiceCountry: String,
+	pub invoiceName: String,
+	pub invoiceVatIdNo: String,
+	pub paymentInterval: i64,
+	pub paymentMethod: i64,
+	pub paymentMethodInfo: Option<String>,
+	pub paymentToken: Option<String>,
+	pub creditCard: Option<CreditCard>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for PaymentDataServicePutData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PaymentDataServicePutData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PaymentDataServicePutData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentDataServicePutReturn {
-    pub _format: i64,
-    pub result: i64,
-    pub braintree3dsRequest: Option<Braintree3ds2Request>,
+	pub _format: i64,
+	pub result: i64,
+	pub braintree3dsRequest: Option<Braintree3ds2Request>,
 }
 
 impl Entity for PaymentDataServicePutReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PaymentDataServicePutReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PaymentDataServicePutReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PaymentErrorInfo {
-    pub _id: CustomId,
-    pub errorCode: String,
-    pub errorTime: DateTime,
-    pub thirdPartyErrorId: String,
+	pub _id: CustomId,
+	pub errorCode: String,
+	pub errorTime: DateTime,
+	pub thirdPartyErrorId: String,
 }
 
 impl Entity for PaymentErrorInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PaymentErrorInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PaymentErrorInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Permission {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub bucketEncSessionKey: Option<Vec<u8>>,
-    pub listElementApplication: Option<String>,
-    pub listElementTypeId: Option<i64>,
-    pub ops: Option<String>,
-    #[serde(with = "serde_bytes")]
-    pub symEncSessionKey: Option<Vec<u8>>,
-    pub symKeyVersion: Option<i64>,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub bucket: Option<Bucket>,
-    pub group: Option<GeneratedId>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub bucketEncSessionKey: Option<Vec<u8>>,
+	pub listElementApplication: Option<String>,
+	pub listElementTypeId: Option<i64>,
+	pub ops: Option<String>,
+	#[serde(with = "serde_bytes")]
+	pub symEncSessionKey: Option<Vec<u8>>,
+	pub symKeyVersion: Option<i64>,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub bucket: Option<Bucket>,
+	pub group: Option<GeneratedId>,
 }
 
 impl Entity for Permission {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Permission",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Permission",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PlanConfiguration {
-    pub _id: CustomId,
-    pub autoResponder: bool,
-    pub contactList: bool,
-    pub customDomainType: i64,
-    pub eventInvites: bool,
-    pub multiUser: bool,
-    pub nbrOfAliases: i64,
-    pub sharing: bool,
-    pub storageGb: i64,
-    pub templates: bool,
-    pub whitelabel: bool,
+	pub _id: CustomId,
+	pub autoResponder: bool,
+	pub contactList: bool,
+	pub customDomainType: i64,
+	pub eventInvites: bool,
+	pub multiUser: bool,
+	pub nbrOfAliases: i64,
+	pub sharing: bool,
+	pub storageGb: i64,
+	pub templates: bool,
+	pub whitelabel: bool,
 }
 
 impl Entity for PlanConfiguration {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PlanConfiguration",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PlanConfiguration",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PlanPrices {
-    pub _id: CustomId,
-    pub additionalUserPriceMonthly: i64,
-    pub business: bool,
-    pub businessPlan: bool,
-    pub customDomains: i64,
-    pub firstYearDiscount: i64,
-    pub includedAliases: i64,
-    pub includedStorage: i64,
-    pub monthlyPrice: i64,
-    pub monthlyReferencePrice: i64,
-    pub planName: String,
-    pub sharing: bool,
-    pub whitelabel: bool,
-    pub planConfiguration: PlanConfiguration,
+	pub _id: CustomId,
+	pub additionalUserPriceMonthly: i64,
+	pub business: bool,
+	pub businessPlan: bool,
+	pub customDomains: i64,
+	pub firstYearDiscount: i64,
+	pub includedAliases: i64,
+	pub includedStorage: i64,
+	pub monthlyPrice: i64,
+	pub monthlyReferencePrice: i64,
+	pub planName: String,
+	pub sharing: bool,
+	pub whitelabel: bool,
+	pub planConfiguration: PlanConfiguration,
 }
 
 impl Entity for PlanPrices {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PlanPrices",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PlanPrices",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PlanServiceGetOut {
-    pub _format: i64,
-    pub config: PlanConfiguration,
+	pub _format: i64,
+	pub config: PlanConfiguration,
 }
 
 impl Entity for PlanServiceGetOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PlanServiceGetOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PlanServiceGetOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PriceData {
-    pub _id: CustomId,
-    pub paymentInterval: i64,
-    pub price: i64,
-    pub taxIncluded: bool,
-    pub items: Vec<PriceItemData>,
+	pub _id: CustomId,
+	pub paymentInterval: i64,
+	pub price: i64,
+	pub taxIncluded: bool,
+	pub items: Vec<PriceItemData>,
 }
 
 impl Entity for PriceData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PriceData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PriceData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PriceItemData {
-    pub _id: CustomId,
-    pub count: i64,
-    pub featureType: i64,
-    pub price: i64,
-    pub singleType: bool,
+	pub _id: CustomId,
+	pub count: i64,
+	pub featureType: i64,
+	pub price: i64,
+	pub singleType: bool,
 }
 
 impl Entity for PriceItemData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PriceItemData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PriceItemData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PriceRequestData {
-    pub _id: CustomId,
-    pub accountType: Option<i64>,
-    pub business: Option<bool>,
-    pub count: i64,
-    pub featureType: i64,
-    pub paymentInterval: Option<i64>,
-    pub reactivate: bool,
+	pub _id: CustomId,
+	pub accountType: Option<i64>,
+	pub business: Option<bool>,
+	pub count: i64,
+	pub featureType: i64,
+	pub paymentInterval: Option<i64>,
+	pub reactivate: bool,
 }
 
 impl Entity for PriceRequestData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PriceRequestData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PriceRequestData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PriceServiceData {
-    pub _format: i64,
-    pub date: Option<DateTime>,
-    pub priceRequest: Option<PriceRequestData>,
+	pub _format: i64,
+	pub date: Option<DateTime>,
+	pub priceRequest: Option<PriceRequestData>,
 }
 
 impl Entity for PriceServiceData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PriceServiceData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PriceServiceData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PriceServiceReturn {
-    pub _format: i64,
-    pub currentPeriodAddedPrice: Option<i64>,
-    pub periodEndDate: DateTime,
-    pub currentPriceNextPeriod: Option<PriceData>,
-    pub currentPriceThisPeriod: Option<PriceData>,
-    pub futurePriceNextPeriod: Option<PriceData>,
+	pub _format: i64,
+	pub currentPeriodAddedPrice: Option<i64>,
+	pub periodEndDate: DateTime,
+	pub currentPriceNextPeriod: Option<PriceData>,
+	pub currentPriceThisPeriod: Option<PriceData>,
+	pub futurePriceNextPeriod: Option<PriceData>,
 }
 
 impl Entity for PriceServiceReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PriceServiceReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PriceServiceReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PubEncKeyData {
-    pub _id: CustomId,
-    pub mailAddress: String,
-    pub protocolVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubEncBucketKey: Vec<u8>,
-    pub recipientKeyVersion: i64,
-    pub senderKeyVersion: Option<i64>,
+	pub _id: CustomId,
+	pub mailAddress: String,
+	pub protocolVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubEncBucketKey: Vec<u8>,
+	pub recipientKeyVersion: i64,
+	pub senderKeyVersion: Option<i64>,
 }
 
 impl Entity for PubEncKeyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PubEncKeyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PubEncKeyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PublicKeyGetIn {
-    pub _format: i64,
-    pub mailAddress: String,
-    pub version: Option<i64>,
+	pub _format: i64,
+	pub mailAddress: String,
+	pub version: Option<i64>,
 }
 
 impl Entity for PublicKeyGetIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PublicKeyGetIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PublicKeyGetIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PublicKeyGetOut {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubEccKey: Option<Vec<u8>>,
-    pub pubKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubKyberKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub pubRsaKey: Option<Vec<u8>>,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubEccKey: Option<Vec<u8>>,
+	pub pubKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubKyberKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub pubRsaKey: Option<Vec<u8>>,
 }
 
 impl Entity for PublicKeyGetOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PublicKeyGetOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PublicKeyGetOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PublicKeyPutIn {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubEccKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub symEncPrivEccKey: Vec<u8>,
-    pub keyGroup: GeneratedId,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubEccKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub symEncPrivEccKey: Vec<u8>,
+	pub keyGroup: GeneratedId,
 }
 
 impl Entity for PublicKeyPutIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PublicKeyPutIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PublicKeyPutIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PushIdentifier {
-    pub _area: i64,
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _owner: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub app: i64,
-    pub disabled: bool,
-    pub displayName: String,
-    pub identifier: String,
-    pub language: String,
-    pub lastNotificationDate: Option<DateTime>,
-    pub lastUsageTime: DateTime,
-    pub pushServiceType: i64,
+	pub _area: i64,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _owner: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub app: i64,
+	pub disabled: bool,
+	pub displayName: String,
+	pub identifier: String,
+	pub language: String,
+	pub lastNotificationDate: Option<DateTime>,
+	pub lastUsageTime: DateTime,
+	pub pushServiceType: i64,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for PushIdentifier {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PushIdentifier",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PushIdentifier",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PushIdentifierList {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for PushIdentifierList {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "PushIdentifierList",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "PushIdentifierList",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReceivedGroupInvitation {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub capability: i64,
-    pub groupType: Option<i64>,
-    pub inviteeMailAddress: String,
-    pub inviterMailAddress: String,
-    pub inviterName: String,
-    #[serde(with = "serde_bytes")]
-    pub sharedGroupKey: Vec<u8>,
-    pub sharedGroupKeyVersion: i64,
-    pub sharedGroupName: String,
-    pub sentInvitation: IdTuple,
-    pub sharedGroup: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub capability: i64,
+	pub groupType: Option<i64>,
+	pub inviteeMailAddress: String,
+	pub inviterMailAddress: String,
+	pub inviterName: String,
+	#[serde(with = "serde_bytes")]
+	pub sharedGroupKey: Vec<u8>,
+	pub sharedGroupKeyVersion: i64,
+	pub sharedGroupName: String,
+	pub sentInvitation: IdTuple,
+	pub sharedGroup: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ReceivedGroupInvitation {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ReceivedGroupInvitation",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ReceivedGroupInvitation",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RecoverCode {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub recoverCodeEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncRecoverCode: Vec<u8>,
-    pub userKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub verifier: Vec<u8>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub recoverCodeEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncRecoverCode: Vec<u8>,
+	pub userKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub verifier: Vec<u8>,
 }
 
 impl Entity for RecoverCode {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RecoverCode",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RecoverCode",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RecoverCodeData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub recoveryCodeEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub recoveryCodeVerifier: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncRecoveryCode: Vec<u8>,
-    pub userKeyVersion: i64,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub recoveryCodeEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub recoveryCodeVerifier: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncRecoveryCode: Vec<u8>,
+	pub userKeyVersion: i64,
 }
 
 impl Entity for RecoverCodeData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RecoverCodeData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RecoverCodeData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReferralCodeGetIn {
-    pub _format: i64,
-    pub referralCode: GeneratedId,
+	pub _format: i64,
+	pub referralCode: GeneratedId,
 }
 
 impl Entity for ReferralCodeGetIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ReferralCodeGetIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ReferralCodeGetIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReferralCodePostIn {
-    pub _format: i64,
+	pub _format: i64,
 }
 
 impl Entity for ReferralCodePostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ReferralCodePostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ReferralCodePostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReferralCodePostOut {
-    pub _format: i64,
-    pub referralCode: GeneratedId,
+	pub _format: i64,
+	pub referralCode: GeneratedId,
 }
 
 impl Entity for ReferralCodePostOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ReferralCodePostOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ReferralCodePostOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RegistrationCaptchaServiceData {
-    pub _format: i64,
-    pub response: String,
-    pub token: String,
+	pub _format: i64,
+	pub response: String,
+	pub token: String,
 }
 
 impl Entity for RegistrationCaptchaServiceData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RegistrationCaptchaServiceData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RegistrationCaptchaServiceData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RegistrationCaptchaServiceGetData {
-    pub _format: i64,
-    pub businessUseSelected: bool,
-    pub mailAddress: String,
-    pub paidSubscriptionSelected: bool,
-    pub signupToken: Option<String>,
-    pub token: Option<String>,
+	pub _format: i64,
+	pub businessUseSelected: bool,
+	pub mailAddress: String,
+	pub paidSubscriptionSelected: bool,
+	pub signupToken: Option<String>,
+	pub token: Option<String>,
 }
 
 impl Entity for RegistrationCaptchaServiceGetData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RegistrationCaptchaServiceGetData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RegistrationCaptchaServiceGetData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RegistrationCaptchaServiceReturn {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub challenge: Option<Vec<u8>>,
-    pub token: String,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub challenge: Option<Vec<u8>>,
+	pub token: String,
 }
 
 impl Entity for RegistrationCaptchaServiceReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RegistrationCaptchaServiceReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RegistrationCaptchaServiceReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RegistrationReturn {
-    pub _format: i64,
-    pub authToken: String,
+	pub _format: i64,
+	pub authToken: String,
 }
 
 impl Entity for RegistrationReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RegistrationReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RegistrationReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RegistrationServiceData {
-    pub _format: i64,
-    pub source: Option<String>,
-    pub starterDomain: String,
-    pub state: i64,
+	pub _format: i64,
+	pub source: Option<String>,
+	pub starterDomain: String,
+	pub state: i64,
 }
 
 impl Entity for RegistrationServiceData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RegistrationServiceData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RegistrationServiceData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RejectedSender {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub reason: String,
-    pub recipientMailAddress: String,
-    pub senderHostname: String,
-    pub senderIp: String,
-    pub senderMailAddress: String,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub reason: String,
+	pub recipientMailAddress: String,
+	pub senderHostname: String,
+	pub senderIp: String,
+	pub senderMailAddress: String,
 }
 
 impl Entity for RejectedSender {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RejectedSender",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RejectedSender",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RejectedSendersRef {
-    pub _id: CustomId,
-    pub items: GeneratedId,
+	pub _id: CustomId,
+	pub items: GeneratedId,
 }
 
 impl Entity for RejectedSendersRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RejectedSendersRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RejectedSendersRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RepeatRule {
-    pub _id: CustomId,
-    pub endType: i64,
-    pub endValue: Option<i64>,
-    pub frequency: i64,
-    pub interval: i64,
-    pub timeZone: String,
-    pub excludedDates: Vec<DateWrapper>,
+	pub _id: CustomId,
+	pub endType: i64,
+	pub endValue: Option<i64>,
+	pub frequency: i64,
+	pub interval: i64,
+	pub timeZone: String,
+	pub excludedDates: Vec<DateWrapper>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for RepeatRule {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RepeatRule",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RepeatRule",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ResetFactorsDeleteData {
-    pub _format: i64,
-    pub authVerifier: String,
-    pub mailAddress: String,
-    pub recoverCodeVerifier: String,
+	pub _format: i64,
+	pub authVerifier: String,
+	pub mailAddress: String,
+	pub recoverCodeVerifier: String,
 }
 
 impl Entity for ResetFactorsDeleteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ResetFactorsDeleteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ResetFactorsDeleteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ResetPasswordPostIn {
-    pub _format: i64,
-    pub kdfVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pwEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub salt: Vec<u8>,
-    pub userGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub verifier: Vec<u8>,
-    pub user: GeneratedId,
+	pub _format: i64,
+	pub kdfVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pwEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub salt: Vec<u8>,
+	pub userGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub verifier: Vec<u8>,
+	pub user: GeneratedId,
 }
 
 impl Entity for ResetPasswordPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "ResetPasswordPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "ResetPasswordPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RootInstance {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub reference: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub reference: GeneratedId,
 }
 
 impl Entity for RootInstance {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "RootInstance",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "RootInstance",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SaltData {
-    pub _format: i64,
-    pub mailAddress: String,
+	pub _format: i64,
+	pub mailAddress: String,
 }
 
 impl Entity for SaltData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SaltData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SaltData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SaltReturn {
-    pub _format: i64,
-    pub kdfVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub salt: Vec<u8>,
+	pub _format: i64,
+	pub kdfVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub salt: Vec<u8>,
 }
 
 impl Entity for SaltReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SaltReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SaltReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecondFactor {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub name: String,
-    #[serde(with = "serde_bytes")]
-    pub otpSecret: Option<Vec<u8>>,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub u2f: Option<U2fRegisteredDevice>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub name: String,
+	#[serde(with = "serde_bytes")]
+	pub otpSecret: Option<Vec<u8>>,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub u2f: Option<U2fRegisteredDevice>,
 }
 
 impl Entity for SecondFactor {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SecondFactor",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SecondFactor",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecondFactorAuthAllowedReturn {
-    pub _format: i64,
-    pub allowed: bool,
+	pub _format: i64,
+	pub allowed: bool,
 }
 
 impl Entity for SecondFactorAuthAllowedReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SecondFactorAuthAllowedReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SecondFactorAuthAllowedReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecondFactorAuthData {
-    pub _format: i64,
-    pub otpCode: Option<i64>,
-    #[serde(rename = "type")]
-    pub r#type: Option<i64>,
-    pub session: Option<IdTuple>,
-    pub u2f: Option<U2fResponseData>,
-    pub webauthn: Option<WebauthnResponseData>,
+	pub _format: i64,
+	pub otpCode: Option<i64>,
+	#[serde(rename = "type")]
+	pub r#type: Option<i64>,
+	pub session: Option<IdTuple>,
+	pub u2f: Option<U2fResponseData>,
+	pub webauthn: Option<WebauthnResponseData>,
 }
 
 impl Entity for SecondFactorAuthData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SecondFactorAuthData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SecondFactorAuthData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecondFactorAuthDeleteData {
-    pub _format: i64,
-    pub session: IdTuple,
+	pub _format: i64,
+	pub session: IdTuple,
 }
 
 impl Entity for SecondFactorAuthDeleteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SecondFactorAuthDeleteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SecondFactorAuthDeleteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecondFactorAuthGetData {
-    pub _format: i64,
-    pub accessToken: String,
+	pub _format: i64,
+	pub accessToken: String,
 }
 
 impl Entity for SecondFactorAuthGetData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SecondFactorAuthGetData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SecondFactorAuthGetData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecondFactorAuthGetReturn {
-    pub _format: i64,
-    pub secondFactorPending: bool,
+	pub _format: i64,
+	pub secondFactorPending: bool,
 }
 
 impl Entity for SecondFactorAuthGetReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SecondFactorAuthGetReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SecondFactorAuthGetReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecondFactorAuthentication {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub code: String,
-    pub finished: bool,
-    pub service: String,
-    pub verifyCount: i64,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub code: String,
+	pub finished: bool,
+	pub service: String,
+	pub verifyCount: i64,
 }
 
 impl Entity for SecondFactorAuthentication {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SecondFactorAuthentication",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SecondFactorAuthentication",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SendRegistrationCodeData {
-    pub _format: i64,
-    pub accountType: i64,
-    pub authToken: String,
-    pub language: String,
-    pub mobilePhoneNumber: String,
+	pub _format: i64,
+	pub accountType: i64,
+	pub authToken: String,
+	pub language: String,
+	pub mobilePhoneNumber: String,
 }
 
 impl Entity for SendRegistrationCodeData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SendRegistrationCodeData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SendRegistrationCodeData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SendRegistrationCodeReturn {
-    pub _format: i64,
-    pub authToken: String,
+	pub _format: i64,
+	pub authToken: String,
 }
 
 impl Entity for SendRegistrationCodeReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SendRegistrationCodeReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SendRegistrationCodeReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SentGroupInvitation {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub capability: i64,
-    pub inviteeMailAddress: String,
-    pub receivedInvitation: Option<IdTuple>,
-    pub sharedGroup: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub capability: i64,
+	pub inviteeMailAddress: String,
+	pub receivedInvitation: Option<IdTuple>,
+	pub sharedGroup: GeneratedId,
 }
 
 impl Entity for SentGroupInvitation {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SentGroupInvitation",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SentGroupInvitation",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Session {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub accessKey: Option<Vec<u8>>,
-    pub clientIdentifier: String,
-    pub lastAccessTime: DateTime,
-    pub loginIpAddress: Option<String>,
-    pub loginTime: DateTime,
-    pub state: i64,
-    pub challenges: Vec<Challenge>,
-    pub user: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub accessKey: Option<Vec<u8>>,
+	pub clientIdentifier: String,
+	pub lastAccessTime: DateTime,
+	pub loginIpAddress: Option<String>,
+	pub loginTime: DateTime,
+	pub state: i64,
+	pub challenges: Vec<Challenge>,
+	pub user: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Session {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Session",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Session",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SignOrderProcessingAgreementData {
-    pub _format: i64,
-    pub customerAddress: String,
-    pub version: String,
+	pub _format: i64,
+	pub customerAddress: String,
+	pub version: String,
 }
 
 impl Entity for SignOrderProcessingAgreementData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SignOrderProcessingAgreementData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SignOrderProcessingAgreementData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SseConnectData {
-    pub _format: i64,
-    pub identifier: String,
-    pub userIds: Vec<GeneratedIdWrapper>,
+	pub _format: i64,
+	pub identifier: String,
+	pub userIds: Vec<GeneratedIdWrapper>,
 }
 
 impl Entity for SseConnectData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SseConnectData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SseConnectData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct StringConfigValue {
-    pub _id: CustomId,
-    pub name: String,
-    pub value: String,
+	pub _id: CustomId,
+	pub name: String,
+	pub value: String,
 }
 
 impl Entity for StringConfigValue {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "StringConfigValue",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "StringConfigValue",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct StringWrapper {
-    pub _id: CustomId,
-    pub value: String,
+	pub _id: CustomId,
+	pub value: String,
 }
 
 impl Entity for StringWrapper {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "StringWrapper",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "StringWrapper",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SurveyData {
-    pub _id: CustomId,
-    pub category: i64,
-    pub details: Option<String>,
-    pub reason: i64,
-    pub version: i64,
+	pub _id: CustomId,
+	pub category: i64,
+	pub details: Option<String>,
+	pub reason: i64,
+	pub version: i64,
 }
 
 impl Entity for SurveyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SurveyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SurveyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SwitchAccountTypePostIn {
-    pub _format: i64,
-    pub accountType: i64,
-    pub customer: Option<GeneratedId>,
-    pub date: Option<DateTime>,
-    pub plan: i64,
-    pub specialPriceUserSingle: Option<i64>,
-    pub referralCode: Option<GeneratedId>,
-    pub surveyData: Option<SurveyData>,
+	pub _format: i64,
+	pub accountType: i64,
+	pub customer: Option<GeneratedId>,
+	pub date: Option<DateTime>,
+	pub plan: i64,
+	pub specialPriceUserSingle: Option<i64>,
+	pub referralCode: Option<GeneratedId>,
+	pub surveyData: Option<SurveyData>,
 }
 
 impl Entity for SwitchAccountTypePostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SwitchAccountTypePostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SwitchAccountTypePostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SystemKeysReturn {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub freeGroupKey: Vec<u8>,
-    pub freeGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub premiumGroupKey: Vec<u8>,
-    pub premiumGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub systemAdminPubEccKey: Option<Vec<u8>>,
-    pub systemAdminPubKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub systemAdminPubKyberKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub systemAdminPubRsaKey: Option<Vec<u8>>,
-    pub freeGroup: Option<GeneratedId>,
-    pub premiumGroup: Option<GeneratedId>,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub freeGroupKey: Vec<u8>,
+	pub freeGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub premiumGroupKey: Vec<u8>,
+	pub premiumGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub systemAdminPubEccKey: Option<Vec<u8>>,
+	pub systemAdminPubKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub systemAdminPubKyberKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub systemAdminPubRsaKey: Option<Vec<u8>>,
+	pub freeGroup: Option<GeneratedId>,
+	pub premiumGroup: Option<GeneratedId>,
 }
 
 impl Entity for SystemKeysReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "SystemKeysReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "SystemKeysReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct TakeOverDeletedAddressData {
-    pub _format: i64,
-    pub authVerifier: String,
-    pub mailAddress: String,
-    pub recoverCodeVerifier: Option<String>,
-    pub targetAccountMailAddress: String,
+	pub _format: i64,
+	pub authVerifier: String,
+	pub mailAddress: String,
+	pub recoverCodeVerifier: Option<String>,
+	pub targetAccountMailAddress: String,
 }
 
 impl Entity for TakeOverDeletedAddressData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "TakeOverDeletedAddressData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "TakeOverDeletedAddressData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct TypeInfo {
-    pub _id: CustomId,
-    pub application: String,
-    pub typeId: i64,
+	pub _id: CustomId,
+	pub application: String,
+	pub typeId: i64,
 }
 
 impl Entity for TypeInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "TypeInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "TypeInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct U2fChallenge {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub challenge: Vec<u8>,
-    pub keys: Vec<U2fKey>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub challenge: Vec<u8>,
+	pub keys: Vec<U2fKey>,
 }
 
 impl Entity for U2fChallenge {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "U2fChallenge",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "U2fChallenge",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct U2fKey {
-    pub _id: CustomId,
-    pub appId: String,
-    #[serde(with = "serde_bytes")]
-    pub keyHandle: Vec<u8>,
-    pub secondFactor: IdTuple,
+	pub _id: CustomId,
+	pub appId: String,
+	#[serde(with = "serde_bytes")]
+	pub keyHandle: Vec<u8>,
+	pub secondFactor: IdTuple,
 }
 
 impl Entity for U2fKey {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "U2fKey",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "U2fKey",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct U2fRegisteredDevice {
-    pub _id: CustomId,
-    pub appId: String,
-    pub compromised: bool,
-    pub counter: i64,
-    #[serde(with = "serde_bytes")]
-    pub keyHandle: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub publicKey: Vec<u8>,
+	pub _id: CustomId,
+	pub appId: String,
+	pub compromised: bool,
+	pub counter: i64,
+	#[serde(with = "serde_bytes")]
+	pub keyHandle: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub publicKey: Vec<u8>,
 }
 
 impl Entity for U2fRegisteredDevice {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "U2fRegisteredDevice",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "U2fRegisteredDevice",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct U2fResponseData {
-    pub _id: CustomId,
-    pub clientData: String,
-    pub keyHandle: String,
-    pub signatureData: String,
+	pub _id: CustomId,
+	pub clientData: String,
+	pub keyHandle: String,
+	pub signatureData: String,
 }
 
 impl Entity for U2fResponseData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "U2fResponseData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "U2fResponseData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UpdatePermissionKeyData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncSessionKey: Vec<u8>,
-    pub ownerKeyVersion: i64,
-    pub bucketPermission: IdTuple,
-    pub permission: IdTuple,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncSessionKey: Vec<u8>,
+	pub ownerKeyVersion: i64,
+	pub bucketPermission: IdTuple,
+	pub permission: IdTuple,
 }
 
 impl Entity for UpdatePermissionKeyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UpdatePermissionKeyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UpdatePermissionKeyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UpdateSessionKeysPostIn {
-    pub _format: i64,
-    pub ownerEncSessionKeys: Vec<InstanceSessionKey>,
+	pub _format: i64,
+	pub ownerEncSessionKeys: Vec<InstanceSessionKey>,
 }
 
 impl Entity for UpdateSessionKeysPostIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UpdateSessionKeysPostIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UpdateSessionKeysPostIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UpgradePriceServiceData {
-    pub _format: i64,
-    pub campaign: Option<String>,
-    pub date: Option<DateTime>,
-    pub referralCode: Option<GeneratedId>,
+	pub _format: i64,
+	pub campaign: Option<String>,
+	pub date: Option<DateTime>,
+	pub referralCode: Option<GeneratedId>,
 }
 
 impl Entity for UpgradePriceServiceData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UpgradePriceServiceData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UpgradePriceServiceData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UpgradePriceServiceReturn {
-    pub _format: i64,
-    pub bonusMonthsForYearlyPlan: i64,
-    pub business: bool,
-    pub messageTextId: Option<String>,
-    pub advancedPrices: PlanPrices,
-    pub essentialPrices: PlanPrices,
-    pub freePrices: PlanPrices,
-    pub legendaryPrices: PlanPrices,
-    pub plans: Vec<PlanPrices>,
-    pub premiumBusinessPrices: PlanPrices,
-    pub premiumPrices: PlanPrices,
-    pub proPrices: PlanPrices,
-    pub revolutionaryPrices: PlanPrices,
-    pub teamsBusinessPrices: PlanPrices,
-    pub teamsPrices: PlanPrices,
-    pub unlimitedPrices: PlanPrices,
+	pub _format: i64,
+	pub bonusMonthsForYearlyPlan: i64,
+	pub business: bool,
+	pub messageTextId: Option<String>,
+	pub advancedPrices: PlanPrices,
+	pub essentialPrices: PlanPrices,
+	pub freePrices: PlanPrices,
+	pub legendaryPrices: PlanPrices,
+	pub plans: Vec<PlanPrices>,
+	pub premiumBusinessPrices: PlanPrices,
+	pub premiumPrices: PlanPrices,
+	pub proPrices: PlanPrices,
+	pub revolutionaryPrices: PlanPrices,
+	pub teamsBusinessPrices: PlanPrices,
+	pub teamsPrices: PlanPrices,
+	pub unlimitedPrices: PlanPrices,
 }
 
 impl Entity for UpgradePriceServiceReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UpgradePriceServiceReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UpgradePriceServiceReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct User {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub accountType: i64,
-    pub enabled: bool,
-    pub kdfVersion: i64,
-    pub requirePasswordUpdate: bool,
-    #[serde(with = "serde_bytes")]
-    pub salt: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub verifier: Vec<u8>,
-    pub alarmInfoList: Option<UserAlarmInfoListType>,
-    pub auth: Option<UserAuthentication>,
-    pub authenticatedDevices: Vec<AuthenticatedDevice>,
-    pub customer: Option<GeneratedId>,
-    pub externalAuthInfo: Option<UserExternalAuthInfo>,
-    pub failedLogins: GeneratedId,
-    pub memberships: Vec<GroupMembership>,
-    pub pushIdentifierList: Option<PushIdentifierList>,
-    pub secondFactorAuthentications: GeneratedId,
-    pub successfulLogins: GeneratedId,
-    pub userGroup: GroupMembership,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub accountType: i64,
+	pub enabled: bool,
+	pub kdfVersion: i64,
+	pub requirePasswordUpdate: bool,
+	#[serde(with = "serde_bytes")]
+	pub salt: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub verifier: Vec<u8>,
+	pub alarmInfoList: Option<UserAlarmInfoListType>,
+	pub auth: Option<UserAuthentication>,
+	pub authenticatedDevices: Vec<AuthenticatedDevice>,
+	pub customer: Option<GeneratedId>,
+	pub externalAuthInfo: Option<UserExternalAuthInfo>,
+	pub failedLogins: GeneratedId,
+	pub memberships: Vec<GroupMembership>,
+	pub pushIdentifierList: Option<PushIdentifierList>,
+	pub secondFactorAuthentications: GeneratedId,
+	pub successfulLogins: GeneratedId,
+	pub userGroup: GroupMembership,
 }
 
 impl Entity for User {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "User",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "User",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAlarmInfo {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub alarmInfo: AlarmInfo,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub alarmInfo: AlarmInfo,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for UserAlarmInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserAlarmInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserAlarmInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAlarmInfoListType {
-    pub _id: CustomId,
-    pub alarms: GeneratedId,
+	pub _id: CustomId,
+	pub alarms: GeneratedId,
 }
 
 impl Entity for UserAlarmInfoListType {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserAlarmInfoListType",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserAlarmInfoListType",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAreaGroups {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for UserAreaGroups {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserAreaGroups",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserAreaGroups",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAuthentication {
-    pub _id: CustomId,
-    pub recoverCode: Option<GeneratedId>,
-    pub secondFactors: GeneratedId,
-    pub sessions: GeneratedId,
+	pub _id: CustomId,
+	pub recoverCode: Option<GeneratedId>,
+	pub secondFactors: GeneratedId,
+	pub sessions: GeneratedId,
 }
 
 impl Entity for UserAuthentication {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserAuthentication",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserAuthentication",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserDataDelete {
-    pub _format: i64,
-    pub date: Option<DateTime>,
-    pub restore: bool,
-    pub user: GeneratedId,
+	pub _format: i64,
+	pub date: Option<DateTime>,
+	pub restore: bool,
+	pub user: GeneratedId,
 }
 
 impl Entity for UserDataDelete {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserDataDelete",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserDataDelete",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserExternalAuthInfo {
-    pub _id: CustomId,
-    pub authUpdateCounter: i64,
-    pub autoAuthenticationId: GeneratedId,
-    pub autoTransmitPassword: Option<String>,
-    #[serde(with = "serde_bytes")]
-    pub latestSaltHash: Option<Vec<u8>>,
-    pub variableAuthInfo: GeneratedId,
+	pub _id: CustomId,
+	pub authUpdateCounter: i64,
+	pub autoAuthenticationId: GeneratedId,
+	pub autoTransmitPassword: Option<String>,
+	#[serde(with = "serde_bytes")]
+	pub latestSaltHash: Option<Vec<u8>>,
+	pub variableAuthInfo: GeneratedId,
 }
 
 impl Entity for UserExternalAuthInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserExternalAuthInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserExternalAuthInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserGroupKeyDistribution {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub distributionEncUserGroupKey: Vec<u8>,
-    pub userGroupKeyVersion: i64,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub distributionEncUserGroupKey: Vec<u8>,
+	pub userGroupKeyVersion: i64,
 }
 
 impl Entity for UserGroupKeyDistribution {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserGroupKeyDistribution",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserGroupKeyDistribution",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserGroupKeyRotationData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub adminGroupEncUserGroupKey: Vec<u8>,
-    pub adminGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub authVerifier: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub distributionKeyEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub passphraseEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userGroupEncPreviousGroupKey: Vec<u8>,
-    pub userGroupKeyVersion: i64,
-    pub group: GeneratedId,
-    pub keyPair: KeyPair,
-    pub recoverCodeData: Option<RecoverCodeData>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub adminGroupEncUserGroupKey: Vec<u8>,
+	pub adminGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub authVerifier: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub distributionKeyEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub passphraseEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userGroupEncPreviousGroupKey: Vec<u8>,
+	pub userGroupKeyVersion: i64,
+	pub group: GeneratedId,
+	pub keyPair: KeyPair,
+	pub recoverCodeData: Option<RecoverCodeData>,
 }
 
 impl Entity for UserGroupKeyRotationData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserGroupKeyRotationData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserGroupKeyRotationData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserGroupRoot {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub groupKeyUpdates: Option<GroupKeyUpdatesRef>,
-    pub invitations: GeneratedId,
-    pub keyRotations: Option<KeyRotationsRef>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub groupKeyUpdates: Option<GroupKeyUpdatesRef>,
+	pub invitations: GeneratedId,
+	pub keyRotations: Option<KeyRotationsRef>,
 }
 
 impl Entity for UserGroupRoot {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "UserGroupRoot",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "UserGroupRoot",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct VariableExternalAuthInfo {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub authUpdateCounter: i64,
-    pub lastSentTimestamp: DateTime,
-    #[serde(with = "serde_bytes")]
-    pub loggedInIpAddressHash: Option<Vec<u8>>,
-    pub loggedInTimestamp: Option<DateTime>,
-    #[serde(with = "serde_bytes")]
-    pub loggedInVerifier: Option<Vec<u8>>,
-    pub sentCount: i64,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub authUpdateCounter: i64,
+	pub lastSentTimestamp: DateTime,
+	#[serde(with = "serde_bytes")]
+	pub loggedInIpAddressHash: Option<Vec<u8>>,
+	pub loggedInTimestamp: Option<DateTime>,
+	#[serde(with = "serde_bytes")]
+	pub loggedInVerifier: Option<Vec<u8>>,
+	pub sentCount: i64,
 }
 
 impl Entity for VariableExternalAuthInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "VariableExternalAuthInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "VariableExternalAuthInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct VerifyRegistrationCodeData {
-    pub _format: i64,
-    pub authToken: String,
-    pub code: String,
+	pub _format: i64,
+	pub authToken: String,
+	pub code: String,
 }
 
 impl Entity for VerifyRegistrationCodeData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "VerifyRegistrationCodeData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "VerifyRegistrationCodeData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Version {
-    pub _id: CustomId,
-    pub operation: String,
-    pub timestamp: DateTime,
-    pub version: GeneratedId,
-    pub author: GeneratedId,
-    pub authorGroupInfo: IdTuple,
+	pub _id: CustomId,
+	pub operation: String,
+	pub timestamp: DateTime,
+	pub version: GeneratedId,
+	pub author: GeneratedId,
+	pub authorGroupInfo: IdTuple,
 }
 
 impl Entity for Version {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "Version",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "Version",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct VersionData {
-    pub _format: i64,
-    pub application: String,
-    pub id: GeneratedId,
-    pub listId: Option<GeneratedId>,
-    pub typeId: i64,
+	pub _format: i64,
+	pub application: String,
+	pub id: GeneratedId,
+	pub listId: Option<GeneratedId>,
+	pub typeId: i64,
 }
 
 impl Entity for VersionData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "VersionData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "VersionData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct VersionInfo {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub app: String,
-    pub operation: String,
-    pub referenceList: Option<GeneratedId>,
-    pub timestamp: DateTime,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    #[serde(with = "serde_bytes")]
-    pub versionData: Option<Vec<u8>>,
-    pub author: GeneratedId,
-    pub authorGroupInfo: IdTuple,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub app: String,
+	pub operation: String,
+	pub referenceList: Option<GeneratedId>,
+	pub timestamp: DateTime,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	#[serde(with = "serde_bytes")]
+	pub versionData: Option<Vec<u8>>,
+	pub author: GeneratedId,
+	pub authorGroupInfo: IdTuple,
 }
 
 impl Entity for VersionInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "VersionInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "VersionInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct VersionReturn {
-    pub _format: i64,
-    pub versions: Vec<Version>,
+	pub _format: i64,
+	pub versions: Vec<Version>,
 }
 
 impl Entity for VersionReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "VersionReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "VersionReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WebauthnResponseData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub authenticatorData: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub clientData: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub keyHandle: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub signature: Vec<u8>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub authenticatorData: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub clientData: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub keyHandle: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub signature: Vec<u8>,
 }
 
 impl Entity for WebauthnResponseData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WebauthnResponseData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WebauthnResponseData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WebsocketCounterData {
-    pub _format: i64,
-    pub mailGroup: GeneratedId,
-    pub counterValues: Vec<WebsocketCounterValue>,
+	pub _format: i64,
+	pub mailGroup: GeneratedId,
+	pub counterValues: Vec<WebsocketCounterValue>,
 }
 
 impl Entity for WebsocketCounterData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WebsocketCounterData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WebsocketCounterData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WebsocketCounterValue {
-    pub _id: CustomId,
-    pub count: i64,
-    pub counterId: GeneratedId,
+	pub _id: CustomId,
+	pub count: i64,
+	pub counterId: GeneratedId,
 }
 
 impl Entity for WebsocketCounterValue {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WebsocketCounterValue",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WebsocketCounterValue",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WebsocketEntityData {
-    pub _format: i64,
-    pub eventBatchId: GeneratedId,
-    pub eventBatchOwner: GeneratedId,
-    pub eventBatch: Vec<EntityUpdate>,
+	pub _format: i64,
+	pub eventBatchId: GeneratedId,
+	pub eventBatchOwner: GeneratedId,
+	pub eventBatch: Vec<EntityUpdate>,
 }
 
 impl Entity for WebsocketEntityData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WebsocketEntityData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WebsocketEntityData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WebsocketLeaderStatus {
-    pub _format: i64,
-    pub leaderStatus: bool,
+	pub _format: i64,
+	pub leaderStatus: bool,
 }
 
 impl Entity for WebsocketLeaderStatus {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WebsocketLeaderStatus",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WebsocketLeaderStatus",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WhitelabelChild {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub comment: String,
-    pub createdDate: DateTime,
-    pub deletedDate: Option<DateTime>,
-    pub mailAddress: String,
-    pub customer: GeneratedId,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub comment: String,
+	pub createdDate: DateTime,
+	pub deletedDate: Option<DateTime>,
+	pub mailAddress: String,
+	pub customer: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for WhitelabelChild {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WhitelabelChild",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WhitelabelChild",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WhitelabelChildrenRef {
-    pub _id: CustomId,
-    pub items: GeneratedId,
+	pub _id: CustomId,
+	pub items: GeneratedId,
 }
 
 impl Entity for WhitelabelChildrenRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WhitelabelChildrenRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WhitelabelChildrenRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WhitelabelConfig {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub germanLanguageCode: Option<String>,
-    pub imprintUrl: Option<String>,
-    pub jsonTheme: String,
-    pub metaTags: String,
-    pub privacyStatementUrl: Option<String>,
-    pub whitelabelCode: String,
-    pub bootstrapCustomizations: Vec<BootstrapFeature>,
-    pub certificateInfo: Option<CertificateInfo>,
-    pub whitelabelRegistrationDomains: Vec<StringWrapper>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub germanLanguageCode: Option<String>,
+	pub imprintUrl: Option<String>,
+	pub jsonTheme: String,
+	pub metaTags: String,
+	pub privacyStatementUrl: Option<String>,
+	pub whitelabelCode: String,
+	pub bootstrapCustomizations: Vec<BootstrapFeature>,
+	pub certificateInfo: Option<CertificateInfo>,
+	pub whitelabelRegistrationDomains: Vec<StringWrapper>,
 }
 
 impl Entity for WhitelabelConfig {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WhitelabelConfig",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WhitelabelConfig",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct WhitelabelParent {
-    pub _id: CustomId,
-    pub customer: GeneratedId,
-    pub whitelabelChildInParent: IdTuple,
+	pub _id: CustomId,
+	pub customer: GeneratedId,
+	pub whitelabelChildInParent: IdTuple,
 }
 
 impl Entity for WhitelabelParent {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "sys",
-            type_: "WhitelabelParent",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "WhitelabelParent",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/tutanota.rs
+++ b/tuta-sdk/rust/sdk/src/entities/tutanota.rs
@@ -1,2492 +1,2379 @@
 #![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct AttachmentKeyData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub bucketEncFileSessionKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub fileSessionKey: Option<Vec<u8>>,
-    pub file: IdTuple,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub bucketEncFileSessionKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub fileSessionKey: Option<Vec<u8>>,
+	pub file: IdTuple,
 }
 
 impl Entity for AttachmentKeyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "AttachmentKeyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "AttachmentKeyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Birthday {
-    pub _id: CustomId,
-    pub day: i64,
-    pub month: i64,
-    pub year: Option<i64>,
+	pub _id: CustomId,
+	pub day: i64,
+	pub month: i64,
+	pub year: Option<i64>,
 }
 
 impl Entity for Birthday {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "Birthday",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "Birthday",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Body {
-    pub _id: CustomId,
-    pub compressedText: Option<Vec<u8>>,
-    pub text: Option<String>,
+	pub _id: CustomId,
+	pub compressedText: Option<Vec<u8>>,
+	pub text: Option<String>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Body {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "Body",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "Body",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarDeleteData {
-    pub _format: i64,
-    pub groupRootId: GeneratedId,
+	pub _format: i64,
+	pub groupRootId: GeneratedId,
 }
 
 impl Entity for CalendarDeleteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarDeleteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarDeleteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarEvent {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub description: String,
-    pub endTime: DateTime,
-    #[serde(with = "serde_bytes")]
-    pub hashedUid: Option<Vec<u8>>,
-    pub invitedConfidentially: Option<bool>,
-    pub location: String,
-    pub recurrenceId: Option<DateTime>,
-    pub sequence: i64,
-    pub startTime: DateTime,
-    pub summary: String,
-    pub uid: Option<String>,
-    pub alarmInfos: Vec<IdTuple>,
-    pub attendees: Vec<CalendarEventAttendee>,
-    pub organizer: Option<EncryptedMailAddress>,
-    pub repeatRule: Option<CalendarRepeatRule>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub description: String,
+	pub endTime: DateTime,
+	#[serde(with = "serde_bytes")]
+	pub hashedUid: Option<Vec<u8>>,
+	pub invitedConfidentially: Option<bool>,
+	pub location: String,
+	pub recurrenceId: Option<DateTime>,
+	pub sequence: i64,
+	pub startTime: DateTime,
+	pub summary: String,
+	pub uid: Option<String>,
+	pub alarmInfos: Vec<IdTuple>,
+	pub attendees: Vec<CalendarEventAttendee>,
+	pub organizer: Option<EncryptedMailAddress>,
+	pub repeatRule: Option<CalendarRepeatRule>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEvent {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarEvent",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarEvent",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarEventAttendee {
-    pub _id: CustomId,
-    pub status: i64,
-    pub address: EncryptedMailAddress,
+	pub _id: CustomId,
+	pub status: i64,
+	pub address: EncryptedMailAddress,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEventAttendee {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarEventAttendee",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarEventAttendee",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarEventIndexRef {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for CalendarEventIndexRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarEventIndexRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarEventIndexRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarEventUidIndex {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub alteredInstances: Vec<IdTuple>,
-    pub progenitor: Option<IdTuple>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub alteredInstances: Vec<IdTuple>,
+	pub progenitor: Option<IdTuple>,
 }
 
 impl Entity for CalendarEventUidIndex {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarEventUidIndex",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarEventUidIndex",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarEventUpdate {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub sender: String,
-    pub file: IdTuple,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub sender: String,
+	pub file: IdTuple,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEventUpdate {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarEventUpdate",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarEventUpdate",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarEventUpdateList {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for CalendarEventUpdateList {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarEventUpdateList",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarEventUpdateList",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarGroupRoot {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub index: Option<CalendarEventIndexRef>,
-    pub longEvents: GeneratedId,
-    pub shortEvents: GeneratedId,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub index: Option<CalendarEventIndexRef>,
+	pub longEvents: GeneratedId,
+	pub shortEvents: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarGroupRoot {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarGroupRoot",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarGroupRoot",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CalendarRepeatRule {
-    pub _id: CustomId,
-    pub endType: i64,
-    pub endValue: Option<i64>,
-    pub frequency: i64,
-    pub interval: i64,
-    pub timeZone: String,
-    pub excludedDates: Vec<sys::DateWrapper>,
+	pub _id: CustomId,
+	pub endType: i64,
+	pub endValue: Option<i64>,
+	pub frequency: i64,
+	pub interval: i64,
+	pub timeZone: String,
+	pub excludedDates: Vec<sys::DateWrapper>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarRepeatRule {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CalendarRepeatRule",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CalendarRepeatRule",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Contact {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub birthdayIso: Option<String>,
-    pub comment: String,
-    pub company: String,
-    pub department: Option<String>,
-    pub firstName: String,
-    pub lastName: String,
-    pub middleName: Option<String>,
-    pub nameSuffix: Option<String>,
-    pub nickname: Option<String>,
-    pub oldBirthdayDate: Option<DateTime>,
-    pub phoneticFirst: Option<String>,
-    pub phoneticLast: Option<String>,
-    pub phoneticMiddle: Option<String>,
-    pub presharedPassword: Option<String>,
-    pub role: String,
-    pub title: Option<String>,
-    pub addresses: Vec<ContactAddress>,
-    pub customDate: Vec<ContactCustomDate>,
-    pub mailAddresses: Vec<ContactMailAddress>,
-    pub messengerHandles: Vec<ContactMessengerHandle>,
-    pub oldBirthdayAggregate: Option<Birthday>,
-    pub phoneNumbers: Vec<ContactPhoneNumber>,
-    pub photo: Option<IdTuple>,
-    pub pronouns: Vec<ContactPronouns>,
-    pub relationships: Vec<ContactRelationship>,
-    pub socialIds: Vec<ContactSocialId>,
-    pub websites: Vec<ContactWebsite>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub birthdayIso: Option<String>,
+	pub comment: String,
+	pub company: String,
+	pub department: Option<String>,
+	pub firstName: String,
+	pub lastName: String,
+	pub middleName: Option<String>,
+	pub nameSuffix: Option<String>,
+	pub nickname: Option<String>,
+	pub oldBirthdayDate: Option<DateTime>,
+	pub phoneticFirst: Option<String>,
+	pub phoneticLast: Option<String>,
+	pub phoneticMiddle: Option<String>,
+	pub presharedPassword: Option<String>,
+	pub role: String,
+	pub title: Option<String>,
+	pub addresses: Vec<ContactAddress>,
+	pub customDate: Vec<ContactCustomDate>,
+	pub mailAddresses: Vec<ContactMailAddress>,
+	pub messengerHandles: Vec<ContactMessengerHandle>,
+	pub oldBirthdayAggregate: Option<Birthday>,
+	pub phoneNumbers: Vec<ContactPhoneNumber>,
+	pub photo: Option<IdTuple>,
+	pub pronouns: Vec<ContactPronouns>,
+	pub relationships: Vec<ContactRelationship>,
+	pub socialIds: Vec<ContactSocialId>,
+	pub websites: Vec<ContactWebsite>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Contact {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "Contact",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "Contact",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactAddress {
-    pub _id: CustomId,
-    pub address: String,
-    pub customTypeName: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub address: String,
+	pub customTypeName: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactAddress {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactAddress",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactAddress",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactCustomDate {
-    pub _id: CustomId,
-    pub customTypeName: String,
-    pub dateIso: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub customTypeName: String,
+	pub dateIso: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactCustomDate {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactCustomDate",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactCustomDate",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactList {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub contacts: GeneratedId,
-    pub photos: Option<PhotosRef>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub contacts: GeneratedId,
+	pub photos: Option<PhotosRef>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactList {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactList",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactList",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactListEntry {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub emailAddress: String,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub emailAddress: String,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactListEntry {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactListEntry",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactListEntry",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactListGroupRoot {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub entries: GeneratedId,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub entries: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactListGroupRoot {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactListGroupRoot",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactListGroupRoot",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactMailAddress {
-    pub _id: CustomId,
-    pub address: String,
-    pub customTypeName: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub address: String,
+	pub customTypeName: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactMailAddress {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactMailAddress",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactMailAddress",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactMessengerHandle {
-    pub _id: CustomId,
-    pub customTypeName: String,
-    pub handle: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub customTypeName: String,
+	pub handle: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactMessengerHandle {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactMessengerHandle",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactMessengerHandle",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactPhoneNumber {
-    pub _id: CustomId,
-    pub customTypeName: String,
-    pub number: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub customTypeName: String,
+	pub number: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactPhoneNumber {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactPhoneNumber",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactPhoneNumber",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactPronouns {
-    pub _id: CustomId,
-    pub language: String,
-    pub pronouns: String,
+	pub _id: CustomId,
+	pub language: String,
+	pub pronouns: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactPronouns {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactPronouns",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactPronouns",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactRelationship {
-    pub _id: CustomId,
-    pub customTypeName: String,
-    pub person: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub customTypeName: String,
+	pub person: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactRelationship {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactRelationship",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactRelationship",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactSocialId {
-    pub _id: CustomId,
-    pub customTypeName: String,
-    pub socialId: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub customTypeName: String,
+	pub socialId: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactSocialId {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactSocialId",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactSocialId",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ContactWebsite {
-    pub _id: CustomId,
-    pub customTypeName: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub url: String,
+	pub _id: CustomId,
+	pub customTypeName: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub url: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactWebsite {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ContactWebsite",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ContactWebsite",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ConversationEntry {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub conversationType: i64,
-    pub messageId: String,
-    pub mail: Option<IdTuple>,
-    pub previous: Option<IdTuple>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub conversationType: i64,
+	pub messageId: String,
+	pub mail: Option<IdTuple>,
+	pub previous: Option<IdTuple>,
 }
 
 impl Entity for ConversationEntry {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ConversationEntry",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ConversationEntry",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateExternalUserGroupData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub externalPwEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub internalUserEncUserGroupKey: Vec<u8>,
-    pub internalUserGroupKeyVersion: i64,
-    pub mailAddress: String,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub externalPwEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub internalUserEncUserGroupKey: Vec<u8>,
+	pub internalUserGroupKeyVersion: i64,
+	pub mailAddress: String,
 }
 
 impl Entity for CreateExternalUserGroupData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CreateExternalUserGroupData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CreateExternalUserGroupData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateGroupPostReturn {
-    pub _format: i64,
-    pub group: GeneratedId,
+	pub _format: i64,
+	pub group: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateGroupPostReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CreateGroupPostReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CreateGroupPostReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateMailFolderData {
-    pub _format: i64,
-    pub folderName: String,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncSessionKey: Vec<u8>,
-    pub ownerGroup: Option<GeneratedId>,
-    pub ownerKeyVersion: i64,
-    pub parentFolder: Option<IdTuple>,
+	pub _format: i64,
+	pub folderName: String,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncSessionKey: Vec<u8>,
+	pub ownerGroup: Option<GeneratedId>,
+	pub ownerKeyVersion: i64,
+	pub parentFolder: Option<IdTuple>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateMailFolderData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CreateMailFolderData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CreateMailFolderData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateMailFolderReturn {
-    pub _format: i64,
-    pub newFolder: IdTuple,
+	pub _format: i64,
+	pub newFolder: IdTuple,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateMailFolderReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CreateMailFolderReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CreateMailFolderReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CreateMailGroupData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub encryptedName: Vec<u8>,
-    pub mailAddress: String,
-    #[serde(with = "serde_bytes")]
-    pub mailEncMailboxSessionKey: Vec<u8>,
-    pub groupData: InternalGroupData,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub encryptedName: Vec<u8>,
+	pub mailAddress: String,
+	#[serde(with = "serde_bytes")]
+	pub mailEncMailboxSessionKey: Vec<u8>,
+	pub groupData: InternalGroupData,
 }
 
 impl Entity for CreateMailGroupData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CreateMailGroupData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CreateMailGroupData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct CustomerAccountCreateData {
-    pub _format: i64,
-    pub accountGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub adminEncAccountingInfoSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub adminEncCustomerServerPropertiesSessionKey: Vec<u8>,
-    pub authToken: String,
-    pub code: String,
-    pub date: Option<DateTime>,
-    pub lang: String,
-    #[serde(with = "serde_bytes")]
-    pub systemAdminPubEncAccountingInfoSessionKey: Vec<u8>,
-    pub systemAdminPubKeyVersion: i64,
-    pub systemAdminPublicProtocolVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub userEncAccountGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncAdminGroupKey: Vec<u8>,
-    pub adminGroupData: InternalGroupData,
-    pub customerGroupData: InternalGroupData,
-    pub userData: UserAccountUserData,
-    pub userGroupData: InternalGroupData,
+	pub _format: i64,
+	pub accountGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub adminEncAccountingInfoSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub adminEncCustomerServerPropertiesSessionKey: Vec<u8>,
+	pub authToken: String,
+	pub code: String,
+	pub date: Option<DateTime>,
+	pub lang: String,
+	#[serde(with = "serde_bytes")]
+	pub systemAdminPubEncAccountingInfoSessionKey: Vec<u8>,
+	pub systemAdminPubKeyVersion: i64,
+	pub systemAdminPublicProtocolVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub userEncAccountGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncAdminGroupKey: Vec<u8>,
+	pub adminGroupData: InternalGroupData,
+	pub customerGroupData: InternalGroupData,
+	pub userData: UserAccountUserData,
+	pub userGroupData: InternalGroupData,
 }
 
 impl Entity for CustomerAccountCreateData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "CustomerAccountCreateData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "CustomerAccountCreateData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DefaultAlarmInfo {
-    pub _id: CustomId,
-    pub trigger: String,
+	pub _id: CustomId,
+	pub trigger: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DefaultAlarmInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DefaultAlarmInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DefaultAlarmInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DeleteGroupData {
-    pub _format: i64,
-    pub restore: bool,
-    pub group: GeneratedId,
+	pub _format: i64,
+	pub restore: bool,
+	pub group: GeneratedId,
 }
 
 impl Entity for DeleteGroupData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DeleteGroupData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DeleteGroupData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DeleteMailData {
-    pub _format: i64,
-    pub folder: Option<IdTuple>,
-    pub mails: Vec<IdTuple>,
+	pub _format: i64,
+	pub folder: Option<IdTuple>,
+	pub mails: Vec<IdTuple>,
 }
 
 impl Entity for DeleteMailData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DeleteMailData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DeleteMailData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DeleteMailFolderData {
-    pub _format: i64,
-    pub folders: Vec<IdTuple>,
+	pub _format: i64,
+	pub folders: Vec<IdTuple>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DeleteMailFolderData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DeleteMailFolderData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DeleteMailFolderData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DraftAttachment {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncFileSessionKey: Vec<u8>,
-    pub ownerKeyVersion: i64,
-    pub existingFile: Option<IdTuple>,
-    pub newFile: Option<NewDraftAttachment>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncFileSessionKey: Vec<u8>,
+	pub ownerKeyVersion: i64,
+	pub existingFile: Option<IdTuple>,
+	pub newFile: Option<NewDraftAttachment>,
 }
 
 impl Entity for DraftAttachment {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DraftAttachment",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DraftAttachment",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DraftCreateData {
-    pub _format: i64,
-    pub conversationType: i64,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncSessionKey: Vec<u8>,
-    pub ownerKeyVersion: i64,
-    pub previousMessageId: Option<String>,
-    pub draftData: DraftData,
+	pub _format: i64,
+	pub conversationType: i64,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncSessionKey: Vec<u8>,
+	pub ownerKeyVersion: i64,
+	pub previousMessageId: Option<String>,
+	pub draftData: DraftData,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftCreateData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DraftCreateData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DraftCreateData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DraftCreateReturn {
-    pub _format: i64,
-    pub draft: IdTuple,
+	pub _format: i64,
+	pub draft: IdTuple,
 }
 
 impl Entity for DraftCreateReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DraftCreateReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DraftCreateReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DraftData {
-    pub _id: CustomId,
-    pub bodyText: String,
-    pub compressedBodyText: Option<Vec<u8>>,
-    pub confidential: bool,
-    pub method: i64,
-    pub senderMailAddress: String,
-    pub senderName: String,
-    pub subject: String,
-    pub addedAttachments: Vec<DraftAttachment>,
-    pub bccRecipients: Vec<DraftRecipient>,
-    pub ccRecipients: Vec<DraftRecipient>,
-    pub removedAttachments: Vec<IdTuple>,
-    pub replyTos: Vec<EncryptedMailAddress>,
-    pub toRecipients: Vec<DraftRecipient>,
+	pub _id: CustomId,
+	pub bodyText: String,
+	pub compressedBodyText: Option<Vec<u8>>,
+	pub confidential: bool,
+	pub method: i64,
+	pub senderMailAddress: String,
+	pub senderName: String,
+	pub subject: String,
+	pub addedAttachments: Vec<DraftAttachment>,
+	pub bccRecipients: Vec<DraftRecipient>,
+	pub ccRecipients: Vec<DraftRecipient>,
+	pub removedAttachments: Vec<IdTuple>,
+	pub replyTos: Vec<EncryptedMailAddress>,
+	pub toRecipients: Vec<DraftRecipient>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DraftData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DraftData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DraftRecipient {
-    pub _id: CustomId,
-    pub mailAddress: String,
-    pub name: String,
+	pub _id: CustomId,
+	pub mailAddress: String,
+	pub name: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftRecipient {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DraftRecipient",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DraftRecipient",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DraftUpdateData {
-    pub _format: i64,
-    pub draft: IdTuple,
-    pub draftData: DraftData,
+	pub _format: i64,
+	pub draft: IdTuple,
+	pub draftData: DraftData,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftUpdateData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DraftUpdateData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DraftUpdateData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct DraftUpdateReturn {
-    pub _format: i64,
-    pub attachments: Vec<IdTuple>,
+	pub _format: i64,
+	pub attachments: Vec<IdTuple>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftUpdateReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "DraftUpdateReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "DraftUpdateReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EmailTemplate {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub tag: String,
-    pub title: String,
-    pub contents: Vec<EmailTemplateContent>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub tag: String,
+	pub title: String,
+	pub contents: Vec<EmailTemplateContent>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EmailTemplate {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "EmailTemplate",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "EmailTemplate",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EmailTemplateContent {
-    pub _id: CustomId,
-    pub languageCode: String,
-    pub text: String,
+	pub _id: CustomId,
+	pub languageCode: String,
+	pub text: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EmailTemplateContent {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "EmailTemplateContent",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "EmailTemplateContent",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EncryptTutanotaPropertiesData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub symEncSessionKey: Vec<u8>,
-    pub symKeyVersion: i64,
-    pub properties: GeneratedId,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub symEncSessionKey: Vec<u8>,
+	pub symKeyVersion: i64,
+	pub properties: GeneratedId,
 }
 
 impl Entity for EncryptTutanotaPropertiesData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "EncryptTutanotaPropertiesData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "EncryptTutanotaPropertiesData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EncryptedMailAddress {
-    pub _id: CustomId,
-    pub address: String,
-    pub name: String,
+	pub _id: CustomId,
+	pub address: String,
+	pub name: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EncryptedMailAddress {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "EncryptedMailAddress",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "EncryptedMailAddress",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct EntropyData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub userEncEntropy: Vec<u8>,
-    pub userKeyVersion: i64,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub userEncEntropy: Vec<u8>,
+	pub userKeyVersion: i64,
 }
 
 impl Entity for EntropyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "EntropyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "EntropyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ExternalUserData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub externalMailEncMailBoxSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub externalMailEncMailGroupInfoSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub externalUserEncEntropy: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub externalUserEncMailGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub externalUserEncTutanotaPropertiesSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub externalUserEncUserGroupInfoSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub internalMailEncMailGroupInfoSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub internalMailEncUserGroupInfoSessionKey: Vec<u8>,
-    pub internalMailGroupKeyVersion: i64,
-    pub kdfVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub verifier: Vec<u8>,
-    pub userGroupData: CreateExternalUserGroupData,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub externalMailEncMailBoxSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub externalMailEncMailGroupInfoSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub externalUserEncEntropy: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub externalUserEncMailGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub externalUserEncTutanotaPropertiesSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub externalUserEncUserGroupInfoSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub internalMailEncMailGroupInfoSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub internalMailEncUserGroupInfoSessionKey: Vec<u8>,
+	pub internalMailGroupKeyVersion: i64,
+	pub kdfVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub verifier: Vec<u8>,
+	pub userGroupData: CreateExternalUserGroupData,
 }
 
 impl Entity for ExternalUserData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ExternalUserData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ExternalUserData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct TutanotaFile {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub cid: Option<String>,
-    pub mimeType: Option<String>,
-    pub name: String,
-    pub size: i64,
-    pub blobs: Vec<sys::Blob>,
-    pub parent: Option<IdTuple>,
-    pub subFiles: Option<Subfiles>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub cid: Option<String>,
+	pub mimeType: Option<String>,
+	pub name: String,
+	pub size: i64,
+	pub blobs: Vec<sys::Blob>,
+	pub parent: Option<IdTuple>,
+	pub subFiles: Option<Subfiles>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TutanotaFile {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "TutanotaFile",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "TutanotaFile",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct FileSystem {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub files: GeneratedId,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub files: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for FileSystem {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "FileSystem",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "FileSystem",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupInvitationDeleteData {
-    pub _format: i64,
-    pub receivedInvitation: IdTuple,
+	pub _format: i64,
+	pub receivedInvitation: IdTuple,
 }
 
 impl Entity for GroupInvitationDeleteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "GroupInvitationDeleteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "GroupInvitationDeleteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupInvitationPostData {
-    pub _format: i64,
-    pub internalKeyData: Vec<InternalRecipientKeyData>,
-    pub sharedGroupData: SharedGroupData,
+	pub _format: i64,
+	pub internalKeyData: Vec<InternalRecipientKeyData>,
+	pub sharedGroupData: SharedGroupData,
 }
 
 impl Entity for GroupInvitationPostData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "GroupInvitationPostData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "GroupInvitationPostData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupInvitationPostReturn {
-    pub _format: i64,
-    pub existingMailAddresses: Vec<MailAddress>,
-    pub invalidMailAddresses: Vec<MailAddress>,
-    pub invitedMailAddresses: Vec<MailAddress>,
+	pub _format: i64,
+	pub existingMailAddresses: Vec<MailAddress>,
+	pub invalidMailAddresses: Vec<MailAddress>,
+	pub invitedMailAddresses: Vec<MailAddress>,
 }
 
 impl Entity for GroupInvitationPostReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "GroupInvitationPostReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "GroupInvitationPostReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupInvitationPutData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub sharedGroupEncInviteeGroupInfoKey: Vec<u8>,
-    pub sharedGroupKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub userGroupEncGroupKey: Vec<u8>,
-    pub userGroupKeyVersion: i64,
-    pub receivedInvitation: IdTuple,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub sharedGroupEncInviteeGroupInfoKey: Vec<u8>,
+	pub sharedGroupKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub userGroupEncGroupKey: Vec<u8>,
+	pub userGroupKeyVersion: i64,
+	pub receivedInvitation: IdTuple,
 }
 
 impl Entity for GroupInvitationPutData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "GroupInvitationPutData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "GroupInvitationPutData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct GroupSettings {
-    pub _id: CustomId,
-    pub color: String,
-    pub name: Option<String>,
-    pub sourceUrl: Option<String>,
-    pub defaultAlarmsList: Vec<DefaultAlarmInfo>,
-    pub group: GeneratedId,
+	pub _id: CustomId,
+	pub color: String,
+	pub name: Option<String>,
+	pub sourceUrl: Option<String>,
+	pub defaultAlarmsList: Vec<DefaultAlarmInfo>,
+	pub group: GeneratedId,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupSettings {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "GroupSettings",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "GroupSettings",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Header {
-    pub _id: CustomId,
-    pub compressedHeaders: Option<Vec<u8>>,
-    pub headers: Option<String>,
+	pub _id: CustomId,
+	pub compressedHeaders: Option<Vec<u8>>,
+	pub headers: Option<String>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Header {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "Header",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "Header",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ImapFolder {
-    pub _id: CustomId,
-    pub lastseenuid: String,
-    pub name: String,
-    pub uidvalidity: String,
-    pub syncInfo: GeneratedId,
+	pub _id: CustomId,
+	pub lastseenuid: String,
+	pub name: String,
+	pub uidvalidity: String,
+	pub syncInfo: GeneratedId,
 }
 
 impl Entity for ImapFolder {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ImapFolder",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ImapFolder",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ImapSyncConfiguration {
-    pub _id: CustomId,
-    pub host: String,
-    pub password: String,
-    pub port: i64,
-    pub user: String,
-    pub imapSyncState: Option<GeneratedId>,
+	pub _id: CustomId,
+	pub host: String,
+	pub password: String,
+	pub port: i64,
+	pub user: String,
+	pub imapSyncState: Option<GeneratedId>,
 }
 
 impl Entity for ImapSyncConfiguration {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ImapSyncConfiguration",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ImapSyncConfiguration",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ImapSyncState {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub folders: Vec<ImapFolder>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub folders: Vec<ImapFolder>,
 }
 
 impl Entity for ImapSyncState {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ImapSyncState",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ImapSyncState",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InboxRule {
-    pub _id: CustomId,
-    #[serde(rename = "type")]
-    pub r#type: String,
-    pub value: String,
-    pub targetFolder: IdTuple,
+	pub _id: CustomId,
+	#[serde(rename = "type")]
+	pub r#type: String,
+	pub value: String,
+	pub targetFolder: IdTuple,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for InboxRule {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "InboxRule",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "InboxRule",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InternalGroupData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub adminEncGroupKey: Vec<u8>,
-    pub adminKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub groupEncPrivEccKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub groupEncPrivKyberKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub groupEncPrivRsaKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncGroupInfoSessionKey: Vec<u8>,
-    pub ownerKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubEccKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub pubKyberKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub pubRsaKey: Option<Vec<u8>>,
-    pub adminGroup: Option<GeneratedId>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub adminEncGroupKey: Vec<u8>,
+	pub adminKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub groupEncPrivEccKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub groupEncPrivKyberKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub groupEncPrivRsaKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncGroupInfoSessionKey: Vec<u8>,
+	pub ownerKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubEccKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub pubKyberKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub pubRsaKey: Option<Vec<u8>>,
+	pub adminGroup: Option<GeneratedId>,
 }
 
 impl Entity for InternalGroupData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "InternalGroupData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "InternalGroupData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct InternalRecipientKeyData {
-    pub _id: CustomId,
-    pub mailAddress: String,
-    pub protocolVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub pubEncBucketKey: Vec<u8>,
-    pub recipientKeyVersion: i64,
-    pub senderKeyVersion: Option<i64>,
+	pub _id: CustomId,
+	pub mailAddress: String,
+	pub protocolVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub pubEncBucketKey: Vec<u8>,
+	pub recipientKeyVersion: i64,
+	pub senderKeyVersion: Option<i64>,
 }
 
 impl Entity for InternalRecipientKeyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "InternalRecipientKeyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "InternalRecipientKeyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct KnowledgeBaseEntry {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub description: String,
-    pub title: String,
-    pub keywords: Vec<KnowledgeBaseEntryKeyword>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub description: String,
+	pub title: String,
+	pub keywords: Vec<KnowledgeBaseEntryKeyword>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for KnowledgeBaseEntry {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "KnowledgeBaseEntry",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "KnowledgeBaseEntry",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct KnowledgeBaseEntryKeyword {
-    pub _id: CustomId,
-    pub keyword: String,
+	pub _id: CustomId,
+	pub keyword: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for KnowledgeBaseEntryKeyword {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "KnowledgeBaseEntryKeyword",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "KnowledgeBaseEntryKeyword",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ListUnsubscribeData {
-    pub _format: i64,
-    pub headers: String,
-    pub recipient: String,
-    pub mail: IdTuple,
+	pub _format: i64,
+	pub headers: String,
+	pub recipient: String,
+	pub mail: IdTuple,
 }
 
 impl Entity for ListUnsubscribeData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ListUnsubscribeData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ListUnsubscribeData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Mail {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub authStatus: Option<i64>,
-    pub confidential: bool,
-    pub differentEnvelopeSender: Option<String>,
-    pub encryptionAuthStatus: Option<i64>,
-    pub listUnsubscribe: bool,
-    pub method: i64,
-    pub movedTime: Option<DateTime>,
-    pub phishingStatus: i64,
-    pub receivedDate: DateTime,
-    pub recipientCount: i64,
-    pub replyType: i64,
-    pub state: i64,
-    pub subject: String,
-    pub unread: bool,
-    pub attachments: Vec<IdTuple>,
-    pub bucketKey: Option<sys::BucketKey>,
-    pub conversationEntry: IdTuple,
-    pub firstRecipient: Option<MailAddress>,
-    pub mailDetails: Option<IdTuple>,
-    pub mailDetailsDraft: Option<IdTuple>,
-    pub sender: MailAddress,
-    pub sets: Vec<IdTuple>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub authStatus: Option<i64>,
+	pub confidential: bool,
+	pub differentEnvelopeSender: Option<String>,
+	pub encryptionAuthStatus: Option<i64>,
+	pub listUnsubscribe: bool,
+	pub method: i64,
+	pub movedTime: Option<DateTime>,
+	pub phishingStatus: i64,
+	pub receivedDate: DateTime,
+	pub recipientCount: i64,
+	pub replyType: i64,
+	pub state: i64,
+	pub subject: String,
+	pub unread: bool,
+	pub attachments: Vec<IdTuple>,
+	pub bucketKey: Option<sys::BucketKey>,
+	pub conversationEntry: IdTuple,
+	pub firstRecipient: Option<MailAddress>,
+	pub mailDetails: Option<IdTuple>,
+	pub mailDetailsDraft: Option<IdTuple>,
+	pub sender: MailAddress,
+	pub sets: Vec<IdTuple>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Mail {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "Mail",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "Mail",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddress {
-    pub _id: CustomId,
-    pub address: String,
-    pub name: String,
-    pub contact: Option<IdTuple>,
+	pub _id: CustomId,
+	pub address: String,
+	pub name: String,
+	pub contact: Option<IdTuple>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailAddress {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailAddress",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailAddress",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailAddressProperties {
-    pub _id: CustomId,
-    pub mailAddress: String,
-    pub senderName: String,
+	pub _id: CustomId,
+	pub mailAddress: String,
+	pub senderName: String,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailAddressProperties {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailAddressProperties",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailAddressProperties",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailBag {
-    pub _id: CustomId,
-    pub mails: GeneratedId,
+	pub _id: CustomId,
+	pub mails: GeneratedId,
 }
 
 impl Entity for MailBag {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailBag",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailBag",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailBox {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub lastInfoDate: DateTime,
-    pub archivedMailBags: Vec<MailBag>,
-    pub currentMailBag: Option<MailBag>,
-    pub folders: Option<MailFolderRef>,
-    pub mailDetailsDrafts: Option<MailDetailsDraftsRef>,
-    pub receivedAttachments: GeneratedId,
-    pub sentAttachments: GeneratedId,
-    pub spamResults: Option<SpamResults>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub lastInfoDate: DateTime,
+	pub archivedMailBags: Vec<MailBag>,
+	pub currentMailBag: Option<MailBag>,
+	pub folders: Option<MailFolderRef>,
+	pub mailDetailsDrafts: Option<MailDetailsDraftsRef>,
+	pub receivedAttachments: GeneratedId,
+	pub sentAttachments: GeneratedId,
+	pub spamResults: Option<SpamResults>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailBox {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailBox",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailBox",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailDetails {
-    pub _id: CustomId,
-    pub authStatus: i64,
-    pub sentDate: DateTime,
-    pub body: Body,
-    pub headers: Option<Header>,
-    pub recipients: Recipients,
-    pub replyTos: Vec<EncryptedMailAddress>,
+	pub _id: CustomId,
+	pub authStatus: i64,
+	pub sentDate: DateTime,
+	pub body: Body,
+	pub headers: Option<Header>,
+	pub recipients: Recipients,
+	pub replyTos: Vec<EncryptedMailAddress>,
 }
 
 impl Entity for MailDetails {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailDetails",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailDetails",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailDetailsBlob {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub details: MailDetails,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub details: MailDetails,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailDetailsBlob {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailDetailsBlob",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailDetailsBlob",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailDetailsDraft {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub details: MailDetails,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub details: MailDetails,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailDetailsDraft {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailDetailsDraft",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailDetailsDraft",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailDetailsDraftsRef {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for MailDetailsDraftsRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailDetailsDraftsRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailDetailsDraftsRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailFolder {
-    pub _format: i64,
-    pub _id: IdTuple,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub folderType: i64,
-    pub isLabel: bool,
-    pub isMailSet: bool,
-    pub name: String,
-    pub entries: GeneratedId,
-    pub mails: GeneratedId,
-    pub parentFolder: Option<IdTuple>,
+	pub _format: i64,
+	pub _id: IdTuple,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub folderType: i64,
+	pub isLabel: bool,
+	pub isMailSet: bool,
+	pub name: String,
+	pub entries: GeneratedId,
+	pub mails: GeneratedId,
+	pub parentFolder: Option<IdTuple>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailFolder {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailFolder",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailFolder",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailFolderRef {
-    pub _id: CustomId,
-    pub folders: GeneratedId,
+	pub _id: CustomId,
+	pub folders: GeneratedId,
 }
 
 impl Entity for MailFolderRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailFolderRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailFolderRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailSetEntry {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub mail: IdTuple,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub mail: IdTuple,
 }
 
 impl Entity for MailSetEntry {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailSetEntry",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailSetEntry",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailboxGroupRoot {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub calendarEventUpdates: Option<CalendarEventUpdateList>,
-    pub mailbox: GeneratedId,
-    pub mailboxProperties: Option<GeneratedId>,
-    pub outOfOfficeNotification: Option<GeneratedId>,
-    pub outOfOfficeNotificationRecipientList: Option<OutOfOfficeNotificationRecipientList>,
-    pub serverProperties: GeneratedId,
-    pub whitelistRequests: GeneratedId,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub calendarEventUpdates: Option<CalendarEventUpdateList>,
+	pub mailbox: GeneratedId,
+	pub mailboxProperties: Option<GeneratedId>,
+	pub outOfOfficeNotification: Option<GeneratedId>,
+	pub outOfOfficeNotificationRecipientList: Option<OutOfOfficeNotificationRecipientList>,
+	pub serverProperties: GeneratedId,
+	pub whitelistRequests: GeneratedId,
 }
 
 impl Entity for MailboxGroupRoot {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailboxGroupRoot",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailboxGroupRoot",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailboxProperties {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub reportMovedMails: i64,
-    pub mailAddressProperties: Vec<MailAddressProperties>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub reportMovedMails: i64,
+	pub mailAddressProperties: Vec<MailAddressProperties>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailboxProperties {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailboxProperties",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailboxProperties",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MailboxServerProperties {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub whitelistProtectionEnabled: bool,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub whitelistProtectionEnabled: bool,
 }
 
 impl Entity for MailboxServerProperties {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MailboxServerProperties",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MailboxServerProperties",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct MoveMailData {
-    pub _format: i64,
-    pub mails: Vec<IdTuple>,
-    pub sourceFolder: Option<IdTuple>,
-    pub targetFolder: IdTuple,
+	pub _format: i64,
+	pub mails: Vec<IdTuple>,
+	pub sourceFolder: Option<IdTuple>,
+	pub targetFolder: IdTuple,
 }
 
 impl Entity for MoveMailData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "MoveMailData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "MoveMailData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NewDraftAttachment {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub encCid: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub encFileName: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub encMimeType: Vec<u8>,
-    pub referenceTokens: Vec<sys::BlobReferenceTokenWrapper>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub encCid: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub encFileName: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub encMimeType: Vec<u8>,
+	pub referenceTokens: Vec<sys::BlobReferenceTokenWrapper>,
 }
 
 impl Entity for NewDraftAttachment {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "NewDraftAttachment",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "NewDraftAttachment",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NewsId {
-    pub _id: CustomId,
-    pub newsItemId: GeneratedId,
-    pub newsItemName: String,
+	pub _id: CustomId,
+	pub newsItemId: GeneratedId,
+	pub newsItemName: String,
 }
 
 impl Entity for NewsId {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "NewsId",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "NewsId",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NewsIn {
-    pub _format: i64,
-    pub newsItemId: Option<GeneratedId>,
+	pub _format: i64,
+	pub newsItemId: Option<GeneratedId>,
 }
 
 impl Entity for NewsIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "NewsIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "NewsIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NewsOut {
-    pub _format: i64,
-    pub newsItemIds: Vec<NewsId>,
+	pub _format: i64,
+	pub newsItemIds: Vec<NewsId>,
 }
 
 impl Entity for NewsOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "NewsOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "NewsOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct NotificationMail {
-    pub _id: CustomId,
-    pub bodyText: String,
-    pub mailboxLink: String,
-    pub recipientMailAddress: String,
-    pub recipientName: String,
-    pub subject: String,
+	pub _id: CustomId,
+	pub bodyText: String,
+	pub mailboxLink: String,
+	pub recipientMailAddress: String,
+	pub recipientName: String,
+	pub subject: String,
 }
 
 impl Entity for NotificationMail {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "NotificationMail",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "NotificationMail",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct OutOfOfficeNotification {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub enabled: bool,
-    pub endDate: Option<DateTime>,
-    pub startDate: Option<DateTime>,
-    pub notifications: Vec<OutOfOfficeNotificationMessage>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub enabled: bool,
+	pub endDate: Option<DateTime>,
+	pub startDate: Option<DateTime>,
+	pub notifications: Vec<OutOfOfficeNotificationMessage>,
 }
 
 impl Entity for OutOfOfficeNotification {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "OutOfOfficeNotification",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "OutOfOfficeNotification",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct OutOfOfficeNotificationMessage {
-    pub _id: CustomId,
-    pub message: String,
-    pub subject: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
+	pub _id: CustomId,
+	pub message: String,
+	pub subject: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
 }
 
 impl Entity for OutOfOfficeNotificationMessage {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "OutOfOfficeNotificationMessage",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "OutOfOfficeNotificationMessage",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct OutOfOfficeNotificationRecipientList {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for OutOfOfficeNotificationRecipientList {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "OutOfOfficeNotificationRecipientList",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "OutOfOfficeNotificationRecipientList",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PhishingMarkerWebsocketData {
-    pub _format: i64,
-    pub lastId: GeneratedId,
-    pub markers: Vec<ReportedMailFieldMarker>,
+	pub _format: i64,
+	pub lastId: GeneratedId,
+	pub markers: Vec<ReportedMailFieldMarker>,
 }
 
 impl Entity for PhishingMarkerWebsocketData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "PhishingMarkerWebsocketData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "PhishingMarkerWebsocketData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct PhotosRef {
-    pub _id: CustomId,
-    pub files: GeneratedId,
+	pub _id: CustomId,
+	pub files: GeneratedId,
 }
 
 impl Entity for PhotosRef {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "PhotosRef",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "PhotosRef",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReceiveInfoServiceData {
-    pub _format: i64,
-    pub language: String,
+	pub _format: i64,
+	pub language: String,
 }
 
 impl Entity for ReceiveInfoServiceData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ReceiveInfoServiceData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ReceiveInfoServiceData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Recipients {
-    pub _id: CustomId,
-    pub bccRecipients: Vec<MailAddress>,
-    pub ccRecipients: Vec<MailAddress>,
-    pub toRecipients: Vec<MailAddress>,
+	pub _id: CustomId,
+	pub bccRecipients: Vec<MailAddress>,
+	pub ccRecipients: Vec<MailAddress>,
+	pub toRecipients: Vec<MailAddress>,
 }
 
 impl Entity for Recipients {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "Recipients",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "Recipients",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct RemoteImapSyncInfo {
-    pub _format: i64,
-    pub _id: IdTuple,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _permissions: GeneratedId,
-    pub seen: bool,
-    pub message: IdTuple,
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub seen: bool,
+	pub message: IdTuple,
 }
 
 impl Entity for RemoteImapSyncInfo {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "RemoteImapSyncInfo",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "RemoteImapSyncInfo",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReportMailPostData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub mailSessionKey: Vec<u8>,
-    pub reportType: i64,
-    pub mailId: IdTuple,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub mailSessionKey: Vec<u8>,
+	pub reportType: i64,
+	pub mailId: IdTuple,
 }
 
 impl Entity for ReportMailPostData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ReportMailPostData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ReportMailPostData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct ReportedMailFieldMarker {
-    pub _id: CustomId,
-    pub marker: String,
-    pub status: i64,
+	pub _id: CustomId,
+	pub marker: String,
+	pub status: i64,
 }
 
 impl Entity for ReportedMailFieldMarker {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "ReportedMailFieldMarker",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "ReportedMailFieldMarker",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SecureExternalRecipientKeyData {
-    pub _id: CustomId,
-    pub kdfVersion: i64,
-    pub mailAddress: String,
-    #[serde(with = "serde_bytes")]
-    pub ownerEncBucketKey: Vec<u8>,
-    pub ownerKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub passwordVerifier: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub pwEncCommunicationKey: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub salt: Option<Vec<u8>>,
-    #[serde(with = "serde_bytes")]
-    pub saltHash: Option<Vec<u8>>,
-    pub userGroupKeyVersion: i64,
+	pub _id: CustomId,
+	pub kdfVersion: i64,
+	pub mailAddress: String,
+	#[serde(with = "serde_bytes")]
+	pub ownerEncBucketKey: Vec<u8>,
+	pub ownerKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub passwordVerifier: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub pwEncCommunicationKey: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub salt: Option<Vec<u8>>,
+	#[serde(with = "serde_bytes")]
+	pub saltHash: Option<Vec<u8>>,
+	pub userGroupKeyVersion: i64,
 }
 
 impl Entity for SecureExternalRecipientKeyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "SecureExternalRecipientKeyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "SecureExternalRecipientKeyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SendDraftData {
-    pub _format: i64,
-    #[serde(with = "serde_bytes")]
-    pub bucketEncMailSessionKey: Option<Vec<u8>>,
-    pub calendarMethod: bool,
-    pub language: String,
-    #[serde(with = "serde_bytes")]
-    pub mailSessionKey: Option<Vec<u8>>,
-    pub plaintext: bool,
-    pub senderNameUnencrypted: Option<String>,
-    #[serde(with = "serde_bytes")]
-    pub sessionEncEncryptionAuthStatus: Option<Vec<u8>>,
-    pub attachmentKeyData: Vec<AttachmentKeyData>,
-    pub internalRecipientKeyData: Vec<InternalRecipientKeyData>,
-    pub mail: IdTuple,
-    pub secureExternalRecipientKeyData: Vec<SecureExternalRecipientKeyData>,
-    pub symEncInternalRecipientKeyData: Vec<SymEncInternalRecipientKeyData>,
+	pub _format: i64,
+	#[serde(with = "serde_bytes")]
+	pub bucketEncMailSessionKey: Option<Vec<u8>>,
+	pub calendarMethod: bool,
+	pub language: String,
+	#[serde(with = "serde_bytes")]
+	pub mailSessionKey: Option<Vec<u8>>,
+	pub plaintext: bool,
+	pub senderNameUnencrypted: Option<String>,
+	#[serde(with = "serde_bytes")]
+	pub sessionEncEncryptionAuthStatus: Option<Vec<u8>>,
+	pub attachmentKeyData: Vec<AttachmentKeyData>,
+	pub internalRecipientKeyData: Vec<InternalRecipientKeyData>,
+	pub mail: IdTuple,
+	pub secureExternalRecipientKeyData: Vec<SecureExternalRecipientKeyData>,
+	pub symEncInternalRecipientKeyData: Vec<SymEncInternalRecipientKeyData>,
 }
 
 impl Entity for SendDraftData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "SendDraftData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "SendDraftData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SendDraftReturn {
-    pub _format: i64,
-    pub messageId: String,
-    pub sentDate: DateTime,
-    pub notifications: Vec<NotificationMail>,
-    pub sentMail: IdTuple,
+	pub _format: i64,
+	pub messageId: String,
+	pub sentDate: DateTime,
+	pub notifications: Vec<NotificationMail>,
+	pub sentMail: IdTuple,
 }
 
 impl Entity for SendDraftReturn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "SendDraftReturn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "SendDraftReturn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SharedGroupData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub bucketEncInvitationSessionKey: Vec<u8>,
-    pub capability: i64,
-    #[serde(with = "serde_bytes")]
-    pub sessionEncInviterName: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub sessionEncSharedGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub sessionEncSharedGroupName: Vec<u8>,
-    pub sharedGroup: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub sharedGroupEncInviterGroupInfoKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub sharedGroupEncSharedGroupInfoKey: Vec<u8>,
-    pub sharedGroupKeyVersion: i64,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub bucketEncInvitationSessionKey: Vec<u8>,
+	pub capability: i64,
+	#[serde(with = "serde_bytes")]
+	pub sessionEncInviterName: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub sessionEncSharedGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub sessionEncSharedGroupName: Vec<u8>,
+	pub sharedGroup: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub sharedGroupEncInviterGroupInfoKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub sharedGroupEncSharedGroupInfoKey: Vec<u8>,
+	pub sharedGroupKeyVersion: i64,
 }
 
 impl Entity for SharedGroupData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "SharedGroupData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "SharedGroupData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SpamResults {
-    pub _id: CustomId,
-    pub list: GeneratedId,
+	pub _id: CustomId,
+	pub list: GeneratedId,
 }
 
 impl Entity for SpamResults {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "SpamResults",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "SpamResults",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct Subfiles {
-    pub _id: CustomId,
-    pub files: GeneratedId,
+	pub _id: CustomId,
+	pub files: GeneratedId,
 }
 
 impl Entity for Subfiles {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "Subfiles",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "Subfiles",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct SymEncInternalRecipientKeyData {
-    pub _id: CustomId,
-    pub mailAddress: String,
-    #[serde(with = "serde_bytes")]
-    pub symEncBucketKey: Vec<u8>,
-    pub symKeyVersion: i64,
-    pub keyGroup: GeneratedId,
+	pub _id: CustomId,
+	pub mailAddress: String,
+	#[serde(with = "serde_bytes")]
+	pub symEncBucketKey: Vec<u8>,
+	pub symKeyVersion: i64,
+	pub keyGroup: GeneratedId,
 }
 
 impl Entity for SymEncInternalRecipientKeyData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "SymEncInternalRecipientKeyData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "SymEncInternalRecipientKeyData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct TemplateGroupRoot {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub knowledgeBase: GeneratedId,
-    pub templates: GeneratedId,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub knowledgeBase: GeneratedId,
+	pub templates: GeneratedId,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TemplateGroupRoot {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "TemplateGroupRoot",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "TemplateGroupRoot",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct TranslationGetIn {
-    pub _format: i64,
-    pub lang: String,
+	pub _format: i64,
+	pub lang: String,
 }
 
 impl Entity for TranslationGetIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "TranslationGetIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "TranslationGetIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct TranslationGetOut {
-    pub _format: i64,
-    pub giftCardSubject: String,
-    pub invitationSubject: String,
+	pub _format: i64,
+	pub giftCardSubject: String,
+	pub invitationSubject: String,
 }
 
 impl Entity for TranslationGetOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "TranslationGetOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "TranslationGetOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct TutanotaProperties {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub customEmailSignature: String,
-    pub defaultSender: Option<String>,
-    pub defaultUnconfidential: bool,
-    pub emailSignatureType: i64,
-    pub lastSeenAnnouncement: i64,
-    pub noAutomaticContacts: bool,
-    pub notificationMailLanguage: Option<String>,
-    pub sendPlaintextOnly: bool,
-    #[serde(with = "serde_bytes")]
-    pub userEncEntropy: Option<Vec<u8>>,
-    pub userKeyVersion: Option<i64>,
-    pub imapSyncConfig: Vec<ImapSyncConfiguration>,
-    pub inboxRules: Vec<InboxRule>,
-    pub lastPushedMail: Option<IdTuple>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub customEmailSignature: String,
+	pub defaultSender: Option<String>,
+	pub defaultUnconfidential: bool,
+	pub emailSignatureType: i64,
+	pub lastSeenAnnouncement: i64,
+	pub noAutomaticContacts: bool,
+	pub notificationMailLanguage: Option<String>,
+	pub sendPlaintextOnly: bool,
+	#[serde(with = "serde_bytes")]
+	pub userEncEntropy: Option<Vec<u8>>,
+	pub userKeyVersion: Option<i64>,
+	pub imapSyncConfig: Vec<ImapSyncConfiguration>,
+	pub inboxRules: Vec<InboxRule>,
+	pub lastPushedMail: Option<IdTuple>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TutanotaProperties {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "TutanotaProperties",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "TutanotaProperties",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UpdateMailFolderData {
-    pub _format: i64,
-    pub folder: IdTuple,
-    pub newParent: Option<IdTuple>,
+	pub _format: i64,
+	pub folder: IdTuple,
+	pub newParent: Option<IdTuple>,
 }
 
 impl Entity for UpdateMailFolderData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "UpdateMailFolderData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "UpdateMailFolderData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAccountCreateData {
-    pub _format: i64,
-    pub date: Option<DateTime>,
-    pub userData: UserAccountUserData,
-    pub userGroupData: InternalGroupData,
+	pub _format: i64,
+	pub date: Option<DateTime>,
+	pub userData: UserAccountUserData,
+	pub userGroupData: InternalGroupData,
 }
 
 impl Entity for UserAccountCreateData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "UserAccountCreateData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "UserAccountCreateData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAccountUserData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub contactEncContactListSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub customerEncContactGroupInfoSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub customerEncFileGroupInfoSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub customerEncMailGroupInfoSessionKey: Vec<u8>,
-    pub customerKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub encryptedName: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub fileEncFileSystemSessionKey: Vec<u8>,
-    pub kdfVersion: i64,
-    pub mailAddress: String,
-    #[serde(with = "serde_bytes")]
-    pub mailEncMailBoxSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub pwEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub recoverCodeEncUserGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub recoverCodeVerifier: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub salt: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncContactGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncCustomerGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncEntropy: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncFileGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncMailGroupKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncRecoverCode: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncTutanotaPropertiesSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub verifier: Vec<u8>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub contactEncContactListSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub customerEncContactGroupInfoSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub customerEncFileGroupInfoSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub customerEncMailGroupInfoSessionKey: Vec<u8>,
+	pub customerKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub encryptedName: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub fileEncFileSystemSessionKey: Vec<u8>,
+	pub kdfVersion: i64,
+	pub mailAddress: String,
+	#[serde(with = "serde_bytes")]
+	pub mailEncMailBoxSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub pwEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub recoverCodeEncUserGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub recoverCodeVerifier: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub salt: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncContactGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncCustomerGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncEntropy: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncFileGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncMailGroupKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncRecoverCode: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncTutanotaPropertiesSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub verifier: Vec<u8>,
 }
 
 impl Entity for UserAccountUserData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "UserAccountUserData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "UserAccountUserData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAreaGroupData {
-    pub _id: CustomId,
-    #[serde(with = "serde_bytes")]
-    pub adminEncGroupKey: Option<Vec<u8>>,
-    pub adminKeyVersion: Option<i64>,
-    #[serde(with = "serde_bytes")]
-    pub customerEncGroupInfoSessionKey: Vec<u8>,
-    pub customerKeyVersion: i64,
-    #[serde(with = "serde_bytes")]
-    pub groupEncGroupRootSessionKey: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub groupInfoEncName: Vec<u8>,
-    #[serde(with = "serde_bytes")]
-    pub userEncGroupKey: Vec<u8>,
-    pub userKeyVersion: i64,
-    pub adminGroup: Option<GeneratedId>,
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub adminEncGroupKey: Option<Vec<u8>>,
+	pub adminKeyVersion: Option<i64>,
+	#[serde(with = "serde_bytes")]
+	pub customerEncGroupInfoSessionKey: Vec<u8>,
+	pub customerKeyVersion: i64,
+	#[serde(with = "serde_bytes")]
+	pub groupEncGroupRootSessionKey: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub groupInfoEncName: Vec<u8>,
+	#[serde(with = "serde_bytes")]
+	pub userEncGroupKey: Vec<u8>,
+	pub userKeyVersion: i64,
+	pub adminGroup: Option<GeneratedId>,
 }
 
 impl Entity for UserAreaGroupData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "UserAreaGroupData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "UserAreaGroupData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAreaGroupDeleteData {
-    pub _format: i64,
-    pub group: GeneratedId,
+	pub _format: i64,
+	pub group: GeneratedId,
 }
 
 impl Entity for UserAreaGroupDeleteData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "UserAreaGroupDeleteData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "UserAreaGroupDeleteData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserAreaGroupPostData {
-    pub _format: i64,
-    pub groupData: UserAreaGroupData,
+	pub _format: i64,
+	pub groupData: UserAreaGroupData,
 }
 
 impl Entity for UserAreaGroupPostData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "UserAreaGroupPostData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "UserAreaGroupPostData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UserSettingsGroupRoot {
-    pub _format: i64,
-    pub _id: GeneratedId,
-    #[serde(with = "serde_bytes")]
-    pub _ownerEncSessionKey: Option<Vec<u8>>,
-    pub _ownerGroup: Option<GeneratedId>,
-    pub _ownerKeyVersion: Option<i64>,
-    pub _permissions: GeneratedId,
-    pub startOfTheWeek: i64,
-    pub timeFormat: i64,
-    pub usageDataOptedIn: Option<bool>,
-    pub groupSettings: Vec<GroupSettings>,
+	pub _format: i64,
+	pub _id: GeneratedId,
+	#[serde(with = "serde_bytes")]
+	pub _ownerEncSessionKey: Option<Vec<u8>>,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _ownerKeyVersion: Option<i64>,
+	pub _permissions: GeneratedId,
+	pub startOfTheWeek: i64,
+	pub timeFormat: i64,
+	pub usageDataOptedIn: Option<bool>,
+	pub groupSettings: Vec<GroupSettings>,
 	pub _errors: Option<Errors>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for UserSettingsGroupRoot {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "tutanota",
-            type_: "UserSettingsGroupRoot",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "tutanota",
+			type_: "UserSettingsGroupRoot",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/usage.rs
+++ b/tuta-sdk/rust/sdk/src/entities/usage.rs
@@ -1,146 +1,139 @@
 #![allow(non_snake_case, unused_imports)]
 use super::*;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestAssignment {
-    pub _id: CustomId,
-    pub name: String,
-    pub sendPings: bool,
-    pub testId: GeneratedId,
-    pub variant: Option<i64>,
-    pub stages: Vec<UsageTestStage>,
+	pub _id: CustomId,
+	pub name: String,
+	pub sendPings: bool,
+	pub testId: GeneratedId,
+	pub variant: Option<i64>,
+	pub stages: Vec<UsageTestStage>,
 }
 
 impl Entity for UsageTestAssignment {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestAssignment",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestAssignment",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestAssignmentIn {
-    pub _format: i64,
-    pub testDeviceId: Option<GeneratedId>,
+	pub _format: i64,
+	pub testDeviceId: Option<GeneratedId>,
 }
 
 impl Entity for UsageTestAssignmentIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestAssignmentIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestAssignmentIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestAssignmentOut {
-    pub _format: i64,
-    pub testDeviceId: GeneratedId,
-    pub assignments: Vec<UsageTestAssignment>,
+	pub _format: i64,
+	pub testDeviceId: GeneratedId,
+	pub assignments: Vec<UsageTestAssignment>,
 }
 
 impl Entity for UsageTestAssignmentOut {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestAssignmentOut",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestAssignmentOut",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestMetricConfig {
-    pub _id: CustomId,
-    pub name: String,
-    #[serde(rename = "type")]
-    pub r#type: i64,
-    pub configValues: Vec<UsageTestMetricConfigValue>,
+	pub _id: CustomId,
+	pub name: String,
+	#[serde(rename = "type")]
+	pub r#type: i64,
+	pub configValues: Vec<UsageTestMetricConfigValue>,
 }
 
 impl Entity for UsageTestMetricConfig {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestMetricConfig",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestMetricConfig",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestMetricConfigValue {
-    pub _id: CustomId,
-    pub key: String,
-    pub value: String,
+	pub _id: CustomId,
+	pub key: String,
+	pub value: String,
 }
 
 impl Entity for UsageTestMetricConfigValue {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestMetricConfigValue",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestMetricConfigValue",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestMetricData {
-    pub _id: CustomId,
-    pub name: String,
-    pub value: String,
+	pub _id: CustomId,
+	pub name: String,
+	pub value: String,
 }
 
 impl Entity for UsageTestMetricData {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestMetricData",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestMetricData",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestParticipationIn {
-    pub _format: i64,
-    pub stage: i64,
-    pub testDeviceId: GeneratedId,
-    pub testId: GeneratedId,
-    pub metrics: Vec<UsageTestMetricData>,
+	pub _format: i64,
+	pub stage: i64,
+	pub testDeviceId: GeneratedId,
+	pub testId: GeneratedId,
+	pub metrics: Vec<UsageTestMetricData>,
 }
 
 impl Entity for UsageTestParticipationIn {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestParticipationIn",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestParticipationIn",
+		}
+	}
 }
-
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize, Debug)]
 pub struct UsageTestStage {
-    pub _id: CustomId,
-    pub maxPings: i64,
-    pub minPings: i64,
-    pub name: String,
-    pub metrics: Vec<UsageTestMetricConfig>,
+	pub _id: CustomId,
+	pub maxPings: i64,
+	pub minPings: i64,
+	pub name: String,
+	pub metrics: Vec<UsageTestMetricConfig>,
 }
 
 impl Entity for UsageTestStage {
-    fn type_ref() -> TypeRef {
-        TypeRef {
-            app: "usage",
-            type_: "UsageTestStage",
-         }
-    }
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "usage",
+			type_: "UsageTestStage",
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/entity_client.rs
@@ -3,206 +3,233 @@ use std::sync::Arc;
 
 use crate::element_value::{ElementValue, ParsedEntity};
 use crate::generated_id::GeneratedId;
-use crate::{ApiCallError, AuthHeadersProvider, IdTuple, ListLoadDirection, SdkState, TypeRef};
-use crate::json_serializer::JsonSerializer;
 use crate::json_element::RawEntity;
+use crate::json_serializer::JsonSerializer;
 use crate::metamodel::TypeModel;
 use crate::rest_client::{HttpMethod, RestClient, RestClientOptions};
 use crate::rest_error::HttpError;
 use crate::type_model_provider::TypeModelProvider;
-
+use crate::{ApiCallError, AuthHeadersProvider, IdTuple, ListLoadDirection, SdkState, TypeRef};
 
 /// Denotes an ID that can be serialised into a string and used to access resources
 pub trait IdType: Display + 'static {}
 
 /// A high level interface to manipulate unencrypted entities/instances via the REST API
 pub struct EntityClient {
-    rest_client: Arc<dyn RestClient>,
-    base_url: String,
-    sdk_state: Arc<SdkState>,
-    json_serializer: Arc<JsonSerializer>,
-    type_model_provider: Arc<TypeModelProvider>,
+	rest_client: Arc<dyn RestClient>,
+	base_url: String,
+	sdk_state: Arc<SdkState>,
+	json_serializer: Arc<JsonSerializer>,
+	type_model_provider: Arc<TypeModelProvider>,
 }
 
 impl EntityClient {
-    #[allow(dead_code)]
-    pub(crate) fn new(
-        rest_client: Arc<dyn RestClient>,
-        json_serializer: Arc<JsonSerializer>,
-        base_url: &str,
-        sdk_state: Arc<SdkState>,
-        type_model_provider: Arc<TypeModelProvider>,
-    ) -> Self {
-        EntityClient {
-            rest_client,
-            json_serializer,
-            base_url: base_url.to_owned(),
-            sdk_state,
-            type_model_provider,
-        }
-    }
+	#[allow(dead_code)]
+	pub(crate) fn new(
+		rest_client: Arc<dyn RestClient>,
+		json_serializer: Arc<JsonSerializer>,
+		base_url: &str,
+		sdk_state: Arc<SdkState>,
+		type_model_provider: Arc<TypeModelProvider>,
+	) -> Self {
+		EntityClient {
+			rest_client,
+			json_serializer,
+			base_url: base_url.to_owned(),
+			sdk_state,
+			type_model_provider,
+		}
+	}
 
-    /// Gets an entity/instance of type `type_ref` from the backend
-    pub async fn load<Id: IdType>(
-        &self,
-        type_ref: &TypeRef,
-        id: &Id,
-    ) -> Result<ParsedEntity, ApiCallError> {
-        let type_model = self.get_type_model(type_ref)?;
-        let url = format!("{}/rest/{}/{}/{}", self.base_url, type_ref.app, type_ref.type_, id);
-        let model_version: u32 = type_model.version.parse().map_err(|_| {
-            let message = format!("Tried to parse invalid model_version {}", type_model.version);
-            ApiCallError::InternalSdkError { error_message: message }
-        })?;
-        let options = RestClientOptions {
-            body: None,
-            headers: self.sdk_state.create_auth_headers(model_version),
-        };
-        let response = self
-            .rest_client
-            .request_binary(url, HttpMethod::GET, options)
-            .await?;
-        let precondition = response.headers.get("precondition");
-        match response.status {
-            200..=299 => {
-                // Ok
-            }
-            _ => return Err(ApiCallError::ServerResponseError { source: HttpError::from_http_response(response.status, precondition)? })
-        }
-        let response_bytes = response.body.expect("no body");
-        let response_entity = serde_json::from_slice::<RawEntity>(response_bytes.as_slice()).unwrap();
-        let parsed_entity = self.json_serializer.parse(type_ref, response_entity)?;
-        Ok(parsed_entity)
-    }
+	/// Gets an entity/instance of type `type_ref` from the backend
+	pub async fn load<Id: IdType>(
+		&self,
+		type_ref: &TypeRef,
+		id: &Id,
+	) -> Result<ParsedEntity, ApiCallError> {
+		let type_model = self.get_type_model(type_ref)?;
+		let url = format!(
+			"{}/rest/{}/{}/{}",
+			self.base_url, type_ref.app, type_ref.type_, id
+		);
+		let model_version: u32 = type_model.version.parse().map_err(|_| {
+			let message = format!(
+				"Tried to parse invalid model_version {}",
+				type_model.version
+			);
+			ApiCallError::InternalSdkError {
+				error_message: message,
+			}
+		})?;
+		let options = RestClientOptions {
+			body: None,
+			headers: self.sdk_state.create_auth_headers(model_version),
+		};
+		let response = self
+			.rest_client
+			.request_binary(url, HttpMethod::GET, options)
+			.await?;
+		let precondition = response.headers.get("precondition");
+		match response.status {
+			200..=299 => {
+				// Ok
+			},
+			_ => {
+				return Err(ApiCallError::ServerResponseError {
+					source: HttpError::from_http_response(response.status, precondition)?,
+				})
+			},
+		}
+		let response_bytes = response.body.expect("no body");
+		let response_entity =
+			serde_json::from_slice::<RawEntity>(response_bytes.as_slice()).unwrap();
+		let parsed_entity = self.json_serializer.parse(type_ref, response_entity)?;
+		Ok(parsed_entity)
+	}
 
-    /// Returns the definition of an entity/instance type using the internal `TypeModelProvider`
-    pub fn get_type_model(&self, type_ref: &TypeRef) -> Result<&TypeModel, ApiCallError> {
-        self.type_model_provider.get_type_model(type_ref.app, type_ref.type_)
-            .ok_or_else(|| {
-                let message = format!("Model {} not found in app {}", type_ref.type_, type_ref.app);
-                ApiCallError::InternalSdkError { error_message: message }
-            })
-    }
+	/// Returns the definition of an entity/instance type using the internal `TypeModelProvider`
+	pub fn get_type_model(&self, type_ref: &TypeRef) -> Result<&TypeModel, ApiCallError> {
+		self.type_model_provider
+			.get_type_model(type_ref.app, type_ref.type_)
+			.ok_or_else(|| {
+				let message = format!("Model {} not found in app {}", type_ref.type_, type_ref.app);
+				ApiCallError::InternalSdkError {
+					error_message: message,
+				}
+			})
+	}
 
-    /// Fetches and returns all entities/instances in a list element type
-    #[allow(clippy::unused_async)]
-    pub async fn load_all(
-        &self,
-        _type_ref: &TypeRef,
-        _list_id: &IdTuple,
-        _start: Option<String>,
-    ) -> Result<Vec<ParsedEntity>, ApiCallError> {
-        todo!("entity client load_all")
-    }
+	/// Fetches and returns all entities/instances in a list element type
+	#[allow(clippy::unused_async)]
+	pub async fn load_all(
+		&self,
+		_type_ref: &TypeRef,
+		_list_id: &IdTuple,
+		_start: Option<String>,
+	) -> Result<Vec<ParsedEntity>, ApiCallError> {
+		todo!("entity client load_all")
+	}
 
-    /// Fetches and returns a specified number (`count`) of entities/instances
-    /// in a list element type starting at the index `start_id`
-    #[allow(clippy::unused_async)]
-    pub async fn load_range(
-        &self,
-        _type_ref: &TypeRef,
-        _list_id: &GeneratedId,
-        _start_id: &GeneratedId,
-        _count: usize,
-        _list_load_direction: ListLoadDirection,
-    ) -> Result<Vec<ParsedEntity>, ApiCallError> {
-        todo!("entity client load_range")
-    }
+	/// Fetches and returns a specified number (`count`) of entities/instances
+	/// in a list element type starting at the index `start_id`
+	#[allow(clippy::unused_async)]
+	pub async fn load_range(
+		&self,
+		_type_ref: &TypeRef,
+		_list_id: &GeneratedId,
+		_start_id: &GeneratedId,
+		_count: usize,
+		_list_load_direction: ListLoadDirection,
+	) -> Result<Vec<ParsedEntity>, ApiCallError> {
+		todo!("entity client load_range")
+	}
 
-    /// Stores a newly created entity/instance as a single element on the backend
-    #[allow(clippy::unused_async)]
-    pub async fn setup_element(&self, _type_ref: &TypeRef, _entity: RawEntity) -> Vec<String> {
-        todo!("entity client setup_element")
-    }
+	/// Stores a newly created entity/instance as a single element on the backend
+	#[allow(clippy::unused_async)]
+	pub async fn setup_element(&self, _type_ref: &TypeRef, _entity: RawEntity) -> Vec<String> {
+		todo!("entity client setup_element")
+	}
 
-    /// Stores a newly created entity/instance as a part of a list element on the backend
-    #[allow(clippy::unused_async)]
-    pub async fn setup_list_element(
-        &self,
-        _type_ref: &TypeRef,
-        _list_id: &IdTuple,
-        _entity: RawEntity,
-    ) -> Vec<String> {
-        todo!("entity client setup_list_element")
-    }
+	/// Stores a newly created entity/instance as a part of a list element on the backend
+	#[allow(clippy::unused_async)]
+	pub async fn setup_list_element(
+		&self,
+		_type_ref: &TypeRef,
+		_list_id: &IdTuple,
+		_entity: RawEntity,
+	) -> Vec<String> {
+		todo!("entity client setup_list_element")
+	}
 
-    /// Updates an entity/instance in the backend
-    pub async fn update(&self, type_ref: &TypeRef, entity: ParsedEntity,
-                        model_version: u32) -> Result<(), ApiCallError> {
-        let id = match &entity.get("_id").unwrap() {
-            ElementValue::IdTupleId(ref id_tuple) => id_tuple.to_string(),
-            _ => panic!("id is not string or array"),
-        };
-        let raw_entity = self.json_serializer.serialize(type_ref, entity)?;
-        let body = serde_json::to_vec(&raw_entity).unwrap();
-        let options = RestClientOptions {
-            body: Some(body),
-            headers: self.sdk_state.create_auth_headers(model_version),
-        };
-        // FIXME we should look at type model whether it is ET or LET
-        let url = format!(
-            "{}/rest/{}/{}/{}",
-            self.base_url, type_ref.app, type_ref.type_, id
-        );
-        self.rest_client
-            .request_binary(url, HttpMethod::PUT, options)
-            .await?;
-        Ok(())
-    }
+	/// Updates an entity/instance in the backend
+	pub async fn update(
+		&self,
+		type_ref: &TypeRef,
+		entity: ParsedEntity,
+		model_version: u32,
+	) -> Result<(), ApiCallError> {
+		let id = match &entity.get("_id").unwrap() {
+			ElementValue::IdTupleId(ref id_tuple) => id_tuple.to_string(),
+			_ => panic!("id is not string or array"),
+		};
+		let raw_entity = self.json_serializer.serialize(type_ref, entity)?;
+		let body = serde_json::to_vec(&raw_entity).unwrap();
+		let options = RestClientOptions {
+			body: Some(body),
+			headers: self.sdk_state.create_auth_headers(model_version),
+		};
+		// FIXME we should look at type model whether it is ET or LET
+		let url = format!(
+			"{}/rest/{}/{}/{}",
+			self.base_url, type_ref.app, type_ref.type_, id
+		);
+		self.rest_client
+			.request_binary(url, HttpMethod::PUT, options)
+			.await?;
+		Ok(())
+	}
 
-    /// Deletes an existing single entity/instance on the backend
-    #[allow(clippy::unused_async)]
-    pub async fn erase_element(&self, _type_ref: &TypeRef, _id: &GeneratedId) -> Result<(), ApiCallError> {
-        todo!("entity client erase_element")
-    }
+	/// Deletes an existing single entity/instance on the backend
+	#[allow(clippy::unused_async)]
+	pub async fn erase_element(
+		&self,
+		_type_ref: &TypeRef,
+		_id: &GeneratedId,
+	) -> Result<(), ApiCallError> {
+		todo!("entity client erase_element")
+	}
 
-    /// Deletes an existing entity/instance of a list element type on the backend
-    #[allow(clippy::unused_async)]
-    pub async fn erase_list_element(&self, _type_ref: &TypeRef, _id: IdTuple) -> Result<(), ApiCallError> {
-        todo!("entity client erase_list_element")
-    }
+	/// Deletes an existing entity/instance of a list element type on the backend
+	#[allow(clippy::unused_async)]
+	pub async fn erase_list_element(
+		&self,
+		_type_ref: &TypeRef,
+		_id: IdTuple,
+	) -> Result<(), ApiCallError> {
+		todo!("entity client erase_list_element")
+	}
 }
 
 #[cfg(test)]
 mockall::mock! {
-    pub EntityClient {
-        pub fn new(
-            rest_client: Arc<dyn RestClient>,
-            json_serializer: Arc<JsonSerializer>,
-            base_url: &str,
-            sdk_state: Arc<SdkState>,
-            type_model_provider: Arc<TypeModelProvider>,
-        ) -> Self;
-        pub fn get_type_model(&self, type_ref: &TypeRef) -> Result<&'static TypeModel, ApiCallError>;
-        pub async fn load<Id: IdType>(
-            &self,
-            type_ref: &TypeRef,
-            id: &Id,
-         ) -> Result<ParsedEntity, ApiCallError>;
-        async fn load_all(
-            &self,
-            type_ref: &TypeRef,
-            list_id: &IdTuple,
-            start: Option<String>,
-        ) -> Result<Vec<ParsedEntity>, ApiCallError>;
-        async fn load_range(
-            &self,
-            type_ref: &TypeRef,
-            list_id: &GeneratedId,
-            start_id: &GeneratedId,
-            count: usize,
-            list_load_direction: ListLoadDirection,
-        ) -> Result<Vec<ParsedEntity>, ApiCallError>;
-        async fn setup_element(&self, type_ref: &TypeRef, entity: RawEntity) -> Vec<String>;
-        async fn setup_list_element(
-            &self,
-            type_ref: &TypeRef,
-            list_id: &IdTuple,
-            entity: RawEntity,
-        ) -> Vec<String>;
-        async fn update(&self, type_ref: &TypeRef, entity: ParsedEntity, model_version: u32)
-                        -> Result<(), ApiCallError>;
-        async fn erase_element(&self, type_ref: &TypeRef, id: &GeneratedId) -> Result<(), ApiCallError>;
-        async fn erase_list_element(&self, type_ref: &TypeRef, id: IdTuple) -> Result<(), ApiCallError>;
-    }
+	pub EntityClient {
+		pub fn new(
+			rest_client: Arc<dyn RestClient>,
+			json_serializer: Arc<JsonSerializer>,
+			base_url: &str,
+			sdk_state: Arc<SdkState>,
+			type_model_provider: Arc<TypeModelProvider>,
+		) -> Self;
+		pub fn get_type_model(&self, type_ref: &TypeRef) -> Result<&'static TypeModel, ApiCallError>;
+		pub async fn load<Id: IdType>(
+			&self,
+			type_ref: &TypeRef,
+			id: &Id,
+		 ) -> Result<ParsedEntity, ApiCallError>;
+		async fn load_all(
+			&self,
+			type_ref: &TypeRef,
+			list_id: &IdTuple,
+			start: Option<String>,
+		) -> Result<Vec<ParsedEntity>, ApiCallError>;
+		async fn load_range(
+			&self,
+			type_ref: &TypeRef,
+			list_id: &GeneratedId,
+			start_id: &GeneratedId,
+			count: usize,
+			list_load_direction: ListLoadDirection,
+		) -> Result<Vec<ParsedEntity>, ApiCallError>;
+		async fn setup_element(&self, type_ref: &TypeRef, entity: RawEntity) -> Vec<String>;
+		async fn setup_list_element(
+			&self,
+			type_ref: &TypeRef,
+			list_id: &IdTuple,
+			entity: RawEntity,
+		) -> Vec<String>;
+		async fn update(&self, type_ref: &TypeRef, entity: ParsedEntity, model_version: u32)
+						-> Result<(), ApiCallError>;
+		async fn erase_element(&self, type_ref: &TypeRef, id: &GeneratedId) -> Result<(), ApiCallError>;
+		async fn erase_list_element(&self, type_ref: &TypeRef, id: IdTuple) -> Result<(), ApiCallError>;
+	}
 }

--- a/tuta-sdk/rust/sdk/src/generated_id.rs
+++ b/tuta-sdk/rust/sdk/src/generated_id.rs
@@ -1,7 +1,7 @@
-use std::fmt::{Debug, Display, Formatter};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde::de::{Error, Visitor};
 use crate::entity_client::IdType;
+use serde::de::{Error, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::{Debug, Display, Formatter};
 
 pub const GENERATED_ID_BYTES_LENGTH: usize = 9;
 
@@ -11,37 +11,37 @@ pub const GENERATED_ID_BYTES_LENGTH: usize = 9;
 pub struct GeneratedId(pub String);
 
 impl GeneratedId {
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
+	#[must_use]
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
 
-    /// Generates and returns a random `CustomId`
-    #[cfg(test)]
-    #[must_use]
-    pub fn test_random() -> Self {
-        use crate::util::test_utils::generate_random_string;
-        // not the actual alphabet we use in real generated IDs, but we aren't dealing with parsing generated IDs yet, so it's fine
-        Self(generate_random_string::<9>())
-    }
+	/// Generates and returns a random `CustomId`
+	#[cfg(test)]
+	#[must_use]
+	pub fn test_random() -> Self {
+		use crate::util::test_utils::generate_random_string;
+		// not the actual alphabet we use in real generated IDs, but we aren't dealing with parsing generated IDs yet, so it's fine
+		Self(generate_random_string::<9>())
+	}
 }
 
 impl From<GeneratedId> for String {
-    fn from(value: GeneratedId) -> Self {
-        value.0
-    }
+	fn from(value: GeneratedId) -> Self {
+		value.0
+	}
 }
 
 impl Display for GeneratedId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
 }
 
 impl Debug for GeneratedId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Generated ID: \"{self}\"")
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "Generated ID: \"{self}\"")
+	}
 }
 
 impl IdType for GeneratedId {}
@@ -49,32 +49,43 @@ impl IdType for GeneratedId {}
 uniffi::custom_newtype!(GeneratedId, String);
 
 impl Serialize for GeneratedId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
-        serializer.serialize_newtype_struct("GeneratedId", &self.0)
-    }
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		serializer.serialize_newtype_struct("GeneratedId", &self.0)
+	}
 }
 
 impl<'de> Deserialize<'de> for GeneratedId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-        deserializer.deserialize_string(IdVisitor)
-    }
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_string(IdVisitor)
+	}
 }
 
 struct IdVisitor;
 
 impl Visitor<'_> for IdVisitor {
-    type Value = GeneratedId;
+	type Value = GeneratedId;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("a string")
-    }
+	fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+		formatter.write_str("a string")
+	}
 
-    fn visit_string<E>(self, s: String) -> Result<Self::Value, E> where E: Error {
-        Ok(GeneratedId(s))
-    }
+	fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(GeneratedId(s))
+	}
 
-    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E> where E: Error {
-        Ok(GeneratedId(s.to_owned()))
-    }
+	fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(GeneratedId(s.to_owned()))
+	}
 }
-

--- a/tuta-sdk/rust/sdk/src/instance_mapper.rs
+++ b/tuta-sdk/rust/sdk/src/instance_mapper.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
-use serde::{de, Deserialize, Deserializer, ser, Serialize, Serializer};
-use serde::de::{DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, Unexpected, VariantAccess, Visitor};
+use serde::de::{
+	DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, Unexpected, VariantAccess, Visitor,
+};
 use serde::ser::{Impossible, SerializeMap, SerializeSeq, SerializeStruct};
+use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
 use crate::custom_id::CustomId;
@@ -17,26 +19,26 @@ use crate::IdTuple;
 pub struct InstanceMapper {}
 
 impl InstanceMapper {
-    pub fn new() -> Self {
-        InstanceMapper {}
-    }
-    pub fn parse_entity<'a, T: Entity + Deserialize<'a>>(
-        &self,
-        map: ParsedEntity,
-    ) -> Result<T, DeError> {
-        let de = DictionaryDeserializer::from_iterable(map);
-        T::deserialize(de)
-    }
+	pub fn new() -> Self {
+		InstanceMapper {}
+	}
+	pub fn parse_entity<'a, T: Entity + Deserialize<'a>>(
+		&self,
+		map: ParsedEntity,
+	) -> Result<T, DeError> {
+		let de = DictionaryDeserializer::from_iterable(map);
+		T::deserialize(de)
+	}
 
-    #[allow(unused)] // TODO: Remove this when implementing mutations for entities
-    pub fn serialize_entity<T: Entity + Serialize>(
-        &self,
-        entity: T,
-    ) -> Result<ParsedEntity, SerError> {
-        entity
-            .serialize(ElementValueSerializer)
-            .map(|v| v.assert_dict())
-    }
+	#[allow(unused)] // TODO: Remove this when implementing mutations for entities
+	pub fn serialize_entity<T: Entity + Serialize>(
+		&self,
+		entity: T,
+	) -> Result<ParsedEntity, SerError> {
+		entity
+			.serialize(ElementValueSerializer)
+			.map(|v| v.assert_dict())
+	}
 }
 
 #[derive(Error, Debug)]
@@ -44,12 +46,12 @@ impl InstanceMapper {
 pub struct SerError(String);
 
 impl ser::Error for SerError {
-    fn custom<T>(msg: T) -> Self
-    where
-        T: Display,
-    {
-        SerError(msg.to_string())
-    }
+	fn custom<T>(msg: T) -> Self
+	where
+		T: Display,
+	{
+		SerError(msg.to_string())
+	}
 }
 
 #[derive(Error, Debug)]
@@ -57,21 +59,21 @@ impl ser::Error for SerError {
 pub struct DeError(String);
 
 impl DeError {
-    fn wrong_type(key: &str, value: &ElementValue, expected: &str) -> Self {
-        Self(format!(
-            "Invalid type at {key}: Expected: {expected}, got: {}",
-            value.as_unexpected()
-        ))
-    }
+	fn wrong_type(key: &str, value: &ElementValue, expected: &str) -> Self {
+		Self(format!(
+			"Invalid type at {key}: Expected: {expected}, got: {}",
+			value.as_unexpected()
+		))
+	}
 }
 
 impl de::Error for DeError {
-    fn custom<T>(msg: T) -> Self
-    where
-        T: Display,
-    {
-        Self(msg.to_string())
-    }
+	fn custom<T>(msg: T) -> Self
+	where
+		T: Display,
+	{
+		Self(msg.to_string())
+	}
 }
 
 /// (De)Serialization consist of two parts:
@@ -89,441 +91,444 @@ impl de::Error for DeError {
 /// nested aggregates and for "errors" map.
 struct DictionaryDeserializer<I>
 where
-    I: Iterator<Item = (String, ElementValue)>,
+	I: Iterator<Item = (String, ElementValue)>,
 {
-    iter: I,
-    value: Option<(String, ElementValue)>,
+	iter: I,
+	value: Option<(String, ElementValue)>,
 }
 
 impl<I> DictionaryDeserializer<I>
 where
-    I: Iterator<Item = (String, ElementValue)>,
+	I: Iterator<Item = (String, ElementValue)>,
 {
-    // We accept iterable and not a map because we have to give iterator a specific type but we
-    // need to let the compiler infer it from the signature.
-    fn from_iterable<II>(iterable: II) -> DictionaryDeserializer<I>
-    where
-        II: IntoIterator<Item = (String, ElementValue), IntoIter = I>,
-    {
-        DictionaryDeserializer {
-            iter: iterable.into_iter(),
-            value: None,
-        }
-    }
+	// We accept iterable and not a map because we have to give iterator a specific type but we
+	// need to let the compiler infer it from the signature.
+	fn from_iterable<II>(iterable: II) -> DictionaryDeserializer<I>
+	where
+		II: IntoIterator<Item = (String, ElementValue), IntoIter = I>,
+	{
+		DictionaryDeserializer {
+			iter: iterable.into_iter(),
+			value: None,
+		}
+	}
 }
 
 impl<'de, I> Deserializer<'de> for DictionaryDeserializer<I>
 where
-    I: Iterator<Item = (String, ElementValue)>,
+	I: Iterator<Item = (String, ElementValue)>,
 {
-    type Error = DeError;
+	type Error = DeError;
 
-    serde::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
-        byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map enum identifier ignored_any
-    }
+	serde::forward_to_deserialize_any! {
+		bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
+		byte_buf option unit unit_struct newtype_struct seq tuple
+		tuple_struct map enum identifier ignored_any
+	}
 
-    fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        Err(de::Error::custom("deserialize_any is not supported!"))
-    }
+	fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		Err(de::Error::custom("deserialize_any is not supported!"))
+	}
 
-    fn deserialize_struct<V>(
-        self,
-        _: &'static str,
-        _: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_map(self)
-    }
+	fn deserialize_struct<V>(
+		self,
+		_: &'static str,
+		_: &'static [&'static str],
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		visitor.visit_map(self)
+	}
 }
 
 impl<'de, I> MapAccess<'de> for DictionaryDeserializer<I>
 where
-    I: Iterator<Item = (String, ElementValue)>,
+	I: Iterator<Item = (String, ElementValue)>,
 {
-    type Error = DeError;
+	type Error = DeError;
 
-    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-    where
-        K: DeserializeSeed<'de>,
-    {
-        match self.iter.next() {
-            Some((k, v)) => {
-                let result = seed.deserialize(k.as_str().into_deserializer());
-                self.value = Some((k, v));
-                result.map(Some)
-            }
-            None => Ok(None),
-        }
-    }
+	fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+	where
+		K: DeserializeSeed<'de>,
+	{
+		match self.iter.next() {
+			Some((k, v)) => {
+				let result = seed.deserialize(k.as_str().into_deserializer());
+				self.value = Some((k, v));
+				result.map(Some)
+			},
+			None => Ok(None),
+		}
+	}
 
-    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-    where
-        V: DeserializeSeed<'de>,
-    {
-        let (key, value) = self.value.take().expect("next_key must be called first!");
-        let deserializer = ElementValueDeserializer {
-            key: key.as_str(),
-            value,
-        };
-        seed.deserialize(deserializer)
-    }
+	fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+	where
+		V: DeserializeSeed<'de>,
+	{
+		let (key, value) = self.value.take().expect("next_key must be called first!");
+		let deserializer = ElementValueDeserializer {
+			key: key.as_str(),
+			value,
+		};
+		seed.deserialize(deserializer)
+	}
 
-    fn next_entry_seed<K, V>(
-        &mut self,
-        kseed: K,
-        vseed: V,
-    ) -> Result<Option<(K::Value, V::Value)>, Self::Error>
-    where
-        K: DeserializeSeed<'de>,
-        V: DeserializeSeed<'de>,
-    {
-        match self.iter.next() {
-            Some((key, value)) => {
-                let key_result = kseed.deserialize(key.as_str().into_deserializer())?;
-                let value_result = vseed.deserialize(ElementValueDeserializer {
-                    key: key.as_str(),
-                    value,
-                })?;
-                Ok(Some((key_result, value_result)))
-            }
-            None => Ok(None),
-        }
-    }
+	fn next_entry_seed<K, V>(
+		&mut self,
+		kseed: K,
+		vseed: V,
+	) -> Result<Option<(K::Value, V::Value)>, Self::Error>
+	where
+		K: DeserializeSeed<'de>,
+		V: DeserializeSeed<'de>,
+	{
+		match self.iter.next() {
+			Some((key, value)) => {
+				let key_result = kseed.deserialize(key.as_str().into_deserializer())?;
+				let value_result = vseed.deserialize(ElementValueDeserializer {
+					key: key.as_str(),
+					value,
+				})?;
+				Ok(Some((key_result, value_result)))
+			},
+			None => Ok(None),
+		}
+	}
 
-    fn size_hint(&self) -> Option<usize> {
-        // taken from serde::de::size_hint
-        match self.iter.size_hint() {
-            (lower, Some(upper)) if lower == upper => Some(upper),
-            _ => None,
-        }
-    }
+	fn size_hint(&self) -> Option<usize> {
+		// taken from serde::de::size_hint
+		match self.iter.size_hint() {
+			(lower, Some(upper)) if lower == upper => Some(upper),
+			_ => None,
+		}
+	}
 }
 
 /// Deserializer for a single ElementValue.
 struct ElementValueDeserializer<'s> {
-    /// Key for which we are deserializing the value. Useful for diagnostics.
-    key: &'s str,
-    /// The value being deserialized
-    value: ElementValue,
+	/// Key for which we are deserializing the value. Useful for diagnostics.
+	key: &'s str,
+	/// The value being deserialized
+	value: ElementValue,
 }
 
 impl<'s> ElementValueDeserializer<'s> {
-    fn wrong_type_err(&self, expected: &str) -> DeError {
-        DeError::wrong_type(self.key, &self.value, expected)
-    }
+	fn wrong_type_err(&self, expected: &str) -> DeError {
+		DeError::wrong_type(self.key, &self.value, expected)
+	}
 }
 
 impl<'de, 's> Deserializer<'de> for ElementValueDeserializer<'s> {
-    type Error = DeError;
+	type Error = DeError;
 
-    serde::forward_to_deserialize_any! {
-    i8 i16 i32 u8 u16 u32 f32 f64 char str bytes
-            unit unit_struct newtype_struct tuple
-            tuple_struct ignored_any
-        }
+	serde::forward_to_deserialize_any! {
+	i8 i16 i32 u8 u16 u32 f32 f64 char str bytes
+			unit unit_struct newtype_struct tuple
+			tuple_struct ignored_any
+		}
 
-    fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        let type_name = self.value.type_variant_name();
-        Err(de::Error::custom(format_args!("deserialize_any is not supported! key: `{}`, value type: `{type_name}`", self.key)))
-    }
+	fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		let type_name = self.value.type_variant_name();
+		Err(de::Error::custom(format_args!(
+			"deserialize_any is not supported! key: `{}`, value type: `{type_name}`",
+			self.key
+		)))
+	}
 
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if let ElementValue::Date(date) = self.value {
-            visitor.visit_u64(date.as_millis())
-        } else {
-            Err(self.wrong_type_err("u64"))
-        }
-    }
+	fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		if let ElementValue::Date(date) = self.value {
+			visitor.visit_u64(date.as_millis())
+		} else {
+			Err(self.wrong_type_err("u64"))
+		}
+	}
 
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if let ElementValue::Bool(bool) = self.value {
-            visitor.visit_bool(bool)
-        } else {
-            Err(self.wrong_type_err("bool"))
-        }
-    }
+	fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		if let ElementValue::Bool(bool) = self.value {
+			visitor.visit_bool(bool)
+		} else {
+			Err(self.wrong_type_err("bool"))
+		}
+	}
 
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if let ElementValue::Number(num) = self.value {
-            visitor.visit_i64(num)
-        } else {
-            Err(self.wrong_type_err("i64"))
-        }
-    }
+	fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		if let ElementValue::Number(num) = self.value {
+			visitor.visit_i64(num)
+		} else {
+			Err(self.wrong_type_err("i64"))
+		}
+	}
 
-    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        return match self.value {
-            ElementValue::String(str) => visitor.visit_string(str),
-            ElementValue::IdGeneratedId(GeneratedId(id))
-            | ElementValue::IdCustomId(CustomId(id)) => visitor.visit_string(id),
-            _ => Err(self.wrong_type_err("string")),
-        };
-    }
+	fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		return match self.value {
+			ElementValue::String(str) => visitor.visit_string(str),
+			ElementValue::IdGeneratedId(GeneratedId(id))
+			| ElementValue::IdCustomId(CustomId(id)) => visitor.visit_string(id),
+			_ => Err(self.wrong_type_err("string")),
+		};
+	}
 
-    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if let ElementValue::Bytes(bytes) = self.value {
-            visitor.visit_byte_buf(bytes)
-        } else {
-            Err(self.wrong_type_err("bytes"))
-        }
-    }
+	fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		if let ElementValue::Bytes(bytes) = self.value {
+			visitor.visit_byte_buf(bytes)
+		} else {
+			Err(self.wrong_type_err("bytes"))
+		}
+	}
 
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        match self.value {
-            ElementValue::Null => visitor.visit_none(),
-            // We have the same value but the visitor who is driving us will proceed to inner type
-            _ => visitor.visit_some(self),
-        }
-    }
+	fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		match self.value {
+			ElementValue::Null => visitor.visit_none(),
+			// We have the same value but the visitor who is driving us will proceed to inner type
+			_ => visitor.visit_some(self),
+		}
+	}
 
-    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if let ElementValue::Array(arr) = self.value {
-            visitor.visit_seq(ArrayDeserializer {
-                key: self.key,
-                iter: arr.into_iter(),
-            })
-        } else {
-            Err(self.wrong_type_err("sequence"))
-        }
-    }
+	fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		if let ElementValue::Array(arr) = self.value {
+			visitor.visit_seq(ArrayDeserializer {
+				key: self.key,
+				iter: arr.into_iter(),
+			})
+		} else {
+			Err(self.wrong_type_err("sequence"))
+		}
+	}
 
-    fn deserialize_struct<V>(
-        self,
-        name: &'static str,
-        fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if name == "IdTuple" {
-            struct IdTupleMapAccess<I: Iterator<Item = (&'static str, GeneratedId)>> {
-                iter: I,
-                value: Option<GeneratedId>,
-            }
+	fn deserialize_struct<V>(
+		self,
+		name: &'static str,
+		fields: &'static [&'static str],
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		if name == "IdTuple" {
+			struct IdTupleMapAccess<I: Iterator<Item = (&'static str, GeneratedId)>> {
+				iter: I,
+				value: Option<GeneratedId>,
+			}
 
-            impl<'a, I> MapAccess<'a> for IdTupleMapAccess<I>
-            where
-                I: Iterator<Item = (&'static str, GeneratedId)>,
-            {
-                type Error = DeError;
+			impl<'a, I> MapAccess<'a> for IdTupleMapAccess<I>
+			where
+				I: Iterator<Item = (&'static str, GeneratedId)>,
+			{
+				type Error = DeError;
 
-                fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
-                where
-                    K: DeserializeSeed<'a>,
-                {
-                    match self.iter.next() {
-                        Some((key, value)) => {
-                            self.value.replace(value);
-                            seed.deserialize(key.into_deserializer()).map(Some)
-                        }
-                        None => Ok(None),
-                    }
-                }
+				fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+				where
+					K: DeserializeSeed<'a>,
+				{
+					match self.iter.next() {
+						Some((key, value)) => {
+							self.value.replace(value);
+							seed.deserialize(key.into_deserializer()).map(Some)
+						},
+						None => Ok(None),
+					}
+				}
 
-                fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
-                where
-                    V: DeserializeSeed<'a>,
-                {
-                    match self.value.take() {
-                        None => unreachable!(),
-                        Some(v) => seed.deserialize(String::from(v).into_deserializer()),
-                    }
-                }
-            }
-            return if let ElementValue::IdTupleId(IdTuple {
-                list_id,
-                element_id,
-            }) = self.value
-            {
-                visitor.visit_map(IdTupleMapAccess {
-                    iter: [("list_id", list_id), ("element_id", element_id)].into_iter(),
-                    value: None,
-                })
-            } else {
-                Err(self.wrong_type_err("IdTuple"))
-            };
-        }
-        if let ElementValue::Dict(dict) = self.value {
-            let deserializer = DictionaryDeserializer::from_iterable(dict);
-            deserializer.deserialize_struct(name, fields, visitor)
-        } else {
-            Err(self.wrong_type_err("dict"))
-        }
-    }
+				fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+				where
+					V: DeserializeSeed<'a>,
+				{
+					match self.value.take() {
+						None => unreachable!(),
+						Some(v) => seed.deserialize(String::from(v).into_deserializer()),
+					}
+				}
+			}
+			return if let ElementValue::IdTupleId(IdTuple {
+				list_id,
+				element_id,
+			}) = self.value
+			{
+				visitor.visit_map(IdTupleMapAccess {
+					iter: [("list_id", list_id), ("element_id", element_id)].into_iter(),
+					value: None,
+				})
+			} else {
+				Err(self.wrong_type_err("IdTuple"))
+			};
+		}
+		if let ElementValue::Dict(dict) = self.value {
+			let deserializer = DictionaryDeserializer::from_iterable(dict);
+			deserializer.deserialize_struct(name, fields, visitor)
+		} else {
+			Err(self.wrong_type_err("dict"))
+		}
+	}
 
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        if let ElementValue::Dict(dict) = self.value {
-            let de = DictionaryDeserializer::from_iterable(dict);
-            visitor.visit_map(de)
-        } else {
-            Err(self.wrong_type_err("dict"))
-        }
-    }
+	fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		if let ElementValue::Dict(dict) = self.value {
+			let de = DictionaryDeserializer::from_iterable(dict);
+			visitor.visit_map(de)
+		} else {
+			Err(self.wrong_type_err("dict"))
+		}
+	}
 
-    fn deserialize_enum<V>(
-        self,
-        _: &'static str,
-        _: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_enum(self)
-    }
+	fn deserialize_enum<V>(
+		self,
+		_: &'static str,
+		_: &'static [&'static str],
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		visitor.visit_enum(self)
+	}
 
-    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_str(self.value.type_variant_name())
-    }
+	fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		visitor.visit_str(self.value.type_variant_name())
+	}
 }
 
 impl<'de, 's> EnumAccess<'de> for ElementValueDeserializer<'s> {
-    type Error = DeError;
-    type Variant = Self;
+	type Error = DeError;
+	type Variant = Self;
 
-    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
-    where
-        V: DeserializeSeed<'de>
-    {
-        let discriminator_de = self.value.type_variant_name().into_deserializer();
-        let val = seed.deserialize(discriminator_de)?;
-        Ok((val, self))
-    }
+	fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+	where
+		V: DeserializeSeed<'de>,
+	{
+		let discriminator_de = self.value.type_variant_name().into_deserializer();
+		let val = seed.deserialize(discriminator_de)?;
+		Ok((val, self))
+	}
 }
 
 impl<'de, 's> VariantAccess<'de> for ElementValueDeserializer<'s> {
-    type Error = DeError;
+	type Error = DeError;
 
-    fn unit_variant(self) -> Result<(), Self::Error> {
-        unimplemented!()
-    }
+	fn unit_variant(self) -> Result<(), Self::Error> {
+		unimplemented!()
+	}
 
-    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
-    where
-        T: DeserializeSeed<'de>
-    {
-        seed.deserialize(self)
-    }
+	fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+	where
+		T: DeserializeSeed<'de>,
+	{
+		seed.deserialize(self)
+	}
 
-    fn tuple_variant<V>(self, _: usize, _: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>
-    {
-        unimplemented!()
-    }
+	fn tuple_variant<V>(self, _: usize, _: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		unimplemented!()
+	}
 
-    fn struct_variant<V>(self, _: &'static [&'static str], _: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>
-    {
-        unimplemented!()
-    }
+	fn struct_variant<V>(self, _: &'static [&'static str], _: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		unimplemented!()
+	}
 }
 
 /// Deserializer for sequence of elements (like an array or vec).
 struct ArrayDeserializer<'s, I>
 where
-    I: Iterator<Item = ElementValue>,
+	I: Iterator<Item = ElementValue>,
 {
-    /// Key under which the entities are. Will be passed to the deserializer for elements.
-    key: &'s str,
-    iter: I,
+	/// Key under which the entities are. Will be passed to the deserializer for elements.
+	key: &'s str,
+	iter: I,
 }
 
 impl<'de, I> Deserializer<'de> for ArrayDeserializer<'de, I>
 where
-    I: Iterator<Item = ElementValue>,
+	I: Iterator<Item = ElementValue>,
 {
-    type Error = DeError;
+	type Error = DeError;
 
-    serde::forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
-        byte_buf option unit unit_struct newtype_struct tuple
-        tuple_struct map struct enum identifier ignored_any
-    }
+	serde::forward_to_deserialize_any! {
+		bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
+		byte_buf option unit unit_struct newtype_struct tuple
+		tuple_struct map struct enum identifier ignored_any
+	}
 
-    fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        unimplemented!("not an array")
-    }
+	fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		unimplemented!("not an array")
+	}
 
-    fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
-    where
-        V: Visitor<'de>,
-    {
-        visitor.visit_seq(&mut self)
-    }
+	fn deserialize_seq<V>(mut self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: Visitor<'de>,
+	{
+		visitor.visit_seq(&mut self)
+	}
 }
 
 impl<'de, 's, I> de::SeqAccess<'de> for ArrayDeserializer<'s, I>
 where
-    I: Iterator<Item = ElementValue>,
+	I: Iterator<Item = ElementValue>,
 {
-    type Error = DeError;
+	type Error = DeError;
 
-    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
-    where
-        T: DeserializeSeed<'de>,
-    {
-        match self.iter.next() {
-            Some(value) => seed
-                .deserialize(ElementValueDeserializer {
-                    value,
-                    key: self.key,
-                })
-                .map(Some),
-            None => Ok(None),
-        }
-    }
+	fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+	where
+		T: DeserializeSeed<'de>,
+	{
+		match self.iter.next() {
+			Some(value) => seed
+				.deserialize(ElementValueDeserializer {
+					value,
+					key: self.key,
+				})
+				.map(Some),
+			None => Ok(None),
+		}
+	}
 
-    fn size_hint(&self) -> Option<usize> {
-        // taken from serde::de::size_hint
-        match self.iter.size_hint() {
-            (lower, Some(upper)) if lower == upper => Some(upper),
-            _ => None,
-        }
-    }
+	fn size_hint(&self) -> Option<usize> {
+		// taken from serde::de::size_hint
+		match self.iter.size_hint() {
+			(lower, Some(upper)) if lower == upper => Some(upper),
+			_ => None,
+		}
+	}
 }
 
 /// Serialize Entity into ElementValue variant.
@@ -531,708 +536,759 @@ where
 struct ElementValueSerializer;
 
 enum ElementValueStructSerializer {
-    Struct {
-        map: HashMap<String, ElementValue>,
-    },
-    IdTuple {
-        list_id: Option<GeneratedId>,
-        element_id: Option<GeneratedId>,
-    },
+	Struct {
+		map: HashMap<String, ElementValue>,
+	},
+	IdTuple {
+		list_id: Option<GeneratedId>,
+		element_id: Option<GeneratedId>,
+	},
 }
 
 struct ElementValueSeqSerializer {
-    vec: Vec<ElementValue>,
+	vec: Vec<ElementValue>,
 }
 
 impl Serializer for ElementValueSerializer {
-    type Ok = ElementValue;
-    type Error = SerError;
-    type SerializeSeq = ElementValueSeqSerializer;
-    type SerializeTuple = ser::Impossible<ElementValue, SerError>;
-    type SerializeTupleStruct = ser::Impossible<ElementValue, SerError>;
-    type SerializeTupleVariant = ser::Impossible<ElementValue, SerError>;
-    type SerializeMap = ElementValueMapSerializer;
-    type SerializeStruct = ElementValueStructSerializer;
-    type SerializeStructVariant = ser::Impossible<ElementValue, SerError>;
+	type Ok = ElementValue;
+	type Error = SerError;
+	type SerializeSeq = ElementValueSeqSerializer;
+	type SerializeTuple = ser::Impossible<ElementValue, SerError>;
+	type SerializeTupleStruct = ser::Impossible<ElementValue, SerError>;
+	type SerializeTupleVariant = ser::Impossible<ElementValue, SerError>;
+	type SerializeMap = ElementValueMapSerializer;
+	type SerializeStruct = ElementValueStructSerializer;
+	type SerializeStructVariant = ser::Impossible<ElementValue, SerError>;
 
-    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Bool(v))
-    }
+	fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Bool(v))
+	}
 
-    fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
-        unsupported("i8")
-    }
+	fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+		unsupported("i8")
+	}
 
-    fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
-        unsupported("i16")
-    }
+	fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+		unsupported("i16")
+	}
 
-    fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
-        unsupported("i32")
-    }
+	fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+		unsupported("i32")
+	}
 
-    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Number(v))
-    }
+	fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Number(v))
+	}
 
-    fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
-        unsupported("u8")
-    }
+	fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+		unsupported("u8")
+	}
 
-    fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
-        unsupported("u16")
-    }
+	fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+		unsupported("u16")
+	}
 
-    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Number(v as i64))
-    }
+	fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Number(v as i64))
+	}
 
-    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Number(v as i64))
-    }
+	fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Number(v as i64))
+	}
 
-    fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
-        unsupported("f32")
-    }
+	fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+		unsupported("f32")
+	}
 
-    fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
-        unsupported("f64")
-    }
+	fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+		unsupported("f64")
+	}
 
-    fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
-        unsupported("char")
-    }
+	fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+		unsupported("char")
+	}
 
-    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::String(v.to_string()))
-    }
+	fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::String(v.to_string()))
+	}
 
-    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Bytes(v.into()))
-    }
+	fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Bytes(v.into()))
+	}
 
-    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Null)
-    }
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Null)
+	}
 
-    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        value.serialize(self)
-    }
+	fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		value.serialize(self)
+	}
 
-    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        unsupported("unit")
-    }
+	fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+		unsupported("unit")
+	}
 
-    fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
-        unsupported("unit_struct")
-    }
+	fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+		unsupported("unit_struct")
+	}
 
-    fn serialize_unit_variant(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-    ) -> Result<Self::Ok, Self::Error> {
-        unsupported("serialize_unit_variant")
-    }
+	fn serialize_unit_variant(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+	) -> Result<Self::Ok, Self::Error> {
+		unsupported("serialize_unit_variant")
+	}
 
-    fn serialize_newtype_struct<T>(
-        self,
-        name: &'static str,
-        value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        match name {
-            "GeneratedId" => {
-                let Ok(ElementValue::String(id_string)) = value.serialize(self) else {
-                    unreachable!();
-                };
-                Ok(ElementValue::IdGeneratedId(GeneratedId(id_string)))
-            }
-            "CustomId" => {
-                let Ok(ElementValue::String(id_string)) = value.serialize(self) else {
-                    unreachable!();
-                };
-                Ok(ElementValue::IdCustomId(CustomId(id_string)))
-            }
-            "Date" => {
-                let Ok(ElementValue::Number(timestamp)) = value.serialize(self) else {
-                    unreachable!();
-                };
-                Ok(ElementValue::Date(DateTime::from_millis(timestamp as u64)))
-            }
-            other => unsupported(other),
-        }
-    }
+	fn serialize_newtype_struct<T>(
+		self,
+		name: &'static str,
+		value: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match name {
+			"GeneratedId" => {
+				let Ok(ElementValue::String(id_string)) = value.serialize(self) else {
+					unreachable!();
+				};
+				Ok(ElementValue::IdGeneratedId(GeneratedId(id_string)))
+			},
+			"CustomId" => {
+				let Ok(ElementValue::String(id_string)) = value.serialize(self) else {
+					unreachable!();
+				};
+				Ok(ElementValue::IdCustomId(CustomId(id_string)))
+			},
+			"Date" => {
+				let Ok(ElementValue::Number(timestamp)) = value.serialize(self) else {
+					unreachable!();
+				};
+				Ok(ElementValue::Date(DateTime::from_millis(timestamp as u64)))
+			},
+			other => unsupported(other),
+		}
+	}
 
-    fn serialize_newtype_variant<T>(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        unsupported("newtype_variant")
-    }
+	fn serialize_newtype_variant<T>(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+		_: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		unsupported("newtype_variant")
+	}
 
-    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        let vec = match len {
-            None => Vec::new(),
-            Some(l) => Vec::with_capacity(l),
-        };
-        Ok(ElementValueSeqSerializer { vec })
-    }
+	fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+		let vec = match len {
+			None => Vec::new(),
+			Some(l) => Vec::with_capacity(l),
+		};
+		Ok(ElementValueSeqSerializer { vec })
+	}
 
-    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        unsupported("len")
-    }
+	fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		unsupported("len")
+	}
 
-    fn serialize_tuple_struct(
-        self,
-        _: &'static str,
-        _: usize,
-    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        unsupported("tuple_struct")
-    }
+	fn serialize_tuple_struct(
+		self,
+		_: &'static str,
+		_: usize,
+	) -> Result<Self::SerializeTupleStruct, Self::Error> {
+		unsupported("tuple_struct")
+	}
 
-    fn serialize_tuple_variant(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: usize,
-    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        unsupported("tuple_variant")
-    }
+	fn serialize_tuple_variant(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+		_: usize,
+	) -> Result<Self::SerializeTupleVariant, Self::Error> {
+		unsupported("tuple_variant")
+	}
 
-    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Ok(ElementValueMapSerializer { map: HashMap::new(), next_key: None })
-    }
+	fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+		Ok(ElementValueMapSerializer {
+			map: HashMap::new(),
+			next_key: None,
+		})
+	}
 
-    fn serialize_struct(
-        self,
-        name: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeStruct, Self::Error> {
-        if name == "IdTuple" {
-            Ok(ElementValueStructSerializer::IdTuple {
-                list_id: None,
-                element_id: None,
-            })
-        } else {
-            Ok(ElementValueStructSerializer::Struct {
-                map: HashMap::with_capacity(len),
-            })
-        }
-    }
+	fn serialize_struct(
+		self,
+		name: &'static str,
+		len: usize,
+	) -> Result<Self::SerializeStruct, Self::Error> {
+		if name == "IdTuple" {
+			Ok(ElementValueStructSerializer::IdTuple {
+				list_id: None,
+				element_id: None,
+			})
+		} else {
+			Ok(ElementValueStructSerializer::Struct {
+				map: HashMap::with_capacity(len),
+			})
+		}
+	}
 
-    fn serialize_struct_variant(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: usize,
-    ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        unsupported("struct_variant")
-    }
+	fn serialize_struct_variant(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+		_: usize,
+	) -> Result<Self::SerializeStructVariant, Self::Error> {
+		unsupported("struct_variant")
+	}
 }
 
 fn unsupported(data_type: &str) -> ! {
-    panic!("Unsupported data type: {}", data_type)
+	panic!("Unsupported data type: {}", data_type)
 }
 
 impl SerializeSeq for ElementValueSeqSerializer {
-    type Ok = ElementValue;
-    type Error = SerError;
+	type Ok = ElementValue;
+	type Error = SerError;
 
-    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        self.vec.push(value.serialize(ElementValueSerializer)?);
-        Ok(())
-    }
+	fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.vec.push(value.serialize(ElementValueSerializer)?);
+		Ok(())
+	}
 
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Array(self.vec))
-    }
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Array(self.vec))
+	}
 }
 
 impl SerializeStruct for ElementValueStructSerializer {
-    type Ok = ElementValue;
-    type Error = SerError;
+	type Ok = ElementValue;
+	type Error = SerError;
 
-    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
-    where
-        T: ?Sized + Serialize,
-    {
-        match self {
-            Self::Struct { map } => {
-                if key == "_errors" {
-                    // Throw decryption errors away since they are not part of the actual type.
-                    return Ok(());
-                }
-                map.insert(key.to_string(), value.serialize(ElementValueSerializer)?);
-            }
-            Self::IdTuple {
-                list_id,
-                element_id,
-            } => match key {
-                "list_id" => {
-                    *list_id = Some(
-                        value
-                            .serialize(ElementValueSerializer)?
-                            .assert_generated_id()
-                            .to_owned(),
-                    )
-                }
-                "element_id" => {
-                    *element_id = Some(
-                        value
-                            .serialize(ElementValueSerializer)?
-                            .assert_generated_id()
-                            .to_owned(),
-                    )
-                }
-                _ => unreachable!("unexpected key {key} for IdTuple", key = key),
-            },
-        };
-        Ok(())
-    }
+	fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		match self {
+			Self::Struct { map } => {
+				if key == "_errors" {
+					// Throw decryption errors away since they are not part of the actual type.
+					return Ok(());
+				}
+				map.insert(key.to_string(), value.serialize(ElementValueSerializer)?);
+			},
+			Self::IdTuple {
+				list_id,
+				element_id,
+			} => match key {
+				"list_id" => {
+					*list_id = Some(
+						value
+							.serialize(ElementValueSerializer)?
+							.assert_generated_id()
+							.to_owned(),
+					)
+				},
+				"element_id" => {
+					*element_id = Some(
+						value
+							.serialize(ElementValueSerializer)?
+							.assert_generated_id()
+							.to_owned(),
+					)
+				},
+				_ => unreachable!("unexpected key {key} for IdTuple", key = key),
+			},
+		};
+		Ok(())
+	}
 
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        match self {
-            Self::Struct { map } => Ok(ElementValue::Dict(map)),
-            Self::IdTuple {
-                list_id,
-                element_id,
-            } => Ok(ElementValue::IdTupleId(IdTuple {
-                list_id: list_id.unwrap(),
-                element_id: element_id.unwrap(),
-            })),
-        }
-    }
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		match self {
+			Self::Struct { map } => Ok(ElementValue::Dict(map)),
+			Self::IdTuple {
+				list_id,
+				element_id,
+			} => Ok(ElementValue::IdTupleId(IdTuple {
+				list_id: list_id.unwrap(),
+				element_id: element_id.unwrap(),
+			})),
+		}
+	}
 }
 
 /// Yet Another Serializer, this one serializes a map with dynamic keys.
 struct ElementValueMapSerializer {
-    next_key: Option<String>,
-    map: HashMap<String, ElementValue>,
+	next_key: Option<String>,
+	map: HashMap<String, ElementValue>,
 }
 
 impl SerializeMap for ElementValueMapSerializer {
-    type Ok = ElementValue;
-    type Error = SerError;
+	type Ok = ElementValue;
+	type Error = SerError;
 
-    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
-    where
-        T: ?Sized + Serialize
-    {
-        self.next_key = Some(key.serialize(MapKeySerializer)?);
-        Ok(())
-    }
+	fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		self.next_key = Some(key.serialize(MapKeySerializer)?);
+		Ok(())
+	}
 
-    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: ?Sized + Serialize
-    {
-        let key = self.next_key.take().expect("key must be serialized first");
-        self.map.insert(key, value.serialize(ElementValueSerializer)?);
-        Ok(())
-    }
+	fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		let key = self.next_key.take().expect("key must be serialized first");
+		self.map
+			.insert(key, value.serialize(ElementValueSerializer)?);
+		Ok(())
+	}
 
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        Ok(ElementValue::Dict(self.map))
-    }
+	fn end(self) -> Result<Self::Ok, Self::Error> {
+		Ok(ElementValue::Dict(self.map))
+	}
 }
 
 impl ElementValue {
-    fn as_unexpected(&self) -> Unexpected {
-        match self {
-            ElementValue::Null => Unexpected::Other("null"),
-            ElementValue::String(v) => Unexpected::Str(v),
-            ElementValue::Number(v) => Unexpected::Signed(*v),
-            ElementValue::Bytes(v) => Unexpected::Bytes(v.as_slice()),
-            ElementValue::Date(_) => Unexpected::Other("Date"),
-            ElementValue::Bool(v) => Unexpected::Bool(*v),
-            ElementValue::IdGeneratedId(_) => Unexpected::Other("GeneratedId"),
-            ElementValue::IdCustomId(_) => Unexpected::Other("CustomId"),
-            ElementValue::IdTupleId(_) => Unexpected::Other("IdTuple"),
-            ElementValue::Dict(_) => Unexpected::Map,
-            ElementValue::Array(_) => Unexpected::Seq,
-        }
-    }
+	fn as_unexpected(&self) -> Unexpected {
+		match self {
+			ElementValue::Null => Unexpected::Other("null"),
+			ElementValue::String(v) => Unexpected::Str(v),
+			ElementValue::Number(v) => Unexpected::Signed(*v),
+			ElementValue::Bytes(v) => Unexpected::Bytes(v.as_slice()),
+			ElementValue::Date(_) => Unexpected::Other("Date"),
+			ElementValue::Bool(v) => Unexpected::Bool(*v),
+			ElementValue::IdGeneratedId(_) => Unexpected::Other("GeneratedId"),
+			ElementValue::IdCustomId(_) => Unexpected::Other("CustomId"),
+			ElementValue::IdTupleId(_) => Unexpected::Other("IdTuple"),
+			ElementValue::Dict(_) => Unexpected::Map,
+			ElementValue::Array(_) => Unexpected::Seq,
+		}
+	}
 }
 
 /// Yet Another Serializer, this one serializes a single string
 struct MapKeySerializer;
 
 impl Serializer for MapKeySerializer {
-    type Ok = String;
-    type Error = SerError;
-    type SerializeSeq = Impossible<String, SerError>;
-    type SerializeTuple = Impossible<String, SerError>;
-    type SerializeTupleStruct = Impossible<String, SerError>;
-    type SerializeTupleVariant = Impossible<String, SerError>;
-    type SerializeMap = Impossible<String, SerError>;
-    type SerializeStruct = Impossible<String, SerError>;
-    type SerializeStructVariant = Impossible<String, SerError>;
+	type Ok = String;
+	type Error = SerError;
+	type SerializeSeq = Impossible<String, SerError>;
+	type SerializeTuple = Impossible<String, SerError>;
+	type SerializeTupleStruct = Impossible<String, SerError>;
+	type SerializeTupleVariant = Impossible<String, SerError>;
+	type SerializeMap = Impossible<String, SerError>;
+	type SerializeStruct = Impossible<String, SerError>;
+	type SerializeStructVariant = Impossible<String, SerError>;
 
-    fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_i8(self, _: i8) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_i16(self, _: i16) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_i32(self, _: i32) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_i64(self, _: i64) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_u8(self, _: u8) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_u16(self, _: u16) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_u32(self, _: u32) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_u64(self, _: u64) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_f32(self, _: f32) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_f64(self, _: f64) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_char(self, _: char) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        Ok(v.to_owned())
-    }
+	fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+		Ok(v.to_owned())
+	}
 
-    fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_bytes(self, _: &[u8]) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_some<T>(self, _: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize
-    {
-        unreachable!()
-    }
+	fn serialize_some<T>(self, _: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		unreachable!()
+	}
 
-    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<Self::Ok, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_unit_variant(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+	) -> Result<Self::Ok, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_newtype_struct<T>(self, _: &'static str, _: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize
-    {
-        unreachable!()
-    }
+	fn serialize_newtype_struct<T>(self, _: &'static str, _: &T) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		unreachable!()
+	}
 
-    fn serialize_newtype_variant<T>(self, _: &'static str, _: u32, _: &'static str, _: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: ?Sized + Serialize
-    {
-        unreachable!()
-    }
+	fn serialize_newtype_variant<T>(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+		_: &T,
+	) -> Result<Self::Ok, Self::Error>
+	where
+		T: ?Sized + Serialize,
+	{
+		unreachable!()
+	}
 
-    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_tuple_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_tuple_struct(
+		self,
+		_: &'static str,
+		_: usize,
+	) -> Result<Self::SerializeTupleStruct, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_tuple_variant(self, _: &'static str, _: u32, _: &'static str, _: usize) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_tuple_variant(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+		_: usize,
+	) -> Result<Self::SerializeTupleVariant, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeStruct, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_struct(
+		self,
+		_: &'static str,
+		_: usize,
+	) -> Result<Self::SerializeStruct, Self::Error> {
+		unreachable!()
+	}
 
-    fn serialize_struct_variant(self, _: &'static str, _: u32, _: &'static str, _: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
-        unreachable!()
-    }
+	fn serialize_struct_variant(
+		self,
+		_: &'static str,
+		_: u32,
+		_: &'static str,
+		_: usize,
+	) -> Result<Self::SerializeStructVariant, Self::Error> {
+		unreachable!()
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+	use std::sync::Arc;
 
-    use crate::entities::sys::{Group, GroupInfo};
-    use crate::entities::tutanota::{Mail, MailboxGroupRoot, OutOfOfficeNotification, OutOfOfficeNotificationRecipientList};
-    use crate::generated_id::GeneratedId;
-    use crate::json_element::RawEntity;
-    use crate::json_serializer::JsonSerializer;
-    use crate::type_model_provider::init_type_model_provider;
-    use crate::TypeRef;
-    use crate::util::test_utils::{create_test_entity, generate_random_group};
+	use crate::entities::sys::{Group, GroupInfo};
+	use crate::entities::tutanota::{
+		Mail, MailboxGroupRoot, OutOfOfficeNotification, OutOfOfficeNotificationRecipientList,
+	};
+	use crate::generated_id::GeneratedId;
+	use crate::json_element::RawEntity;
+	use crate::json_serializer::JsonSerializer;
+	use crate::type_model_provider::init_type_model_provider;
+	use crate::util::test_utils::{create_test_entity, generate_random_group};
+	use crate::TypeRef;
 
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_de_group() {
-        let json = include_str!("../test_data/group_response.json");
-        let parsed_entity = get_parsed_entity::<Group>(json);
-        let mapper = InstanceMapper::new();
-        let group: Group = mapper.parse_entity(parsed_entity).unwrap();
-        assert_eq!(5_i64, group.r#type);
-        assert_eq!(Some(0_i64), group.adminGroupKeyVersion);
-        assert_eq!("LIopQQI--k-0", group.groupInfo.list_id.as_str());
-    }
+	#[test]
+	fn test_de_group() {
+		let json = include_str!("../test_data/group_response.json");
+		let parsed_entity = get_parsed_entity::<Group>(json);
+		let mapper = InstanceMapper::new();
+		let group: Group = mapper.parse_entity(parsed_entity).unwrap();
+		assert_eq!(5_i64, group.r#type);
+		assert_eq!(Some(0_i64), group.adminGroupKeyVersion);
+		assert_eq!("LIopQQI--k-0", group.groupInfo.list_id.as_str());
+	}
 
-    #[test]
-    fn test_de_group_info() {
-        let json = include_str!("../test_data/group_info_response.json");
-        let mut parsed_entity = get_parsed_entity::<GroupInfo>(json);
-        // this is encrypted, so we can't actually deserialize it without replacing it with a decrypted version
-        parsed_entity.insert(
-            "name".to_owned(),
-            ElementValue::String("some string".to_owned()),
-        );
-        let mapper = InstanceMapper::new();
-        let group_info: GroupInfo = mapper.parse_entity(parsed_entity).unwrap();
-        assert_eq!(DateTime::from_millis(1533116004052), group_info.created);
-    }
+	#[test]
+	fn test_de_group_info() {
+		let json = include_str!("../test_data/group_info_response.json");
+		let mut parsed_entity = get_parsed_entity::<GroupInfo>(json);
+		// this is encrypted, so we can't actually deserialize it without replacing it with a decrypted version
+		parsed_entity.insert(
+			"name".to_owned(),
+			ElementValue::String("some string".to_owned()),
+		);
+		let mapper = InstanceMapper::new();
+		let group_info: GroupInfo = mapper.parse_entity(parsed_entity).unwrap();
+		assert_eq!(DateTime::from_millis(1533116004052), group_info.created);
+	}
 
-    #[test]
-    fn test_de_error_wrong_type() {
-        let parsed_entity = [("_id".to_owned(), ElementValue::Number(2))].into();
-        let mapper = InstanceMapper::new();
-        let group_result = mapper.parse_entity::<Group>(parsed_entity);
-        let err = group_result.unwrap_err();
-        assert!(
-            err.to_string().contains("_id"),
-            "error message should contain _id"
-        )
-    }
+	#[test]
+	fn test_de_error_wrong_type() {
+		let parsed_entity = [("_id".to_owned(), ElementValue::Number(2))].into();
+		let mapper = InstanceMapper::new();
+		let group_result = mapper.parse_entity::<Group>(parsed_entity);
+		let err = group_result.unwrap_err();
+		assert!(
+			err.to_string().contains("_id"),
+			"error message should contain _id"
+		)
+	}
 
-    #[test]
-    fn test_de_error_missing_key() {
-        let parsed_entity = [(
-            "_id".to_owned(),
-            ElementValue::IdGeneratedId(GeneratedId("id".to_owned())),
-        )]
-        .into();
-        let mapper = InstanceMapper::new();
-        let group_result = mapper.parse_entity::<Group>(parsed_entity);
-        assert!(group_result.is_err(), "result is an err");
-        let e = group_result.unwrap_err().to_string();
-        assert!(
-            e.contains("missing field"),
-            "error message should contain missing field"
-        );
-    }
+	#[test]
+	fn test_de_error_missing_key() {
+		let parsed_entity = [(
+			"_id".to_owned(),
+			ElementValue::IdGeneratedId(GeneratedId("id".to_owned())),
+		)]
+		.into();
+		let mapper = InstanceMapper::new();
+		let group_result = mapper.parse_entity::<Group>(parsed_entity);
+		assert!(group_result.is_err(), "result is an err");
+		let e = group_result.unwrap_err().to_string();
+		assert!(
+			e.contains("missing field"),
+			"error message should contain missing field"
+		);
+	}
 
-    #[test]
-    fn test_de_mailbox_group_root() {
-        let json = include_str!("../test_data/mailbox_group_root_response.json");
-        let parsed_entity = get_parsed_entity::<MailboxGroupRoot>(json);
-        let mapper = InstanceMapper::new();
-        let _group_root: MailboxGroupRoot = mapper.parse_entity(parsed_entity).unwrap();
-    }
+	#[test]
+	fn test_de_mailbox_group_root() {
+		let json = include_str!("../test_data/mailbox_group_root_response.json");
+		let parsed_entity = get_parsed_entity::<MailboxGroupRoot>(json);
+		let mapper = InstanceMapper::new();
+		let _group_root: MailboxGroupRoot = mapper.parse_entity(parsed_entity).unwrap();
+	}
 
-    #[test]
-    fn test_de_out_of_office_notification() {
-        let parsed_entity: ParsedEntity = HashMap::from_iter(
-            [
-                ("_format", ElementValue::Number(0)),
-                (
-                    "_id",
-                    ElementValue::IdGeneratedId(GeneratedId("id".to_owned())),
-                ),
-                ("_ownerGroup", ElementValue::Null),
-                (
-                    "_permissions",
-                    ElementValue::IdGeneratedId(GeneratedId("permissions".to_owned())),
-                ),
-                ("enabled", ElementValue::Bool(true)),
-                (
-                    "endDate",
-                    ElementValue::Date(DateTime::from_millis(1723193495816)),
-                ),
-                ("startDate", ElementValue::Null),
-                ("notifications", ElementValue::Array(vec![])),
-            ]
-            .into_iter()
-            .map(|(k, v)| (k.to_owned(), v)),
-        );
-        let result: OutOfOfficeNotification =
-            InstanceMapper::new().parse_entity(parsed_entity).unwrap();
-        assert_eq!(Some(DateTime::from_millis(1723193495816)), result.endDate)
-    }
+	#[test]
+	fn test_de_out_of_office_notification() {
+		let parsed_entity: ParsedEntity = HashMap::from_iter(
+			[
+				("_format", ElementValue::Number(0)),
+				(
+					"_id",
+					ElementValue::IdGeneratedId(GeneratedId("id".to_owned())),
+				),
+				("_ownerGroup", ElementValue::Null),
+				(
+					"_permissions",
+					ElementValue::IdGeneratedId(GeneratedId("permissions".to_owned())),
+				),
+				("enabled", ElementValue::Bool(true)),
+				(
+					"endDate",
+					ElementValue::Date(DateTime::from_millis(1723193495816)),
+				),
+				("startDate", ElementValue::Null),
+				("notifications", ElementValue::Array(vec![])),
+			]
+			.into_iter()
+			.map(|(k, v)| (k.to_owned(), v)),
+		);
+		let result: OutOfOfficeNotification =
+			InstanceMapper::new().parse_entity(parsed_entity).unwrap();
+		assert_eq!(Some(DateTime::from_millis(1723193495816)), result.endDate)
+	}
 
-    #[test]
-    fn test_de_map() {
-        #[allow(dead_code)]
-        #[derive(Deserialize)]
-        struct StructWithErrors {
-            _errors: HashMap<String, ElementValue>,
-        }
+	#[test]
+	fn test_de_map() {
+		#[allow(dead_code)]
+		#[derive(Deserialize)]
+		struct StructWithErrors {
+			_errors: HashMap<String, ElementValue>,
+		}
 
-        impl Entity for StructWithErrors {
-            fn type_ref() -> TypeRef {
-                unimplemented!("type_ref")
-            }
-        }
+		impl Entity for StructWithErrors {
+			fn type_ref() -> TypeRef {
+				unimplemented!("type_ref")
+			}
+		}
 
-        let data = HashMap::from_iter([(
-            "_errors".to_owned(),
-            ElementValue::Dict(HashMap::from_iter([
-                (
-                    "first".to_owned(),
-                    ElementValue::String("Outer error".to_owned()),
-                ),
-                (
-                    "second".to_owned(),
-                    ElementValue::Dict(HashMap::from_iter([(
-                        "nested".to_owned(),
-                        ElementValue::String("Nested error".to_string()),
-                    )])),
-                ),
-            ])),
-        )]);
-        let _deserialized: StructWithErrors = InstanceMapper::new().parse_entity(data).unwrap();
-    }
+		let data = HashMap::from_iter([(
+			"_errors".to_owned(),
+			ElementValue::Dict(HashMap::from_iter([
+				(
+					"first".to_owned(),
+					ElementValue::String("Outer error".to_owned()),
+				),
+				(
+					"second".to_owned(),
+					ElementValue::Dict(HashMap::from_iter([(
+						"nested".to_owned(),
+						ElementValue::String("Nested error".to_string()),
+					)])),
+				),
+			])),
+		)]);
+		let _deserialized: StructWithErrors = InstanceMapper::new().parse_entity(data).unwrap();
+	}
 
-    #[test]
-    fn test_ser_mailbox_group_root() {
-        let group_root = MailboxGroupRoot {
-            _format: 0,
-            _id: GeneratedId::test_random(),
-            _ownerGroup: None,
-            _permissions: GeneratedId::test_random(),
-            calendarEventUpdates: None,
-            mailbox: GeneratedId::test_random(),
-            mailboxProperties: None,
-            outOfOfficeNotification: None,
-            outOfOfficeNotificationRecipientList: Some(OutOfOfficeNotificationRecipientList {
-                _id: CustomId::test_random(),
-                list: GeneratedId::test_random(),
-            }),
-            serverProperties: GeneratedId::test_random(),
-            whitelistRequests: GeneratedId::test_random(),
-        };
-        let mapper = InstanceMapper::new();
-        let result = mapper.serialize_entity(group_root.clone()).unwrap();
-        assert_eq!(&ElementValue::Number(0), result.get("_format").unwrap());
-    }
+	#[test]
+	fn test_ser_mailbox_group_root() {
+		let group_root = MailboxGroupRoot {
+			_format: 0,
+			_id: GeneratedId::test_random(),
+			_ownerGroup: None,
+			_permissions: GeneratedId::test_random(),
+			calendarEventUpdates: None,
+			mailbox: GeneratedId::test_random(),
+			mailboxProperties: None,
+			outOfOfficeNotification: None,
+			outOfOfficeNotificationRecipientList: Some(OutOfOfficeNotificationRecipientList {
+				_id: CustomId::test_random(),
+				list: GeneratedId::test_random(),
+			}),
+			serverProperties: GeneratedId::test_random(),
+			whitelistRequests: GeneratedId::test_random(),
+		};
+		let mapper = InstanceMapper::new();
+		let result = mapper.serialize_entity(group_root.clone()).unwrap();
+		assert_eq!(&ElementValue::Number(0), result.get("_format").unwrap());
+	}
 
-    #[test]
-    fn test_ser_group() {
-        let group_root = generate_random_group(None, None);
-        let mapper = InstanceMapper::new();
-        let result = mapper.serialize_entity(group_root.clone()).unwrap();
-        assert_eq!(&ElementValue::Number(0), result.get("_format").unwrap());
-        assert_eq!(
-            &ElementValue::Bytes(vec![1, 2, 3]),
-            result.get("pubAdminGroupEncGKey").unwrap()
-        )
-    }
+	#[test]
+	fn test_ser_group() {
+		let group_root = generate_random_group(None, None);
+		let mapper = InstanceMapper::new();
+		let result = mapper.serialize_entity(group_root.clone()).unwrap();
+		assert_eq!(&ElementValue::Number(0), result.get("_format").unwrap());
+		assert_eq!(
+			&ElementValue::Bytes(vec![1, 2, 3]),
+			result.get("pubAdminGroupEncGKey").unwrap()
+		)
+	}
 
-    #[test]
-    fn test_ser_group_info() {
-        let group_info = GroupInfo {
-            _format: 0,
-            _id: IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random()),
-            _ownerEncSessionKey: None,
-            _listEncSessionKey: None,
-            _ownerGroup: None,
-            _ownerKeyVersion: None,
-            _permissions: GeneratedId::test_random(),
-            created: DateTime::from_millis(1533116004052),
-            deleted: None,
-            groupType: None,
-            mailAddress: None,
-            name: "encName".to_owned(),
-            group: GeneratedId::test_random(),
-            localAdmin: None,
-            mailAddressAliases: vec![],
-            _errors: Default::default(),
-            _finalIvs: Default::default(),
-        };
-        let mapper = InstanceMapper::new();
-        let parsed_entity = mapper.serialize_entity(group_info).unwrap();
+	#[test]
+	fn test_ser_group_info() {
+		let group_info = GroupInfo {
+			_format: 0,
+			_id: IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random()),
+			_ownerEncSessionKey: None,
+			_listEncSessionKey: None,
+			_ownerGroup: None,
+			_ownerKeyVersion: None,
+			_permissions: GeneratedId::test_random(),
+			created: DateTime::from_millis(1533116004052),
+			deleted: None,
+			groupType: None,
+			mailAddress: None,
+			name: "encName".to_owned(),
+			group: GeneratedId::test_random(),
+			localAdmin: None,
+			mailAddressAliases: vec![],
+			_errors: Default::default(),
+			_finalIvs: Default::default(),
+		};
+		let mapper = InstanceMapper::new();
+		let parsed_entity = mapper.serialize_entity(group_info).unwrap();
 
-        assert_eq!(
-            ElementValue::Date(DateTime::from_millis(1533116004052)),
-            *parsed_entity.get("created").unwrap()
-        );
-    }
+		assert_eq!(
+			ElementValue::Date(DateTime::from_millis(1533116004052)),
+			*parsed_entity.get("created").unwrap()
+		);
+	}
 
-    #[test]
-    fn test_ser_mail() {
-        let mut mail = create_test_entity::<Mail>();
-        mail.sender = create_test_entity();
-        let sender_name = "Sender name".to_owned();
-        mail.sender.name = sender_name.clone();
-        let serialized = InstanceMapper::new().serialize_entity(mail).unwrap();
-        assert_eq!(sender_name, serialized.get("sender").unwrap().assert_dict().get("name").unwrap().assert_str())
-    }
+	#[test]
+	fn test_ser_mail() {
+		let mut mail = create_test_entity::<Mail>();
+		mail.sender = create_test_entity();
+		let sender_name = "Sender name".to_owned();
+		mail.sender.name = sender_name.clone();
+		let serialized = InstanceMapper::new().serialize_entity(mail).unwrap();
+		assert_eq!(
+			sender_name,
+			serialized
+				.get("sender")
+				.unwrap()
+				.assert_dict()
+				.get("name")
+				.unwrap()
+				.assert_str()
+		)
+	}
 
-    fn get_parsed_entity<T: Entity>(email_string: &str) -> ParsedEntity {
-        let raw_entity: RawEntity = serde_json::from_str(email_string).unwrap();
-        let type_model_provider = Arc::new(init_type_model_provider());
-        let json_serializer = JsonSerializer::new(type_model_provider.clone());
-        let type_ref = T::type_ref();
-        let mut parsed_entity = json_serializer.parse(&type_ref, raw_entity).unwrap();
-        let type_model = type_model_provider.get_type_model(type_ref.app, type_ref.type_).unwrap();
-        if type_model.is_encrypted() {
-            parsed_entity.insert("_finalIvs".to_owned(), ElementValue::Dict(Default::default()));
-        }
-        parsed_entity
-    }
+	fn get_parsed_entity<T: Entity>(email_string: &str) -> ParsedEntity {
+		let raw_entity: RawEntity = serde_json::from_str(email_string).unwrap();
+		let type_model_provider = Arc::new(init_type_model_provider());
+		let json_serializer = JsonSerializer::new(type_model_provider.clone());
+		let type_ref = T::type_ref();
+		let mut parsed_entity = json_serializer.parse(&type_ref, raw_entity).unwrap();
+		let type_model = type_model_provider
+			.get_type_model(type_ref.app, type_ref.type_)
+			.unwrap();
+		if type_model.is_encrypted() {
+			parsed_entity.insert(
+				"_finalIvs".to_owned(),
+				ElementValue::Dict(Default::default()),
+			);
+		}
+		parsed_entity
+	}
 }

--- a/tuta-sdk/rust/sdk/src/json_element.rs
+++ b/tuta-sdk/rust/sdk/src/json_element.rs
@@ -1,18 +1,18 @@
-use std::collections::HashMap;
-use serde::{Deserialize, Deserializer, Serialize};
 use serde::de::{Error, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::collections::HashMap;
 use std::fmt::Formatter;
 
 /// The types of values in a JSON element containing an entity/instance
 #[derive(uniffi::Enum, Debug, PartialEq, Serialize, Clone)]
 #[serde(untagged)]
 pub enum JsonElement {
-    Null,
-    String(String),
-    Number(i32),
-    Dict(HashMap<String, JsonElement>),
-    Array(Vec<JsonElement>),
-    Bool(bool),
+	Null,
+	String(String),
+	Number(i32),
+	Dict(HashMap<String, JsonElement>),
+	Array(Vec<JsonElement>),
+	Bool(bool),
 }
 
 /// A JSON object containing an entity/instance
@@ -21,111 +21,165 @@ pub type RawEntity = HashMap<String, JsonElement>;
 struct JsonElementVisitor;
 
 impl<'de> Visitor<'de> for JsonElementVisitor {
-    type Value = JsonElement;
+	type Value = JsonElement;
 
-    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        formatter.write_str("A json element")
-    }
+	fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+		formatter.write_str("A json element")
+	}
 
-    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::Number(v))
-    }
+	fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::Number(v))
+	}
 
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::Number(i32::try_from(v).unwrap()))
-    }
+	fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::Number(i32::try_from(v).unwrap()))
+	}
 
-    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::Number(i32::try_from(v).unwrap()))
-    }
+	fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::Number(i32::try_from(v).unwrap()))
+	}
 
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::Number(i32::try_from(v).unwrap()))
-    }
+	fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::Number(i32::try_from(v).unwrap()))
+	}
 
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::String(v.to_owned()))
-    }
+	fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::String(v.to_owned()))
+	}
 
-    fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::String(v))
-    }
+	fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::String(v))
+	}
 
-    fn visit_none<E>(self) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::Null)
-    }
+	fn visit_none<E>(self) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::Null)
+	}
 
-    fn visit_unit<E>(self) -> Result<Self::Value, E> where E: Error {
-        Ok(JsonElement::Null)
-    }
+	fn visit_unit<E>(self) -> Result<Self::Value, E>
+	where
+		E: Error,
+	{
+		Ok(JsonElement::Null)
+	}
 
-    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'de> {
-        let mut elements = Vec::new();
-        while let Some(elem) = seq.next_element()? {
-            elements.push(elem);
-        }
-        Ok(JsonElement::Array(elements))
-    }
+	fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+	where
+		A: SeqAccess<'de>,
+	{
+		let mut elements = Vec::new();
+		while let Some(elem) = seq.next_element()? {
+			elements.push(elem);
+		}
+		Ok(JsonElement::Array(elements))
+	}
 
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error> where A: MapAccess<'de> {
-        let mut elements = HashMap::new();
-        while let Some((key, value)) = map.next_entry::<String, JsonElement>()? {
-            elements.insert(key, value);
-        }
-        Ok(JsonElement::Dict(elements))
-    }
+	fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+	where
+		A: MapAccess<'de>,
+	{
+		let mut elements = HashMap::new();
+		while let Some((key, value)) = map.next_entry::<String, JsonElement>()? {
+			elements.insert(key, value);
+		}
+		Ok(JsonElement::Dict(elements))
+	}
 }
 
 impl<'de> Deserialize<'de> for JsonElement {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error> where D: Deserializer<'de> {
-        deserializer.deserialize_any(JsonElementVisitor {})
-    }
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		deserializer.deserialize_any(JsonElementVisitor {})
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::json_element;
-    use super::*;
+	use super::*;
+	use crate::json_element;
 
-    #[test]
-    fn can_deserialize_null() {
-        let json = "null";
-        assert_eq!(serde_json::from_str::<json_element::JsonElement>(json).unwrap(), json_element::JsonElement::Null);
-    }
+	#[test]
+	fn can_deserialize_null() {
+		let json = "null";
+		assert_eq!(
+			serde_json::from_str::<json_element::JsonElement>(json).unwrap(),
+			json_element::JsonElement::Null
+		);
+	}
 
-    #[test]
-    fn can_deserialize_number() {
-        let json = "42";
-        assert_eq!(serde_json::from_str::<json_element::JsonElement>(json).unwrap(), json_element::JsonElement::Number(42));
-    }
+	#[test]
+	fn can_deserialize_number() {
+		let json = "42";
+		assert_eq!(
+			serde_json::from_str::<json_element::JsonElement>(json).unwrap(),
+			json_element::JsonElement::Number(42)
+		);
+	}
 
-    #[test]
-    fn can_deserialize_map() {
-        let json = r#"{"number": 42}"#;
-        assert_eq!(serde_json::from_str::<HashMap<String, JsonElement>>(json).unwrap(), HashMap::from([("number".to_owned(), json_element::JsonElement::Number(42))]));
-    }
+	#[test]
+	fn can_deserialize_map() {
+		let json = r#"{"number": 42}"#;
+		assert_eq!(
+			serde_json::from_str::<HashMap<String, JsonElement>>(json).unwrap(),
+			HashMap::from([("number".to_owned(), json_element::JsonElement::Number(42))])
+		);
+	}
 
-    #[test]
-    fn can_deserialize_email() {
-        let json = include_str!("../test_data/email_response.json");
-        let parsed = serde_json::from_str::<HashMap<String, JsonElement>>(json).unwrap();
-        let JsonElement::Dict(address_map) = parsed.get("firstRecipient").unwrap() else {
-            panic!("Not a map!")
-        };
-        let JsonElement::String(address) = address_map.get("address").unwrap() else {
-            panic!("Not a string")
-        };
-        assert_eq!("bed-free@tutanota.de", address);
-    }
+	#[test]
+	fn can_deserialize_email() {
+		let json = include_str!("../test_data/email_response.json");
+		let parsed = serde_json::from_str::<HashMap<String, JsonElement>>(json).unwrap();
+		let JsonElement::Dict(address_map) = parsed.get("firstRecipient").unwrap() else {
+			panic!("Not a map!")
+		};
+		let JsonElement::String(address) = address_map.get("address").unwrap() else {
+			panic!("Not a string")
+		};
+		assert_eq!("bed-free@tutanota.de", address);
+	}
 
-    #[test]
-    fn can_serialize_map() {
-        let hash_map = HashMap::from([
-            ("number".to_owned(), JsonElement::Number(42)),
-            ("string".to_owned(), JsonElement::String("a string".to_owned())),
-            ("dict".to_owned(), JsonElement::Dict(HashMap::from([("nested".to_owned(), JsonElement::String("value".to_owned()))])))
-        ]);
-        let map = JsonElement::Dict(hash_map);
-        assert_eq!(map, serde_json::from_str(&serde_json::to_string(&map).unwrap()).unwrap());
-    }
+	#[test]
+	fn can_serialize_map() {
+		let hash_map = HashMap::from([
+			("number".to_owned(), JsonElement::Number(42)),
+			(
+				"string".to_owned(),
+				JsonElement::String("a string".to_owned()),
+			),
+			(
+				"dict".to_owned(),
+				JsonElement::Dict(HashMap::from([(
+					"nested".to_owned(),
+					JsonElement::String("value".to_owned()),
+				)])),
+			),
+		]);
+		let map = JsonElement::Dict(hash_map);
+		assert_eq!(
+			map,
+			serde_json::from_str(&serde_json::to_string(&map).unwrap()).unwrap()
+		);
+	}
 }

--- a/tuta-sdk/rust/sdk/src/json_serializer.rs
+++ b/tuta-sdk/rust/sdk/src/json_serializer.rs
@@ -11,587 +11,587 @@ use crate::generated_id::GeneratedId;
 use crate::json_element::{JsonElement, RawEntity};
 use crate::json_serializer::InstanceMapperError::InvalidValue;
 use crate::metamodel::{
-    AssociationType, Cardinality, ElementType, ModelValue, TypeModel, ValueType,
+	AssociationType, Cardinality, ElementType, ModelValue, TypeModel, ValueType,
 };
 use crate::type_model_provider::TypeModelProvider;
 use crate::{IdTuple, TypeRef};
 
 impl From<&TypeModel> for TypeRef {
-    fn from(value: &TypeModel) -> Self {
-        TypeRef {
-            app: value.app,
-            type_: value.name,
-        }
-    }
+	fn from(value: &TypeModel) -> Self {
+		TypeRef {
+			app: value.app,
+			type_: value.name,
+		}
+	}
 }
 
 /// Provides serialization and deserialization conversion between JSON representations and logical
 /// types for entities.
 /// It validates the schema along the way (to some degree).
 pub struct JsonSerializer {
-    type_model_provider: Arc<TypeModelProvider>,
+	type_model_provider: Arc<TypeModelProvider>,
 }
 
 #[derive(Error, Debug)]
 pub enum InstanceMapperError {
-    #[error("InstanceMapperError: Type not found: {type_ref}")]
-    TypeNotFound { type_ref: TypeRef },
-    #[error("InstanceMapperError: Invalid value: {type_ref} {field}")]
-    InvalidValue { type_ref: TypeRef, field: String },
+	#[error("InstanceMapperError: Type not found: {type_ref}")]
+	TypeNotFound { type_ref: TypeRef },
+	#[error("InstanceMapperError: Invalid value: {type_ref} {field}")]
+	InvalidValue { type_ref: TypeRef, field: String },
 }
 
 impl JsonSerializer {
-    pub fn new(type_model_provider: Arc<TypeModelProvider>) -> JsonSerializer {
-        JsonSerializer {
-            type_model_provider,
-        }
-    }
+	pub fn new(type_model_provider: Arc<TypeModelProvider>) -> JsonSerializer {
+		JsonSerializer {
+			type_model_provider,
+		}
+	}
 
-    /// Creates an entity from JSON data
-    pub fn parse(
-        &self,
-        type_ref: &TypeRef,
-        mut raw_entity: RawEntity,
-    ) -> Result<ParsedEntity, InstanceMapperError> {
-        let type_model = self.get_type_model(type_ref)?;
-        let mut mapped: HashMap<String, ElementValue> = HashMap::new();
-        for (&value_name, value_type) in &type_model.values {
-            // reuse the name
-            let (value_name, value) =
-                raw_entity
-                    .remove_entry(value_name)
-                    .ok_or_else(|| InvalidValue {
-                        type_ref: type_ref.clone(),
-                        field: value_name.to_owned(),
-                    })?;
+	/// Creates an entity from JSON data
+	pub fn parse(
+		&self,
+		type_ref: &TypeRef,
+		mut raw_entity: RawEntity,
+	) -> Result<ParsedEntity, InstanceMapperError> {
+		let type_model = self.get_type_model(type_ref)?;
+		let mut mapped: HashMap<String, ElementValue> = HashMap::new();
+		for (&value_name, value_type) in &type_model.values {
+			// reuse the name
+			let (value_name, value) =
+				raw_entity
+					.remove_entry(value_name)
+					.ok_or_else(|| InvalidValue {
+						type_ref: type_ref.clone(),
+						field: value_name.to_owned(),
+					})?;
 
-            let mapped_value = match (&value_type.cardinality, value) {
-                (Cardinality::ZeroOrOne, JsonElement::Null) => ElementValue::Null,
-                (Cardinality::One, JsonElement::String(v)) if v.is_empty() => {
-                    ElementValue::String(String::new())
-                }
-                (Cardinality::One | Cardinality::ZeroOrOne, JsonElement::String(s))
-                    if value_type.encrypted =>
-                {
-                    ElementValue::Bytes(BASE64_STANDARD.decode(s).map_err(|_| InvalidValue {
-                        type_ref: type_ref.clone(),
-                        field: value_name.clone(),
-                    })?)
-                }
-                (_, value) if !value_type.encrypted => {
-                    self.parse_value(type_model, &value_name, value_type, value)?
-                }
-                _ => {
-                    return Err(InvalidValue {
-                        type_ref: type_ref.clone(),
-                        field: value_name.clone(),
-                    })
-                }
-            };
-            mapped.insert(value_name, mapped_value);
-        }
+			let mapped_value = match (&value_type.cardinality, value) {
+				(Cardinality::ZeroOrOne, JsonElement::Null) => ElementValue::Null,
+				(Cardinality::One, JsonElement::String(v)) if v.is_empty() => {
+					ElementValue::String(String::new())
+				},
+				(Cardinality::One | Cardinality::ZeroOrOne, JsonElement::String(s))
+					if value_type.encrypted =>
+				{
+					ElementValue::Bytes(BASE64_STANDARD.decode(s).map_err(|_| InvalidValue {
+						type_ref: type_ref.clone(),
+						field: value_name.clone(),
+					})?)
+				},
+				(_, value) if !value_type.encrypted => {
+					self.parse_value(type_model, &value_name, value_type, value)?
+				},
+				_ => {
+					return Err(InvalidValue {
+						type_ref: type_ref.clone(),
+						field: value_name.clone(),
+					})
+				},
+			};
+			mapped.insert(value_name, mapped_value);
+		}
 
-        for (&association_name, association_type) in &type_model.associations {
-            // reuse the name
-            let (association_name, value) =
-                raw_entity
-                    .remove_entry(association_name)
-                    .ok_or_else(|| InvalidValue {
-                        type_ref: type_ref.clone(),
-                        field: association_name.to_owned(),
-                    })?;
-            let association_type_ref = TypeRef {
-                app: association_type.dependency.unwrap_or(type_ref.app),
-                type_: association_type.ref_type,
-            };
-            match (
-                &association_type.association_type,
-                &association_type.cardinality,
-                value,
-            ) {
-                (
-                    AssociationType::Aggregation,
-                    Cardinality::One | Cardinality::ZeroOrOne,
-                    JsonElement::Dict(dict),
-                ) => {
-                    let parsed = self.parse(&association_type_ref, dict)?;
-                    mapped.insert(association_name, ElementValue::Dict(parsed));
-                }
-                (AssociationType::Aggregation, Cardinality::Any, JsonElement::Array(elements)) => {
-                    let parsed_aggregates = self.parse_aggregated_array(
-                        &association_name,
-                        &association_type_ref,
-                        elements,
-                    )?;
-                    mapped.insert(association_name, ElementValue::Array(parsed_aggregates));
-                }
-                (_, Cardinality::ZeroOrOne, JsonElement::Null) => {
-                    mapped.insert(association_name, ElementValue::Null);
-                }
-                (
-                    AssociationType::ElementAssociation | AssociationType::ListAssociation,
-                    Cardinality::One | Cardinality::ZeroOrOne,
-                    JsonElement::String(id),
-                ) => {
-                    // FIXME it's not always generated id but it's fine probably
-                    mapped.insert(
-                        association_name,
-                        ElementValue::IdGeneratedId(GeneratedId(id)),
-                    );
-                }
-                (
-                    AssociationType::ListElementAssociation,
-                    Cardinality::One | Cardinality::ZeroOrOne,
-                    JsonElement::Array(vec),
-                ) => {
-                    let id_tuple = match Self::parse_id_tuple(vec) {
-                        None => {
-                            return Err(InvalidValue {
-                                type_ref: association_type_ref,
-                                field: association_name,
-                            });
-                        }
-                        Some(id_tuple) => id_tuple,
-                    };
-                    mapped.insert(association_name, ElementValue::IdTupleId(id_tuple));
-                }
-                (
-                    AssociationType::ListElementAssociation,
-                    Cardinality::Any,
-                    JsonElement::Array(vec),
-                ) => {
-                    let ids = self.parse_id_tuple_list(type_ref, &association_name, vec)?;
+		for (&association_name, association_type) in &type_model.associations {
+			// reuse the name
+			let (association_name, value) =
+				raw_entity
+					.remove_entry(association_name)
+					.ok_or_else(|| InvalidValue {
+						type_ref: type_ref.clone(),
+						field: association_name.to_owned(),
+					})?;
+			let association_type_ref = TypeRef {
+				app: association_type.dependency.unwrap_or(type_ref.app),
+				type_: association_type.ref_type,
+			};
+			match (
+				&association_type.association_type,
+				&association_type.cardinality,
+				value,
+			) {
+				(
+					AssociationType::Aggregation,
+					Cardinality::One | Cardinality::ZeroOrOne,
+					JsonElement::Dict(dict),
+				) => {
+					let parsed = self.parse(&association_type_ref, dict)?;
+					mapped.insert(association_name, ElementValue::Dict(parsed));
+				},
+				(AssociationType::Aggregation, Cardinality::Any, JsonElement::Array(elements)) => {
+					let parsed_aggregates = self.parse_aggregated_array(
+						&association_name,
+						&association_type_ref,
+						elements,
+					)?;
+					mapped.insert(association_name, ElementValue::Array(parsed_aggregates));
+				},
+				(_, Cardinality::ZeroOrOne, JsonElement::Null) => {
+					mapped.insert(association_name, ElementValue::Null);
+				},
+				(
+					AssociationType::ElementAssociation | AssociationType::ListAssociation,
+					Cardinality::One | Cardinality::ZeroOrOne,
+					JsonElement::String(id),
+				) => {
+					// FIXME it's not always generated id but it's fine probably
+					mapped.insert(
+						association_name,
+						ElementValue::IdGeneratedId(GeneratedId(id)),
+					);
+				},
+				(
+					AssociationType::ListElementAssociation,
+					Cardinality::One | Cardinality::ZeroOrOne,
+					JsonElement::Array(vec),
+				) => {
+					let id_tuple = match Self::parse_id_tuple(vec) {
+						None => {
+							return Err(InvalidValue {
+								type_ref: association_type_ref,
+								field: association_name,
+							});
+						},
+						Some(id_tuple) => id_tuple,
+					};
+					mapped.insert(association_name, ElementValue::IdTupleId(id_tuple));
+				},
+				(
+					AssociationType::ListElementAssociation,
+					Cardinality::Any,
+					JsonElement::Array(vec),
+				) => {
+					let ids = self.parse_id_tuple_list(type_ref, &association_name, vec)?;
 
-                    mapped.insert(association_name, ElementValue::Array(ids));
-                }
-                (
-                    AssociationType::BlobElementAssociation,
-                    Cardinality::One | Cardinality::ZeroOrOne,
-                    JsonElement::Array(vec),
-                ) => {
-                    let id_tuple = match Self::parse_id_tuple(vec) {
-                        None => {
-                            return Err(InvalidValue {
-                                type_ref: association_type_ref,
-                                field: association_name,
-                            });
-                        }
-                        Some(id_tuple) => id_tuple,
-                    };
-                    mapped.insert(association_name, ElementValue::IdTupleId(id_tuple));
-                }
-                _ => {}
-            }
-        }
+					mapped.insert(association_name, ElementValue::Array(ids));
+				},
+				(
+					AssociationType::BlobElementAssociation,
+					Cardinality::One | Cardinality::ZeroOrOne,
+					JsonElement::Array(vec),
+				) => {
+					let id_tuple = match Self::parse_id_tuple(vec) {
+						None => {
+							return Err(InvalidValue {
+								type_ref: association_type_ref,
+								field: association_name,
+							});
+						},
+						Some(id_tuple) => id_tuple,
+					};
+					mapped.insert(association_name, ElementValue::IdTupleId(id_tuple));
+				},
+				_ => {},
+			}
+		}
 
-        Ok(mapped)
-    }
+		Ok(mapped)
+	}
 
-    /// Parses an aggregated array from a value of a JSON object containing an entity/instance
-    fn parse_aggregated_array(
-        &self,
-        association_name: &str,
-        association_type_ref: &TypeRef,
-        elements: Vec<JsonElement>,
-    ) -> Result<Vec<ElementValue>, InstanceMapperError> {
-        let mut parsed_aggregates = Vec::new();
-        for element in elements {
-            match element {
-                JsonElement::Dict(a) => {
-                    let parsed = self.parse(association_type_ref, a)?;
-                    parsed_aggregates.push(ElementValue::Dict(parsed));
-                }
-                _ => {
-                    return Err(InvalidValue {
-                        type_ref: association_type_ref.clone(),
-                        field: association_name.to_owned(),
-                    });
-                }
-            };
-        }
-        Ok(parsed_aggregates)
-    }
+	/// Parses an aggregated array from a value of a JSON object containing an entity/instance
+	fn parse_aggregated_array(
+		&self,
+		association_name: &str,
+		association_type_ref: &TypeRef,
+		elements: Vec<JsonElement>,
+	) -> Result<Vec<ElementValue>, InstanceMapperError> {
+		let mut parsed_aggregates = Vec::new();
+		for element in elements {
+			match element {
+				JsonElement::Dict(a) => {
+					let parsed = self.parse(association_type_ref, a)?;
+					parsed_aggregates.push(ElementValue::Dict(parsed));
+				},
+				_ => {
+					return Err(InvalidValue {
+						type_ref: association_type_ref.clone(),
+						field: association_name.to_owned(),
+					});
+				},
+			};
+		}
+		Ok(parsed_aggregates)
+	}
 
-    fn parse_id_tuple_list(
-        &self,
-        outer_type_ref: &TypeRef,
-        association_name: &str,
-        elements: Vec<JsonElement>,
-    ) -> Result<Vec<ElementValue>, InstanceMapperError> {
-        elements
-            .into_iter()
-            .map(|json_element| {
-                let JsonElement::Array(id_vec) = json_element else {
-                    return Err(InvalidValue {
-                        field: association_name.to_owned(),
-                        type_ref: outer_type_ref.clone(),
-                    });
-                };
-                let id_tuple = Self::parse_id_tuple(id_vec).ok_or_else(|| InvalidValue {
-                    field: association_name.to_owned(),
-                    type_ref: outer_type_ref.clone(),
-                })?;
-                Ok(ElementValue::IdTupleId(id_tuple))
-            })
-            .collect()
-    }
+	fn parse_id_tuple_list(
+		&self,
+		outer_type_ref: &TypeRef,
+		association_name: &str,
+		elements: Vec<JsonElement>,
+	) -> Result<Vec<ElementValue>, InstanceMapperError> {
+		elements
+			.into_iter()
+			.map(|json_element| {
+				let JsonElement::Array(id_vec) = json_element else {
+					return Err(InvalidValue {
+						field: association_name.to_owned(),
+						type_ref: outer_type_ref.clone(),
+					});
+				};
+				let id_tuple = Self::parse_id_tuple(id_vec).ok_or_else(|| InvalidValue {
+					field: association_name.to_owned(),
+					type_ref: outer_type_ref.clone(),
+				})?;
+				Ok(ElementValue::IdTupleId(id_tuple))
+			})
+			.collect()
+	}
 
-    /// Transforms an entity/instance into JSON data
-    pub fn serialize(
-        &self,
-        type_ref: &TypeRef,
-        mut entity: ParsedEntity,
-    ) -> Result<RawEntity, InstanceMapperError> {
-        let type_model = self.get_type_model(type_ref)?;
-        let mut mapped: RawEntity = HashMap::new();
-        for (&value_name, value_type) in &type_model.values {
-            // we take out of the map to reuse the names/values
-            let (value_name, value) =
-                entity
-                    .remove_entry(value_name)
-                    .ok_or_else(|| InvalidValue {
-                        type_ref: type_ref.clone(),
-                        field: value_name.to_owned(),
-                    })?;
+	/// Transforms an entity/instance into JSON data
+	pub fn serialize(
+		&self,
+		type_ref: &TypeRef,
+		mut entity: ParsedEntity,
+	) -> Result<RawEntity, InstanceMapperError> {
+		let type_model = self.get_type_model(type_ref)?;
+		let mut mapped: RawEntity = HashMap::new();
+		for (&value_name, value_type) in &type_model.values {
+			// we take out of the map to reuse the names/values
+			let (value_name, value) =
+				entity
+					.remove_entry(value_name)
+					.ok_or_else(|| InvalidValue {
+						type_ref: type_ref.clone(),
+						field: value_name.to_owned(),
+					})?;
 
-            if !value_type.encrypted {
-                let serialized_value =
-                    self.serialize_value(type_model, &value_name, value_type, value)?;
-                mapped.insert(value_name, serialized_value);
-            } else if let ElementValue::Null = value {
-                mapped.insert(value_name, JsonElement::Null);
-                continue;
-            } else if let (ElementValue::String(v), true) = (value, value_type.encrypted) {
-                mapped.insert(value_name, JsonElement::String(v));
-                continue;
-            } else {
-                panic!("Unknown entity elements!! {}", value_name)
-            }
-        }
+			if !value_type.encrypted {
+				let serialized_value =
+					self.serialize_value(type_model, &value_name, value_type, value)?;
+				mapped.insert(value_name, serialized_value);
+			} else if let ElementValue::Null = value {
+				mapped.insert(value_name, JsonElement::Null);
+				continue;
+			} else if let (ElementValue::String(v), true) = (value, value_type.encrypted) {
+				mapped.insert(value_name, JsonElement::String(v));
+				continue;
+			} else {
+				panic!("Unknown entity elements!! {}", value_name)
+			}
+		}
 
-        for (&association_name, association_type) in &type_model.associations {
-            let (association_name, value) =
-                entity
-                    .remove_entry(association_name)
-                    .ok_or_else(|| InvalidValue {
-                        type_ref: type_ref.clone(),
-                        field: association_name.to_owned(),
-                    })?;
-            let association_type_ref = TypeRef {
-                app: type_ref.app,
-                type_: association_type.ref_type,
-            };
-            match (
-                &association_type.association_type,
-                &association_type.cardinality,
-                value,
-            ) {
-                (
-                    AssociationType::Aggregation,
-                    Cardinality::One | Cardinality::ZeroOrOne,
-                    ElementValue::Dict(dict),
-                ) => {
-                    let serialized = self.serialize(&association_type_ref, dict)?;
-                    mapped.insert(association_name, JsonElement::Dict(serialized));
-                }
-                (
-                    AssociationType::Aggregation | AssociationType::ListElementAssociation,
-                    Cardinality::Any,
-                    ElementValue::Array(elements),
-                ) => {
-                    let serialized_aggregates = self.make_serialized_aggregated_array(
-                        &association_name,
-                        &association_type_ref,
-                        elements,
-                    )?;
-                    mapped.insert(association_name, JsonElement::Array(serialized_aggregates));
-                }
-                (_, Cardinality::ZeroOrOne, ElementValue::Null) => {
-                    mapped.insert(association_name, JsonElement::Null);
-                }
-                (
-                    AssociationType::ElementAssociation | AssociationType::ListAssociation,
-                    Cardinality::One | Cardinality::ZeroOrOne,
-                    ElementValue::IdGeneratedId(id),
-                ) => {
-                    // FIXME it's not always generated id but it's fine probably
-                    mapped.insert(association_name, JsonElement::String(id.into()));
-                }
-                (
-                    AssociationType::ListElementAssociation,
-                    Cardinality::One,
-                    ElementValue::IdTupleId(id_tuple),
-                ) => {
-                    mapped.insert(
-                        association_name,
-                        JsonElement::Array(vec![
-                            JsonElement::String(id_tuple.list_id.into()),
-                            JsonElement::String(id_tuple.element_id.into()),
-                        ]),
-                    );
-                }
-                (AssociationType::BlobElementAssociation, _, ElementValue::Array(elements)) => {
-                    // Blobs ate copied as-is for now
-                    let serialized_aggregates = self.make_serialized_aggregated_array(
-                        &association_name,
-                        &association_type_ref,
-                        elements,
-                    )?;
-                    mapped.insert(association_name, JsonElement::Array(serialized_aggregates));
-                }
-                _ => {}
-            }
-        }
+		for (&association_name, association_type) in &type_model.associations {
+			let (association_name, value) =
+				entity
+					.remove_entry(association_name)
+					.ok_or_else(|| InvalidValue {
+						type_ref: type_ref.clone(),
+						field: association_name.to_owned(),
+					})?;
+			let association_type_ref = TypeRef {
+				app: type_ref.app,
+				type_: association_type.ref_type,
+			};
+			match (
+				&association_type.association_type,
+				&association_type.cardinality,
+				value,
+			) {
+				(
+					AssociationType::Aggregation,
+					Cardinality::One | Cardinality::ZeroOrOne,
+					ElementValue::Dict(dict),
+				) => {
+					let serialized = self.serialize(&association_type_ref, dict)?;
+					mapped.insert(association_name, JsonElement::Dict(serialized));
+				},
+				(
+					AssociationType::Aggregation | AssociationType::ListElementAssociation,
+					Cardinality::Any,
+					ElementValue::Array(elements),
+				) => {
+					let serialized_aggregates = self.make_serialized_aggregated_array(
+						&association_name,
+						&association_type_ref,
+						elements,
+					)?;
+					mapped.insert(association_name, JsonElement::Array(serialized_aggregates));
+				},
+				(_, Cardinality::ZeroOrOne, ElementValue::Null) => {
+					mapped.insert(association_name, JsonElement::Null);
+				},
+				(
+					AssociationType::ElementAssociation | AssociationType::ListAssociation,
+					Cardinality::One | Cardinality::ZeroOrOne,
+					ElementValue::IdGeneratedId(id),
+				) => {
+					// FIXME it's not always generated id but it's fine probably
+					mapped.insert(association_name, JsonElement::String(id.into()));
+				},
+				(
+					AssociationType::ListElementAssociation,
+					Cardinality::One,
+					ElementValue::IdTupleId(id_tuple),
+				) => {
+					mapped.insert(
+						association_name,
+						JsonElement::Array(vec![
+							JsonElement::String(id_tuple.list_id.into()),
+							JsonElement::String(id_tuple.element_id.into()),
+						]),
+					);
+				},
+				(AssociationType::BlobElementAssociation, _, ElementValue::Array(elements)) => {
+					// Blobs ate copied as-is for now
+					let serialized_aggregates = self.make_serialized_aggregated_array(
+						&association_name,
+						&association_type_ref,
+						elements,
+					)?;
+					mapped.insert(association_name, JsonElement::Array(serialized_aggregates));
+				},
+				_ => {},
+			}
+		}
 
-        Ok(mapped)
-    }
+		Ok(mapped)
+	}
 
-    /// Creates a JSON array from an aggregated array
-    fn make_serialized_aggregated_array(
-        &self,
-        association_name: &String,
-        association_type_ref: &TypeRef,
-        elements: Vec<ElementValue>,
-    ) -> Result<Vec<JsonElement>, InstanceMapperError> {
-        let mut serialized_elements: Vec<JsonElement> = Vec::new();
-        for element in elements {
-            match element {
-                ElementValue::Dict(a) => {
-                    let serialized = self.serialize(association_type_ref, a)?;
-                    serialized_elements.push(JsonElement::Dict(serialized));
-                }
-                ElementValue::String(v) => {
-                    serialized_elements.push(JsonElement::String(v));
-                }
-                _ => {
-                    return Err(InvalidValue {
-                        type_ref: association_type_ref.clone(),
-                        field: association_name.to_owned(),
-                    });
-                }
-            };
-        }
-        Ok(serialized_elements)
-    }
+	/// Creates a JSON array from an aggregated array
+	fn make_serialized_aggregated_array(
+		&self,
+		association_name: &String,
+		association_type_ref: &TypeRef,
+		elements: Vec<ElementValue>,
+	) -> Result<Vec<JsonElement>, InstanceMapperError> {
+		let mut serialized_elements: Vec<JsonElement> = Vec::new();
+		for element in elements {
+			match element {
+				ElementValue::Dict(a) => {
+					let serialized = self.serialize(association_type_ref, a)?;
+					serialized_elements.push(JsonElement::Dict(serialized));
+				},
+				ElementValue::String(v) => {
+					serialized_elements.push(JsonElement::String(v));
+				},
+				_ => {
+					return Err(InvalidValue {
+						type_ref: association_type_ref.clone(),
+						field: association_name.to_owned(),
+					});
+				},
+			};
+		}
+		Ok(serialized_elements)
+	}
 
-    /// Returns the type model referenced by a `TypeRef`
-    /// from the `InstanceMapper`'s `TypeModelProvider`
-    fn get_type_model(&self, type_ref: &TypeRef) -> Result<&TypeModel, InstanceMapperError> {
-        self.type_model_provider
-            .get_type_model(type_ref.app, type_ref.type_)
-            .ok_or_else(|| InstanceMapperError::TypeNotFound {
-                type_ref: type_ref.clone(),
-            })
-    }
+	/// Returns the type model referenced by a `TypeRef`
+	/// from the `InstanceMapper`'s `TypeModelProvider`
+	fn get_type_model(&self, type_ref: &TypeRef) -> Result<&TypeModel, InstanceMapperError> {
+		self.type_model_provider
+			.get_type_model(type_ref.app, type_ref.type_)
+			.ok_or_else(|| InstanceMapperError::TypeNotFound {
+				type_ref: type_ref.clone(),
+			})
+	}
 
-    /// Transforms an `ElementValue` into a JSON Value
-    fn serialize_value(
-        &self,
-        type_model: &TypeModel,
-        value_name: &str,
-        model_value: &ModelValue,
-        element_value: ElementValue,
-    ) -> Result<JsonElement, InstanceMapperError> {
-        let invalid_value = || {
-            Err(InvalidValue {
-                type_ref: type_model.into(),
-                field: value_name.to_owned(),
-            })
-        };
+	/// Transforms an `ElementValue` into a JSON Value
+	fn serialize_value(
+		&self,
+		type_model: &TypeModel,
+		value_name: &str,
+		model_value: &ModelValue,
+		element_value: ElementValue,
+	) -> Result<JsonElement, InstanceMapperError> {
+		let invalid_value = || {
+			Err(InvalidValue {
+				type_ref: type_model.into(),
+				field: value_name.to_owned(),
+			})
+		};
 
-        // FIXME there are more null/empty cases we need to take care of
-        if model_value.cardinality == Cardinality::ZeroOrOne && element_value == ElementValue::Null
-        {
-            return Ok(JsonElement::Null);
-        }
+		// FIXME there are more null/empty cases we need to take care of
+		if model_value.cardinality == Cardinality::ZeroOrOne && element_value == ElementValue::Null
+		{
+			return Ok(JsonElement::Null);
+		}
 
-        if value_name == "_id" {
-            return match (
-                &model_value.value_type,
-                element_value,
-                &type_model.element_type,
-            ) {
-                (
-                    ValueType::GeneratedId | ValueType::CustomId,
-                    ElementValue::String(v),
-                    ElementType::Element | ElementType::Aggregated,
-                ) => Ok(JsonElement::String(v)),
-                (
-                    ValueType::GeneratedId | ValueType::CustomId,
-                    ElementValue::IdTupleId(arr),
-                    ElementType::ListElement,
-                ) => Ok(JsonElement::Array(vec![
-                    JsonElement::String(arr.list_id.into()),
-                    JsonElement::String(arr.element_id.into()),
-                ])),
-                _ => invalid_value(),
-            };
-        }
+		if value_name == "_id" {
+			return match (
+				&model_value.value_type,
+				element_value,
+				&type_model.element_type,
+			) {
+				(
+					ValueType::GeneratedId | ValueType::CustomId,
+					ElementValue::String(v),
+					ElementType::Element | ElementType::Aggregated,
+				) => Ok(JsonElement::String(v)),
+				(
+					ValueType::GeneratedId | ValueType::CustomId,
+					ElementValue::IdTupleId(arr),
+					ElementType::ListElement,
+				) => Ok(JsonElement::Array(vec![
+					JsonElement::String(arr.list_id.into()),
+					JsonElement::String(arr.element_id.into()),
+				])),
+				_ => invalid_value(),
+			};
+		}
 
-        match (&model_value.value_type, element_value) {
-            (ValueType::String, ElementValue::String(v)) => Ok(JsonElement::String(v)),
-            (ValueType::Number, ElementValue::Number(v)) => Ok(JsonElement::String(v.to_string())),
-            (ValueType::Bytes, ElementValue::Bytes(v)) => {
-                let str = BASE64_STANDARD.encode(v);
-                Ok(JsonElement::String(str))
-            }
-            (ValueType::Date, ElementValue::Date(v)) => {
-                Ok(JsonElement::String(v.as_millis().to_string()))
-            }
-            (ValueType::Boolean, ElementValue::Bool(v)) => {
-                Ok(JsonElement::String(if v { "1" } else { "0" }.to_owned()))
-            }
-            (ValueType::GeneratedId, ElementValue::IdGeneratedId(v)) => {
-                Ok(JsonElement::String(v.into()))
-            }
-            (ValueType::CustomId, ElementValue::IdCustomId(v)) => Ok(JsonElement::String(v.into())),
-            (ValueType::CompressedString, ElementValue::String(_)) => {
-                unimplemented!("compressed string")
-            }
-            _ => invalid_value(),
-        }
-    }
+		match (&model_value.value_type, element_value) {
+			(ValueType::String, ElementValue::String(v)) => Ok(JsonElement::String(v)),
+			(ValueType::Number, ElementValue::Number(v)) => Ok(JsonElement::String(v.to_string())),
+			(ValueType::Bytes, ElementValue::Bytes(v)) => {
+				let str = BASE64_STANDARD.encode(v);
+				Ok(JsonElement::String(str))
+			},
+			(ValueType::Date, ElementValue::Date(v)) => {
+				Ok(JsonElement::String(v.as_millis().to_string()))
+			},
+			(ValueType::Boolean, ElementValue::Bool(v)) => {
+				Ok(JsonElement::String(if v { "1" } else { "0" }.to_owned()))
+			},
+			(ValueType::GeneratedId, ElementValue::IdGeneratedId(v)) => {
+				Ok(JsonElement::String(v.into()))
+			},
+			(ValueType::CustomId, ElementValue::IdCustomId(v)) => Ok(JsonElement::String(v.into())),
+			(ValueType::CompressedString, ElementValue::String(_)) => {
+				unimplemented!("compressed string")
+			},
+			_ => invalid_value(),
+		}
+	}
 
-    /// Transforms a JSON array into an `IdTuple`
-    fn parse_id_tuple(vec: Vec<JsonElement>) -> Option<IdTuple> {
-        let mut it = vec.into_iter();
-        match (it.next(), it.next(), it.next()) {
-            (Some(JsonElement::String(list_id)), Some(JsonElement::String(element_id)), None) => {
-                // would like to consume the array here but oh well
-                Some(IdTuple::new(GeneratedId(list_id), GeneratedId(element_id)))
-            }
-            _ => None,
-        }
-    }
+	/// Transforms a JSON array into an `IdTuple`
+	fn parse_id_tuple(vec: Vec<JsonElement>) -> Option<IdTuple> {
+		let mut it = vec.into_iter();
+		match (it.next(), it.next(), it.next()) {
+			(Some(JsonElement::String(list_id)), Some(JsonElement::String(element_id)), None) => {
+				// would like to consume the array here but oh well
+				Some(IdTuple::new(GeneratedId(list_id), GeneratedId(element_id)))
+			},
+			_ => None,
+		}
+	}
 
-    /// Transforms a JSON value into an `ElementValue`
-    fn parse_value(
-        &self,
-        type_model: &TypeModel,
-        value_name: &str,
-        model_value: &ModelValue,
-        json_value: JsonElement,
-    ) -> Result<ElementValue, InstanceMapperError> {
-        let invalid_value = || {
-            Err(InvalidValue {
-                type_ref: type_model.into(),
-                field: value_name.to_owned(),
-            })
-        };
+	/// Transforms a JSON value into an `ElementValue`
+	fn parse_value(
+		&self,
+		type_model: &TypeModel,
+		value_name: &str,
+		model_value: &ModelValue,
+		json_value: JsonElement,
+	) -> Result<ElementValue, InstanceMapperError> {
+		let invalid_value = || {
+			Err(InvalidValue {
+				type_ref: type_model.into(),
+				field: value_name.to_owned(),
+			})
+		};
 
-        // FIXME there are more null/empty cases we need to take care of
-        if model_value.cardinality == Cardinality::ZeroOrOne && json_value == JsonElement::Null {
-            return Ok(ElementValue::Null);
-        }
+		// FIXME there are more null/empty cases we need to take care of
+		if model_value.cardinality == Cardinality::ZeroOrOne && json_value == JsonElement::Null {
+			return Ok(ElementValue::Null);
+		}
 
-        // Type models for ids are special.
-        // The actual type depends on the type of the Element.
-        // e.g. for ListElementType the GeneratedId actually means IdTuple.-
-        if value_name == "_id" {
-            return match (
-                &model_value.value_type,
-                json_value,
-                &type_model.element_type,
-            ) {
-                (
-                    ValueType::GeneratedId | ValueType::CustomId,
-                    JsonElement::String(v),
-                    ElementType::Element | ElementType::Aggregated,
-                ) => Ok(ElementValue::String(v)),
-                (
-                    ValueType::GeneratedId | ValueType::CustomId,
-                    JsonElement::Array(arr),
-                    ElementType::ListElement,
-                ) if arr.len() == 2 => match Self::parse_id_tuple(arr) {
-                    None => invalid_value(),
-                    Some(id_tuple) => Ok(ElementValue::IdTupleId(id_tuple)),
-                },
-                _ => invalid_value(),
-            };
-        }
+		// Type models for ids are special.
+		// The actual type depends on the type of the Element.
+		// e.g. for ListElementType the GeneratedId actually means IdTuple.-
+		if value_name == "_id" {
+			return match (
+				&model_value.value_type,
+				json_value,
+				&type_model.element_type,
+			) {
+				(
+					ValueType::GeneratedId | ValueType::CustomId,
+					JsonElement::String(v),
+					ElementType::Element | ElementType::Aggregated,
+				) => Ok(ElementValue::String(v)),
+				(
+					ValueType::GeneratedId | ValueType::CustomId,
+					JsonElement::Array(arr),
+					ElementType::ListElement,
+				) if arr.len() == 2 => match Self::parse_id_tuple(arr) {
+					None => invalid_value(),
+					Some(id_tuple) => Ok(ElementValue::IdTupleId(id_tuple)),
+				},
+				_ => invalid_value(),
+			};
+		}
 
-        match (&model_value.value_type, json_value) {
-            (ValueType::String, JsonElement::String(v)) => Ok(ElementValue::String(v)),
-            (ValueType::Number, JsonElement::String(v)) => match v.parse::<i64>() {
-                Ok(num) => Ok(ElementValue::Number(num)),
-                Err(_) => invalid_value(),
-            },
-            (ValueType::Bytes, JsonElement::String(v)) => {
-                let vec = match BASE64_STANDARD.decode(v) {
-                    Ok(v) => Ok(v),
-                    Err(_) => Err(InvalidValue {
-                        type_ref: type_model.into(),
-                        field: value_name.to_owned(),
-                    }),
-                }?;
-                Ok(ElementValue::Bytes(vec))
-            }
-            (ValueType::Date, JsonElement::String(v)) => {
-                let system_time = v.parse::<u64>().map_err(|_| InvalidValue {
-                    type_ref: type_model.into(),
-                    field: value_name.to_owned(),
-                })?;
-                Ok(ElementValue::Date(DateTime::from_millis(system_time)))
-            }
-            (ValueType::Boolean, JsonElement::String(v)) => match v.as_str() {
-                "0" => Ok(ElementValue::Bool(false)),
-                "1" => Ok(ElementValue::Bool(true)),
-                _ => invalid_value(),
-            },
-            (ValueType::GeneratedId, JsonElement::String(v)) => {
-                Ok(ElementValue::IdGeneratedId(GeneratedId(v)))
-            }
-            (ValueType::CustomId, JsonElement::String(v)) => {
-                Ok(ElementValue::IdCustomId(CustomId(v)))
-            }
-            (ValueType::CompressedString, JsonElement::String(_)) => {
-                unimplemented!("compressed string")
-            }
-            _ => invalid_value(),
-        }
-    }
+		match (&model_value.value_type, json_value) {
+			(ValueType::String, JsonElement::String(v)) => Ok(ElementValue::String(v)),
+			(ValueType::Number, JsonElement::String(v)) => match v.parse::<i64>() {
+				Ok(num) => Ok(ElementValue::Number(num)),
+				Err(_) => invalid_value(),
+			},
+			(ValueType::Bytes, JsonElement::String(v)) => {
+				let vec = match BASE64_STANDARD.decode(v) {
+					Ok(v) => Ok(v),
+					Err(_) => Err(InvalidValue {
+						type_ref: type_model.into(),
+						field: value_name.to_owned(),
+					}),
+				}?;
+				Ok(ElementValue::Bytes(vec))
+			},
+			(ValueType::Date, JsonElement::String(v)) => {
+				let system_time = v.parse::<u64>().map_err(|_| InvalidValue {
+					type_ref: type_model.into(),
+					field: value_name.to_owned(),
+				})?;
+				Ok(ElementValue::Date(DateTime::from_millis(system_time)))
+			},
+			(ValueType::Boolean, JsonElement::String(v)) => match v.as_str() {
+				"0" => Ok(ElementValue::Bool(false)),
+				"1" => Ok(ElementValue::Bool(true)),
+				_ => invalid_value(),
+			},
+			(ValueType::GeneratedId, JsonElement::String(v)) => {
+				Ok(ElementValue::IdGeneratedId(GeneratedId(v)))
+			},
+			(ValueType::CustomId, JsonElement::String(v)) => {
+				Ok(ElementValue::IdCustomId(CustomId(v)))
+			},
+			(ValueType::CompressedString, JsonElement::String(_)) => {
+				unimplemented!("compressed string")
+			},
+			_ => invalid_value(),
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::type_model_provider::init_type_model_provider;
+	use super::*;
+	use crate::type_model_provider::init_type_model_provider;
 
-    #[test]
-    fn test_parse_mail() {
-        let type_model_provider = Arc::new(init_type_model_provider());
-        let mapper = JsonSerializer {
-            type_model_provider,
-        };
-        // TODO: Expand this test to cover bucket keys in mail
-        let email_json = include_str!("../test_data/email_response.json");
-        let raw_entity = serde_json::from_str::<RawEntity>(email_json).unwrap();
-        let type_ref = TypeRef {
-            app: "tutanota",
-            type_: "Mail",
-        };
-        mapper.parse(&type_ref, raw_entity).unwrap();
-    }
+	#[test]
+	fn test_parse_mail() {
+		let type_model_provider = Arc::new(init_type_model_provider());
+		let mapper = JsonSerializer {
+			type_model_provider,
+		};
+		// TODO: Expand this test to cover bucket keys in mail
+		let email_json = include_str!("../test_data/email_response.json");
+		let raw_entity = serde_json::from_str::<RawEntity>(email_json).unwrap();
+		let type_ref = TypeRef {
+			app: "tutanota",
+			type_: "Mail",
+		};
+		mapper.parse(&type_ref, raw_entity).unwrap();
+	}
 
-    #[test]
-    fn test_parse_mail_with_attachments() {
-        let type_model_provider = Arc::new(init_type_model_provider());
-        let mapper = JsonSerializer {
-            type_model_provider,
-        };
-        let email_json = include_str!("../test_data/email_response_attachments.json");
-        let raw_entity = serde_json::from_str::<RawEntity>(email_json).unwrap();
-        let type_ref = TypeRef {
-            app: "tutanota",
-            type_: "Mail",
-        };
-        let parsed = mapper.parse(&type_ref, raw_entity).unwrap();
-        assert_eq!(
-            &ElementValue::Array(vec![ElementValue::IdTupleId(IdTuple::new(
-                GeneratedId("O3lYN71--J-0".to_owned()),
-                GeneratedId("O3lYUQI----0".to_owned()),
-            ))]),
-            parsed.get("attachments").expect("has attachments")
-        )
-    }
+	#[test]
+	fn test_parse_mail_with_attachments() {
+		let type_model_provider = Arc::new(init_type_model_provider());
+		let mapper = JsonSerializer {
+			type_model_provider,
+		};
+		let email_json = include_str!("../test_data/email_response_attachments.json");
+		let raw_entity = serde_json::from_str::<RawEntity>(email_json).unwrap();
+		let type_ref = TypeRef {
+			app: "tutanota",
+			type_: "Mail",
+		};
+		let parsed = mapper.parse(&type_ref, raw_entity).unwrap();
+		assert_eq!(
+			&ElementValue::Array(vec![ElementValue::IdTupleId(IdTuple::new(
+				GeneratedId("O3lYN71--J-0".to_owned()),
+				GeneratedId("O3lYUQI----0".to_owned()),
+			))]),
+			parsed.get("attachments").expect("has attachments")
+		)
+	}
 }

--- a/tuta-sdk/rust/sdk/src/key_cache.rs
+++ b/tuta-sdk/rust/sdk/src/key_cache.rs
@@ -1,57 +1,60 @@
-use std::collections::HashMap;
-use std::sync::RwLock;
 use crate::crypto::Aes256Key;
 use crate::entities::sys::User;
 use crate::generated_id::GeneratedId;
 use crate::key_loader_facade::VersionedAesKey;
+use std::collections::HashMap;
+use std::sync::RwLock;
 
 pub struct KeyCache {
-    current_group_keys: RwLock<HashMap<GeneratedId, VersionedAesKey>>,
-    current_user_group_key: RwLock<Option<VersionedAesKey>>,
-    user_group_key_distribution_key: RwLock<Option<Aes256Key>>,
+	current_group_keys: RwLock<HashMap<GeneratedId, VersionedAesKey>>,
+	current_user_group_key: RwLock<Option<VersionedAesKey>>,
+	user_group_key_distribution_key: RwLock<Option<Aes256Key>>,
 }
 
 #[cfg_attr(test, mockall::automock)]
 impl KeyCache {
-    pub fn new() -> Self {
-        KeyCache {
-            current_group_keys: RwLock::new(HashMap::new()),
-            current_user_group_key: RwLock::new(None),
-            user_group_key_distribution_key: RwLock::new(None),
-        }
-    }
+	pub fn new() -> Self {
+		KeyCache {
+			current_group_keys: RwLock::new(HashMap::new()),
+			current_user_group_key: RwLock::new(None),
+			user_group_key_distribution_key: RwLock::new(None),
+		}
+	}
 
-    pub fn set_current_user_group_key(&self, new_user_group_key: VersionedAesKey) {
-        let mut current_user_group_key_lock = self.current_user_group_key.write().unwrap();
-        match current_user_group_key_lock.as_ref() {
-            Some(current_user_group_key) if current_user_group_key.version > new_user_group_key.version => {
-                log::warn!("Tried to set an outdated user group key with version {}; current user group key version: {}", new_user_group_key.version, current_user_group_key.version);
-            }
-            _ => *current_user_group_key_lock = Some(new_user_group_key)
-        };
-    }
+	pub fn set_current_user_group_key(&self, new_user_group_key: VersionedAesKey) {
+		let mut current_user_group_key_lock = self.current_user_group_key.write().unwrap();
+		match current_user_group_key_lock.as_ref() {
+			Some(current_user_group_key)
+				if current_user_group_key.version > new_user_group_key.version =>
+			{
+				log::warn!("Tried to set an outdated user group key with version {}; current user group key version: {}", new_user_group_key.version, current_user_group_key.version);
+			},
+			_ => *current_user_group_key_lock = Some(new_user_group_key),
+		};
+	}
 
-    pub fn get_current_user_group_key(&self) -> Option<VersionedAesKey> {
-        let referenced = self.current_user_group_key.read().unwrap();
-        referenced.clone()
-    }
+	pub fn get_current_user_group_key(&self) -> Option<VersionedAesKey> {
+		let referenced = self.current_user_group_key.read().unwrap();
+		referenced.clone()
+	}
 
-    pub fn set_user_group_key_distribution_key(&self, user_group_key_distribution_key: Aes256Key) {
-        *self.user_group_key_distribution_key.write().unwrap() = Some(user_group_key_distribution_key);
-    }
+	pub fn set_user_group_key_distribution_key(&self, user_group_key_distribution_key: Aes256Key) {
+		*self.user_group_key_distribution_key.write().unwrap() =
+			Some(user_group_key_distribution_key);
+	}
 
-    pub fn get_current_group_key(&self, group_id: &GeneratedId) -> Option<VersionedAesKey> {
-        let lock = self.current_group_keys.read().unwrap();
-        lock.get(group_id).cloned()
-    }
+	pub fn get_current_group_key(&self, group_id: &GeneratedId) -> Option<VersionedAesKey> {
+		let lock = self.current_group_keys.read().unwrap();
+		lock.get(group_id).cloned()
+	}
 
-    pub fn put_group_key(&self, group_id: &GeneratedId, key: &VersionedAesKey) {
-        let mut lock = self.current_group_keys.write().unwrap();
-        lock.insert(group_id.to_owned(), key.to_owned());
-    }
+	pub fn put_group_key(&self, group_id: &GeneratedId, key: &VersionedAesKey) {
+		let mut lock = self.current_group_keys.write().unwrap();
+		lock.insert(group_id.to_owned(), key.to_owned());
+	}
 
-    #[allow(clippy::unused_async)]
-    pub async fn remove_outdated_group_keys(&self, _user: &User) {
-        todo!("key cache remove_outdated_group_keys")
-    }
+	#[allow(clippy::unused_async)]
+	pub async fn remove_outdated_group_keys(&self, _user: &User) {
+		todo!("key cache remove_outdated_group_keys")
+	}
 }

--- a/tuta-sdk/rust/sdk/src/key_loader_facade.rs
+++ b/tuta-sdk/rust/sdk/src/key_loader_facade.rs
@@ -1,574 +1,752 @@
-use std::cmp::Ordering;
-use std::sync::Arc;
-use base64::Engine;
-use futures::future::BoxFuture;
 use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey, KeyLoadError};
 use crate::crypto::key_encryption::decrypt_key_pair;
 use crate::entities::sys::{Group, GroupKey};
 use crate::generated_id::GeneratedId;
-use crate::ListLoadDirection;
 #[mockall_double::double]
 use crate::typed_entity_client::TypedEntityClient;
 #[mockall_double::double]
 use crate::user_facade::UserFacade;
 use crate::util::Versioned;
+use crate::ListLoadDirection;
+use base64::Engine;
+use futures::future::BoxFuture;
+use std::cmp::Ordering;
+use std::sync::Arc;
 
 pub struct KeyLoaderFacade {
-    user_facade: Arc<UserFacade>,
-    entity_client: Arc<TypedEntityClient>,
+	user_facade: Arc<UserFacade>,
+	entity_client: Arc<TypedEntityClient>,
 }
 
 #[cfg_attr(test, mockall::automock)]
 impl KeyLoaderFacade {
-    pub fn new(
-        user_facade: Arc<UserFacade>,
-        entity_client: Arc<TypedEntityClient>,
-    ) -> Self {
-        KeyLoaderFacade {
-            user_facade,
-            entity_client,
-        }
-    }
+	pub fn new(user_facade: Arc<UserFacade>, entity_client: Arc<TypedEntityClient>) -> Self {
+		KeyLoaderFacade {
+			user_facade,
+			entity_client,
+		}
+	}
 
-    pub async fn load_sym_group_key(&self, group_id: &GeneratedId, version: i64, current_group_key: Option<VersionedAesKey>) -> Result<GenericAesKey, KeyLoadError> {
-        let group_key = match current_group_key {
-            Some(n) => {
-                let group_key_version = n.version;
-                if group_key_version < version {
-                    return Err(KeyLoadError { reason: format!("Provided current group key is too old (${group_key_version}) to load the requested version ${version} for group ${group_id}") });
-                }
-                n
-            }
-            None => self.get_current_sym_group_key(group_id).await?
-        };
+	pub async fn load_sym_group_key(
+		&self,
+		group_id: &GeneratedId,
+		version: i64,
+		current_group_key: Option<VersionedAesKey>,
+	) -> Result<GenericAesKey, KeyLoadError> {
+		let group_key = match current_group_key {
+			Some(n) => {
+				let group_key_version = n.version;
+				if group_key_version < version {
+					return Err(KeyLoadError { reason: format!("Provided current group key is too old (${group_key_version}) to load the requested version ${version} for group ${group_id}") });
+				}
+				n
+			},
+			None => self.get_current_sym_group_key(group_id).await?,
+		};
 
-        if group_key.version == version {
-            Ok(group_key.object)
-        } else {
-            let group: Group = self.entity_client.load(&group_id.to_owned()).await?;
-            let FormerGroupKey { symmetric_group_key, .. } = self.find_former_group_key(&group, &group_key, version).await?;
-            Ok(symmetric_group_key)
-        }
-    }
+		if group_key.version == version {
+			Ok(group_key.object)
+		} else {
+			let group: Group = self.entity_client.load(&group_id.to_owned()).await?;
+			let FormerGroupKey {
+				symmetric_group_key,
+				..
+			} = self
+				.find_former_group_key(&group, &group_key, version)
+				.await?;
+			Ok(symmetric_group_key)
+		}
+	}
 
-    async fn find_former_group_key(&self, group: &Group, current_group_key: &VersionedAesKey, target_key_version: i64) -> Result<FormerGroupKey, KeyLoadError> {
-        let list_id = group.formerGroupKeys.clone().unwrap().list;
+	async fn find_former_group_key(
+		&self,
+		group: &Group,
+		current_group_key: &VersionedAesKey,
+		target_key_version: i64,
+	) -> Result<FormerGroupKey, KeyLoadError> {
+		let list_id = group.formerGroupKeys.clone().unwrap().list;
 
-        let start_id = GeneratedId(base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(current_group_key.version.to_string()));
-        let amount_of_keys_including_target = (current_group_key.version - target_key_version) as usize;
+		let start_id = GeneratedId(
+			base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(current_group_key.version.to_string()),
+		);
+		let amount_of_keys_including_target =
+			(current_group_key.version - target_key_version) as usize;
 
-        let former_keys: Vec<GroupKey> = self.entity_client.load_range(&list_id, &start_id, amount_of_keys_including_target, ListLoadDirection::DESC).await?;
+		let former_keys: Vec<GroupKey> = self
+			.entity_client
+			.load_range(
+				&list_id,
+				&start_id,
+				amount_of_keys_including_target,
+				ListLoadDirection::DESC,
+			)
+			.await?;
 
-        let VersionedAesKey {
-            version: mut last_version,
-            object: mut last_group_key
-        } = current_group_key.to_owned();
+		let VersionedAesKey {
+			version: mut last_version,
+			object: mut last_group_key,
+		} = current_group_key.to_owned();
 
-        let mut last_group_key_instance: Option<GroupKey> = None;
-        let retrieved_keys_count = former_keys.len();
+		let mut last_group_key_instance: Option<GroupKey> = None;
+		let retrieved_keys_count = former_keys.len();
 
-        for former_key in former_keys {
-            let version = self.decode_group_key_version(&former_key._id.element_id)?;
-            let next_version = version + 1;
+		for former_key in former_keys {
+			let version = self.decode_group_key_version(&former_key._id.element_id)?;
+			let next_version = version + 1;
 
-            match next_version.cmp(&last_version) {
-                Ordering::Less => return Err(KeyLoadError { reason: format!("Unexpected group key version {version}; expected {last_version}") }),
-                Ordering::Greater => continue,
-                Ordering::Equal => {
-                    last_version = version;
-                    last_group_key = last_group_key.decrypt_aes_key(&former_key.ownerEncGKey).map_err(|e| {
-                        KeyLoadError { reason: e.to_string() }
-                    })?;
-                    last_group_key_instance = Some(former_key);
-                    if last_version <= target_key_version {
-                        break;
-                    }
-                }
-            }
-        }
+			match next_version.cmp(&last_version) {
+				Ordering::Less => {
+					return Err(KeyLoadError {
+						reason: format!(
+							"Unexpected group key version {version}; expected {last_version}"
+						),
+					})
+				},
+				Ordering::Greater => continue,
+				Ordering::Equal => {
+					last_version = version;
+					last_group_key = last_group_key
+						.decrypt_aes_key(&former_key.ownerEncGKey)
+						.map_err(|e| KeyLoadError {
+							reason: e.to_string(),
+						})?;
+					last_group_key_instance = Some(former_key);
+					if last_version <= target_key_version {
+						break;
+					}
+				},
+			}
+		}
 
-        if last_version != target_key_version || last_group_key_instance.is_none() {
-            return Err(KeyLoadError { reason: format!("Could not get last version (last version is {last_version} of {retrieved_keys_count} key(s) loaded from list {list_id}") });
-        }
+		if last_version != target_key_version || last_group_key_instance.is_none() {
+			return Err(KeyLoadError { reason: format!("Could not get last version (last version is {last_version} of {retrieved_keys_count} key(s) loaded from list {list_id}") });
+		}
 
-        Ok(FormerGroupKey { symmetric_group_key: last_group_key, group_key_instance: last_group_key_instance.unwrap() })
-    }
+		Ok(FormerGroupKey {
+			symmetric_group_key: last_group_key,
+			group_key_instance: last_group_key_instance.unwrap(),
+		})
+	}
 
-    fn decode_group_key_version(&self, element_id: &GeneratedId) -> Result<i64, KeyLoadError> {
-        element_id.as_str().parse().map_err(|_|
-            KeyLoadError {
-                reason: format!("Failed to decode group key version: {}", element_id)
-            }
-        )
-    }
+	fn decode_group_key_version(&self, element_id: &GeneratedId) -> Result<i64, KeyLoadError> {
+		element_id.as_str().parse().map_err(|_| KeyLoadError {
+			reason: format!("Failed to decode group key version: {}", element_id),
+		})
+	}
 
-    pub async fn get_current_sym_group_key(&self, group_id: &GeneratedId) -> Result<VersionedAesKey, KeyLoadError> {
-        if *group_id == self.user_facade.get_user_group_id() {
-            return self.get_current_sym_user_group_key().ok_or_else(|| KeyLoadError { reason: "no current group key".to_owned() });
-        }
+	pub async fn get_current_sym_group_key(
+		&self,
+		group_id: &GeneratedId,
+	) -> Result<VersionedAesKey, KeyLoadError> {
+		if *group_id == self.user_facade.get_user_group_id() {
+			return self
+				.get_current_sym_user_group_key()
+				.ok_or_else(|| KeyLoadError {
+					reason: "no current group key".to_owned(),
+				});
+		}
 
-        if let Some(key) = self.user_facade.key_cache().get_current_group_key(group_id) {
-            return Ok(key);
-        }
+		if let Some(key) = self.user_facade.key_cache().get_current_group_key(group_id) {
+			return Ok(key);
+		}
 
-        // The call leads to recursive calls down the chain, so BoxFuture is used to wrap the recursive async calls
-        fn get_key_for_version<'a>(facade: &'a KeyLoaderFacade, group_id: &'a GeneratedId) -> BoxFuture<'a, Result<VersionedAesKey, KeyLoadError>> {
-            Box::pin(facade.load_and_decrypt_current_sym_group_key(group_id))
-        }
+		// The call leads to recursive calls down the chain, so BoxFuture is used to wrap the recursive async calls
+		fn get_key_for_version<'a>(
+			facade: &'a KeyLoaderFacade,
+			group_id: &'a GeneratedId,
+		) -> BoxFuture<'a, Result<VersionedAesKey, KeyLoadError>> {
+			Box::pin(facade.load_and_decrypt_current_sym_group_key(group_id))
+		}
 
-        let key = get_key_for_version(self, group_id).await?;
-        self.user_facade.key_cache().put_group_key(group_id, &key);
-        Ok(key)
-    }
+		let key = get_key_for_version(self, group_id).await?;
+		self.user_facade.key_cache().put_group_key(group_id, &key);
+		Ok(key)
+	}
 
-    async fn load_and_decrypt_current_sym_group_key(&self, group_id: &GeneratedId) -> Result<VersionedAesKey, KeyLoadError> {
-        let group_membership = self.user_facade.get_membership(group_id)?;
-        let required_user_group_key = self.load_sym_user_group_key(group_membership.symKeyVersion).await?;
-        let version = group_membership.groupKeyVersion;
-        let object = required_user_group_key.decrypt_aes_key(&group_membership.symEncGKey).map_err(|e| {
-            KeyLoadError { reason: e.to_string() }
-        })?;
-        Ok(VersionedAesKey { version, object })
-    }
+	async fn load_and_decrypt_current_sym_group_key(
+		&self,
+		group_id: &GeneratedId,
+	) -> Result<VersionedAesKey, KeyLoadError> {
+		let group_membership = self.user_facade.get_membership(group_id)?;
+		let required_user_group_key = self
+			.load_sym_user_group_key(group_membership.symKeyVersion)
+			.await?;
+		let version = group_membership.groupKeyVersion;
+		let object = required_user_group_key
+			.decrypt_aes_key(&group_membership.symEncGKey)
+			.map_err(|e| KeyLoadError {
+				reason: e.to_string(),
+			})?;
+		Ok(VersionedAesKey { version, object })
+	}
 
-    async fn load_sym_user_group_key(&self, user_group_key_version: i64) -> Result<GenericAesKey, KeyLoadError> {
-        self.load_sym_group_key(
-            &self.user_facade.get_user_group_id(),
-            user_group_key_version,
-            Some(self.user_facade.get_current_user_group_key().ok_or_else(|| KeyLoadError { reason: "No use group key loaded".to_string() })?),
-        ).await
-    }
+	async fn load_sym_user_group_key(
+		&self,
+		user_group_key_version: i64,
+	) -> Result<GenericAesKey, KeyLoadError> {
+		self.load_sym_group_key(
+			&self.user_facade.get_user_group_id(),
+			user_group_key_version,
+			Some(
+				self.user_facade
+					.get_current_user_group_key()
+					.ok_or_else(|| KeyLoadError {
+						reason: "No use group key loaded".to_string(),
+					})?,
+			),
+		)
+		.await
+	}
 
-    fn get_current_sym_user_group_key(&self) -> Option<VersionedAesKey> {
-        self.user_facade.get_current_user_group_key()
-    }
+	fn get_current_sym_user_group_key(&self) -> Option<VersionedAesKey> {
+		self.user_facade.get_current_user_group_key()
+	}
 
-    pub async fn load_key_pair(&self, key_pair_group_id: &GeneratedId, group_key_version: i64) -> Result<AsymmetricKeyPair, KeyLoadError> {
-        let group: Group = self.entity_client.load(key_pair_group_id).await?;
-        let group_key = self.get_current_sym_group_key(&group._id).await?;
+	pub async fn load_key_pair(
+		&self,
+		key_pair_group_id: &GeneratedId,
+		group_key_version: i64,
+	) -> Result<AsymmetricKeyPair, KeyLoadError> {
+		let group: Group = self.entity_client.load(key_pair_group_id).await?;
+		let group_key = self.get_current_sym_group_key(&group._id).await?;
 
-        if group_key.version == group_key_version {
-            return self.get_and_decrypt_key_pair(&group, &group_key.object);
-        }
-        let FormerGroupKey { symmetric_group_key, group_key_instance: GroupKey { keyPair: key_pair, .. }, .. } = self.find_former_group_key(&group, &group_key, group_key_version).await?;
-        if let Some(key) = key_pair {
-            decrypt_key_pair(&symmetric_group_key, &key)
-        } else {
-            Err(KeyLoadError { reason: format!("key pair not found for group {key_pair_group_id} and version {group_key_version}") })
-        }
-    }
-    fn get_and_decrypt_key_pair(&self, group: &Group, group_key: &GenericAesKey) -> Result<AsymmetricKeyPair, KeyLoadError> {
-        match &group.currentKeys {
-            Some(keys) => decrypt_key_pair(group_key, keys),
-            None => Err(KeyLoadError { reason: format!("no key pair on group {}", group._id) })
-        }
-    }
+		if group_key.version == group_key_version {
+			return self.get_and_decrypt_key_pair(&group, &group_key.object);
+		}
+		let FormerGroupKey {
+			symmetric_group_key,
+			group_key_instance: GroupKey {
+				keyPair: key_pair, ..
+			},
+			..
+		} = self
+			.find_former_group_key(&group, &group_key, group_key_version)
+			.await?;
+		if let Some(key) = key_pair {
+			decrypt_key_pair(&symmetric_group_key, &key)
+		} else {
+			Err(KeyLoadError { reason: format!("key pair not found for group {key_pair_group_id} and version {group_key_version}") })
+		}
+	}
+	fn get_and_decrypt_key_pair(
+		&self,
+		group: &Group,
+		group_key: &GenericAesKey,
+	) -> Result<AsymmetricKeyPair, KeyLoadError> {
+		match &group.currentKeys {
+			Some(keys) => decrypt_key_pair(group_key, keys),
+			None => Err(KeyLoadError {
+				reason: format!("no key pair on group {}", group._id),
+			}),
+		}
+	}
 }
 
 pub type VersionedAesKey = Versioned<GenericAesKey>;
 
 struct FormerGroupKey {
-    symmetric_group_key: GenericAesKey,
-    group_key_instance: GroupKey,
+	symmetric_group_key: GenericAesKey,
+	group_key_instance: GroupKey,
 }
 
 #[cfg(test)]
 mod tests {
-    use std::array::from_fn;
-    use crate::IdTuple;
-    use crate::crypto::{Aes256Key, Iv, PQKeyPairs};
-    use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
-    use crate::entities::sys::{GroupKeysRef, GroupMembership, KeyPair};
-    use crate::key_cache::MockKeyCache;
-    use crate::typed_entity_client::MockTypedEntityClient;
-    use crate::user_facade::MockUserFacade;
-    use super::*;
-    use crate::util::test_utils::{generate_random_group, random_aes256_key};
-    use mockall::{predicate};
-    use crate::crypto::randomizer_facade::RandomizerFacade;
-    use crate::custom_id::CustomId;
-    use crate::util::get_vec_reversed;
+	use super::*;
+	use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
+	use crate::crypto::randomizer_facade::RandomizerFacade;
+	use crate::crypto::{Aes256Key, Iv, PQKeyPairs};
+	use crate::custom_id::CustomId;
+	use crate::entities::sys::{GroupKeysRef, GroupMembership, KeyPair};
+	use crate::key_cache::MockKeyCache;
+	use crate::typed_entity_client::MockTypedEntityClient;
+	use crate::user_facade::MockUserFacade;
+	use crate::util::get_vec_reversed;
+	use crate::util::test_utils::{generate_random_group, random_aes256_key};
+	use crate::IdTuple;
+	use mockall::predicate;
+	use std::array::from_fn;
 
-    fn generate_group_key(version: i64) -> VersionedAesKey {
-        VersionedAesKey { object: random_aes256_key().into(), version }
-    }
+	fn generate_group_key(version: i64) -> VersionedAesKey {
+		VersionedAesKey {
+			object: random_aes256_key().into(),
+			version,
+		}
+	}
 
-    fn generate_group_data() -> (Group, VersionedAesKey) {
-        (
-            generate_random_group(None, None),
-            generate_group_key(1)
-        )
-    }
+	fn generate_group_data() -> (Group, VersionedAesKey) {
+		(generate_random_group(None, None), generate_group_key(1))
+	}
 
-    fn generate_group_with_keys(current_key_pair: &PQKeyPairs, current_group_key: &VersionedAesKey, randomizer_facade: &RandomizerFacade) -> Group {
-        let PQKeyPairs { ecc_keys, kyber_keys } = current_key_pair;
-        let group_key = &current_group_key.object;
-        let sym_enc_priv_ecc_key = group_key.encrypt_data(ecc_keys.private_key.as_bytes(), Iv::generate(randomizer_facade)).unwrap();
-        let sync_enc_priv_kyber_key = group_key.encrypt_data(&kyber_keys.private_key.serialize(), Iv::generate(randomizer_facade)).unwrap();
-        generate_random_group(
-            Some(
-                KeyPair {
-                    _id: Default::default(),
-                    pubEccKey: Some(ecc_keys.public_key.as_bytes().to_vec()),
-                    pubKyberKey: Some(kyber_keys.public_key.serialize()),
-                    pubRsaKey: None,
-                    symEncPrivEccKey: Some(sym_enc_priv_ecc_key),
-                    symEncPrivKyberKey: Some(sync_enc_priv_kyber_key),
-                    symEncPrivRsaKey: None,
-                }
-            ),
-            Some(
-                GroupKeysRef {
-                    _id: Default::default(),
-                    list: GeneratedId("list".to_owned()), // Refers to `former_keys`
-                }
-            ),
-        )
-    }
+	fn generate_group_with_keys(
+		current_key_pair: &PQKeyPairs,
+		current_group_key: &VersionedAesKey,
+		randomizer_facade: &RandomizerFacade,
+	) -> Group {
+		let PQKeyPairs {
+			ecc_keys,
+			kyber_keys,
+		} = current_key_pair;
+		let group_key = &current_group_key.object;
+		let sym_enc_priv_ecc_key = group_key
+			.encrypt_data(
+				ecc_keys.private_key.as_bytes(),
+				Iv::generate(randomizer_facade),
+			)
+			.unwrap();
+		let sync_enc_priv_kyber_key = group_key
+			.encrypt_data(
+				&kyber_keys.private_key.serialize(),
+				Iv::generate(randomizer_facade),
+			)
+			.unwrap();
+		generate_random_group(
+			Some(KeyPair {
+				_id: Default::default(),
+				pubEccKey: Some(ecc_keys.public_key.as_bytes().to_vec()),
+				pubKyberKey: Some(kyber_keys.public_key.serialize()),
+				pubRsaKey: None,
+				symEncPrivEccKey: Some(sym_enc_priv_ecc_key),
+				symEncPrivKyberKey: Some(sync_enc_priv_kyber_key),
+				symEncPrivRsaKey: None,
+			}),
+			Some(GroupKeysRef {
+				_id: Default::default(),
+				list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+			}),
+		)
+	}
 
-    const FORMER_KEYS: usize = 2;
+	const FORMER_KEYS: usize = 2;
 
-    /// Returns `(former_keys, former_key_pairs_decrypted, former_keys_decrypted)`
-    fn generate_former_keys(current_group_key: &VersionedAesKey, randomizer_facade: &RandomizerFacade) -> ([GroupKey; FORMER_KEYS], [PQKeyPairs; FORMER_KEYS], [Aes256Key; FORMER_KEYS]) {
-        // Using `from_fn` has the same performance as using mutable vecs but less memory usage
-        let former_keys_decrypted: [Aes256Key; FORMER_KEYS] = from_fn(|_| {
-            random_aes256_key()
-        });
-        let former_key_pairs_decrypted: [PQKeyPairs; FORMER_KEYS] = from_fn(|_| {
-            PQKeyPairs::generate(&make_thread_rng_facade())
-        });
+	/// Returns `(former_keys, former_key_pairs_decrypted, former_keys_decrypted)`
+	fn generate_former_keys(
+		current_group_key: &VersionedAesKey,
+		randomizer_facade: &RandomizerFacade,
+	) -> (
+		[GroupKey; FORMER_KEYS],
+		[PQKeyPairs; FORMER_KEYS],
+		[Aes256Key; FORMER_KEYS],
+	) {
+		// Using `from_fn` has the same performance as using mutable vecs but less memory usage
+		let former_keys_decrypted: [Aes256Key; FORMER_KEYS] = from_fn(|_| random_aes256_key());
+		let former_key_pairs_decrypted: [PQKeyPairs; FORMER_KEYS] =
+			from_fn(|_| PQKeyPairs::generate(&make_thread_rng_facade()));
 
-        let mut former_keys = Vec::with_capacity(FORMER_KEYS);
-        let mut last_key = current_group_key.object.clone();
+		let mut former_keys = Vec::with_capacity(FORMER_KEYS);
+		let mut last_key = current_group_key.object.clone();
 
-        for (i, current_key) in former_keys_decrypted.iter().enumerate().rev() {
-            let pq_key_pair = &former_key_pairs_decrypted[i];
-            // Get the previous key to use as the owner key
-            let current_key: &GenericAesKey = &current_key.clone().into();
+		for (i, current_key) in former_keys_decrypted.iter().enumerate().rev() {
+			let pq_key_pair = &former_key_pairs_decrypted[i];
+			// Get the previous key to use as the owner key
+			let current_key: &GenericAesKey = &current_key.clone().into();
 
-            let owner_enc_g_key = last_key.encrypt_key(current_key, Iv::generate(randomizer_facade)).as_slice().to_vec();
-            let sym_enc_priv_ecc_key = current_key.encrypt_data(
-                pq_key_pair.ecc_keys.private_key.clone().as_bytes(),
-                Iv::generate(randomizer_facade)).unwrap();
+			let owner_enc_g_key = last_key
+				.encrypt_key(current_key, Iv::generate(randomizer_facade))
+				.as_slice()
+				.to_vec();
+			let sym_enc_priv_ecc_key = current_key
+				.encrypt_data(
+					pq_key_pair.ecc_keys.private_key.clone().as_bytes(),
+					Iv::generate(randomizer_facade),
+				)
+				.unwrap();
 
-            former_keys.insert(0, GroupKey {
-                _format: 0,
-                _id: IdTuple {
-                    list_id: GeneratedId("list".to_owned()),
-                    element_id: GeneratedId(i.to_string()),
-                },
-                _ownerGroup: None,
-                _permissions: Default::default(),
-                adminGroupEncGKey: None,
-                adminGroupKeyVersion: None,
-                ownerEncGKey: owner_enc_g_key,
-                ownerKeyVersion: 0,
-                pubAdminGroupEncGKey: None,
-                keyPair: Some(KeyPair {
-                    _id: Default::default(),
-                    pubEccKey: Some(pq_key_pair.ecc_keys.public_key.as_bytes().to_vec()),
-                    pubKyberKey: Some(pq_key_pair.kyber_keys.public_key.serialize()),
-                    pubRsaKey: None,
-                    symEncPrivEccKey: Some(sym_enc_priv_ecc_key
-                    ),
-                    symEncPrivKyberKey: Some(current_key.encrypt_data(
-                        pq_key_pair.kyber_keys.private_key.serialize().as_slice(),
-                        Iv::generate(randomizer_facade)).unwrap()
-                    ),
-                    symEncPrivRsaKey: None,
-                }),
-            });
-            last_key = current_key.clone();
-        }
+			former_keys.insert(
+				0,
+				GroupKey {
+					_format: 0,
+					_id: IdTuple {
+						list_id: GeneratedId("list".to_owned()),
+						element_id: GeneratedId(i.to_string()),
+					},
+					_ownerGroup: None,
+					_permissions: Default::default(),
+					adminGroupEncGKey: None,
+					adminGroupKeyVersion: None,
+					ownerEncGKey: owner_enc_g_key,
+					ownerKeyVersion: 0,
+					pubAdminGroupEncGKey: None,
+					keyPair: Some(KeyPair {
+						_id: Default::default(),
+						pubEccKey: Some(pq_key_pair.ecc_keys.public_key.as_bytes().to_vec()),
+						pubKyberKey: Some(pq_key_pair.kyber_keys.public_key.serialize()),
+						pubRsaKey: None,
+						symEncPrivEccKey: Some(sym_enc_priv_ecc_key),
+						symEncPrivKyberKey: Some(
+							current_key
+								.encrypt_data(
+									pq_key_pair.kyber_keys.private_key.serialize().as_slice(),
+									Iv::generate(randomizer_facade),
+								)
+								.unwrap(),
+						),
+						symEncPrivRsaKey: None,
+					}),
+				},
+			);
+			last_key = current_key.clone();
+		}
 
-        (former_keys.try_into().unwrap_or_else(|_| panic!()), former_key_pairs_decrypted, former_keys_decrypted)
-    }
+		(
+			former_keys.try_into().unwrap_or_else(|_| panic!()),
+			former_key_pairs_decrypted,
+			former_keys_decrypted,
+		)
+	}
 
-    fn make_mocks_with_former_keys(group: &Group, current_group_key: &VersionedAesKey, randomizer: &RandomizerFacade, former_keys: &[GroupKey; FORMER_KEYS]) -> KeyLoaderFacade {
-        let (user_facade_mock, mut typed_entity_client_mock) = make_mocks(group, current_group_key, randomizer);
-        {
-            for i in 0..FORMER_KEYS {
-                let group = group.clone();
-                let former_keys = former_keys.clone();
+	fn make_mocks_with_former_keys(
+		group: &Group,
+		current_group_key: &VersionedAesKey,
+		randomizer: &RandomizerFacade,
+		former_keys: &[GroupKey; FORMER_KEYS],
+	) -> KeyLoaderFacade {
+		let (user_facade_mock, mut typed_entity_client_mock) =
+			make_mocks(group, current_group_key, randomizer);
+		{
+			for i in 0..FORMER_KEYS {
+				let group = group.clone();
+				let former_keys = former_keys.clone();
 
-                let returned_keys = get_vec_reversed(former_keys[i..].to_vec());
-                typed_entity_client_mock.expect_load_range::<GroupKey>()
-                    .with(
-                        predicate::eq(group.formerGroupKeys.unwrap().list),
-                        predicate::eq(GeneratedId(
-                            base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(current_group_key.version.to_string())
-                        )),
-                        predicate::eq(FORMER_KEYS - i),
-                        predicate::eq(ListLoadDirection::DESC),
-                    )
-                    .returning(move |_, _, _, _| Ok(returned_keys.clone()))
-                    .times(1);
-            }
-        }
-        KeyLoaderFacade::new(
-            Arc::new(user_facade_mock),
-            Arc::new(typed_entity_client_mock),
-        )
-    }
+				let returned_keys = get_vec_reversed(former_keys[i..].to_vec());
+				typed_entity_client_mock
+					.expect_load_range::<GroupKey>()
+					.with(
+						predicate::eq(group.formerGroupKeys.unwrap().list),
+						predicate::eq(GeneratedId(
+							base64::prelude::BASE64_URL_SAFE_NO_PAD
+								.encode(current_group_key.version.to_string()),
+						)),
+						predicate::eq(FORMER_KEYS - i),
+						predicate::eq(ListLoadDirection::DESC),
+					)
+					.returning(move |_, _, _, _| Ok(returned_keys.clone()))
+					.times(1);
+			}
+		}
+		KeyLoaderFacade::new(
+			Arc::new(user_facade_mock),
+			Arc::new(typed_entity_client_mock),
+		)
+	}
 
-    fn make_mocks(group: &Group, current_group_key: &VersionedAesKey, randomizer: &RandomizerFacade) -> (MockUserFacade, MockTypedEntityClient) {
-        let user_group_key = generate_group_key(0);
-        let user_group = generate_random_group(None, None);
+	fn make_mocks(
+		group: &Group,
+		current_group_key: &VersionedAesKey,
+		randomizer: &RandomizerFacade,
+	) -> (MockUserFacade, MockTypedEntityClient) {
+		let user_group_key = generate_group_key(0);
+		let user_group = generate_random_group(None, None);
 
-        let mut user_facade_mock = MockUserFacade::default();
-        {
-            let user_group_key = user_group_key.clone();
-            user_facade_mock.expect_get_current_user_group_key()
-                .returning(move || Some(user_group_key.clone()));
-        }
-        {
-            let current_group_key = current_group_key.clone();
-            let mut key_cache_mock = MockKeyCache::default();
-            key_cache_mock.expect_get_current_group_key()
-                .returning(move |_| Some(current_group_key.clone()));
-            let key_cache = Arc::new(key_cache_mock);
-            user_facade_mock.expect_key_cache()
-                .returning(move || key_cache.clone());
-        }
-        {
-            let user_group_id = user_group._id.clone();
-            let sym_enc_g_key = user_group_key.object.encrypt_key(
-                &current_group_key.object,
-                Iv::generate(randomizer),
-            );
-            let current_group_key = current_group_key.clone();
-            user_facade_mock.expect_get_membership()
-                .with(predicate::eq(user_group_id.clone()))
-                .returning(move |_| Ok(GroupMembership {
-                    _id: CustomId(user_group_id.clone().to_string()),
-                    admin: false,
-                    capability: None,
-                    groupKeyVersion: current_group_key.clone().version,
-                    groupType: None,
-                    symEncGKey: sym_enc_g_key.clone(),
-                    symKeyVersion: user_group_key.version,
-                    group: user_group_id.clone(),
-                    groupInfo: IdTuple { list_id: Default::default(), element_id: Default::default() },
-                    groupMember: IdTuple { list_id: Default::default(), element_id: Default::default() },
-                }));
-        }
-        {
-            let user_group_id = user_group._id.clone();
-            user_facade_mock.expect_get_user_group_id().returning(move || user_group_id.clone());
-        }
+		let mut user_facade_mock = MockUserFacade::default();
+		{
+			let user_group_key = user_group_key.clone();
+			user_facade_mock
+				.expect_get_current_user_group_key()
+				.returning(move || Some(user_group_key.clone()));
+		}
+		{
+			let current_group_key = current_group_key.clone();
+			let mut key_cache_mock = MockKeyCache::default();
+			key_cache_mock
+				.expect_get_current_group_key()
+				.returning(move |_| Some(current_group_key.clone()));
+			let key_cache = Arc::new(key_cache_mock);
+			user_facade_mock
+				.expect_key_cache()
+				.returning(move || key_cache.clone());
+		}
+		{
+			let user_group_id = user_group._id.clone();
+			let sym_enc_g_key = user_group_key
+				.object
+				.encrypt_key(&current_group_key.object, Iv::generate(randomizer));
+			let current_group_key = current_group_key.clone();
+			user_facade_mock
+				.expect_get_membership()
+				.with(predicate::eq(user_group_id.clone()))
+				.returning(move |_| {
+					Ok(GroupMembership {
+						_id: CustomId(user_group_id.clone().to_string()),
+						admin: false,
+						capability: None,
+						groupKeyVersion: current_group_key.clone().version,
+						groupType: None,
+						symEncGKey: sym_enc_g_key.clone(),
+						symKeyVersion: user_group_key.version,
+						group: user_group_id.clone(),
+						groupInfo: IdTuple {
+							list_id: Default::default(),
+							element_id: Default::default(),
+						},
+						groupMember: IdTuple {
+							list_id: Default::default(),
+							element_id: Default::default(),
+						},
+					})
+				});
+		}
+		{
+			let user_group_id = user_group._id.clone();
+			user_facade_mock
+				.expect_get_user_group_id()
+				.returning(move || user_group_id.clone());
+		}
 
-        let mut typed_entity_client_mock = MockTypedEntityClient::default();
-        {
-            let group = group.clone();
-            typed_entity_client_mock.expect_load::<Group, GeneratedId>()
-                .with(predicate::eq(group._id.clone()))
-                .returning(move |_| Ok(group.clone()));
-        }
-        (user_facade_mock, typed_entity_client_mock)
-    }
+		let mut typed_entity_client_mock = MockTypedEntityClient::default();
+		{
+			let group = group.clone();
+			typed_entity_client_mock
+				.expect_load::<Group, GeneratedId>()
+				.with(predicate::eq(group._id.clone()))
+				.returning(move |_| Ok(group.clone()));
+		}
+		(user_facade_mock, typed_entity_client_mock)
+	}
 
-    #[tokio::test]
-    async fn get_user_group_key() {
-        let (user_group, user_group_key) = generate_group_data();
+	#[tokio::test]
+	async fn get_user_group_key() {
+		let (user_group, user_group_key) = generate_group_data();
 
-        let mut user_facade_mock = MockUserFacade::default();
-        {
-            let user_group = user_group.clone();
-            user_facade_mock.expect_get_user_group_id().returning(move || user_group._id.clone());
-        }
-        {
-            let user_group_key = user_group_key.clone();
-            user_facade_mock.expect_get_current_user_group_key()
-                .returning(move || Some(user_group_key.clone()))
-                .times(2);
-        }
+		let mut user_facade_mock = MockUserFacade::default();
+		{
+			let user_group = user_group.clone();
+			user_facade_mock
+				.expect_get_user_group_id()
+				.returning(move || user_group._id.clone());
+		}
+		{
+			let user_group_key = user_group_key.clone();
+			user_facade_mock
+				.expect_get_current_user_group_key()
+				.returning(move || Some(user_group_key.clone()))
+				.times(2);
+		}
 
-        let typed_entity_client_mock = MockTypedEntityClient::default();
+		let typed_entity_client_mock = MockTypedEntityClient::default();
 
-        let key_loader_facade = KeyLoaderFacade::new(Arc::new(user_facade_mock), Arc::new(typed_entity_client_mock));
+		let key_loader_facade = KeyLoaderFacade::new(
+			Arc::new(user_facade_mock),
+			Arc::new(typed_entity_client_mock),
+		);
 
-        let current_user_group_key = key_loader_facade.get_current_sym_group_key(&user_group._id).await.unwrap();
-        assert_eq!(current_user_group_key.version, user_group.groupKeyVersion);
-        assert_eq!(current_user_group_key.object, user_group_key.object);
+		let current_user_group_key = key_loader_facade
+			.get_current_sym_group_key(&user_group._id)
+			.await
+			.unwrap();
+		assert_eq!(current_user_group_key.version, user_group.groupKeyVersion);
+		assert_eq!(current_user_group_key.object, user_group_key.object);
 
-        let _ = key_loader_facade.get_current_sym_group_key(&user_group._id).await;// should not be cached
-    }
+		let _ = key_loader_facade
+			.get_current_sym_group_key(&user_group._id)
+			.await; // should not be cached
+	}
 
-    #[tokio::test]
-    async fn get_non_user_group_key() {
-        let (group, current_group_key) = generate_group_data();
+	#[tokio::test]
+	async fn get_non_user_group_key() {
+		let (group, current_group_key) = generate_group_data();
 
-        let mut user_facade_mock = MockUserFacade::default();
-        {
-            let user_group = group.clone();
-            user_facade_mock.expect_get_user_group_id().returning(move || user_group._id.clone());
-        }
-        {
-            let user_group_key = current_group_key.clone();
-            user_facade_mock.expect_get_current_user_group_key()
-                .returning(move || Some(user_group_key.clone()));
-        }
+		let mut user_facade_mock = MockUserFacade::default();
+		{
+			let user_group = group.clone();
+			user_facade_mock
+				.expect_get_user_group_id()
+				.returning(move || user_group._id.clone());
+		}
+		{
+			let user_group_key = current_group_key.clone();
+			user_facade_mock
+				.expect_get_current_user_group_key()
+				.returning(move || Some(user_group_key.clone()));
+		}
 
-        let typed_entity_client_mock = MockTypedEntityClient::default();
+		let typed_entity_client_mock = MockTypedEntityClient::default();
 
-        let key_loader_facade = KeyLoaderFacade::new(Arc::new(user_facade_mock), Arc::new(typed_entity_client_mock));
+		let key_loader_facade = KeyLoaderFacade::new(
+			Arc::new(user_facade_mock),
+			Arc::new(typed_entity_client_mock),
+		);
 
-        let group_key = key_loader_facade.get_current_sym_group_key(&group._id).await.unwrap();
-        assert_eq!(group_key.version, group.groupKeyVersion);
-        assert_eq!(group_key.object, current_group_key.object)
-    }
+		let group_key = key_loader_facade
+			.get_current_sym_group_key(&group._id)
+			.await
+			.unwrap();
+		assert_eq!(group_key.version, group.groupKeyVersion);
+		assert_eq!(group_key.object, current_group_key.object)
+	}
 
-    #[tokio::test]
-    async fn load_former_key_pairs() {
-        let randomizer = make_thread_rng_facade();
+	#[tokio::test]
+	async fn load_former_key_pairs() {
+		let randomizer = make_thread_rng_facade();
 
-        // Same as the length of former_keys_deprecated
-        let current_group_key_version = FORMER_KEYS as i64;
-        let current_group_key = generate_group_key(current_group_key_version);
-        let current_key_pair = PQKeyPairs::generate(&randomizer);
+		// Same as the length of former_keys_deprecated
+		let current_group_key_version = FORMER_KEYS as i64;
+		let current_group_key = generate_group_key(current_group_key_version);
+		let current_key_pair = PQKeyPairs::generate(&randomizer);
 
-        let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
+		let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
 
-        let (former_keys, former_key_pairs_decrypted, _) = generate_former_keys(&current_group_key, &randomizer);
+		let (former_keys, former_key_pairs_decrypted, _) =
+			generate_former_keys(&current_group_key, &randomizer);
 
-        let key_loader_facade = make_mocks_with_former_keys(&group, &current_group_key, &randomizer, &former_keys);
+		let key_loader_facade =
+			make_mocks_with_former_keys(&group, &current_group_key, &randomizer, &former_keys);
 
-        for i in 0..FORMER_KEYS {
-            let keypair = key_loader_facade.load_key_pair(&group._id, i as i64).await.unwrap();
-            match keypair {
+		for i in 0..FORMER_KEYS {
+			let keypair = key_loader_facade
+				.load_key_pair(&group._id, i as i64)
+				.await
+				.unwrap();
+			match keypair {
                 AsymmetricKeyPair::RSAKeyPair(_) => panic!("key_loader_facade.load_key_pair() returned an RSAKeyPair! Expected PQKeyPairs."),
                 AsymmetricKeyPair::RSAEccKeyPair(_) => panic!("key_loader_facade.load_key_pair() returned an RSAEccKeyPair! Expected PQKeyPairs."),
                 AsymmetricKeyPair::PQKeyPairs(pq_key_pair) => {
                     assert_eq!(pq_key_pair, *former_key_pairs_decrypted.get(i).expect("former_key_pairs_decrypted should have FORMER_KEYS keys"))
                 }
             }
-        }
-    }
+		}
+	}
 
-    #[tokio::test]
-    async fn load_current_key_pair() {
-        let user_group_key = generate_group_key(1);
-        let randomizer = make_thread_rng_facade();
-        let current_key_pair = PQKeyPairs::generate(&randomizer);
-        let user_group = generate_group_with_keys(
-            &current_key_pair,
-            &user_group_key,
-            &randomizer,
-        );
+	#[tokio::test]
+	async fn load_current_key_pair() {
+		let user_group_key = generate_group_key(1);
+		let randomizer = make_thread_rng_facade();
+		let current_key_pair = PQKeyPairs::generate(&randomizer);
+		let user_group = generate_group_with_keys(&current_key_pair, &user_group_key, &randomizer);
 
-        let mut user_facade_mock = MockUserFacade::default();
-        {
-            let user_group_id = user_group._id.clone();
-            user_facade_mock.expect_get_user_group_id().returning(move || user_group_id.clone());
-        }
-        {
-            let user_group_key = user_group_key.clone();
-            user_facade_mock.expect_get_current_user_group_key()
-                .returning(move || Some(user_group_key.clone()));
-        }
+		let mut user_facade_mock = MockUserFacade::default();
+		{
+			let user_group_id = user_group._id.clone();
+			user_facade_mock
+				.expect_get_user_group_id()
+				.returning(move || user_group_id.clone());
+		}
+		{
+			let user_group_key = user_group_key.clone();
+			user_facade_mock
+				.expect_get_current_user_group_key()
+				.returning(move || Some(user_group_key.clone()));
+		}
 
-        let mut typed_entity_client_mock = MockTypedEntityClient::default();
-        {
-            let user_group = user_group.clone();
-            let group_id = user_group._id.clone();
-            typed_entity_client_mock.expect_load::<Group, GeneratedId>()
-                .withf(move |id| *id == group_id.clone())
-                .returning(move |_| Ok(user_group.clone()));
-        }
+		let mut typed_entity_client_mock = MockTypedEntityClient::default();
+		{
+			let user_group = user_group.clone();
+			let group_id = user_group._id.clone();
+			typed_entity_client_mock
+				.expect_load::<Group, GeneratedId>()
+				.withf(move |id| *id == group_id.clone())
+				.returning(move |_| Ok(user_group.clone()));
+		}
 
-        let key_loader_facade = KeyLoaderFacade::new(Arc::new(user_facade_mock), Arc::new(typed_entity_client_mock));
+		let key_loader_facade = KeyLoaderFacade::new(
+			Arc::new(user_facade_mock),
+			Arc::new(typed_entity_client_mock),
+		);
 
-        let loaded_current_key_pair = key_loader_facade.load_key_pair(&user_group._id, user_group.groupKeyVersion)
-            .await
-            .unwrap();
+		let loaded_current_key_pair = key_loader_facade
+			.load_key_pair(&user_group._id, user_group.groupKeyVersion)
+			.await
+			.unwrap();
 
-        match loaded_current_key_pair {
-            AsymmetricKeyPair::RSAKeyPair(_) => panic!("Expected PQ key pair!"),
-            AsymmetricKeyPair::RSAEccKeyPair(_) => panic!("Expected PQ key pair!"),
-            AsymmetricKeyPair::PQKeyPairs(loaded_current_key_pair) => {
-                assert_eq!(loaded_current_key_pair, current_key_pair);
-            }
-        }
-    }
+		match loaded_current_key_pair {
+			AsymmetricKeyPair::RSAKeyPair(_) => panic!("Expected PQ key pair!"),
+			AsymmetricKeyPair::RSAEccKeyPair(_) => panic!("Expected PQ key pair!"),
+			AsymmetricKeyPair::PQKeyPairs(loaded_current_key_pair) => {
+				assert_eq!(loaded_current_key_pair, current_key_pair);
+			},
+		}
+	}
 
-    #[tokio::test]
-    async fn load_and_decrypt_former_group_key() {
-        let randomizer = make_thread_rng_facade();
+	#[tokio::test]
+	async fn load_and_decrypt_former_group_key() {
+		let randomizer = make_thread_rng_facade();
 
-        // Same as the length of former_keys_deprecated
-        let current_group_key_version = FORMER_KEYS as i64;
-        let current_group_key = generate_group_key(current_group_key_version);
-        let (former_keys, _, former_keys_decrypted) = generate_former_keys(&current_group_key, &randomizer);
+		// Same as the length of former_keys_deprecated
+		let current_group_key_version = FORMER_KEYS as i64;
+		let current_group_key = generate_group_key(current_group_key_version);
+		let (former_keys, _, former_keys_decrypted) =
+			generate_former_keys(&current_group_key, &randomizer);
 
-        let current_key_pair = PQKeyPairs::generate(&randomizer);
-        let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
+		let current_key_pair = PQKeyPairs::generate(&randomizer);
+		let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
 
-        let key_loader_facade = make_mocks_with_former_keys(&group, &current_group_key, &randomizer, &former_keys);
-        for i in 0..FORMER_KEYS {
-            let keypair = key_loader_facade.load_sym_group_key(&group._id, i as i64, None).await.unwrap();
-            match keypair {
+		let key_loader_facade =
+			make_mocks_with_former_keys(&group, &current_group_key, &randomizer, &former_keys);
+		for i in 0..FORMER_KEYS {
+			let keypair = key_loader_facade
+				.load_sym_group_key(&group._id, i as i64, None)
+				.await
+				.unwrap();
+			match keypair {
                 GenericAesKey::Aes128(_) => panic!("key_loader_facade.load_sym_group_key() returned an AES128 key! Expected an AES256 key."),
                 GenericAesKey::Aes256(returned_group_key) => {
                     assert_eq!(returned_group_key, *former_keys_decrypted.get(i).expect("former_keys_decrypted should have FORMER_KEYS keys"))
                 }
             }
-        }
-    }
+		}
+	}
 
-    #[tokio::test]
-    async fn load_and_decrypt_current_group_key() {
-        let randomizer = make_thread_rng_facade();
+	#[tokio::test]
+	async fn load_and_decrypt_current_group_key() {
+		let randomizer = make_thread_rng_facade();
 
-        // Same as the length of former_keys_deprecated
-        let current_group_key_version = FORMER_KEYS as i64;
-        let current_group_key = generate_group_key(current_group_key_version);
+		// Same as the length of former_keys_deprecated
+		let current_group_key_version = FORMER_KEYS as i64;
+		let current_group_key = generate_group_key(current_group_key_version);
 
-        let current_key_pair = PQKeyPairs::generate(&randomizer);
-        let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
+		let current_key_pair = PQKeyPairs::generate(&randomizer);
+		let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
 
+		let (user_facade_mock, typed_entity_client_mock) =
+			make_mocks(&group, &current_group_key, &randomizer);
+		let key_loader_facade = KeyLoaderFacade::new(
+			Arc::new(user_facade_mock),
+			Arc::new(typed_entity_client_mock),
+		);
 
-        let (user_facade_mock, typed_entity_client_mock) = make_mocks(&group, &current_group_key, &randomizer);
-        let key_loader_facade = KeyLoaderFacade::new(
-            Arc::new(user_facade_mock),
-            Arc::new(typed_entity_client_mock),
-        );
+		let returned_key = key_loader_facade
+			.load_sym_group_key(&group._id, current_group_key_version, None)
+			.await
+			.unwrap();
 
-        let returned_key = key_loader_facade.load_sym_group_key(&group._id, current_group_key_version, None).await.unwrap();
+		assert_eq!(returned_key, current_group_key.object)
+	}
 
-        assert_eq!(returned_key, current_group_key.object)
-    }
+	#[tokio::test]
+	async fn outdated_current_group_key_errors() {
+		let randomizer = make_thread_rng_facade();
 
-    #[tokio::test]
-    async fn outdated_current_group_key_errors() {
-        let randomizer = make_thread_rng_facade();
+		// Same as the length of former_keys_deprecated
+		let current_group_key_version = FORMER_KEYS as i64;
+		let current_group_key = generate_group_key(current_group_key_version);
 
-        // Same as the length of former_keys_deprecated
-        let current_group_key_version = FORMER_KEYS as i64;
-        let current_group_key = generate_group_key(current_group_key_version);
+		let current_key_pair = PQKeyPairs::generate(&randomizer);
+		let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
 
-        let current_key_pair = PQKeyPairs::generate(&randomizer);
-        let group = generate_group_with_keys(&current_key_pair, &current_group_key, &randomizer);
+		let (_, _, former_keys_decrypted) = generate_former_keys(&current_group_key, &randomizer);
 
-        let (_, _, former_keys_decrypted) = generate_former_keys(&current_group_key, &randomizer);
+		let outdated_current_group_key_version = current_group_key_version - 1;
+		let outdated_current_group_key = VersionedAesKey {
+			object: former_keys_decrypted[outdated_current_group_key_version as usize]
+				.clone()
+				.into(),
+			version: outdated_current_group_key_version,
+		};
 
-        let outdated_current_group_key_version = current_group_key_version - 1;
-        let outdated_current_group_key = VersionedAesKey {
-            object: former_keys_decrypted[outdated_current_group_key_version as usize].clone().into(),
-            version: outdated_current_group_key_version,
-        };
+		let user_facade_mock = MockUserFacade::default();
+		let typed_entity_client_mock = MockTypedEntityClient::default();
 
-        let user_facade_mock = MockUserFacade::default();
-        let typed_entity_client_mock = MockTypedEntityClient::default();
+		let key_loader_facade = KeyLoaderFacade::new(
+			Arc::new(user_facade_mock),
+			Arc::new(typed_entity_client_mock),
+		);
 
-        let key_loader_facade = KeyLoaderFacade::new(
-            Arc::new(user_facade_mock),
-            Arc::new(typed_entity_client_mock),
-        );
-
-        key_loader_facade.load_sym_group_key(
-            &group._id,
-            current_group_key_version,
-            Some(outdated_current_group_key),
-        ).await.expect_err("Did not error with outdated group key");
-    }
+		key_loader_facade
+			.load_sym_group_key(
+				&group._id,
+				current_group_key_version,
+				Some(outdated_current_group_key),
+			)
+			.await
+			.expect_err("Did not error with outdated group key");
+	}
 }

--- a/tuta-sdk/rust/sdk/src/lib.rs
+++ b/tuta-sdk/rust/sdk/src/lib.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 
-use minicbor::{Encode, Encoder};
 use minicbor::encode::Write;
+use minicbor::{Encode, Encoder};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -31,36 +31,36 @@ use crate::key_loader_facade::KeyLoaderFacade;
 use crate::login::{Credentials, LoginError, LoginFacade};
 use crate::mail_facade::MailFacade;
 use crate::rest_error::{HttpError, ParseFailureError};
-use crate::type_model_provider::{AppName, init_type_model_provider, TypeModelProvider, TypeName};
+use crate::type_model_provider::{init_type_model_provider, AppName, TypeModelProvider, TypeName};
 #[mockall_double::double]
 use crate::typed_entity_client::TypedEntityClient;
 #[mockall_double::double]
 use crate::user_facade::UserFacade;
 
-mod entity_client;
-mod json_serializer;
-mod json_element;
-pub mod rest_client;
-mod element_value;
-mod metamodel;
-mod type_model_provider;
-mod mail_facade;
-mod user_facade;
-mod rest_error;
 mod crypto;
-mod util;
-mod entities;
-mod instance_mapper;
-mod typed_entity_client;
-mod key_loader_facade;
-mod key_cache;
-pub mod date;
-pub mod generated_id;
-mod custom_id;
-pub mod login;
 mod crypto_entity_client;
+mod custom_id;
+pub mod date;
+mod element_value;
+mod entities;
+mod entity_client;
+pub mod generated_id;
+mod instance_mapper;
+mod json_element;
+mod json_serializer;
+mod key_cache;
+mod key_loader_facade;
 mod logging;
+pub mod login;
+mod mail_facade;
+mod metamodel;
+pub mod rest_client;
+mod rest_error;
 mod simple_crypto;
+mod type_model_provider;
+mod typed_entity_client;
+mod user_facade;
+mod util;
 
 uniffi::setup_scaffolding!();
 
@@ -68,8 +68,8 @@ uniffi::setup_scaffolding!();
 /// Definitions for them can be found inside the type model JSON files under `/test_data`
 #[derive(Debug, PartialEq, Clone)]
 pub struct TypeRef {
-    pub app: AppName,
-    pub type_: TypeName,
+	pub app: AppName,
+	pub type_: TypeName,
 }
 
 // Option 1:
@@ -85,265 +85,280 @@ pub struct TypeRef {
 // will work for WASM for sure
 
 impl Display for TypeRef {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "TypeRef({}, {})", self.app, self.type_)
-    }
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "TypeRef({}, {})", self.app, self.type_)
+	}
 }
 
 pub trait AuthHeadersProvider: Send + Sync {
-    /// Gets the HTTP request headers used for authorizing REST requests
-    fn create_auth_headers(&self, model_version: u32) -> HashMap<String, String>;
+	/// Gets the HTTP request headers used for authorizing REST requests
+	fn create_auth_headers(&self, model_version: u32) -> HashMap<String, String>;
 }
 
 impl AuthHeadersProvider for SdkState {
-    /// This version has client_version in header, unlike the LoginState version
-    fn create_auth_headers(&self, model_version: u32) -> HashMap<String, String> {
-        let mut headers = HashMap::from([
-            ("accessToken".to_string(), self.credentials.access_token.clone()),
-        ]);
-        headers.insert("cv".to_owned(), self.client_version.clone());
-        headers.insert("v".to_owned(), model_version.to_string());
-        headers
-    }
+	/// This version has client_version in header, unlike the LoginState version
+	fn create_auth_headers(&self, model_version: u32) -> HashMap<String, String> {
+		let mut headers = HashMap::from([(
+			"accessToken".to_string(),
+			self.credentials.access_token.clone(),
+		)]);
+		headers.insert("cv".to_owned(), self.client_version.clone());
+		headers.insert("v".to_owned(), model_version.to_string());
+		headers
+	}
 }
 
 /// Contains all the high level mutable state of the SDK
 struct SdkState {
-    credentials: Credentials,
-    client_version: String,
+	credentials: Credentials,
+	client_version: String,
 }
 
 /// The external facing interface used by the consuming code via FFI
 #[derive(uniffi::Object)]
 pub struct Sdk {
-    state: Arc<SdkState>,
-    type_model_provider: Arc<TypeModelProvider>,
-    entity_client: Arc<EntityClient>,
-    typed_entity_client: Arc<TypedEntityClient>,
-    instance_mapper: Arc<InstanceMapper>,
+	state: Arc<SdkState>,
+	type_model_provider: Arc<TypeModelProvider>,
+	entity_client: Arc<EntityClient>,
+	typed_entity_client: Arc<TypedEntityClient>,
+	instance_mapper: Arc<InstanceMapper>,
 }
 
 #[uniffi::export]
 impl Sdk {
-    #[uniffi::constructor]
-    pub fn new(base_url: String, rest_client: Arc<dyn RestClient>, credentials: Credentials, client_version: &str) -> Sdk {
-        logging::init_logger();
-        log::debug!("Initializing SDK...");
+	#[uniffi::constructor]
+	pub fn new(
+		base_url: String,
+		rest_client: Arc<dyn RestClient>,
+		credentials: Credentials,
+		client_version: &str,
+	) -> Sdk {
+		logging::init_logger();
+		log::debug!("Initializing SDK...");
 
-        let type_model_provider = Arc::new(init_type_model_provider());
-        // TODO validate parameters
-        let json_serializer = Arc::new(JsonSerializer::new(type_model_provider.clone()));
-        let instance_mapper = Arc::new(InstanceMapper::new());
-        let state = Arc::new(SdkState {
-            credentials,
-            client_version: client_version.to_owned(),
-        });
-        let entity_client = Arc::new(EntityClient::new(
-            rest_client,
-            json_serializer,
-            &base_url,
-            state.clone(),
-            type_model_provider.clone(),
-        ));
-        let typed_entity_client: Arc<TypedEntityClient> = Arc::new(TypedEntityClient::new(
-            entity_client.clone(),
-            instance_mapper.clone()
-        ));
+		let type_model_provider = Arc::new(init_type_model_provider());
+		// TODO validate parameters
+		let json_serializer = Arc::new(JsonSerializer::new(type_model_provider.clone()));
+		let instance_mapper = Arc::new(InstanceMapper::new());
+		let state = Arc::new(SdkState {
+			credentials,
+			client_version: client_version.to_owned(),
+		});
+		let entity_client = Arc::new(EntityClient::new(
+			rest_client,
+			json_serializer,
+			&base_url,
+			state.clone(),
+			type_model_provider.clone(),
+		));
+		let typed_entity_client: Arc<TypedEntityClient> = Arc::new(TypedEntityClient::new(
+			entity_client.clone(),
+			instance_mapper.clone(),
+		));
 
-        Sdk {
-            state,
-            type_model_provider,
-            entity_client,
-            typed_entity_client,
-            instance_mapper
-        }
-    }
+		Sdk {
+			state,
+			type_model_provider,
+			entity_client,
+			typed_entity_client,
+			instance_mapper,
+		}
+	}
 
-    /// Authorizes the SDK's REST requests via inserting `access_token` into the HTTP headers
-    pub async fn login(&self) -> Result<Arc<LoggedInSdk>, LoginError> {
-        // Try to resume session
-        let login_facade = LoginFacade::new(
-            self.entity_client.clone(),
-            self.typed_entity_client.clone(),
-            |user| UserFacade::new(Arc::new(KeyCache::new()), user)
-        );
-        let user_facade = Arc::new(login_facade.resume_session(&self.state.credentials).await?);
+	/// Authorizes the SDK's REST requests via inserting `access_token` into the HTTP headers
+	pub async fn login(&self) -> Result<Arc<LoggedInSdk>, LoginError> {
+		// Try to resume session
+		let login_facade = LoginFacade::new(
+			self.entity_client.clone(),
+			self.typed_entity_client.clone(),
+			|user| UserFacade::new(Arc::new(KeyCache::new()), user),
+		);
+		let user_facade = Arc::new(login_facade.resume_session(&self.state.credentials).await?);
 
-        let key_loader = Arc::new(KeyLoaderFacade::new(
-            user_facade.clone(),
-            self.typed_entity_client.clone()
-        ));
-        let randomizer = RandomizerFacade::from_core(rand_core::OsRng);
-        let crypto_facade = Arc::new(CryptoFacade::new(
-            key_loader.clone(),
-            self.instance_mapper.clone(),
-            randomizer,
-        ));
-        let entity_facade = Arc::new(EntityFacade::new(self.type_model_provider.clone()));
-        let crypto_entity_client: Arc<CryptoEntityClient> = Arc::new(CryptoEntityClient::new(
-            self.entity_client.clone(),
-            entity_facade,
-            crypto_facade,
-            self.instance_mapper.clone()
-        ));
+		let key_loader = Arc::new(KeyLoaderFacade::new(
+			user_facade.clone(),
+			self.typed_entity_client.clone(),
+		));
+		let randomizer = RandomizerFacade::from_core(rand_core::OsRng);
+		let crypto_facade = Arc::new(CryptoFacade::new(
+			key_loader.clone(),
+			self.instance_mapper.clone(),
+			randomizer,
+		));
+		let entity_facade = Arc::new(EntityFacade::new(self.type_model_provider.clone()));
+		let crypto_entity_client: Arc<CryptoEntityClient> = Arc::new(CryptoEntityClient::new(
+			self.entity_client.clone(),
+			entity_facade,
+			crypto_facade,
+			self.instance_mapper.clone(),
+		));
 
-        Ok(Arc::new(LoggedInSdk {
-            user_facade,
-            typed_entity_client: self.typed_entity_client.clone(),
-            crypto_entity_client,
-        }))
-    }
+		Ok(Arc::new(LoggedInSdk {
+			user_facade,
+			typed_entity_client: self.typed_entity_client.clone(),
+			crypto_entity_client,
+		}))
+	}
 }
 
 #[allow(dead_code)]
 #[derive(uniffi::Object)]
 pub struct LoggedInSdk {
-    user_facade: Arc<UserFacade>,
-    typed_entity_client: Arc<TypedEntityClient>,
-    crypto_entity_client: Arc<CryptoEntityClient>
+	user_facade: Arc<UserFacade>,
+	typed_entity_client: Arc<TypedEntityClient>,
+	crypto_entity_client: Arc<CryptoEntityClient>,
 }
 
 #[uniffi::export]
 impl LoggedInSdk {
-    /// Generates a new interface to operate on mail entities
-    #[must_use]
-    pub fn mail_facade(&self) -> MailFacade {
-        MailFacade::new(self.crypto_entity_client.clone())
-    }
+	/// Generates a new interface to operate on mail entities
+	#[must_use]
+	pub fn mail_facade(&self) -> MailFacade {
+		MailFacade::new(self.crypto_entity_client.clone())
+	}
 }
 
 #[derive(uniffi::Enum, Debug, PartialEq)]
 pub enum ListLoadDirection {
-    ASC,
-    /// Reverse order
-    DESC,
+	ASC,
+	/// Reverse order
+	DESC,
 }
 
 /// A set of keys used to identify an element within a List Element Type
 #[derive(uniffi::Record, Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct IdTuple {
-    pub list_id: GeneratedId,
-    pub element_id: GeneratedId,
+	pub list_id: GeneratedId,
+	pub element_id: GeneratedId,
 }
 
 impl IdTuple {
-    #[must_use]
-    pub fn new(list_id: GeneratedId, element_id: GeneratedId) -> Self {
-        Self { list_id, element_id }
-    }
+	#[must_use]
+	pub fn new(list_id: GeneratedId, element_id: GeneratedId) -> Self {
+		Self {
+			list_id,
+			element_id,
+		}
+	}
 }
 
 impl IdType for IdTuple {}
 
 impl Display for IdTuple {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "{}/{}", self.list_id, self.element_id)
-    }
+	fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+		write!(f, "{}/{}", self.list_id, self.element_id)
+	}
 }
 
 /// Contains an error from the SDK to be handled by the consuming code over the FFI
 #[derive(Error, Debug, uniffi::Error)]
 pub enum ApiCallError {
-    #[error("Rest client error, source: {source}")]
-    RestClient {
-        #[from]
-        source: RestClientError,
-    },
-    #[error("ServerResponseError: {source}")]
-    ServerResponseError {
-        #[from]
-        source: HttpError
-    },
-    #[error("InternalSdkError: {error_message}")]
-    InternalSdkError {
-        error_message: String,
-    },
+	#[error("Rest client error, source: {source}")]
+	RestClient {
+		#[from]
+		source: RestClientError,
+	},
+	#[error("ServerResponseError: {source}")]
+	ServerResponseError {
+		#[from]
+		source: HttpError,
+	},
+	#[error("InternalSdkError: {error_message}")]
+	InternalSdkError { error_message: String },
 }
 
 impl ApiCallError {
-    fn internal(message: String) -> ApiCallError {
-        ApiCallError::InternalSdkError { error_message: message }
-    }
-    fn internal_with_err<E: Error>(error: E, message: &str) -> ApiCallError {
-        ApiCallError::InternalSdkError { error_message: format!("{}: {}", error, message) }
-    }
+	fn internal(message: String) -> ApiCallError {
+		ApiCallError::InternalSdkError {
+			error_message: message,
+		}
+	}
+	fn internal_with_err<E: Error>(error: E, message: &str) -> ApiCallError {
+		ApiCallError::InternalSdkError {
+			error_message: format!("{}: {}", error, message),
+		}
+	}
 }
 
 impl From<InstanceMapperError> for ApiCallError {
-    fn from(value: InstanceMapperError) -> Self {
-        ApiCallError::InternalSdkError { error_message: value.to_string() }
-    }
+	fn from(value: InstanceMapperError) -> Self {
+		ApiCallError::InternalSdkError {
+			error_message: value.to_string(),
+		}
+	}
 }
 
 impl From<ParseFailureError> for ApiCallError {
-    fn from(_value: ParseFailureError) -> Self {
-        ApiCallError::InternalSdkError { error_message: "Parse error".to_owned() }
-    }
+	fn from(_value: ParseFailureError) -> Self {
+		ApiCallError::InternalSdkError {
+			error_message: "Parse error".to_owned(),
+		}
+	}
 }
 
 #[uniffi::export]
 #[must_use]
 pub fn serialize_mail(mail: Mail) -> Vec<u8> {
-    let entity_map = InstanceMapper::new().serialize_entity(mail).unwrap();
-    let mut vec = Vec::new();
-    let mut encoder = Encoder::new(&mut vec);
-    encoder.encode(&entity_map).unwrap();
-    vec
+	let entity_map = InstanceMapper::new().serialize_entity(mail).unwrap();
+	let mut vec = Vec::new();
+	let mut encoder = Encoder::new(&mut vec);
+	encoder.encode(&entity_map).unwrap();
+	vec
 }
 
 impl<C> Encode<C> for ElementValue {
-    fn encode<W: Write>(
-        &self,
-        e: &mut Encoder<W>,
-        _: &mut C,
-    ) -> Result<(), minicbor::encode::Error<W::Error>> {
-        match self {
-            ElementValue::Null => e.null()?,
-            ElementValue::String(s) => e.str(s)?,
-            // JS-specific: some numbers might be big, so we encode them as strings
-            ElementValue::Number(n) => e.str(n.to_string().as_str())?,
-            ElementValue::Bytes(b) => e.bytes(b)?,
-            // See OfflineStorage dateEncoder for this tag
-            ElementValue::Date(d) => e.tag(minicbor::data::Tag::new(100))?.u64(d.as_millis())?,
-            ElementValue::Bool(b) => e.bool(*b)?,
-            ElementValue::IdGeneratedId(s) => e.str(s.as_str())?,
-            ElementValue::IdCustomId(s) => e.str(s.as_str())?,
-            ElementValue::IdTupleId(id) => e
-                .array(2)?
-                .str(id.list_id.as_str())?
-                .str(id.element_id.as_str())?,
-            ElementValue::Dict(d) => {
-                e.map(d.len() as u64)?;
-                for (k, v) in d {
-                    e.str(k)?;
-                    e.encode(v)?;
-                }
-                e
-            }
-            ElementValue::Array(a) => {
-                e.array(a.len() as u64)?;
-                for v in a {
-                    e.encode(v)?;
-                }
-                e
-            }
-        };
-        Ok(())
-    }
+	fn encode<W: Write>(
+		&self,
+		e: &mut Encoder<W>,
+		_: &mut C,
+	) -> Result<(), minicbor::encode::Error<W::Error>> {
+		match self {
+			ElementValue::Null => e.null()?,
+			ElementValue::String(s) => e.str(s)?,
+			// JS-specific: some numbers might be big, so we encode them as strings
+			ElementValue::Number(n) => e.str(n.to_string().as_str())?,
+			ElementValue::Bytes(b) => e.bytes(b)?,
+			// See OfflineStorage dateEncoder for this tag
+			ElementValue::Date(d) => e.tag(minicbor::data::Tag::new(100))?.u64(d.as_millis())?,
+			ElementValue::Bool(b) => e.bool(*b)?,
+			ElementValue::IdGeneratedId(s) => e.str(s.as_str())?,
+			ElementValue::IdCustomId(s) => e.str(s.as_str())?,
+			ElementValue::IdTupleId(id) => e
+				.array(2)?
+				.str(id.list_id.as_str())?
+				.str(id.element_id.as_str())?,
+			ElementValue::Dict(d) => {
+				e.map(d.len() as u64)?;
+				for (k, v) in d {
+					e.str(k)?;
+					e.encode(v)?;
+				}
+				e
+			},
+			ElementValue::Array(a) => {
+				e.array(a.len() as u64)?;
+				for v in a {
+					e.encode(v)?;
+				}
+				e
+			},
+		};
+		Ok(())
+	}
 
-    fn is_nil(&self) -> bool {
-        matches!(self, ElementValue::Null)
-    }
+	fn is_nil(&self) -> bool {
+		matches!(self, ElementValue::Null)
+	}
 }
 #[cfg(test)]
 mod tests {
-    use crate::util::test_utils::create_test_entity;
+	use crate::util::test_utils::create_test_entity;
 
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn test_serialize_mail_does_not_panic() {
-        let mail = create_test_entity::<Mail>();
-        let _ = serialize_mail(mail);
-    }
+	#[test]
+	fn test_serialize_mail_does_not_panic() {
+		let mail = create_test_entity::<Mail>();
+		let _ = serialize_mail(mail);
+	}
 }

--- a/tuta-sdk/rust/sdk/src/logging.rs
+++ b/tuta-sdk/rust/sdk/src/logging.rs
@@ -8,26 +8,25 @@ static LOG_INIT: AtomicBool = AtomicBool::new(false);
 /// This is a no-op if it is called multiple times.
 #[allow(unreachable_code)] // android/ios implementations return before simple_logger code
 pub(crate) fn init_logger() {
-    if !LOG_INIT.swap(true, Ordering::Relaxed) {
-        // We need to use android_log so our logs show up in logcat, as standard output isn't so trivial to access.
-        #[cfg(target_os = "android")]
-        {
-            android_log::init("TutaSDK")
-                .expect("failed to load android_log logger");
-            return;
-        }
+	if !LOG_INIT.swap(true, Ordering::Relaxed) {
+		// We need to use android_log so our logs show up in logcat, as standard output isn't so trivial to access.
+		#[cfg(target_os = "android")]
+		{
+			android_log::init("TutaSDK").expect("failed to load android_log logger");
+			return;
+		}
 
-        // For iOS, we can trivially print to stdout which will work when debugging, but messages won't appear in Console, so we need to use the unified logging
-        #[cfg(target_os = "ios")]
-        {
-            oslog::OsLogger::new("de.tutao.tutanota.tutasdk")
-                .level_filter(log::LevelFilter::Trace)
-                .init()
-                .expect("failed to load oslog logger");
-            return;
-        }
+		// For iOS, we can trivially print to stdout which will work when debugging, but messages won't appear in Console, so we need to use the unified logging
+		#[cfg(target_os = "ios")]
+		{
+			oslog::OsLogger::new("de.tutao.tutanota.tutasdk")
+				.level_filter(log::LevelFilter::Trace)
+				.init()
+				.expect("failed to load oslog logger");
+			return;
+		}
 
-        // Use standard output for logging by default
-        simple_logger::init().expect("failed to load simple_logger logger");
-    }
+		// Use standard output for logging by default
+		simple_logger::init().expect("failed to load simple_logger logger");
+	}
 }

--- a/tuta-sdk/rust/sdk/src/login/credentials.rs
+++ b/tuta-sdk/rust/sdk/src/login/credentials.rs
@@ -2,15 +2,15 @@ use crate::generated_id::GeneratedId;
 
 #[derive(uniffi::Record)]
 pub struct Credentials {
-    pub login: String,
-    pub user_id: GeneratedId,
-    pub access_token: String,
-    pub encrypted_passphrase_key: Vec<u8>,
-    pub credential_type: CredentialType,
+	pub login: String,
+	pub user_id: GeneratedId,
+	pub access_token: String,
+	pub encrypted_passphrase_key: Vec<u8>,
+	pub credential_type: CredentialType,
 }
 
 #[derive(uniffi::Enum, Debug, PartialEq, Clone)]
 pub enum CredentialType {
-    Internal,
-    External,
+	Internal,
+	External,
 }

--- a/tuta-sdk/rust/sdk/src/login/login_facade.rs
+++ b/tuta-sdk/rust/sdk/src/login/login_facade.rs
@@ -1,293 +1,336 @@
 use std::sync::Arc;
 
-use base64::{DecodeError, Engine};
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+use base64::{DecodeError, Engine};
 use thiserror::Error;
 
-use crate::{ApiCallError, IdTuple};
-use crate::ApiCallError::InternalSdkError;
-use crate::crypto::{Aes256Key, generate_key_from_passphrase, sha256};
 use crate::crypto::key::GenericAesKey;
+use crate::crypto::{generate_key_from_passphrase, sha256, Aes256Key};
 use crate::element_value::ParsedEntity;
-use crate::entities::Entity;
 use crate::entities::sys::{Session, User};
+use crate::entities::Entity;
 #[mockall_double::double]
 use crate::entity_client::EntityClient;
+use crate::generated_id::{GeneratedId, GENERATED_ID_BYTES_LENGTH};
+use crate::login::credentials::Credentials;
 #[mockall_double::double]
 use crate::typed_entity_client::TypedEntityClient;
-use crate::generated_id::{GENERATED_ID_BYTES_LENGTH, GeneratedId};
-use crate::login::credentials::Credentials;
 #[mockall_double::double]
 use crate::user_facade::UserFacade;
 use crate::util::{array_cast_slice, BASE64_EXT};
+use crate::ApiCallError::InternalSdkError;
+use crate::{ApiCallError, IdTuple};
 
 /// Error that may occur during login and session creation
 #[derive(Error, Debug, uniffi::Error)]
 pub enum LoginError {
-    #[error("InvalidSessionId: {error_message}")]
-    InvalidSessionId {
-        error_message: String,
-    },
-    #[error("InvalidPassphrase: {error_message}")]
-    InvalidPassphrase {
-        error_message: String,
-    },
-    #[error("InvalidKey: {error_message}")]
-    InvalidKey {
-        error_message: String,
-    },
-    #[error("ApiCall: {source}")]
-    ApiCall {
-        #[from]
-        source: ApiCallError,
-    },
+	#[error("InvalidSessionId: {error_message}")]
+	InvalidSessionId { error_message: String },
+	#[error("InvalidPassphrase: {error_message}")]
+	InvalidPassphrase { error_message: String },
+	#[error("InvalidKey: {error_message}")]
+	InvalidKey { error_message: String },
+	#[error("ApiCall: {source}")]
+	ApiCall {
+		#[from]
+		source: ApiCallError,
+	},
 }
 
 pub enum KdfType {
-    Bcrypt,
-    Argon2id,
+	Bcrypt,
+	Argon2id,
 }
 
 impl TryFrom<i64> for KdfType {
-    // TODO: Use a specific error here
-    type Error = ApiCallError;
+	// TODO: Use a specific error here
+	type Error = ApiCallError;
 
-    fn try_from(value: i64) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(KdfType::Bcrypt),
-            1 => Ok(KdfType::Argon2id),
-            _ => Err(InternalSdkError {
-                error_message: format!("Failed to convert int {} into KdfType", value)
-            })
-        }
-    }
+	fn try_from(value: i64) -> Result<Self, Self::Error> {
+		match value {
+			0 => Ok(KdfType::Bcrypt),
+			1 => Ok(KdfType::Argon2id),
+			_ => Err(InternalSdkError {
+				error_message: format!("Failed to convert int {} into KdfType", value),
+			}),
+		}
+	}
 }
 
 /// Simple LoginFacade that take in an existing credential
 /// and returns a UserFacade after resuming the session.
 pub struct LoginFacade {
-    entity_client: Arc<EntityClient>,
-    typed_entity_client: Arc<TypedEntityClient>,
-    user_facade_factory: fn(user: User) -> UserFacade
+	entity_client: Arc<EntityClient>,
+	typed_entity_client: Arc<TypedEntityClient>,
+	user_facade_factory: fn(user: User) -> UserFacade,
 }
 
 impl LoginFacade {
-    pub fn new(
-        entity_client: Arc<EntityClient>,
-        typed_entity_client: Arc<TypedEntityClient>,
-        user_facade_factory: fn(user: User) -> UserFacade
-    ) -> Self {
-        LoginFacade {
-            entity_client,
-            typed_entity_client,
-            user_facade_factory
-        }
-    }
+	pub fn new(
+		entity_client: Arc<EntityClient>,
+		typed_entity_client: Arc<TypedEntityClient>,
+		user_facade_factory: fn(user: User) -> UserFacade,
+	) -> Self {
+		LoginFacade {
+			entity_client,
+			typed_entity_client,
+			user_facade_factory,
+		}
+	}
 
-    /// Resumes previously created session (using persisted credentials).
-    #[allow(dead_code)] // Used over FFI
-    pub async fn resume_session(&self, credentials: &Credentials) -> Result<UserFacade, LoginError> {
-        let session_id = parse_session_id(credentials.access_token.as_str())
-            .map_err(|e| LoginError::InvalidSessionId { error_message: format!("Could not decode session id: {}", e) })?;
-        // Cannot use typed client because session is encrypted, and we haven't init crypto client yet
-        let session: ParsedEntity = self.entity_client.load(&Session::type_ref(), &session_id).await?;
+	/// Resumes previously created session (using persisted credentials).
+	#[allow(dead_code)] // Used over FFI
+	pub async fn resume_session(
+		&self,
+		credentials: &Credentials,
+	) -> Result<UserFacade, LoginError> {
+		let session_id = parse_session_id(credentials.access_token.as_str()).map_err(|e| {
+			LoginError::InvalidSessionId {
+				error_message: format!("Could not decode session id: {}", e),
+			}
+		})?;
+		// Cannot use typed client because session is encrypted, and we haven't init crypto client yet
+		let session: ParsedEntity = self
+			.entity_client
+			.load(&Session::type_ref(), &session_id)
+			.await?;
 
-        let access_key = self.get_access_key(&session)?;
-        let passphrase_key = access_key.decrypt_aes_key(&credentials.encrypted_passphrase_key)
-            .map_err(|e| LoginError::InvalidPassphrase { error_message: format!("Failed to decrypt key: {e}") })?;
+		let access_key = self.get_access_key(&session)?;
+		let passphrase_key = access_key
+			.decrypt_aes_key(&credentials.encrypted_passphrase_key)
+			.map_err(|e| LoginError::InvalidPassphrase {
+				error_message: format!("Failed to decrypt key: {e}"),
+			})?;
 
-        let user: User = self.typed_entity_client.load(&credentials.user_id).await?;
+		let user: User = self.typed_entity_client.load(&credentials.user_id).await?;
 
-        let user_facade = self.init_session(user, passphrase_key)?;
+		let user_facade = self.init_session(user, passphrase_key)?;
 
-        Ok(user_facade)
-    }
+		Ok(user_facade)
+	}
 
-    /// Derive a key given a KDF type, passphrase, and salt
-    #[allow(dead_code)]
-    fn load_user_passphrase_key(&self, user: &User, passphrase: &str) -> Result<Aes256Key, ApiCallError> {
-        let Some(salt) = user.salt.as_ref() else {
-            return Err(InternalSdkError { error_message: "Salt is missing from User!".to_string() });
-        };
-        Ok(derive_user_passphrase_key(
-            KdfType::try_from(user.kdfVersion)?,
-            passphrase,
-            array_cast_slice(salt, "Vec").map_err(|e|
-                ApiCallError::internal_with_err(e, "Invalid salt")
-            )?))
-    }
+	/// Derive a key given a KDF type, passphrase, and salt
+	#[allow(dead_code)]
+	fn load_user_passphrase_key(
+		&self,
+		user: &User,
+		passphrase: &str,
+	) -> Result<Aes256Key, ApiCallError> {
+		let Some(salt) = user.salt.as_ref() else {
+			return Err(InternalSdkError {
+				error_message: "Salt is missing from User!".to_string(),
+			});
+		};
+		Ok(derive_user_passphrase_key(
+			KdfType::try_from(user.kdfVersion)?,
+			passphrase,
+			array_cast_slice(salt, "Vec")
+				.map_err(|e| ApiCallError::internal_with_err(e, "Invalid salt"))?,
+		))
+	}
 
-    /// Initialize a session with given user id and return a new UserFacade
-    fn init_session(&self, user: User, user_passphrase_key: GenericAesKey) -> Result<UserFacade, LoginError> {
-        let user_facade = (self.user_facade_factory)(user);
+	/// Initialize a session with given user id and return a new UserFacade
+	fn init_session(
+		&self,
+		user: User,
+		user_passphrase_key: GenericAesKey,
+	) -> Result<UserFacade, LoginError> {
+		let user_facade = (self.user_facade_factory)(user);
 
-        user_facade.unlock_user_group_key(user_passphrase_key)
-            .map_err(|e| LoginError::InvalidKey { error_message: format!("Failed to unlock user group key: {e}") })?;
-        Ok(user_facade)
-    }
+		user_facade
+			.unlock_user_group_key(user_passphrase_key)
+			.map_err(|e| LoginError::InvalidKey {
+				error_message: format!("Failed to unlock user group key: {e}"),
+			})?;
+		Ok(user_facade)
+	}
 
-    /// Get access key from session
-    fn get_access_key(&self, session: &ParsedEntity) -> Result<GenericAesKey, LoginError> {
-        let access_key_raw = session.get("accessKey")
-            .ok_or_else(|| LoginError::ApiCall {
-                source: InternalSdkError{ error_message: "no access key on session!".to_owned() }
-        })?.assert_bytes();
-        let access_key = GenericAesKey::from_bytes(access_key_raw.as_slice())
-            .map_err(|e| LoginError::ApiCall {
-                source: InternalSdkError {
-                    error_message: format!("Failed to create AES key from access key string: {e}")
-                }
-            })?;
-        Ok(access_key)
-    }
+	/// Get access key from session
+	fn get_access_key(&self, session: &ParsedEntity) -> Result<GenericAesKey, LoginError> {
+		let access_key_raw = session
+			.get("accessKey")
+			.ok_or_else(|| LoginError::ApiCall {
+				source: InternalSdkError {
+					error_message: "no access key on session!".to_owned(),
+				},
+			})?
+			.assert_bytes();
+		let access_key = GenericAesKey::from_bytes(access_key_raw.as_slice()).map_err(|e| {
+			LoginError::ApiCall {
+				source: InternalSdkError {
+					error_message: format!("Failed to create AES key from access key string: {e}"),
+				},
+			}
+		})?;
+		Ok(access_key)
+	}
 }
 
 /// Generate session id tuple from access token
 fn parse_session_id(access_token: &str) -> Result<IdTuple, DecodeError> {
-    let bytes = BASE64_URL_SAFE_NO_PAD.decode(access_token)?;
-    if bytes.len() < GENERATED_ID_BYTES_LENGTH {
-        return Err(DecodeError::InvalidLength(bytes.len()));
-    }
-    let (list_id_bytes, element_id_bytes) = bytes.split_at(GENERATED_ID_BYTES_LENGTH);
-    let list_id = GeneratedId(BASE64_EXT.encode(list_id_bytes));
-    let element_id = GeneratedId(BASE64_URL_SAFE_NO_PAD.encode(sha256(element_id_bytes)));
-    Ok(IdTuple { list_id, element_id })
+	let bytes = BASE64_URL_SAFE_NO_PAD.decode(access_token)?;
+	if bytes.len() < GENERATED_ID_BYTES_LENGTH {
+		return Err(DecodeError::InvalidLength(bytes.len()));
+	}
+	let (list_id_bytes, element_id_bytes) = bytes.split_at(GENERATED_ID_BYTES_LENGTH);
+	let list_id = GeneratedId(BASE64_EXT.encode(list_id_bytes));
+	let element_id = GeneratedId(BASE64_URL_SAFE_NO_PAD.encode(sha256(element_id_bytes)));
+	Ok(IdTuple {
+		list_id,
+		element_id,
+	})
 }
 
 #[allow(dead_code)]
-pub fn derive_user_passphrase_key(kdf_type: KdfType, passphrase: &str, salt: [u8; 16]) -> Aes256Key {
-    match kdf_type {
-        KdfType::Argon2id => {
-            generate_key_from_passphrase(passphrase, salt)
-        }
-        KdfType::Bcrypt => panic!("BCrypt not implemented")
-    }
+pub fn derive_user_passphrase_key(
+	kdf_type: KdfType,
+	passphrase: &str,
+	salt: [u8; 16],
+) -> Aes256Key {
+	match kdf_type {
+		KdfType::Argon2id => generate_key_from_passphrase(passphrase, salt),
+		KdfType::Bcrypt => panic!("BCrypt not implemented"),
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+	use std::sync::Arc;
 
-    use mockall::predicate::eq;
+	use mockall::predicate::eq;
 
-    use crate::crypto::{Aes128Key, Aes256Key, Iv};
-    use crate::crypto::key::GenericAesKey;
-    use crate::crypto::randomizer_facade::RandomizerFacade;
-    use crate::entities::Entity;
-    use crate::entities::sys::{GroupMembership, Session, User, UserExternalAuthInfo};
-    use crate::entity_client::MockEntityClient;
-    use crate::generated_id::GeneratedId;
-    use crate::IdTuple;
-    use crate::login::credentials::{Credentials, CredentialType};
-    use crate::login::login_facade::LoginFacade;
-    use crate::typed_entity_client::MockTypedEntityClient;
-    use crate::user_facade::MockUserFacade;
-    use crate::util::test_utils::{create_test_entity, typed_entity_to_parsed_entity};
+	use crate::crypto::key::GenericAesKey;
+	use crate::crypto::randomizer_facade::RandomizerFacade;
+	use crate::crypto::{Aes128Key, Aes256Key, Iv};
+	use crate::entities::sys::{GroupMembership, Session, User, UserExternalAuthInfo};
+	use crate::entities::Entity;
+	use crate::entity_client::MockEntityClient;
+	use crate::generated_id::GeneratedId;
+	use crate::login::credentials::{CredentialType, Credentials};
+	use crate::login::login_facade::LoginFacade;
+	use crate::typed_entity_client::MockTypedEntityClient;
+	use crate::user_facade::MockUserFacade;
+	use crate::util::test_utils::{create_test_entity, typed_entity_to_parsed_entity};
+	use crate::IdTuple;
 
-    #[tokio::test]
-    async fn test_resume_session() {
-        let randomizer = RandomizerFacade::from_core(rand::rngs::OsRng {});
-        let user_id = GeneratedId::test_random();
-        let access_token = "ZB-VPZfACMABhx-jUBZ91wyBWLlaJ6AIzg".to_string();
-        let passphrase_key = Aes256Key::generate(&randomizer);
-        let salt: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-        let iv = Iv::generate(&randomizer);
-        let access_key = GenericAesKey::from(Aes256Key::generate(&randomizer));
-        let user = make_user(&user_id, salt, passphrase_key.clone(), &randomizer);
-        let session = make_session(&user_id, &access_key);
-        let parsed_session = typed_entity_to_parsed_entity(session.clone());
+	#[tokio::test]
+	async fn test_resume_session() {
+		let randomizer = RandomizerFacade::from_core(rand::rngs::OsRng {});
+		let user_id = GeneratedId::test_random();
+		let access_token = "ZB-VPZfACMABhx-jUBZ91wyBWLlaJ6AIzg".to_string();
+		let passphrase_key = Aes256Key::generate(&randomizer);
+		let salt: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+		let iv = Iv::generate(&randomizer);
+		let access_key = GenericAesKey::from(Aes256Key::generate(&randomizer));
+		let user = make_user(&user_id, salt, passphrase_key.clone(), &randomizer);
+		let session = make_session(&user_id, &access_key);
+		let parsed_session = typed_entity_to_parsed_entity(session.clone());
 
-        let session_id = IdTuple {
-            list_id: GeneratedId("O0yKEOU-1B-0".to_owned()),
-            element_id: GeneratedId("jlv3AEmnv8rvtZe38u2dk-U1kzxpkMXWNusNz-NhnMI".to_owned()),
-        };
-        let mut mock_entity_client = MockEntityClient::default();
-        let mut mock_typed_entity_client = MockTypedEntityClient::default();
+		let session_id = IdTuple {
+			list_id: GeneratedId("O0yKEOU-1B-0".to_owned()),
+			element_id: GeneratedId("jlv3AEmnv8rvtZe38u2dk-U1kzxpkMXWNusNz-NhnMI".to_owned()),
+		};
+		let mut mock_entity_client = MockEntityClient::default();
+		let mut mock_typed_entity_client = MockTypedEntityClient::default();
 
-        {
-            let parsed_session = parsed_session.clone();
-            mock_entity_client.expect_load::<IdTuple>()
-                .with(eq(Session::type_ref()), eq(session_id.clone()))
-                .returning(move |_, _| { Ok(parsed_session.clone()) });
-        }
+		{
+			let parsed_session = parsed_session.clone();
+			mock_entity_client
+				.expect_load::<IdTuple>()
+				.with(eq(Session::type_ref()), eq(session_id.clone()))
+				.returning(move |_, _| Ok(parsed_session.clone()));
+		}
 
-        mock_typed_entity_client.expect_load::<User, GeneratedId>()
-            .with(eq(user_id.clone()))
-            .returning(move |_| { Ok(user.clone()) });
+		mock_typed_entity_client
+			.expect_load::<User, GeneratedId>()
+			.with(eq(user_id.clone()))
+			.returning(move |_| Ok(user.clone()));
 
-        let entity_client = Arc::new(mock_entity_client);
-        let typed_entity_client = Arc::new(mock_typed_entity_client);
-        let login_facade = LoginFacade::new(entity_client.clone(), typed_entity_client.clone(), |_| {
-            let mut facade = MockUserFacade::default();
-            facade.expect_unlock_user_group_key()
-                .returning(|_| Ok(()));
-            facade
-        });
+		let entity_client = Arc::new(mock_entity_client);
+		let typed_entity_client = Arc::new(mock_typed_entity_client);
+		let login_facade =
+			LoginFacade::new(entity_client.clone(), typed_entity_client.clone(), |_| {
+				let mut facade = MockUserFacade::default();
+				facade.expect_unlock_user_group_key().returning(|_| Ok(()));
+				facade
+			});
 
-        let _user_facade = login_facade.resume_session(&Credentials {
-            login: "login@tuta.io".to_string(),
-            user_id: user_id.clone(),
-            access_token: access_token.clone(),
-            encrypted_passphrase_key: access_key.encrypt_key( &passphrase_key.into(), iv),
-            credential_type: CredentialType::Internal,
-        }).await.unwrap();
+		let _user_facade = login_facade
+			.resume_session(&Credentials {
+				login: "login@tuta.io".to_string(),
+				user_id: user_id.clone(),
+				access_token: access_token.clone(),
+				encrypted_passphrase_key: access_key.encrypt_key(&passphrase_key.into(), iv),
+				credential_type: CredentialType::Internal,
+			})
+			.await
+			.unwrap();
 
-        // assert!(matches!(user_facade.get_user(), ))
-    }
+		// assert!(matches!(user_facade.get_user(), ))
+	}
 
-    fn make_session(user_id: &GeneratedId, access_key: &GenericAesKey) -> Session {
-        Session {
-            accessKey: Some(access_key.as_bytes().to_vec()),
-            user: user_id.to_owned(),
-            ..create_test_entity()
-        }
-    }
+	fn make_session(user_id: &GeneratedId, access_key: &GenericAesKey) -> Session {
+		Session {
+			accessKey: Some(access_key.as_bytes().to_vec()),
+			user: user_id.to_owned(),
+			..create_test_entity()
+		}
+	}
 
-    fn make_user(user_id: &GeneratedId, salt: Vec<u8>, passphrase_key: Aes256Key, randomizer: &RandomizerFacade) -> User {
-        let user_group_key = Aes128Key::generate(randomizer);
-        User {
-            _format: 0,
-            _id: user_id.to_owned(),
-            _ownerGroup: None,
-            _permissions: Default::default(),
-            accountType: 0,
-            verifier: Default::default(),
-            alarmInfoList: None,
-            auth: None,
-            authenticatedDevices: vec![],
-            userGroup: GroupMembership {
-                _id: Default::default(),
-                admin: false,
-                capability: None,
-                groupKeyVersion: 0,
-                group: GeneratedId("groupId".to_string()),
-                symEncGKey: GenericAesKey::Aes256(passphrase_key).encrypt_key(&user_group_key.into(), Iv::generate(randomizer)),
-                groupInfo: IdTuple {
-                    list_id: GeneratedId("groupInfoListId".to_string()),
-                    element_id: GeneratedId("groupInfoElId".to_string()),
-                },
-                groupType: None,
-                symKeyVersion: 0,
-                groupMember: IdTuple { list_id: Default::default(), element_id: Default::default() },
-            },
-            kdfVersion: 1, // Argon2
-            requirePasswordUpdate: false,
-            externalAuthInfo: Some(UserExternalAuthInfo {
-                _id: Default::default(),
-                authUpdateCounter: 0,
-                autoAuthenticationId: Default::default(),
-                autoTransmitPassword: None,
-                latestSaltHash: None,
-                variableAuthInfo: Default::default(),
-            }),
-            failedLogins: Default::default(),
-            memberships: vec![],
-            pushIdentifierList: None,
-            secondFactorAuthentications: Default::default(),
-            enabled: false,
-            salt: Some(salt),
-            customer: None,
-            successfulLogins: Default::default(),
-        }
-    }
+	fn make_user(
+		user_id: &GeneratedId,
+		salt: Vec<u8>,
+		passphrase_key: Aes256Key,
+		randomizer: &RandomizerFacade,
+	) -> User {
+		let user_group_key = Aes128Key::generate(randomizer);
+		User {
+			_format: 0,
+			_id: user_id.to_owned(),
+			_ownerGroup: None,
+			_permissions: Default::default(),
+			accountType: 0,
+			verifier: Default::default(),
+			alarmInfoList: None,
+			auth: None,
+			authenticatedDevices: vec![],
+			userGroup: GroupMembership {
+				_id: Default::default(),
+				admin: false,
+				capability: None,
+				groupKeyVersion: 0,
+				group: GeneratedId("groupId".to_string()),
+				symEncGKey: GenericAesKey::Aes256(passphrase_key)
+					.encrypt_key(&user_group_key.into(), Iv::generate(randomizer)),
+				groupInfo: IdTuple {
+					list_id: GeneratedId("groupInfoListId".to_string()),
+					element_id: GeneratedId("groupInfoElId".to_string()),
+				},
+				groupType: None,
+				symKeyVersion: 0,
+				groupMember: IdTuple {
+					list_id: Default::default(),
+					element_id: Default::default(),
+				},
+			},
+			kdfVersion: 1, // Argon2
+			requirePasswordUpdate: false,
+			externalAuthInfo: Some(UserExternalAuthInfo {
+				_id: Default::default(),
+				authUpdateCounter: 0,
+				autoAuthenticationId: Default::default(),
+				autoTransmitPassword: None,
+				latestSaltHash: None,
+				variableAuthInfo: Default::default(),
+			}),
+			failedLogins: Default::default(),
+			memberships: vec![],
+			pushIdentifierList: None,
+			secondFactorAuthentications: Default::default(),
+			enabled: false,
+			salt: Some(salt),
+			customer: None,
+			successfulLogins: Default::default(),
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/login/mod.rs
+++ b/tuta-sdk/rust/sdk/src/login/mod.rs
@@ -1,5 +1,5 @@
-mod login_facade;
 mod credentials;
+mod login_facade;
 
-pub use login_facade::{LoginFacade, LoginError};
 pub use credentials::*;
+pub use login_facade::{LoginError, LoginFacade};

--- a/tuta-sdk/rust/sdk/src/mail_facade.rs
+++ b/tuta-sdk/rust/sdk/src/mail_facade.rs
@@ -1,26 +1,32 @@
-use std::sync::Arc;
-use crate::{ApiCallError, IdTuple};
-use crate::entities::tutanota::Mail;
 #[mockall_double::double]
 use crate::crypto_entity_client::CryptoEntityClient;
-
+use crate::entities::tutanota::Mail;
+use crate::{ApiCallError, IdTuple};
+use std::sync::Arc;
 
 /// Provides high level functions to manipulate mail entities via the REST API
 #[derive(uniffi::Object)]
 pub struct MailFacade {
-    crypto_entity_client: Arc<CryptoEntityClient>,
+	crypto_entity_client: Arc<CryptoEntityClient>,
 }
 
 impl MailFacade {
-    pub fn new(crypto_entity_client: Arc<CryptoEntityClient>) -> Self {
-        MailFacade { crypto_entity_client }
-    }
+	pub fn new(crypto_entity_client: Arc<CryptoEntityClient>) -> Self {
+		MailFacade {
+			crypto_entity_client,
+		}
+	}
 }
 
 #[uniffi::export]
 impl MailFacade {
-    /// Gets an email (an entity/instance of `Mail`) from the backend
-    pub async fn load_email_by_id_encrypted(&self, id_tuple: &IdTuple) -> Result<Mail, ApiCallError> {
-        self.crypto_entity_client.load::<Mail, IdTuple>(id_tuple).await
-    }
+	/// Gets an email (an entity/instance of `Mail`) from the backend
+	pub async fn load_email_by_id_encrypted(
+		&self,
+		id_tuple: &IdTuple,
+	) -> Result<Mail, ApiCallError> {
+		self.crypto_entity_client
+			.load::<Mail, IdTuple>(id_tuple)
+			.await
+	}
 }

--- a/tuta-sdk/rust/sdk/src/metamodel.rs
+++ b/tuta-sdk/rust/sdk/src/metamodel.rs
@@ -5,134 +5,134 @@ use serde::Deserialize;
 /// A kind of element that can appear in the model
 #[derive(Deserialize, PartialEq, Clone)]
 pub enum ElementType {
-    /// Entity referenced by a single id
-    #[serde(rename = "ELEMENT_TYPE")]
-    Element,
-    /// Entity referenced by IdTuple. Belongs to a list
-    #[serde(rename = "LIST_ELEMENT_TYPE")]
-    ListElement,
-    /// Non-persistent element, used for service input/output
-    #[serde(rename = "DATA_TRANSFER_TYPE")]
-    DataTransfer,
-    /// Structure embedded in another type
-    #[serde(rename = "AGGREGATED_TYPE")]
-    Aggregated,
-    /// Element that is backed by blob store
-    #[serde(rename = "BLOB_ELEMENT_TYPE")]
-    BlobElement,
+	/// Entity referenced by a single id
+	#[serde(rename = "ELEMENT_TYPE")]
+	Element,
+	/// Entity referenced by IdTuple. Belongs to a list
+	#[serde(rename = "LIST_ELEMENT_TYPE")]
+	ListElement,
+	/// Non-persistent element, used for service input/output
+	#[serde(rename = "DATA_TRANSFER_TYPE")]
+	DataTransfer,
+	/// Structure embedded in another type
+	#[serde(rename = "AGGREGATED_TYPE")]
+	Aggregated,
+	/// Element that is backed by blob store
+	#[serde(rename = "BLOB_ELEMENT_TYPE")]
+	BlobElement,
 }
 
 #[derive(Deserialize, Clone, Debug)]
 pub enum ValueType {
-    String,
-    Number,
-    Bytes,
-    Date,
-    Boolean,
-    GeneratedId,
-    CustomId,
-    CompressedString,
+	String,
+	Number,
+	Bytes,
+	Date,
+	Boolean,
+	GeneratedId,
+	CustomId,
+	CompressedString,
 }
 
 /// Associations (references and aggregations) have two dimensions: the type they reference and
 /// their cardinality.
 #[derive(Deserialize, PartialEq, Clone)]
 pub enum Cardinality {
-    /// Optional
-    ZeroOrOne,
-    /// A list of items
-    Any,
-    /// Exactly one item
-    One,
+	/// Optional
+	ZeroOrOne,
+	/// A list of items
+	Any,
+	/// Exactly one item
+	One,
 }
 
 /// Relationships between elements are described as association
 #[derive(Deserialize, Clone)]
 pub enum AssociationType {
-    /// References [ElementType] by id
-    #[serde(rename = "ELEMENT_ASSOCIATION")]
-    ElementAssociation,
-    /// References List (of [ListElementType] by list id
-    #[serde(rename = "LIST_ASSOCIATION")]
-    ListAssociation,
-    /// References List elem (of [ListElementType] by list id
-    #[serde(rename = "LIST_ELEMENT_ASSOCIATION")]
-    ListElementAssociation,
-    /// References [Aggregation]
-    #[serde(rename = "AGGREGATION")]
-    Aggregation,
-    /// References [BlobElement]
-    #[serde(rename = "BLOB_ELEMENT_ASSOCIATION")]
-    BlobElementAssociation,
+	/// References [ElementType] by id
+	#[serde(rename = "ELEMENT_ASSOCIATION")]
+	ElementAssociation,
+	/// References List (of [ListElementType] by list id
+	#[serde(rename = "LIST_ASSOCIATION")]
+	ListAssociation,
+	/// References List elem (of [ListElementType] by list id
+	#[serde(rename = "LIST_ELEMENT_ASSOCIATION")]
+	ListElementAssociation,
+	/// References [Aggregation]
+	#[serde(rename = "AGGREGATION")]
+	Aggregation,
+	/// References [BlobElement]
+	#[serde(rename = "BLOB_ELEMENT_ASSOCIATION")]
+	BlobElementAssociation,
 }
 
 /// Description of the value (value field of Element)
 #[derive(Deserialize, Clone)]
 pub struct ModelValue {
-    pub id: u64,
-    #[serde(rename = "type")]
-    pub value_type: ValueType,
-    pub cardinality: Cardinality,
-    /// whether can it be changed
-    #[serde(rename = "final")]
-    pub is_final: bool,
-    pub encrypted: bool,
+	pub id: u64,
+	#[serde(rename = "type")]
+	pub value_type: ValueType,
+	pub cardinality: Cardinality,
+	/// whether can it be changed
+	#[serde(rename = "final")]
+	pub is_final: bool,
+	pub encrypted: bool,
 }
 
 /// Description of the association (association field of Element)
 #[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelAssociation {
-    pub id: u64,
-    #[serde(rename = "type")]
-    pub association_type: AssociationType,
-    pub cardinality: Cardinality,
-    /// Name of the type it is referencing
-    pub ref_type: &'static str,
-    /// Can it be changed
-    #[serde(rename = "final")]
-    pub is_final: bool,
-    /// From which model we import this association from. Currently the field only exists for aggregates because they are only ones
-    /// which can be imported across models.
-    pub dependency: Option<&'static str>,
+	pub id: u64,
+	#[serde(rename = "type")]
+	pub association_type: AssociationType,
+	pub cardinality: Cardinality,
+	/// Name of the type it is referencing
+	pub ref_type: &'static str,
+	/// Can it be changed
+	#[serde(rename = "final")]
+	pub is_final: bool,
+	/// From which model we import this association from. Currently the field only exists for aggregates because they are only ones
+	/// which can be imported across models.
+	pub dependency: Option<&'static str>,
 }
 
 /// Description of a single Element type
 #[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeModel {
-    pub id: u64,
-    /// Since which model version was it introduced
-    pub since: u64,
-    /// App/model it belongs to
-    pub app: &'static str,
-    /// Model version
-    pub version: &'static str,
-    /// Name of the element
-    pub name: &'static str,
-    /// Kind of the element
-    #[serde(rename = "type")]
-    pub element_type: ElementType,
-    pub versioned: bool,
-    encrypted: bool,
-    pub root_id: &'static str,
-    pub values: HashMap<&'static str, ModelValue>,
-    pub associations: HashMap<&'static str, ModelAssociation>,
+	pub id: u64,
+	/// Since which model version was it introduced
+	pub since: u64,
+	/// App/model it belongs to
+	pub app: &'static str,
+	/// Model version
+	pub version: &'static str,
+	/// Name of the element
+	pub name: &'static str,
+	/// Kind of the element
+	#[serde(rename = "type")]
+	pub element_type: ElementType,
+	pub versioned: bool,
+	encrypted: bool,
+	pub root_id: &'static str,
+	pub values: HashMap<&'static str, ModelValue>,
+	pub associations: HashMap<&'static str, ModelAssociation>,
 }
 
 impl TypeModel {
-    /// Whether entity is marked as encrypted in the metamodel.
-    /// This is not the case for aggregates even though they might contain encrypted fields.
-    pub fn marked_encrypted(&self) -> bool {
-        self.encrypted
-    }
-    /// Whether it is expected that the type might contain encrypted fields.
-    pub fn is_encrypted(&self) -> bool {
-        if self.element_type == ElementType::Aggregated {
-            // Aggregates do not track whether they are encrypted
-            self.values.values().any(|v| v.encrypted)
-        } else {
-            self.encrypted
-        }
-    }
+	/// Whether entity is marked as encrypted in the metamodel.
+	/// This is not the case for aggregates even though they might contain encrypted fields.
+	pub fn marked_encrypted(&self) -> bool {
+		self.encrypted
+	}
+	/// Whether it is expected that the type might contain encrypted fields.
+	pub fn is_encrypted(&self) -> bool {
+		if self.element_type == ElementType::Aggregated {
+			// Aggregates do not track whether they are encrypted
+			self.values.values().any(|v| v.encrypted)
+		} else {
+			self.encrypted
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/rest_client.rs
+++ b/tuta-sdk/rust/sdk/src/rest_client.rs
@@ -3,32 +3,32 @@ use thiserror::Error;
 
 #[derive(uniffi::Enum, Debug, PartialEq, Hash, Eq)]
 pub enum HttpMethod {
-    GET,
-    POST,
-    PUT,
-    DELETE,
+	GET,
+	POST,
+	PUT,
+	DELETE,
 }
 
 /// HTTP(S) data inserted by the `RestClient` in its REST requests
 #[derive(uniffi::Record)]
 pub struct RestClientOptions {
-    pub headers: HashMap<String, String>,
-    pub body: Option<Vec<u8>>,
+	pub headers: HashMap<String, String>,
+	pub body: Option<Vec<u8>>,
 }
 
 /// An error thrown by the `RestClient` (the injected HTTP client Kotlin/Swift/JavaScript)
 #[derive(Error, Debug, uniffi::Error)]
 pub enum RestClientError {
-    #[error("Network error")]
-    NetworkError,
+	#[error("Network error")]
+	NetworkError,
 }
 
 /// HTTP(S) data contained within a response from the backend
 #[derive(uniffi::Record, Clone)]
 pub struct RestResponse {
-    pub status: u32,
-    pub headers: HashMap<String, String>,
-    pub body: Option<Vec<u8>>,
+	pub status: u32,
+	pub headers: HashMap<String, String>,
+	pub body: Option<Vec<u8>>,
 }
 
 /// Provides a Rust SDK level interface for performing REST requests
@@ -37,11 +37,11 @@ pub struct RestResponse {
 #[cfg_attr(test, mockall::automock)]
 #[async_trait::async_trait]
 pub trait RestClient: Send + Sync + 'static {
-    /// Performs an HTTP request with binary data in its body using the injected HTTP client
-    async fn request_binary(
-        &self,
-        url: String,
-        method: HttpMethod,
-        options: RestClientOptions,
-    ) -> Result<RestResponse, RestClientError>;
+	/// Performs an HTTP request with binary data in its body using the injected HTTP client
+	async fn request_binary(
+		&self,
+		url: String,
+		method: HttpMethod,
+		options: RestClientOptions,
+	) -> Result<RestResponse, RestClientError>;
 }

--- a/tuta-sdk/rust/sdk/src/rest_error.rs
+++ b/tuta-sdk/rust/sdk/src/rest_error.rs
@@ -1,8 +1,8 @@
 //! Contains the code to handle HTTP error responses from the REST API
 
-use thiserror::Error;
-use std::str::FromStr;
 use crate::ApiCallError;
+use std::str::FromStr;
+use thiserror::Error;
 
 /// The error thrown when an error data string does not match any value in a failure reason enum
 pub struct ParseFailureError;
@@ -10,407 +10,421 @@ pub struct ParseFailureError;
 /// The failed preconditions of a REST request to attempt downgrading an account
 #[derive(Error, Debug, uniffi::Enum, Eq, PartialEq)]
 pub enum UnsubscribeFailureReason {
-    #[error("TooManyEnabledUsers")]
-    TooManyEnabledUsers,
-    #[error("CustomMailAddress")]
-    CustomMailAddress,
-    #[error("TooManyCalendars")]
-    TooManyCalendars,
-    #[error("CalendarType")]
-    CalendarType,
-    #[error("TooManyAliases")]
-    TooManyAliases,
-    #[error("TooMuchStorageUsed")]
-    TooMuchStorageUsed,
-    #[error("TooManyDomains")]
-    TooManyDomains,
-    #[error("HasTemplateGroup")]
-    HasTemplateGroup,
-    #[error("WhitelabelDomainActive")]
-    WhitelabelDomainActive,
-    #[error("SharedGroupActive")]
-    SharedGroupActive,
-    #[error("HasContactForm")]
-    HasContactForm,
-    #[error("NotEnoughCredit")]
-    NotEnoughCredit,
-    #[error("InvoiceNotPaid")]
-    InvoiceNotPaid,
-    #[error("HasContactListGroup")]
-    HasContactListGroup,
+	#[error("TooManyEnabledUsers")]
+	TooManyEnabledUsers,
+	#[error("CustomMailAddress")]
+	CustomMailAddress,
+	#[error("TooManyCalendars")]
+	TooManyCalendars,
+	#[error("CalendarType")]
+	CalendarType,
+	#[error("TooManyAliases")]
+	TooManyAliases,
+	#[error("TooMuchStorageUsed")]
+	TooMuchStorageUsed,
+	#[error("TooManyDomains")]
+	TooManyDomains,
+	#[error("HasTemplateGroup")]
+	HasTemplateGroup,
+	#[error("WhitelabelDomainActive")]
+	WhitelabelDomainActive,
+	#[error("SharedGroupActive")]
+	SharedGroupActive,
+	#[error("HasContactForm")]
+	HasContactForm,
+	#[error("NotEnoughCredit")]
+	NotEnoughCredit,
+	#[error("InvoiceNotPaid")]
+	InvoiceNotPaid,
+	#[error("HasContactListGroup")]
+	HasContactListGroup,
 }
 
 impl FromStr for UnsubscribeFailureReason {
-    type Err = ParseFailureError;
+	type Err = ParseFailureError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use UnsubscribeFailureReason::*;
-        match s {
-            "unsubscribe.too_many_users" => Ok(TooManyEnabledUsers),
-            "unsubscribe.custom_mail_address" => Ok(CustomMailAddress),
-            "unsubscribe.too_many_calendars" => Ok(TooManyCalendars),
-            // This typo is also present in the backend
-            "unsubscirbe.invalid_calendar_type" => Ok(CalendarType),
-            "unsubscribe.too_many_aliases" => Ok(TooManyAliases),
-            "unsubscribe.too_much_storage" => Ok(TooMuchStorageUsed),
-            "unsubscribe.too_many_domains" => Ok(TooManyDomains),
-            "unsubscribe.has_template_group" => Ok(HasTemplateGroup),
-            "unsubscribe.whitelabel_domain_active" => Ok(WhitelabelDomainActive),
-            "unsubscribe.shared_group_active" => Ok(SharedGroupActive),
-            "unsubscribe.has_contact_form" => Ok(HasContactForm),
-            "unsubscribe.not_enough_credit" => Ok(NotEnoughCredit),
-            "unsubscribe.invoice_not_paid" => Ok(InvoiceNotPaid),
-            "unsubscribe.has_contact_list_group" => Ok(HasContactListGroup),
-            _ => Err(ParseFailureError)
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		use UnsubscribeFailureReason::*;
+		match s {
+			"unsubscribe.too_many_users" => Ok(TooManyEnabledUsers),
+			"unsubscribe.custom_mail_address" => Ok(CustomMailAddress),
+			"unsubscribe.too_many_calendars" => Ok(TooManyCalendars),
+			// This typo is also present in the backend
+			"unsubscirbe.invalid_calendar_type" => Ok(CalendarType),
+			"unsubscribe.too_many_aliases" => Ok(TooManyAliases),
+			"unsubscribe.too_much_storage" => Ok(TooMuchStorageUsed),
+			"unsubscribe.too_many_domains" => Ok(TooManyDomains),
+			"unsubscribe.has_template_group" => Ok(HasTemplateGroup),
+			"unsubscribe.whitelabel_domain_active" => Ok(WhitelabelDomainActive),
+			"unsubscribe.shared_group_active" => Ok(SharedGroupActive),
+			"unsubscribe.has_contact_form" => Ok(HasContactForm),
+			"unsubscribe.not_enough_credit" => Ok(NotEnoughCredit),
+			"unsubscribe.invoice_not_paid" => Ok(InvoiceNotPaid),
+			"unsubscribe.has_contact_list_group" => Ok(HasContactListGroup),
+			_ => Err(ParseFailureError),
+		}
+	}
 }
 
 // legacy, should be deleted after clients older than 3.114 have been disabled.
 #[derive(Error, Debug, uniffi::Enum, Eq, PartialEq)]
 pub enum BookingFailureReason {
-    #[error("TooManyDomains")]
-    TooManyDomains,
-    #[error("TooManyAliases")]
-    TooManyAliases,
-    #[error("TooMuchStorageUsed")]
-    TooMuchStorageUsed,
-    #[error("SharedGroupActive")]
-    SharedGroupActive,
-    #[error("WhitelabelDomainActive")]
-    WhitelabelDomainActive,
-    #[error("HasTemplateGroup")]
-    HasTemplateGroup,
+	#[error("TooManyDomains")]
+	TooManyDomains,
+	#[error("TooManyAliases")]
+	TooManyAliases,
+	#[error("TooMuchStorageUsed")]
+	TooMuchStorageUsed,
+	#[error("SharedGroupActive")]
+	SharedGroupActive,
+	#[error("WhitelabelDomainActive")]
+	WhitelabelDomainActive,
+	#[error("HasTemplateGroup")]
+	HasTemplateGroup,
 }
 
 impl FromStr for BookingFailureReason {
-    type Err = ParseFailureError;
+	type Err = ParseFailureError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use BookingFailureReason::*;
-        match s {
-            "bookingservice.too_many_domains" => Ok(TooManyDomains),
-            "bookingservice.too_many_aliases" => Ok(TooManyAliases),
-            "bookingservice.too_much_storage_used" => Ok(TooMuchStorageUsed),
-            "bookingservice.shared_group_active" => Ok(SharedGroupActive),
-            "bookingservice.whitelabel_domain_active" => Ok(WhitelabelDomainActive),
-            "bookingservice.has_template_group" => Ok(HasTemplateGroup),
-            _ => Err(ParseFailureError)
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		use BookingFailureReason::*;
+		match s {
+			"bookingservice.too_many_domains" => Ok(TooManyDomains),
+			"bookingservice.too_many_aliases" => Ok(TooManyAliases),
+			"bookingservice.too_much_storage_used" => Ok(TooMuchStorageUsed),
+			"bookingservice.shared_group_active" => Ok(SharedGroupActive),
+			"bookingservice.whitelabel_domain_active" => Ok(WhitelabelDomainActive),
+			"bookingservice.has_template_group" => Ok(HasTemplateGroup),
+			_ => Err(ParseFailureError),
+		}
+	}
 }
 
 /// The failed preconditions of a REST request to attempt setting a whitelabel domain
 #[derive(Error, Debug, uniffi::Enum, Eq, PartialEq)]
 pub enum DomainFailureReason {
-    // Renamed from FAILURE_CONTACT_FORM_ACTIVE
-    #[error("ContactFormActive")]
-    ContactFormActive,
-    #[error("NotASubdomain")]
-    NotASubdomain,
-    #[error("Invalid")]
-    Invalid,
-    #[error("InvalidCDomain")]
-    InvalidCDomain,
-    #[error("Exists")]
-    Exists,
+	// Renamed from FAILURE_CONTACT_FORM_ACTIVE
+	#[error("ContactFormActive")]
+	ContactFormActive,
+	#[error("NotASubdomain")]
+	NotASubdomain,
+	#[error("Invalid")]
+	Invalid,
+	#[error("InvalidCDomain")]
+	InvalidCDomain,
+	#[error("Exists")]
+	Exists,
 }
 
 impl FromStr for DomainFailureReason {
-    type Err = ParseFailureError;
+	type Err = ParseFailureError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use DomainFailureReason::*;
-        match s {
-            "domain.contact_form_active" => Ok(ContactFormActive),
-            "domain.not_a_subdomain" => Ok(NotASubdomain),
-            "domain.invalid" => Ok(Invalid),
-            "domain.invalid_cname" => Ok(InvalidCDomain),
-            "domain.exists" => Ok(Exists),
-            _ => Err(ParseFailureError)
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		use DomainFailureReason::*;
+		match s {
+			"domain.contact_form_active" => Ok(ContactFormActive),
+			"domain.not_a_subdomain" => Ok(NotASubdomain),
+			"domain.invalid" => Ok(Invalid),
+			"domain.invalid_cname" => Ok(InvalidCDomain),
+			"domain.exists" => Ok(Exists),
+			_ => Err(ParseFailureError),
+		}
+	}
 }
 
 /// The failed preconditions of a REST request to attempt setting a custom domain
 /// for an email address
 #[derive(Error, Debug, uniffi::Enum, Eq, PartialEq)]
 pub enum CustomDomainFailureReason {
-    #[error("LimitReached")]
-    LimitReached,
-    #[error("DomainInUse")]
-    DomainInUse,
+	#[error("LimitReached")]
+	LimitReached,
+	#[error("DomainInUse")]
+	DomainInUse,
 }
 
 impl FromStr for CustomDomainFailureReason {
-    type Err = ParseFailureError;
+	type Err = ParseFailureError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use CustomDomainFailureReason::*;
-        match s {
-            "customdomainservice.limit_reached" => Ok(LimitReached),
-            "customdomainservice.domain_in_use" => Ok(DomainInUse),
-            _ => Err(ParseFailureError)
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		use CustomDomainFailureReason::*;
+		match s {
+			"customdomainservice.limit_reached" => Ok(LimitReached),
+			"customdomainservice.domain_in_use" => Ok(DomainInUse),
+			_ => Err(ParseFailureError),
+		}
+	}
 }
 
 /// The failed preconditions of unsuccessful template group operations
 #[derive(Error, Debug, uniffi::Enum, Eq, PartialEq)]
 pub enum TemplateGroupFailureReason {
-    #[error("BusinessFeatureRequired")]
-    BusinessFeatureRequired,
-    #[error("UnlimitedRequired")]
-    UnlimitedRequired,
+	#[error("BusinessFeatureRequired")]
+	BusinessFeatureRequired,
+	#[error("UnlimitedRequired")]
+	UnlimitedRequired,
 }
 
 impl FromStr for TemplateGroupFailureReason {
-    type Err = ParseFailureError;
+	type Err = ParseFailureError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use TemplateGroupFailureReason::*;
-        match s {
-            "templategroup.business_feature_required" => Ok(BusinessFeatureRequired),
-            "templategroup.unlimited_required" => Ok(UnlimitedRequired),
-            _ => Err(ParseFailureError)
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		use TemplateGroupFailureReason::*;
+		match s {
+			"templategroup.business_feature_required" => Ok(BusinessFeatureRequired),
+			"templategroup.unlimited_required" => Ok(UnlimitedRequired),
+			_ => Err(ParseFailureError),
+		}
+	}
 }
 
 /// The failed preconditions of unsuccessful usage test operations
 #[derive(Error, Debug, uniffi::Enum, Eq, PartialEq)]
 pub enum UsageTestFailureReason {
-    #[error("InvalidState")]
-    InvalidState,
-    #[error("InvalidRestart")]
-    InvalidRestart,
-    #[error("InvalidStage")]
-    InvalidStage,
-    #[error("InvalidStageSkip")]
-    InvalidStageSkip,
-    #[error("InvalidStageRepetition")]
-    InvalidStageRepetition,
+	#[error("InvalidState")]
+	InvalidState,
+	#[error("InvalidRestart")]
+	InvalidRestart,
+	#[error("InvalidStage")]
+	InvalidStage,
+	#[error("InvalidStageSkip")]
+	InvalidStageSkip,
+	#[error("InvalidStageRepetition")]
+	InvalidStageRepetition,
 }
 
 impl FromStr for UsageTestFailureReason {
-    type Err = ParseFailureError;
+	type Err = ParseFailureError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use UsageTestFailureReason::*;
-        match s {
-            "invalid_state" => Ok(InvalidState),
-            "invalid_restart" => Ok(InvalidRestart),
-            "invalid_stage" => Ok(InvalidStage),
-            "invalid_stage_skip" => Ok(InvalidStageSkip),
-            "invalid_stage_repetition" => Ok(InvalidStageSkip),
-            _ => Err(ParseFailureError)
-        }
-    }
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		use UsageTestFailureReason::*;
+		match s {
+			"invalid_state" => Ok(InvalidState),
+			"invalid_restart" => Ok(InvalidRestart),
+			"invalid_stage" => Ok(InvalidStage),
+			"invalid_stage_skip" => Ok(InvalidStageSkip),
+			"invalid_stage_repetition" => Ok(InvalidStageSkip),
+			_ => Err(ParseFailureError),
+		}
+	}
 }
 
 /// The possible failed preconditions when unsuccessfully performing an operation on the backend
 #[derive(Error, Debug, uniffi::Enum, Eq, PartialEq)]
 pub enum PreconditionFailedReason {
-    #[error("UnsubscribeFailure")]
-    UnsubscribeFailure(#[from] UnsubscribeFailureReason),
-    #[error("BookingFailure")]
-    BookingFailure(#[from] BookingFailureReason),
-    #[error("DomainFailure")]
-    DomainFailure(#[from] DomainFailureReason),
-    #[error("CustomDomainFailure")]
-    CustomDomainFailure(#[from] CustomDomainFailureReason),
-    #[error("TemplateGroupFailure")]
-    TemplateGroupFailure(#[from] TemplateGroupFailureReason),
-    #[error("UsageTestFailure")]
-    UsageTestFailure(#[from] UsageTestFailureReason),
-    #[error("FailureLocked")]
-    FailureLocked,
-    #[error("FailureUserDisabled")]
-    FailureUserDisabled,
-    #[error("FailureUpgradeRequired")]
-    FailureUpgradeRequired,
+	#[error("UnsubscribeFailure")]
+	UnsubscribeFailure(#[from] UnsubscribeFailureReason),
+	#[error("BookingFailure")]
+	BookingFailure(#[from] BookingFailureReason),
+	#[error("DomainFailure")]
+	DomainFailure(#[from] DomainFailureReason),
+	#[error("CustomDomainFailure")]
+	CustomDomainFailure(#[from] CustomDomainFailureReason),
+	#[error("TemplateGroupFailure")]
+	TemplateGroupFailure(#[from] TemplateGroupFailureReason),
+	#[error("UsageTestFailure")]
+	UsageTestFailure(#[from] UsageTestFailureReason),
+	#[error("FailureLocked")]
+	FailureLocked,
+	#[error("FailureUserDisabled")]
+	FailureUserDisabled,
+	#[error("FailureUpgradeRequired")]
+	FailureUpgradeRequired,
 }
 
 impl FromStr for PreconditionFailedReason {
-    type Err = ParseFailureError;
+	type Err = ParseFailureError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use PreconditionFailedReason::*;
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		use PreconditionFailedReason::*;
 
-        // Check and return if the string matches a value of `UnsubscribeFailureReason`
-        if let Ok(reason) = UnsubscribeFailureReason::from_str(s) {
-            Ok(UnsubscribeFailure(reason))
-        } else if let Ok(reason) = BookingFailureReason::from_str(s) {
-            Ok(BookingFailure(reason))
-        } else if let Ok(reason) = DomainFailureReason::from_str(s) {
-            Ok(DomainFailure(reason))
-        } else if let Ok(reason) = CustomDomainFailureReason::from_str(s) {
-            Ok(CustomDomainFailure(reason))
-        } else if let Ok(reason) = TemplateGroupFailureReason::from_str(s) {
-            Ok(TemplateGroupFailure(reason))
-        } else if let Ok(reason) = UsageTestFailureReason::from_str(s) {
-            Ok(UsageTestFailure(reason))
-        } else {
-            match s {
-                "lock.locked" => Ok(FailureLocked),
-                "mailaddressaliasservice.group_disabled" => Ok(FailureUserDisabled),
-                "outofoffice.not_available_on_current_plan" => Ok(FailureUpgradeRequired),
-                _ => Err(ParseFailureError)
-            }
-        }
-    }
+		// Check and return if the string matches a value of `UnsubscribeFailureReason`
+		if let Ok(reason) = UnsubscribeFailureReason::from_str(s) {
+			Ok(UnsubscribeFailure(reason))
+		} else if let Ok(reason) = BookingFailureReason::from_str(s) {
+			Ok(BookingFailure(reason))
+		} else if let Ok(reason) = DomainFailureReason::from_str(s) {
+			Ok(DomainFailure(reason))
+		} else if let Ok(reason) = CustomDomainFailureReason::from_str(s) {
+			Ok(CustomDomainFailure(reason))
+		} else if let Ok(reason) = TemplateGroupFailureReason::from_str(s) {
+			Ok(TemplateGroupFailure(reason))
+		} else if let Ok(reason) = UsageTestFailureReason::from_str(s) {
+			Ok(UsageTestFailure(reason))
+		} else {
+			match s {
+				"lock.locked" => Ok(FailureLocked),
+				"mailaddressaliasservice.group_disabled" => Ok(FailureUserDisabled),
+				"outofoffice.not_available_on_current_plan" => Ok(FailureUpgradeRequired),
+				_ => Err(ParseFailureError),
+			}
+		}
+	}
 }
-
 
 /// The possible error responses from the server
 #[derive(Error, Debug, uniffi::Error, Eq, PartialEq)]
 pub enum HttpError {
-    #[error("Connection lost")]
-    ConnectionError,
-    #[error("Bad request")]
-    BadRequestError,
-    #[error("Not authenticated")]
-    NotAuthenticatedError,
-    #[error("Not Authorized")]
-    NotAuthorizedError,
-    #[error("Not Found")]
-    NotFoundError,
-    #[error("Method Not Allowed")]
-    MethodNotAllowedError,
-    #[error("Request Timeout")]
-    RequestTimeoutError,
-    #[error("Precondition Failed")]
-    PreconditionFailedError(Option<PreconditionFailedReason>),
-    #[error("Locked")]
-    LockedError,
-    #[error("Too Many Requests")]
-    TooManyRequestsError,
-    #[error("Session Expired")]
-    SessionExpiredError,
-    #[error("Access Deactivated")]
-    AccessDeactivatedError,
-    /// Happens to external users exclusively, due to password changes
-    #[error("Access Expired")]
-    AccessExpiredError,
-    #[error("Access Blocked")]
-    AccessBlockedError,
-    #[error("Invalid Data")]
-    InvalidDataError,
-    #[error("Invalid Software Version")]
-    InvalidSoftwareVersionError,
-    #[error("Limit Reached")]
-    LimitReachedError,
-    #[error("Internal Server")]
-    InternalServerError,
-    #[error("Bad gateway")]
-    BadGatewayError,
-    #[error("Service Unavailable")]
-    ServiceUnavailableError,
-    #[error("Insufficient Storage")]
-    InsufficientStorageError,
-    #[error("Resource")]
-    ResourceError,
-    #[error("Payload Too Large")]
-    PayloadTooLargeError,
+	#[error("Connection lost")]
+	ConnectionError,
+	#[error("Bad request")]
+	BadRequestError,
+	#[error("Not authenticated")]
+	NotAuthenticatedError,
+	#[error("Not Authorized")]
+	NotAuthorizedError,
+	#[error("Not Found")]
+	NotFoundError,
+	#[error("Method Not Allowed")]
+	MethodNotAllowedError,
+	#[error("Request Timeout")]
+	RequestTimeoutError,
+	#[error("Precondition Failed")]
+	PreconditionFailedError(Option<PreconditionFailedReason>),
+	#[error("Locked")]
+	LockedError,
+	#[error("Too Many Requests")]
+	TooManyRequestsError,
+	#[error("Session Expired")]
+	SessionExpiredError,
+	#[error("Access Deactivated")]
+	AccessDeactivatedError,
+	/// Happens to external users exclusively, due to password changes
+	#[error("Access Expired")]
+	AccessExpiredError,
+	#[error("Access Blocked")]
+	AccessBlockedError,
+	#[error("Invalid Data")]
+	InvalidDataError,
+	#[error("Invalid Software Version")]
+	InvalidSoftwareVersionError,
+	#[error("Limit Reached")]
+	LimitReachedError,
+	#[error("Internal Server")]
+	InternalServerError,
+	#[error("Bad gateway")]
+	BadGatewayError,
+	#[error("Service Unavailable")]
+	ServiceUnavailableError,
+	#[error("Insufficient Storage")]
+	InsufficientStorageError,
+	#[error("Resource")]
+	ResourceError,
+	#[error("Payload Too Large")]
+	PayloadTooLargeError,
 }
 
 impl HttpError {
-    /// Converts an HTTP response code into a `NetworkError`
-    pub fn from_http_response(status: u32, precondition: Option<&String>) -> Result<HttpError, ApiCallError> {
-        use HttpError::*;
-        match status {
-            0 => Ok(ConnectionError),
-            400 => Ok(BadRequestError),
-            401 => Ok(NotAuthenticatedError),
-            403 => Ok(NotAuthorizedError),
-            404 => Ok(NotFoundError),
-            405 => Ok(MethodNotAllowedError),
-            408 => Ok(RequestTimeoutError),
-            412 => {
-                let reason = match precondition {
-                    Some(x) => Some(PreconditionFailedReason::from_str(x)?),
-                    None => None
-                };
-                Ok(PreconditionFailedError(reason))
-            }
-            423 => Ok(LockedError),
-            429 => Ok(TooManyRequestsError),
-            440 => Ok(SessionExpiredError),
-            470 => Ok(AccessDeactivatedError),
-            471 => Ok(AccessExpiredError),
-            472 => Ok(AccessBlockedError),
-            473 => Ok(InvalidDataError),
-            474 => Ok(InvalidSoftwareVersionError),
-            475 => Ok(LimitReachedError),
-            500 => Ok(InternalServerError),
-            502 => Ok(BadGatewayError),
-            503 => Ok(ServiceUnavailableError),
-            507 => Ok(InsufficientStorageError),
-            413 => Ok(PayloadTooLargeError),
-            200..=299 => Err(ApiCallError::InternalSdkError { error_message: format!("HTTP Response code {status} is not an error") }),
-            _ => Ok(ResourceError)
-        }
-    }
+	/// Converts an HTTP response code into a `NetworkError`
+	pub fn from_http_response(
+		status: u32,
+		precondition: Option<&String>,
+	) -> Result<HttpError, ApiCallError> {
+		use HttpError::*;
+		match status {
+			0 => Ok(ConnectionError),
+			400 => Ok(BadRequestError),
+			401 => Ok(NotAuthenticatedError),
+			403 => Ok(NotAuthorizedError),
+			404 => Ok(NotFoundError),
+			405 => Ok(MethodNotAllowedError),
+			408 => Ok(RequestTimeoutError),
+			412 => {
+				let reason = match precondition {
+					Some(x) => Some(PreconditionFailedReason::from_str(x)?),
+					None => None,
+				};
+				Ok(PreconditionFailedError(reason))
+			},
+			423 => Ok(LockedError),
+			429 => Ok(TooManyRequestsError),
+			440 => Ok(SessionExpiredError),
+			470 => Ok(AccessDeactivatedError),
+			471 => Ok(AccessExpiredError),
+			472 => Ok(AccessBlockedError),
+			473 => Ok(InvalidDataError),
+			474 => Ok(InvalidSoftwareVersionError),
+			475 => Ok(LimitReachedError),
+			500 => Ok(InternalServerError),
+			502 => Ok(BadGatewayError),
+			503 => Ok(ServiceUnavailableError),
+			507 => Ok(InsufficientStorageError),
+			413 => Ok(PayloadTooLargeError),
+			200..=299 => Err(ApiCallError::InternalSdkError {
+				error_message: format!("HTTP Response code {status} is not an error"),
+			}),
+			_ => Ok(ResourceError),
+		}
+	}
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+	use super::*;
 
-    #[test]
-    fn from_http_response_connection_error_test() {
-        let error = assert_from_http_response(0, None);
-        assert_eq!(error, HttpError::ConnectionError)
-    }
+	#[test]
+	fn from_http_response_connection_error_test() {
+		let error = assert_from_http_response(0, None);
+		assert_eq!(error, HttpError::ConnectionError)
+	}
 
-    #[test]
-    fn from_http_response_unknown_error_test() {
-        let error = assert_from_http_response(402, None);
-        assert_eq!(error, HttpError::ResourceError)
-    }
+	#[test]
+	fn from_http_response_unknown_error_test() {
+		let error = assert_from_http_response(402, None);
+		assert_eq!(error, HttpError::ResourceError)
+	}
 
-    #[test]
-    fn from_http_response_unused_precondition_test() {
-        let error = assert_from_http_response(0, Some("lock.locked"));
-        assert_eq!(error, HttpError::ConnectionError)
-    }
+	#[test]
+	fn from_http_response_unused_precondition_test() {
+		let error = assert_from_http_response(0, Some("lock.locked"));
+		assert_eq!(error, HttpError::ConnectionError)
+	}
 
-    #[test]
-    fn from_http_response_non_error_test() {
-        let error = HttpError::from_http_response(202, None);
-        error.expect_err("from_http_response_non_error_test received an Ok value!");
-    }
+	#[test]
+	fn from_http_response_non_error_test() {
+		let error = HttpError::from_http_response(202, None);
+		error.expect_err("from_http_response_non_error_test received an Ok value!");
+	}
 
-    #[test]
-    fn from_http_response_precondition_failed_error_test() {
-        assert_precondition_failed_error(Some("lock.locked"), Some(PreconditionFailedReason::FailureLocked))
-    }
+	#[test]
+	fn from_http_response_precondition_failed_error_test() {
+		assert_precondition_failed_error(
+			Some("lock.locked"),
+			Some(PreconditionFailedReason::FailureLocked),
+		)
+	}
 
-    #[test]
-    fn from_http_response_precondition_failed_error_no_reason_test() {
-        assert_precondition_failed_error(None, None)
-    }
+	#[test]
+	fn from_http_response_precondition_failed_error_no_reason_test() {
+		assert_precondition_failed_error(None, None)
+	}
 
-    #[test]
-    fn from_http_response_precondition_failed_error_booking_reason_test() {
-        let expected_reason = PreconditionFailedReason::BookingFailure(BookingFailureReason::TooMuchStorageUsed);
-        assert_precondition_failed_error(Some("bookingservice.too_much_storage_used"), Some(expected_reason))
-    }
+	#[test]
+	fn from_http_response_precondition_failed_error_booking_reason_test() {
+		let expected_reason =
+			PreconditionFailedReason::BookingFailure(BookingFailureReason::TooMuchStorageUsed);
+		assert_precondition_failed_error(
+			Some("bookingservice.too_much_storage_used"),
+			Some(expected_reason),
+		)
+	}
 
-    /// Returns the Ok value from `from_http_response` and panics if the value is None
-    fn assert_from_http_response(status: u32, precondition: Option<&str>) -> HttpError {
-        // Convert the `str` contained within `precondition` into a `String`
-        let string_precondition = precondition.map(|inner_str: &str| { inner_str.to_owned() });
-        let result = HttpError::from_http_response(status, string_precondition.as_ref());
-        result.expect("An error occurred while testing precondition_failed!")
-    }
+	/// Returns the Ok value from `from_http_response` and panics if the value is None
+	fn assert_from_http_response(status: u32, precondition: Option<&str>) -> HttpError {
+		// Convert the `str` contained within `precondition` into a `String`
+		let string_precondition = precondition.map(|inner_str: &str| inner_str.to_owned());
+		let result = HttpError::from_http_response(status, string_precondition.as_ref());
+		result.expect("An error occurred while testing precondition_failed!")
+	}
 
-    /**
-    Asserts `from_http_response` returns the reason `reason` given `precondition`
-    for a `PreconditionFailedError`
-     */
-    fn assert_precondition_failed_error(precondition: Option<&str>, reason: Option<PreconditionFailedReason>) {
-        let error = assert_from_http_response(412, precondition);
-        assert_eq!(error, HttpError::PreconditionFailedError(reason))
-    }
+	/**
+	Asserts `from_http_response` returns the reason `reason` given `precondition`
+	for a `PreconditionFailedError`
+	 */
+	fn assert_precondition_failed_error(
+		precondition: Option<&str>,
+		reason: Option<PreconditionFailedReason>,
+	) {
+		let error = assert_from_http_response(412, precondition);
+		assert_eq!(error, HttpError::PreconditionFailedError(reason))
+	}
 }

--- a/tuta-sdk/rust/sdk/src/simple_crypto.rs
+++ b/tuta-sdk/rust/sdk/src/simple_crypto.rs
@@ -4,91 +4,101 @@
 
 use crate::crypto::randomizer_facade::RandomizerFacade;
 use crate::crypto::rsa::{RSAPrivateKey, RSAPublicKey, SeedBufferRng};
-use base64::prelude::*;
-use zeroize::Zeroizing;
 use crate::crypto::{argon2_id, kyber};
 use crate::util::{array_cast_slice, ArrayCastingError};
+use base64::prelude::*;
+use zeroize::Zeroizing;
 
 /// Error occurred from trying to encapsulate/decapsulate with Kyber
 /// with the simple_crypto kyber_encapsulate/kyber_decapsulate methods.
 #[derive(thiserror::Error, Debug, uniffi::Error)]
 #[uniffi(flat_error)]
 enum KyberError {
-    #[error("KeyError {reason}")]
-    InvalidKey {
-        reason: String,
-    },
-    #[error("InvalidCiphertext")]
-    InvalidCiphertextError,
-    #[error("KyberDecapsulationError {reason}")]
-    KyberDecapsulationError {
-        reason: String,
-    },
+	#[error("KeyError {reason}")]
+	InvalidKey { reason: String },
+	#[error("InvalidCiphertext")]
+	InvalidCiphertextError,
+	#[error("KyberDecapsulationError {reason}")]
+	KyberDecapsulationError { reason: String },
 }
 
 impl From<kyber::KyberKeyError> for KyberError {
-    fn from(value: kyber::KyberKeyError) -> Self {
-        KyberError::InvalidKey { reason: value.reason }
-    }
+	fn from(value: kyber::KyberKeyError) -> Self {
+		KyberError::InvalidKey {
+			reason: value.reason,
+		}
+	}
 }
 
 impl From<kyber::KyberDecapsulationError> for KyberError {
-    fn from(value: kyber::KyberDecapsulationError) -> Self {
-        KyberError::KyberDecapsulationError { reason: value.reason }
-    }
+	fn from(value: kyber::KyberDecapsulationError) -> Self {
+		KyberError::KyberDecapsulationError {
+			reason: value.reason,
+		}
+	}
 }
-
 
 /// Result of kyber encapsulation
 #[derive(uniffi::Record)]
 struct KyberEncapsulation {
-    ciphertext: Vec<u8>,
-    shared_secret: Vec<u8>,
+	ciphertext: Vec<u8>,
+	shared_secret: Vec<u8>,
 }
 
 /// Run kyber encapsulation algorithm
 #[uniffi::export]
-fn kyber_encapsulate_with_pub_key(public_key_bytes: Vec<u8>) -> Result<KyberEncapsulation, KyberError> {
-    use crate::crypto::kyber;
-    let encapsulation = kyber::KyberPublicKey::from_bytes(public_key_bytes.as_slice())?
-        .encapsulate()
-        .into();
-    Ok(encapsulation)
+fn kyber_encapsulate_with_pub_key(
+	public_key_bytes: Vec<u8>,
+) -> Result<KyberEncapsulation, KyberError> {
+	use crate::crypto::kyber;
+	let encapsulation = kyber::KyberPublicKey::from_bytes(public_key_bytes.as_slice())?
+		.encapsulate()
+		.into();
+	Ok(encapsulation)
 }
 
 /// Run kyber decapsulation algorithm
 #[uniffi::export]
-fn kyber_decapsulate_with_priv_key(private_key_bytes: Vec<u8>, ciphertext: Vec<u8>) -> Result<Vec<u8>, KyberError> {
-    use crate::crypto::kyber;
-    let kyber_ciphertext = kyber::KyberCiphertext::try_from(ciphertext.as_slice())
-        .map_err(|_| KyberError::InvalidCiphertextError)?;
-    let plaintext = kyber::KyberPrivateKey::from_bytes(private_key_bytes.as_slice())?
-        .decapsulate(&kyber_ciphertext)?
-        .as_bytes()
-        .to_vec();
-    Ok(plaintext)
+fn kyber_decapsulate_with_priv_key(
+	private_key_bytes: Vec<u8>,
+	ciphertext: Vec<u8>,
+) -> Result<Vec<u8>, KyberError> {
+	use crate::crypto::kyber;
+	let kyber_ciphertext = kyber::KyberCiphertext::try_from(ciphertext.as_slice())
+		.map_err(|_| KyberError::InvalidCiphertextError)?;
+	let plaintext = kyber::KyberPrivateKey::from_bytes(private_key_bytes.as_slice())?
+		.decapsulate(&kyber_ciphertext)?
+		.as_bytes()
+		.to_vec();
+	Ok(plaintext)
 }
 
 #[derive(uniffi::Record)]
 struct KyberKeyPair {
-    public_key: Vec<u8>,
-    private_key: Vec<u8>,
+	public_key: Vec<u8>,
+	private_key: Vec<u8>,
 }
 
 /// Generate new kyber keypair
 #[uniffi::export]
 fn generate_kyber_keypair() -> KyberKeyPair {
-    let kyber::KyberKeyPair { public_key, private_key } = kyber::KyberKeyPair::generate();
-    KyberKeyPair { public_key: public_key.as_bytes().to_vec(), private_key: private_key.as_bytes().to_vec() }
+	let kyber::KyberKeyPair {
+		public_key,
+		private_key,
+	} = kyber::KyberKeyPair::generate();
+	KyberKeyPair {
+		public_key: public_key.as_bytes().to_vec(),
+		private_key: private_key.as_bytes().to_vec(),
+	}
 }
 
 impl From<kyber::KyberEncapsulation> for KyberEncapsulation {
-    fn from(value: kyber::KyberEncapsulation) -> Self {
-        Self {
-            ciphertext: value.ciphertext.into_bytes().into(),
-            shared_secret: value.shared_secret.into_bytes().into(),
-        }
-    }
+	fn from(value: kyber::KyberEncapsulation) -> Self {
+		Self {
+			ciphertext: value.ciphertext.into_bytes().into(),
+			shared_secret: value.shared_secret.into_bytes().into(),
+		}
+	}
 }
 
 /// Error occurred from trying to encrypt/decrypt with RSA with the simple_crypto
@@ -96,70 +106,118 @@ impl From<kyber::KyberEncapsulation> for KyberEncapsulation {
 #[derive(thiserror::Error, Debug, uniffi::Error)]
 #[uniffi(flat_error)]
 enum RSAError {
-    #[error("InvalidKey {reason}")]
-    InvalidKey {
-        reason: String,
-    },
-    #[error("InvalidCiphertext")]
-    InvalidCiphertextError,
-    #[error("RSAEncryptionError {reason}")]
-    RSAEncryptionError {
-        reason: String,
-    },
+	#[error("InvalidKey {reason}")]
+	InvalidKey { reason: String },
+	#[error("InvalidCiphertext")]
+	InvalidCiphertextError,
+	#[error("RSAEncryptionError {reason}")]
+	RSAEncryptionError { reason: String },
 }
 
 /// Decrypt with RSA with the given private key components.
 #[uniffi::export]
-fn rsa_decrypt_with_private_key_components(ciphertext: Vec<u8>, modulus: String, private_exponent: String, prime_p: String, prime_q: String) -> Result<Vec<u8>, RSAError> {
-    let modulus = Zeroizing::new(modulus);
-    let private_exponent = Zeroizing::new(private_exponent);
-    let prime_p = Zeroizing::new(prime_p);
-    let prime_q = Zeroizing::new(prime_q);
+fn rsa_decrypt_with_private_key_components(
+	ciphertext: Vec<u8>,
+	modulus: String,
+	private_exponent: String,
+	prime_p: String,
+	prime_q: String,
+) -> Result<Vec<u8>, RSAError> {
+	let modulus = Zeroizing::new(modulus);
+	let private_exponent = Zeroizing::new(private_exponent);
+	let prime_p = Zeroizing::new(prime_p);
+	let prime_q = Zeroizing::new(prime_q);
 
-    let modulus = Zeroizing::new(BASE64_STANDARD.decode(modulus).map_err(|_| RSAError::InvalidKey { reason: "modulus is not valid base64".to_owned() })?);
-    let private_exponent = Zeroizing::new(BASE64_STANDARD.decode(private_exponent).map_err(|_| RSAError::InvalidKey { reason: "private_exponent is not valid base64".to_owned() })?);
-    let prime_p = Zeroizing::new(BASE64_STANDARD.decode(prime_p).map_err(|_| RSAError::InvalidKey { reason: "prime_p is not valid base64".to_owned() })?);
-    let prime_q = Zeroizing::new(BASE64_STANDARD.decode(prime_q).map_err(|_| RSAError::InvalidKey { reason: "prime_q is not valid base64".to_owned() })?);
+	let modulus =
+		Zeroizing::new(
+			BASE64_STANDARD
+				.decode(modulus)
+				.map_err(|_| RSAError::InvalidKey {
+					reason: "modulus is not valid base64".to_owned(),
+				})?,
+		);
+	let private_exponent =
+		Zeroizing::new(BASE64_STANDARD.decode(private_exponent).map_err(|_| {
+			RSAError::InvalidKey {
+				reason: "private_exponent is not valid base64".to_owned(),
+			}
+		})?);
+	let prime_p =
+		Zeroizing::new(
+			BASE64_STANDARD
+				.decode(prime_p)
+				.map_err(|_| RSAError::InvalidKey {
+					reason: "prime_p is not valid base64".to_owned(),
+				})?,
+		);
+	let prime_q =
+		Zeroizing::new(
+			BASE64_STANDARD
+				.decode(prime_q)
+				.map_err(|_| RSAError::InvalidKey {
+					reason: "prime_q is not valid base64".to_owned(),
+				})?,
+		);
 
-    let key = RSAPrivateKey::from_components(&modulus, &private_exponent, &prime_p, &prime_q)
-        .map_err(|e| RSAError::InvalidKey { reason: e.to_string() })?;
+	let key = RSAPrivateKey::from_components(&modulus, &private_exponent, &prime_p, &prime_q)
+		.map_err(|e| RSAError::InvalidKey {
+			reason: e.to_string(),
+		})?;
 
-    key
-        .decrypt(&ciphertext)
-        .map_err(|_| RSAError::InvalidCiphertextError)
+	key.decrypt(&ciphertext)
+		.map_err(|_| RSAError::InvalidCiphertextError)
 }
 
 /// Encrypt with RSA with the given public key components.
 #[uniffi::export]
-fn rsa_encrypt_with_public_key_components(data: Vec<u8>, seed: Vec<u8>, modulus: String, public_exponent: u32) -> Result<Vec<u8>, RSAError> {
-    let modulus = Zeroizing::new(BASE64_STANDARD.decode(modulus).map_err(|_| RSAError::InvalidKey { reason: "modulus is not valid base64".to_owned() })?);
-    let key = RSAPublicKey::from_components(&modulus, public_exponent)
-        .map_err(|e| RSAError::InvalidKey { reason: e.to_string() })?;
+fn rsa_encrypt_with_public_key_components(
+	data: Vec<u8>,
+	seed: Vec<u8>,
+	modulus: String,
+	public_exponent: u32,
+) -> Result<Vec<u8>, RSAError> {
+	let modulus =
+		Zeroizing::new(
+			BASE64_STANDARD
+				.decode(modulus)
+				.map_err(|_| RSAError::InvalidKey {
+					reason: "modulus is not valid base64".to_owned(),
+				})?,
+		);
+	let key = RSAPublicKey::from_components(&modulus, public_exponent).map_err(|e| {
+		RSAError::InvalidKey {
+			reason: e.to_string(),
+		}
+	})?;
 
-    // Not very elegant to instantiate this here, but this avoids requiring external state while
-    // letting us use seeded RNG, which is how RSA is presently implemented in Tuta.
-    let randomizer_facade_with_seed = RandomizerFacade::from_core(SeedBufferRng::new(seed));
+	// Not very elegant to instantiate this here, but this avoids requiring external state while
+	// letting us use seeded RNG, which is how RSA is presently implemented in Tuta.
+	let randomizer_facade_with_seed = RandomizerFacade::from_core(SeedBufferRng::new(seed));
 
-    key
-        .encrypt(&randomizer_facade_with_seed, &data)
-        .map_err(|e| RSAError::RSAEncryptionError { reason: e.to_string() })
+	key.encrypt(&randomizer_facade_with_seed, &data)
+		.map_err(|e| RSAError::RSAEncryptionError {
+			reason: e.to_string(),
+		})
 }
 
 #[derive(thiserror::Error, Debug, uniffi::Error)]
 #[uniffi(flat_error)]
 enum Argon2idError {
-    #[error("InvalidSaltSize: {actual_size}")]
-    InvalidSaltSize {
-        actual_size: usize,
-    }
+	#[error("InvalidSaltSize: {actual_size}")]
+	InvalidSaltSize { actual_size: usize },
 }
 
 /// Generate a passphrase key with the given passphrase using Argon2id
 #[uniffi::export]
-fn argon2id_generate_key_from_passphrase(passphrase: String, salt: Vec<u8>) -> Result<Vec<u8>, Argon2idError> {
-    let passphrase = Zeroizing::new(passphrase);
-    let salt = array_cast_slice(&salt, "salt")
-        .map_err(| ArrayCastingError { actual_size, .. } | Argon2idError::InvalidSaltSize { actual_size })?;
-    let passphrase_key = argon2_id::generate_key_from_passphrase(passphrase.as_str(), salt);
-    Ok(passphrase_key.as_bytes().to_vec())
+fn argon2id_generate_key_from_passphrase(
+	passphrase: String,
+	salt: Vec<u8>,
+) -> Result<Vec<u8>, Argon2idError> {
+	let passphrase = Zeroizing::new(passphrase);
+	let salt =
+		array_cast_slice(&salt, "salt").map_err(|ArrayCastingError { actual_size, .. }| {
+			Argon2idError::InvalidSaltSize { actual_size }
+		})?;
+	let passphrase_key = argon2_id::generate_key_from_passphrase(passphrase.as_str(), salt);
+	Ok(passphrase_key.as_bytes().to_vec())
 }

--- a/tuta-sdk/rust/sdk/src/type_model_provider.rs
+++ b/tuta-sdk/rust/sdk/src/type_model_provider.rs
@@ -10,19 +10,19 @@ pub type TypeName = &'static str;
 
 /// Contains a map between backend apps and entity/instance types within them
 pub struct TypeModelProvider {
-    app_models: HashMap<AppName, HashMap<TypeName, TypeModel>>,
+	app_models: HashMap<AppName, HashMap<TypeName, TypeModel>>,
 }
 
 impl TypeModelProvider {
-    pub fn new(app_models: HashMap<AppName, HashMap<TypeName, TypeModel>>) -> TypeModelProvider {
-        TypeModelProvider { app_models }
-    }
+	pub fn new(app_models: HashMap<AppName, HashMap<TypeName, TypeModel>>) -> TypeModelProvider {
+		TypeModelProvider { app_models }
+	}
 
-    /// Gets an entity/instance type with a specified name in a backend app
-    pub fn get_type_model(&self, app_name: &str, entity_name: &str) -> Option<&TypeModel> {
-        let app_map = self.app_models.get(app_name)?;
-        app_map.get(entity_name)
-    }
+	/// Gets an entity/instance type with a specified name in a backend app
+	pub fn get_type_model(&self, app_name: &str, entity_name: &str) -> Option<&TypeModel> {
+		let app_map = self.app_models.get(app_name)?;
+		app_map.get(entity_name)
+	}
 }
 
 // Reads all provided type models into a map.
@@ -44,19 +44,18 @@ macro_rules! read_type_models {
     }}
 }
 
-
 /// Creates a new `TypeModelProvider` populated with the type models from the JSON type model files
 pub fn init_type_model_provider() -> TypeModelProvider {
-    let type_model_map = read_type_models![
-        "accounting",
-        "base",
-        "gossip",
-        "monitor",
-        "storage",
-        "sys",
-        "tutanota",
-        "usage"
-        ];
-    let type_model_provider = TypeModelProvider::new(type_model_map);
-    type_model_provider
+	let type_model_map = read_type_models![
+		"accounting",
+		"base",
+		"gossip",
+		"monitor",
+		"storage",
+		"sys",
+		"tutanota",
+		"usage"
+	];
+	let type_model_provider = TypeModelProvider::new(type_model_map);
+	type_model_provider
 }

--- a/tuta-sdk/rust/sdk/src/type_models/sys.json
+++ b/tuta-sdk/rust/sdk/src/type_models/sys.json
@@ -212,7 +212,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AdminGroupKeyRotationPostIn": {
 		"name": "AdminGroupKeyRotationPostIn",
@@ -256,7 +256,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AdministratedGroupsRef": {
 		"name": "AdministratedGroupsRef",
@@ -290,7 +290,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AlarmInfo": {
 		"name": "AlarmInfo",
@@ -342,7 +342,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AlarmNotification": {
 		"name": "AlarmNotification",
@@ -442,7 +442,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AlarmServicePost": {
 		"name": "AlarmServicePost",
@@ -476,7 +476,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ArchiveRef": {
 		"name": "ArchiveRef",
@@ -508,7 +508,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ArchiveType": {
 		"name": "ArchiveType",
@@ -562,7 +562,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AuditLogEntry": {
 		"name": "AuditLogEntry",
@@ -696,7 +696,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AuditLogRef": {
 		"name": "AuditLogRef",
@@ -730,7 +730,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AuthenticatedDevice": {
 		"name": "AuthenticatedDevice",
@@ -780,7 +780,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Authentication": {
 		"name": "Authentication",
@@ -841,7 +841,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AutoLoginDataDelete": {
 		"name": "AutoLoginDataDelete",
@@ -873,7 +873,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AutoLoginDataGet": {
 		"name": "AutoLoginDataGet",
@@ -916,7 +916,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AutoLoginDataReturn": {
 		"name": "AutoLoginDataReturn",
@@ -948,7 +948,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"AutoLoginPostReturn": {
 		"name": "AutoLoginPostReturn",
@@ -980,7 +980,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Blob": {
 		"name": "Blob",
@@ -1030,7 +1030,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BlobReferenceTokenWrapper": {
 		"name": "BlobReferenceTokenWrapper",
@@ -1062,7 +1062,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Booking": {
 		"name": "Booking",
@@ -1186,7 +1186,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BookingItem": {
 		"name": "BookingItem",
@@ -1272,7 +1272,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BookingsRef": {
 		"name": "BookingsRef",
@@ -1306,7 +1306,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BootstrapFeature": {
 		"name": "BootstrapFeature",
@@ -1338,7 +1338,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Braintree3ds2Request": {
 		"name": "Braintree3ds2Request",
@@ -1388,7 +1388,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Braintree3ds2Response": {
 		"name": "Braintree3ds2Response",
@@ -1429,7 +1429,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BrandingDomainData": {
 		"name": "BrandingDomainData",
@@ -1506,7 +1506,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BrandingDomainDeleteData": {
 		"name": "BrandingDomainDeleteData",
@@ -1538,7 +1538,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BrandingDomainGetReturn": {
 		"name": "BrandingDomainGetReturn",
@@ -1572,7 +1572,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Bucket": {
 		"name": "Bucket",
@@ -1606,7 +1606,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BucketKey": {
 		"name": "BucketKey",
@@ -1695,7 +1695,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"BucketPermission": {
 		"name": "BucketPermission",
@@ -1837,7 +1837,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CalendarEventRef": {
 		"name": "CalendarEventRef",
@@ -1878,7 +1878,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CertificateInfo": {
 		"name": "CertificateInfo",
@@ -1939,7 +1939,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Challenge": {
 		"name": "Challenge",
@@ -1992,7 +1992,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ChangeKdfPostIn": {
 		"name": "ChangeKdfPostIn",
@@ -2069,7 +2069,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ChangePasswordPostIn": {
 		"name": "ChangePasswordPostIn",
@@ -2164,7 +2164,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Chat": {
 		"name": "Chat",
@@ -2214,7 +2214,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CloseSessionServicePost": {
 		"name": "CloseSessionServicePost",
@@ -2257,7 +2257,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CreateCustomerServerPropertiesData": {
 		"name": "CreateCustomerServerPropertiesData",
@@ -2298,7 +2298,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CreateCustomerServerPropertiesReturn": {
 		"name": "CreateCustomerServerPropertiesReturn",
@@ -2332,7 +2332,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CreateSessionData": {
 		"name": "CreateSessionData",
@@ -2420,7 +2420,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CreateSessionReturn": {
 		"name": "CreateSessionReturn",
@@ -2473,7 +2473,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CreditCard": {
 		"name": "CreditCard",
@@ -2541,7 +2541,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomDomainCheckGetIn": {
 		"name": "CustomDomainCheckGetIn",
@@ -2584,7 +2584,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomDomainCheckGetOut": {
 		"name": "CustomDomainCheckGetOut",
@@ -2647,7 +2647,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomDomainData": {
 		"name": "CustomDomainData",
@@ -2690,7 +2690,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomDomainReturn": {
 		"name": "CustomDomainReturn",
@@ -2733,7 +2733,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Customer": {
 		"name": "Customer",
@@ -2990,7 +2990,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomerAccountTerminationPostIn": {
 		"name": "CustomerAccountTerminationPostIn",
@@ -3033,7 +3033,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomerAccountTerminationPostOut": {
 		"name": "CustomerAccountTerminationPostOut",
@@ -3067,7 +3067,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomerAccountTerminationRequest": {
 		"name": "CustomerAccountTerminationRequest",
@@ -3146,7 +3146,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomerInfo": {
 		"name": "CustomerInfo",
@@ -3459,7 +3459,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomerProperties": {
 		"name": "CustomerProperties",
@@ -3567,7 +3567,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"CustomerServerProperties": {
 		"name": "CustomerServerProperties",
@@ -3693,7 +3693,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DateWrapper": {
 		"name": "DateWrapper",
@@ -3725,7 +3725,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DebitServicePutData": {
 		"name": "DebitServicePutData",
@@ -3759,7 +3759,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DeleteCustomerData": {
 		"name": "DeleteCustomerData",
@@ -3839,7 +3839,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DnsRecord": {
 		"name": "DnsRecord",
@@ -3889,7 +3889,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DomainInfo": {
 		"name": "DomainInfo",
@@ -3951,7 +3951,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DomainMailAddressAvailabilityData": {
 		"name": "DomainMailAddressAvailabilityData",
@@ -3983,7 +3983,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DomainMailAddressAvailabilityReturn": {
 		"name": "DomainMailAddressAvailabilityReturn",
@@ -4015,7 +4015,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"DomainsRef": {
 		"name": "DomainsRef",
@@ -4049,7 +4049,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"EmailSenderListElement": {
 		"name": "EmailSenderListElement",
@@ -4108,7 +4108,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"EntityEventBatch": {
 		"name": "EntityEventBatch",
@@ -4169,7 +4169,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"EntityUpdate": {
 		"name": "EntityUpdate",
@@ -4237,7 +4237,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Exception": {
 		"name": "Exception",
@@ -4278,7 +4278,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ExternalPropertiesReturn": {
 		"name": "ExternalPropertiesReturn",
@@ -4340,7 +4340,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ExternalUserReference": {
 		"name": "ExternalUserReference",
@@ -4411,7 +4411,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Feature": {
 		"name": "Feature",
@@ -4443,7 +4443,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"File": {
 		"name": "File",
@@ -4493,7 +4493,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GeneratedIdWrapper": {
 		"name": "GeneratedIdWrapper",
@@ -4525,7 +4525,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCard": {
 		"name": "GiftCard",
@@ -4638,7 +4638,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardCreateData": {
 		"name": "GiftCardCreateData",
@@ -4706,7 +4706,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardCreateReturn": {
 		"name": "GiftCardCreateReturn",
@@ -4740,7 +4740,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardDeleteData": {
 		"name": "GiftCardDeleteData",
@@ -4774,7 +4774,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardGetReturn": {
 		"name": "GiftCardGetReturn",
@@ -4826,7 +4826,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardOption": {
 		"name": "GiftCardOption",
@@ -4858,7 +4858,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardRedeemData": {
 		"name": "GiftCardRedeemData",
@@ -4910,7 +4910,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardRedeemGetReturn": {
 		"name": "GiftCardRedeemGetReturn",
@@ -4962,7 +4962,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GiftCardsRef": {
 		"name": "GiftCardsRef",
@@ -4996,7 +4996,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Group": {
 		"name": "Group",
@@ -5220,7 +5220,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupInfo": {
 		"name": "GroupInfo",
@@ -5373,7 +5373,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKey": {
 		"name": "GroupKey",
@@ -5479,7 +5479,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKeyRotationData": {
 		"name": "GroupKeyRotationData",
@@ -5579,7 +5579,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKeyRotationInfoGetOut": {
 		"name": "GroupKeyRotationInfoGetOut",
@@ -5622,7 +5622,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKeyRotationPostIn": {
 		"name": "GroupKeyRotationPostIn",
@@ -5656,7 +5656,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKeyUpdate": {
 		"name": "GroupKeyUpdate",
@@ -5753,7 +5753,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKeyUpdateData": {
 		"name": "GroupKeyUpdateData",
@@ -5814,7 +5814,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKeyUpdatesRef": {
 		"name": "GroupKeyUpdatesRef",
@@ -5848,7 +5848,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupKeysRef": {
 		"name": "GroupKeysRef",
@@ -5882,7 +5882,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupMember": {
 		"name": "GroupMember",
@@ -5972,7 +5972,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupMembership": {
 		"name": "GroupMembership",
@@ -6080,7 +6080,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupMembershipKeyData": {
 		"name": "GroupMembershipKeyData",
@@ -6141,7 +6141,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupMembershipUpdateData": {
 		"name": "GroupMembershipUpdateData",
@@ -6193,7 +6193,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"GroupRoot": {
 		"name": "GroupRoot",
@@ -6274,7 +6274,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"IdTupleWrapper": {
 		"name": "IdTupleWrapper",
@@ -6315,7 +6315,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"InstanceSessionKey": {
 		"name": "InstanceSessionKey",
@@ -6394,7 +6394,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Invoice": {
 		"name": "Invoice",
@@ -6610,7 +6610,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"InvoiceDataGetIn": {
 		"name": "InvoiceDataGetIn",
@@ -6642,7 +6642,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"InvoiceDataGetOut": {
 		"name": "InvoiceDataGetOut",
@@ -6784,7 +6784,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"InvoiceDataItem": {
 		"name": "InvoiceDataItem",
@@ -6861,7 +6861,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"InvoiceInfo": {
 		"name": "InvoiceInfo",
@@ -7040,7 +7040,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"InvoiceItem": {
 		"name": "InvoiceItem",
@@ -7126,7 +7126,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"KeyPair": {
 		"name": "KeyPair",
@@ -7203,7 +7203,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"KeyRotation": {
 		"name": "KeyRotation",
@@ -7271,7 +7271,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"KeyRotationsRef": {
 		"name": "KeyRotationsRef",
@@ -7305,7 +7305,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"LocationServiceGetReturn": {
 		"name": "LocationServiceGetReturn",
@@ -7337,7 +7337,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Login": {
 		"name": "Login",
@@ -7396,7 +7396,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MailAddressAlias": {
 		"name": "MailAddressAlias",
@@ -7437,7 +7437,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MailAddressAliasGetIn": {
 		"name": "MailAddressAliasGetIn",
@@ -7471,7 +7471,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MailAddressAliasServiceData": {
 		"name": "MailAddressAliasServiceData",
@@ -7514,7 +7514,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MailAddressAliasServiceDataDelete": {
 		"name": "MailAddressAliasServiceDataDelete",
@@ -7566,7 +7566,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MailAddressAliasServiceReturn": {
 		"name": "MailAddressAliasServiceReturn",
@@ -7625,7 +7625,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MailAddressAvailability": {
 		"name": "MailAddressAvailability",
@@ -7666,7 +7666,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MailAddressToGroup": {
 		"name": "MailAddressToGroup",
@@ -7727,7 +7727,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MembershipAddData": {
 		"name": "MembershipAddData",
@@ -7798,7 +7798,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MembershipPutIn": {
 		"name": "MembershipPutIn",
@@ -7832,7 +7832,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MembershipRemoveData": {
 		"name": "MembershipRemoveData",
@@ -7876,7 +7876,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MissedNotification": {
 		"name": "MissedNotification",
@@ -7992,7 +7992,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MultipleMailAddressAvailabilityData": {
 		"name": "MultipleMailAddressAvailabilityData",
@@ -8026,7 +8026,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"MultipleMailAddressAvailabilityReturn": {
 		"name": "MultipleMailAddressAvailabilityReturn",
@@ -8060,7 +8060,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"NotificationInfo": {
 		"name": "NotificationInfo",
@@ -8112,7 +8112,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"NotificationMailTemplate": {
 		"name": "NotificationMailTemplate",
@@ -8162,7 +8162,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"NotificationSessionKey": {
 		"name": "NotificationSessionKey",
@@ -8205,7 +8205,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"OrderProcessingAgreement": {
 		"name": "OrderProcessingAgreement",
@@ -8321,7 +8321,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"OtpChallenge": {
 		"name": "OtpChallenge",
@@ -8355,7 +8355,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PaymentDataServiceGetData": {
 		"name": "PaymentDataServiceGetData",
@@ -8387,7 +8387,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PaymentDataServiceGetReturn": {
 		"name": "PaymentDataServiceGetReturn",
@@ -8419,7 +8419,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PaymentDataServicePostData": {
 		"name": "PaymentDataServicePostData",
@@ -8453,7 +8453,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PaymentDataServicePutData": {
 		"name": "PaymentDataServicePutData",
@@ -8568,7 +8568,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PaymentDataServicePutReturn": {
 		"name": "PaymentDataServicePutReturn",
@@ -8611,7 +8611,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PaymentErrorInfo": {
 		"name": "PaymentErrorInfo",
@@ -8661,7 +8661,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Permission": {
 		"name": "Permission",
@@ -8813,7 +8813,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PlanConfiguration": {
 		"name": "PlanConfiguration",
@@ -8926,7 +8926,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PlanPrices": {
 		"name": "PlanPrices",
@@ -9068,7 +9068,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PlanServiceGetOut": {
 		"name": "PlanServiceGetOut",
@@ -9102,7 +9102,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PriceData": {
 		"name": "PriceData",
@@ -9163,7 +9163,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PriceItemData": {
 		"name": "PriceItemData",
@@ -9222,7 +9222,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PriceRequestData": {
 		"name": "PriceRequestData",
@@ -9299,7 +9299,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PriceServiceData": {
 		"name": "PriceServiceData",
@@ -9342,7 +9342,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PriceServiceReturn": {
 		"name": "PriceServiceReturn",
@@ -9414,7 +9414,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PubEncKeyData": {
 		"name": "PubEncKeyData",
@@ -9482,7 +9482,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PublicKeyGetIn": {
 		"name": "PublicKeyGetIn",
@@ -9523,7 +9523,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PublicKeyGetOut": {
 		"name": "PublicKeyGetOut",
@@ -9582,7 +9582,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PublicKeyPutIn": {
 		"name": "PublicKeyPutIn",
@@ -9634,7 +9634,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PushIdentifier": {
 		"name": "PushIdentifier",
@@ -9792,7 +9792,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"PushIdentifierList": {
 		"name": "PushIdentifierList",
@@ -9826,7 +9826,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ReceivedGroupInvitation": {
 		"name": "ReceivedGroupInvitation",
@@ -9987,7 +9987,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RecoverCode": {
 		"name": "RecoverCode",
@@ -10073,7 +10073,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RecoverCodeData": {
 		"name": "RecoverCodeData",
@@ -10132,7 +10132,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ReferralCodeGetIn": {
 		"name": "ReferralCodeGetIn",
@@ -10166,7 +10166,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ReferralCodePostIn": {
 		"name": "ReferralCodePostIn",
@@ -10189,7 +10189,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ReferralCodePostOut": {
 		"name": "ReferralCodePostOut",
@@ -10223,7 +10223,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RegistrationCaptchaServiceData": {
 		"name": "RegistrationCaptchaServiceData",
@@ -10264,7 +10264,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RegistrationCaptchaServiceGetData": {
 		"name": "RegistrationCaptchaServiceGetData",
@@ -10332,7 +10332,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RegistrationCaptchaServiceReturn": {
 		"name": "RegistrationCaptchaServiceReturn",
@@ -10373,7 +10373,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RegistrationReturn": {
 		"name": "RegistrationReturn",
@@ -10405,7 +10405,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RegistrationServiceData": {
 		"name": "RegistrationServiceData",
@@ -10455,7 +10455,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RejectedSender": {
 		"name": "RejectedSender",
@@ -10550,7 +10550,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RejectedSendersRef": {
 		"name": "RejectedSendersRef",
@@ -10584,7 +10584,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RepeatRule": {
 		"name": "RepeatRule",
@@ -10663,7 +10663,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ResetFactorsDeleteData": {
 		"name": "ResetFactorsDeleteData",
@@ -10713,7 +10713,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"ResetPasswordPostIn": {
 		"name": "ResetPasswordPostIn",
@@ -10792,7 +10792,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"RootInstance": {
 		"name": "RootInstance",
@@ -10851,7 +10851,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SaltData": {
 		"name": "SaltData",
@@ -10883,7 +10883,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SaltReturn": {
 		"name": "SaltReturn",
@@ -10924,7 +10924,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SecondFactor": {
 		"name": "SecondFactor",
@@ -11012,7 +11012,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SecondFactorAuthAllowedReturn": {
 		"name": "SecondFactorAuthAllowedReturn",
@@ -11044,7 +11044,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SecondFactorAuthData": {
 		"name": "SecondFactorAuthData",
@@ -11116,7 +11116,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SecondFactorAuthDeleteData": {
 		"name": "SecondFactorAuthDeleteData",
@@ -11150,7 +11150,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SecondFactorAuthGetData": {
 		"name": "SecondFactorAuthGetData",
@@ -11182,7 +11182,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SecondFactorAuthGetReturn": {
 		"name": "SecondFactorAuthGetReturn",
@@ -11214,7 +11214,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SecondFactorAuthentication": {
 		"name": "SecondFactorAuthentication",
@@ -11300,7 +11300,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SendRegistrationCodeData": {
 		"name": "SendRegistrationCodeData",
@@ -11359,7 +11359,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SendRegistrationCodeReturn": {
 		"name": "SendRegistrationCodeReturn",
@@ -11391,7 +11391,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SentGroupInvitation": {
 		"name": "SentGroupInvitation",
@@ -11480,7 +11480,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Session": {
 		"name": "Session",
@@ -11623,7 +11623,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SignOrderProcessingAgreementData": {
 		"name": "SignOrderProcessingAgreementData",
@@ -11664,7 +11664,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SseConnectData": {
 		"name": "SseConnectData",
@@ -11707,7 +11707,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"StringConfigValue": {
 		"name": "StringConfigValue",
@@ -11748,7 +11748,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"StringWrapper": {
 		"name": "StringWrapper",
@@ -11780,7 +11780,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SurveyData": {
 		"name": "SurveyData",
@@ -11839,7 +11839,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SwitchAccountTypePostIn": {
 		"name": "SwitchAccountTypePostIn",
@@ -11928,7 +11928,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"SystemKeysReturn": {
 		"name": "SystemKeysReturn",
@@ -12044,7 +12044,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"TakeOverDeletedAddressData": {
 		"name": "TakeOverDeletedAddressData",
@@ -12103,7 +12103,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"TypeInfo": {
 		"name": "TypeInfo",
@@ -12144,7 +12144,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"U2fChallenge": {
 		"name": "U2fChallenge",
@@ -12187,7 +12187,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"U2fKey": {
 		"name": "U2fKey",
@@ -12239,7 +12239,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"U2fRegisteredDevice": {
 		"name": "U2fRegisteredDevice",
@@ -12307,7 +12307,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"U2fResponseData": {
 		"name": "U2fResponseData",
@@ -12357,7 +12357,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UpdatePermissionKeyData": {
 		"name": "UpdatePermissionKeyData",
@@ -12419,7 +12419,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UpdateSessionKeysPostIn": {
 		"name": "UpdateSessionKeysPostIn",
@@ -12453,7 +12453,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UpgradePriceServiceData": {
 		"name": "UpgradePriceServiceData",
@@ -12505,7 +12505,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UpgradePriceServiceReturn": {
 		"name": "UpgradePriceServiceReturn",
@@ -12676,7 +12676,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"User": {
 		"name": "User",
@@ -12891,7 +12891,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserAlarmInfo": {
 		"name": "UserAlarmInfo",
@@ -12970,7 +12970,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserAlarmInfoListType": {
 		"name": "UserAlarmInfoListType",
@@ -13004,7 +13004,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserAreaGroups": {
 		"name": "UserAreaGroups",
@@ -13038,7 +13038,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserAuthentication": {
 		"name": "UserAuthentication",
@@ -13092,7 +13092,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserDataDelete": {
 		"name": "UserDataDelete",
@@ -13144,7 +13144,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserExternalAuthInfo": {
 		"name": "UserExternalAuthInfo",
@@ -13214,7 +13214,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserGroupKeyDistribution": {
 		"name": "UserGroupKeyDistribution",
@@ -13282,7 +13282,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserGroupKeyRotationData": {
 		"name": "UserGroupKeyRotationData",
@@ -13399,7 +13399,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"UserGroupRoot": {
 		"name": "UserGroupRoot",
@@ -13480,7 +13480,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"VariableExternalAuthInfo": {
 		"name": "VariableExternalAuthInfo",
@@ -13584,7 +13584,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"VerifyRegistrationCodeData": {
 		"name": "VerifyRegistrationCodeData",
@@ -13625,7 +13625,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"Version": {
 		"name": "Version",
@@ -13696,7 +13696,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"VersionData": {
 		"name": "VersionData",
@@ -13755,7 +13755,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"VersionInfo": {
 		"name": "VersionInfo",
@@ -13880,7 +13880,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"VersionReturn": {
 		"name": "VersionReturn",
@@ -13914,7 +13914,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WebauthnResponseData": {
 		"name": "WebauthnResponseData",
@@ -13973,7 +13973,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WebsocketCounterData": {
 		"name": "WebsocketCounterData",
@@ -14016,7 +14016,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WebsocketCounterValue": {
 		"name": "WebsocketCounterValue",
@@ -14057,7 +14057,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WebsocketEntityData": {
 		"name": "WebsocketEntityData",
@@ -14109,7 +14109,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WebsocketLeaderStatus": {
 		"name": "WebsocketLeaderStatus",
@@ -14141,7 +14141,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WhitelabelChild": {
 		"name": "WhitelabelChild",
@@ -14256,7 +14256,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WhitelabelChildrenRef": {
 		"name": "WhitelabelChildrenRef",
@@ -14290,7 +14290,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WhitelabelConfig": {
 		"name": "WhitelabelConfig",
@@ -14425,7 +14425,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	},
 	"WhitelabelParent": {
 		"name": "WhitelabelParent",
@@ -14469,6 +14469,6 @@
 			}
 		},
 		"app": "sys",
-		"version": "108"
+		"version": "109"
 	}
 }

--- a/tuta-sdk/rust/sdk/src/typed_entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/typed_entity_client.rs
@@ -1,86 +1,104 @@
-use std::sync::Arc;
-use serde::Deserialize;
-use crate::{ApiCallError, IdTuple, ListLoadDirection};
 use crate::entities::Entity;
 #[mockall_double::double]
 use crate::entity_client::EntityClient;
 use crate::entity_client::IdType;
 use crate::generated_id::GeneratedId;
 use crate::instance_mapper::InstanceMapper;
+use crate::{ApiCallError, IdTuple, ListLoadDirection};
+use serde::Deserialize;
+use std::sync::Arc;
 
 pub struct TypedEntityClient {
-    entity_client: Arc<EntityClient>,
-    instance_mapper: Arc<InstanceMapper>,
+	entity_client: Arc<EntityClient>,
+	instance_mapper: Arc<InstanceMapper>,
 }
 
 /// Similar to EntityClient, but return a typed object instead of a generic Map
 impl TypedEntityClient {
-    #[allow(unused)]
-    pub(crate) fn new(
-        entity_client: Arc<EntityClient>,
-        instance_mapper: Arc<InstanceMapper>,
-    ) -> Self {
-        TypedEntityClient {
-            entity_client,
-            instance_mapper,
-        }
-    }
+	#[allow(unused)]
+	pub(crate) fn new(
+		entity_client: Arc<EntityClient>,
+		instance_mapper: Arc<InstanceMapper>,
+	) -> Self {
+		TypedEntityClient {
+			entity_client,
+			instance_mapper,
+		}
+	}
 
-    #[allow(clippy::unused_async)]
-    pub async fn load<T: Entity + Deserialize<'static>, Id: IdType>(
-        &self,
-        id: &Id,
-    ) -> Result<T, ApiCallError> {
-        let type_model = self.entity_client.get_type_model(&T::type_ref())?;
-        if type_model.is_encrypted() {
-            return Err(ApiCallError::InternalSdkError {
-                error_message: format!("This client shall not handle encrypted fields! Entity: app: {}, name: {}", &T::type_ref().app, &T::type_ref().type_)
-            });
-        }
-        let parsed_entity = self.entity_client.load::<Id>(&T::type_ref(), id).await?;
-        let typed_entity = self.instance_mapper.parse_entity::<T>(parsed_entity).map_err(|e| {
-            let message = format!("Failed to parse entity into proper types: {e}");
-            ApiCallError::InternalSdkError { error_message: message }
-        })?;
-        Ok(typed_entity)
-    }
+	#[allow(clippy::unused_async)]
+	pub async fn load<T: Entity + Deserialize<'static>, Id: IdType>(
+		&self,
+		id: &Id,
+	) -> Result<T, ApiCallError> {
+		let type_model = self.entity_client.get_type_model(&T::type_ref())?;
+		if type_model.is_encrypted() {
+			return Err(ApiCallError::InternalSdkError {
+				error_message: format!(
+					"This client shall not handle encrypted fields! Entity: app: {}, name: {}",
+					&T::type_ref().app,
+					&T::type_ref().type_
+				),
+			});
+		}
+		let parsed_entity = self.entity_client.load::<Id>(&T::type_ref(), id).await?;
+		let typed_entity = self
+			.instance_mapper
+			.parse_entity::<T>(parsed_entity)
+			.map_err(|e| {
+				let message = format!("Failed to parse entity into proper types: {e}");
+				ApiCallError::InternalSdkError {
+					error_message: message,
+				}
+			})?;
+		Ok(typed_entity)
+	}
 
-    #[allow(dead_code)]
-    #[allow(clippy::unused_async)]
-    async fn load_all<T: Entity + Deserialize<'static>>(&self, _list_id: &IdTuple, _start: Option<String>) -> Result<Vec<T>, ApiCallError> {
-        todo!("typed entity client load_all")
-    }
+	#[allow(dead_code)]
+	#[allow(clippy::unused_async)]
+	async fn load_all<T: Entity + Deserialize<'static>>(
+		&self,
+		_list_id: &IdTuple,
+		_start: Option<String>,
+	) -> Result<Vec<T>, ApiCallError> {
+		todo!("typed entity client load_all")
+	}
 
-    #[allow(dead_code)]
-    #[allow(clippy::unused_async)]
-    pub async fn load_range<T: Entity + Deserialize<'static>>(&self, _list_id: &GeneratedId, _start_id: &GeneratedId, _count: usize, _list_load_direction: ListLoadDirection) -> Result<Vec<T>, ApiCallError> {
-        todo!("typed entity client load_range")
-    }
+	#[allow(dead_code)]
+	#[allow(clippy::unused_async)]
+	pub async fn load_range<T: Entity + Deserialize<'static>>(
+		&self,
+		_list_id: &GeneratedId,
+		_start_id: &GeneratedId,
+		_count: usize,
+		_list_load_direction: ListLoadDirection,
+	) -> Result<Vec<T>, ApiCallError> {
+		todo!("typed entity client load_range")
+	}
 }
-
 
 #[cfg(test)]
 mockall::mock! {
-    pub TypedEntityClient {
-        pub fn new(
-            entity_client: Arc<EntityClient>,
-            instance_mapper: Arc<InstanceMapper>,
-        ) -> Self;
-        pub async fn load<T: Entity + Deserialize<'static>, Id: IdType>(
-            &self,
-            id: &Id,
-         ) -> Result<T, ApiCallError>;
-        async fn load_all<T: Entity + Deserialize<'static>>(
-            &self,
-            list_id: &IdTuple,
-            start: Option<String>,
-        ) -> Result<Vec<T>, ApiCallError>;
-        pub async fn load_range<T: Entity + Deserialize<'static>>(
-            &self,
-            list_id: &GeneratedId,
-            start_id: &GeneratedId,
-            count: usize,
-            list_load_direction: ListLoadDirection,
-        ) -> Result<Vec<T>, ApiCallError>;
-    }
+	pub TypedEntityClient {
+		pub fn new(
+			entity_client: Arc<EntityClient>,
+			instance_mapper: Arc<InstanceMapper>,
+		) -> Self;
+		pub async fn load<T: Entity + Deserialize<'static>, Id: IdType>(
+			&self,
+			id: &Id,
+		 ) -> Result<T, ApiCallError>;
+		async fn load_all<T: Entity + Deserialize<'static>>(
+			&self,
+			list_id: &IdTuple,
+			start: Option<String>,
+		) -> Result<Vec<T>, ApiCallError>;
+		pub async fn load_range<T: Entity + Deserialize<'static>>(
+			&self,
+			list_id: &GeneratedId,
+			start_id: &GeneratedId,
+			count: usize,
+			list_load_direction: ListLoadDirection,
+		) -> Result<Vec<T>, ApiCallError>;
+	}
 }

--- a/tuta-sdk/rust/sdk/src/user_facade.rs
+++ b/tuta-sdk/rust/sdk/src/user_facade.rs
@@ -1,113 +1,144 @@
-use std::borrow::ToOwned;
-use std::sync::{Arc, RwLock};
-use base64::Engine;
-use base64::prelude::BASE64_STANDARD;
-use crate::ApiCallError;
-use crate::crypto::{Aes256Key, AES_256_KEY_SIZE};
 use crate::crypto::hkdf;
+use crate::crypto::key::GenericAesKey;
 use crate::crypto::sha256;
+use crate::crypto::{Aes256Key, AES_256_KEY_SIZE};
 use crate::entities::sys::{GroupMembership, User};
+use crate::generated_id::GeneratedId;
 #[mockall_double::double]
 use crate::key_cache::KeyCache;
-use crate::crypto::key::GenericAesKey;
-use crate::generated_id::GeneratedId;
 use crate::key_loader_facade::VersionedAesKey;
 use crate::util::Versioned;
+use crate::ApiCallError;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
+use std::borrow::ToOwned;
+use std::sync::{Arc, RwLock};
 
 const USER_GROUP_KEY_DISTRIBUTION_KEY_INFO: &str = "userGroupKeyDistributionKey";
 
 pub struct UserFacade {
-    user: RwLock<Arc<User>>,
-    key_cache: Arc<KeyCache>,
+	user: RwLock<Arc<User>>,
+	key_cache: Arc<KeyCache>,
 }
 
 /// UserFacade is tied to a logged in user.
 #[cfg_attr(test, mockall::automock)]
 impl UserFacade {
-    pub fn new(key_cache: Arc<KeyCache>, user: User) -> Self {
-        UserFacade {
-            user: RwLock::new(Arc::new(user)),
-            key_cache,
-        }
-    }
+	pub fn new(key_cache: Arc<KeyCache>, user: User) -> Self {
+		UserFacade {
+			user: RwLock::new(Arc::new(user)),
+			key_cache,
+		}
+	}
 
-    pub fn set_user(&self, user: User) {
-        *self.user.write().unwrap() = Arc::new(user);
-    }
+	pub fn set_user(&self, user: User) {
+		*self.user.write().unwrap() = Arc::new(user);
+	}
 
-    pub fn unlock_user_group_key(&self, user_passphrase_key: GenericAesKey) -> Result<(), ApiCallError> {
-        let user = self.get_user();
-        let user_group_membership = &user.userGroup;
-        let current_user_group_key = Versioned::new(
-            user_passphrase_key.decrypt_aes_key(&user_group_membership.symEncGKey).map_err(|e| {
-                ApiCallError::InternalSdkError { error_message: e.to_string() }
-            })?,
-            user_group_membership.groupKeyVersion,
-        );
-        self.key_cache.set_current_user_group_key(current_user_group_key);
-        self.set_user_group_key_distribution_key(user_passphrase_key);
-        Ok(())
-    }
+	pub fn unlock_user_group_key(
+		&self,
+		user_passphrase_key: GenericAesKey,
+	) -> Result<(), ApiCallError> {
+		let user = self.get_user();
+		let user_group_membership = &user.userGroup;
+		let current_user_group_key = Versioned::new(
+			user_passphrase_key
+				.decrypt_aes_key(&user_group_membership.symEncGKey)
+				.map_err(|e| ApiCallError::InternalSdkError {
+					error_message: e.to_string(),
+				})?,
+			user_group_membership.groupKeyVersion,
+		);
+		self.key_cache
+			.set_current_user_group_key(current_user_group_key);
+		self.set_user_group_key_distribution_key(user_passphrase_key);
+		Ok(())
+	}
 
-    pub fn key_cache(&self) -> Arc<KeyCache> {
-        self.key_cache.clone()
-    }
+	pub fn key_cache(&self) -> Arc<KeyCache> {
+		self.key_cache.clone()
+	}
 
-    fn set_user_group_key_distribution_key(&self, user_passphrase_key: GenericAesKey) {
-        let user = self.get_user();
-        let user_group_membership = &user.userGroup;
-        let user_group_key_distribution_key = self.derive_user_group_key_distribution_key(&user_group_membership.group, user_passphrase_key);
-        self.key_cache.set_user_group_key_distribution_key(user_group_key_distribution_key)
-    }
+	fn set_user_group_key_distribution_key(&self, user_passphrase_key: GenericAesKey) {
+		let user = self.get_user();
+		let user_group_membership = &user.userGroup;
+		let user_group_key_distribution_key = self.derive_user_group_key_distribution_key(
+			&user_group_membership.group,
+			user_passphrase_key,
+		);
+		self.key_cache
+			.set_user_group_key_distribution_key(user_group_key_distribution_key)
+	}
 
-    // TODO: Add a test to check uint8ArrayToBase64 is correct;
-    // there is a max length in the ts version, it seems to be a js thing, can we forego it here?
-    fn derive_user_group_key_distribution_key(&self, user_group_id: &GeneratedId, user_passphrase_key: GenericAesKey) -> Aes256Key {
-        // we prepare a key to encrypt potential user group key rotations with
-        // when passwords are changed clients are logged-out of other sessions
-        // this key is only needed by the logged-in clients, so it should be reliable enough to assume that userPassphraseKey is in sync
-        let user_group_id_hash = sha256(user_group_id.as_str().as_bytes());
-        // we bind this to userGroupId and the domain separator USER_GROUP_KEY_DISTRIBUTION_KEY_INFO
-        // the hkdf salt does not have to be secret but should be unique per user and carry some additional entropy which sha256 ensures
-        let aes_key =
-            hkdf(user_group_id_hash.as_slice(),
-                 BASE64_STANDARD.encode(user_passphrase_key.as_bytes()).as_bytes(),
-                 USER_GROUP_KEY_DISTRIBUTION_KEY_INFO.as_bytes(), AES_256_KEY_SIZE);
+	// TODO: Add a test to check uint8ArrayToBase64 is correct;
+	// there is a max length in the ts version, it seems to be a js thing, can we forego it here?
+	fn derive_user_group_key_distribution_key(
+		&self,
+		user_group_id: &GeneratedId,
+		user_passphrase_key: GenericAesKey,
+	) -> Aes256Key {
+		// we prepare a key to encrypt potential user group key rotations with
+		// when passwords are changed clients are logged-out of other sessions
+		// this key is only needed by the logged-in clients, so it should be reliable enough to assume that userPassphraseKey is in sync
+		let user_group_id_hash = sha256(user_group_id.as_str().as_bytes());
+		// we bind this to userGroupId and the domain separator USER_GROUP_KEY_DISTRIBUTION_KEY_INFO
+		// the hkdf salt does not have to be secret but should be unique per user and carry some additional entropy which sha256 ensures
+		let aes_key = hkdf(
+			user_group_id_hash.as_slice(),
+			BASE64_STANDARD
+				.encode(user_passphrase_key.as_bytes())
+				.as_bytes(),
+			USER_GROUP_KEY_DISTRIBUTION_KEY_INFO.as_bytes(),
+			AES_256_KEY_SIZE,
+		);
 
-        Aes256Key::from_bytes(aes_key.as_slice()).expect("invalid derived key size")
-    }
+		Aes256Key::from_bytes(aes_key.as_slice()).expect("invalid derived key size")
+	}
 
+	pub async fn update_user(&self, user: User) {
+		let user = Arc::new(user);
+		*self.user.write().unwrap() = user.clone();
+		self.key_cache
+			.remove_outdated_group_keys(user.as_ref())
+			.await;
+	}
 
-    pub async fn update_user(&self, user: User) {
-        let user = Arc::new(user);
-        *self.user.write().unwrap() = user.clone();
-        self.key_cache.remove_outdated_group_keys(user.as_ref()).await;
-    }
+	pub fn get_user(&self) -> Arc<User> {
+		self.user.read().unwrap().clone()
+	}
 
-    pub fn get_user(&self) -> Arc<User> {
-        self.user.read().unwrap().clone()
-    }
+	pub fn get_user_group_id(&self) -> GeneratedId {
+		self.get_user().userGroup.group.clone()
+	}
 
-    pub fn get_user_group_id(&self) -> GeneratedId {
-        self.get_user().userGroup.group.clone()
-    }
+	#[allow(dead_code)] // Remove when implementing `generateUserAreaGroupData()`
+	fn get_all_group_ids(&self) -> Vec<GeneratedId> {
+		let mut groups: Vec<GeneratedId> = self
+			.get_user()
+			.memberships
+			.iter()
+			.map(|membership| membership.group.clone())
+			.collect();
+		groups.push(self.get_user().userGroup.group.clone());
+		groups
+	}
 
-    #[allow(dead_code)] // Remove when implementing `generateUserAreaGroupData()`
-    fn get_all_group_ids(&self) -> Vec<GeneratedId> {
-        let mut groups: Vec<GeneratedId> = self.get_user().memberships.iter().map(|membership| membership.group.clone()).collect();
-        groups.push(self.get_user().userGroup.group.clone());
-        groups
-    }
+	pub fn get_current_user_group_key(&self) -> Option<VersionedAesKey> {
+		self.key_cache.get_current_user_group_key()
+	}
 
-    pub fn get_current_user_group_key(&self) -> Option<VersionedAesKey> {
-        self.key_cache.get_current_user_group_key()
-    }
-
-    #[allow(unused)]
-    pub(crate) fn get_membership(&self, group_id: &GeneratedId) -> Result<GroupMembership, ApiCallError> {
-        let memberships = &self.get_user().memberships;
-        memberships.iter().find(|g| g.group == *group_id)
-            .map(|m| m.to_owned())
-            .ok_or_else(|| ApiCallError::InternalSdkError { error_message: format!("No group with groupId {} found!", group_id) })
-    }
+	#[allow(unused)]
+	pub(crate) fn get_membership(
+		&self,
+		group_id: &GeneratedId,
+	) -> Result<GroupMembership, ApiCallError> {
+		let memberships = &self.get_user().memberships;
+		memberships
+			.iter()
+			.find(|g| g.group == *group_id)
+			.map(|m| m.to_owned())
+			.ok_or_else(|| ApiCallError::InternalSdkError {
+				error_message: format!("No group with groupId {} found!", group_id),
+			})
+	}
 }

--- a/tuta-sdk/rust/sdk/src/util/entity_test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/entity_test_utils.rs
@@ -10,34 +10,34 @@ use crate::TypeRef;
 
 /// Generates and returns an encrypted Mail ParsedEntity. It also returns the decrypted Mail for comparison
 pub fn generate_email_entity(
-    session_key: &GenericAesKey,
-    iv: &Iv,
-    confidential: bool,
-    subject: String,
-    sender_name: String,
-    recipient_name: String,
+	session_key: &GenericAesKey,
+	iv: &Iv,
+	confidential: bool,
+	subject: String,
+	sender_name: String,
+	recipient_name: String,
 ) -> (ParsedEntity, ParsedEntity) {
-    let original_mail = Mail {
-        receivedDate: DateTime::from_millis(1470039025474),
-        confidential,
-        subject,
-        firstRecipient: Some(MailAddress {
-            address: "support@yahoo.com".to_owned(),
-            name: recipient_name,
-            ..create_test_entity()
-        }),
-        sender: MailAddress {
-            address: "hello@tutao.de".to_owned(),
-            name: sender_name,
-            ..create_test_entity()
-        },
-        ..create_test_entity()
-    };
+	let original_mail = Mail {
+		receivedDate: DateTime::from_millis(1470039025474),
+		confidential,
+		subject,
+		firstRecipient: Some(MailAddress {
+			address: "support@yahoo.com".to_owned(),
+			name: recipient_name,
+			..create_test_entity()
+		}),
+		sender: MailAddress {
+			address: "hello@tutao.de".to_owned(),
+			name: sender_name,
+			..create_test_entity()
+		},
+		..create_test_entity()
+	};
 
-    let encrypted_mail = typed_entity_to_encrypted_entity(original_mail.clone(), session_key, iv);
-    let original_mail = typed_entity_to_parsed_entity(original_mail);
+	let encrypted_mail = typed_entity_to_encrypted_entity(original_mail.clone(), session_key, iv);
+	let original_mail = typed_entity_to_parsed_entity(original_mail);
 
-    (encrypted_mail, original_mail)
+	(encrypted_mail, original_mail)
 }
 
 /// Convert a typed entity into an encrypted `ParsedEntity` dictionary type.
@@ -47,112 +47,112 @@ pub fn generate_email_entity(
 /// Panics if the resulting entity is invalid and unable to be serialized.
 #[must_use]
 fn typed_entity_to_encrypted_entity<T: Entity + serde::Serialize>(
-    entity: T,
-    session_key: &GenericAesKey,
-    iv: &Iv,
+	entity: T,
+	session_key: &GenericAesKey,
+	iv: &Iv,
 ) -> ParsedEntity {
-    let provider = init_type_model_provider();
-    let mut parsed = typed_entity_to_parsed_entity(entity);
-    let TypeRef { app, type_ } = T::type_ref();
-    encrypt_test_entity_dict_with_provider(&mut parsed, &provider, app, type_, session_key, iv);
-    parsed
+	let provider = init_type_model_provider();
+	let mut parsed = typed_entity_to_parsed_entity(entity);
+	let TypeRef { app, type_ } = T::type_ref();
+	encrypt_test_entity_dict_with_provider(&mut parsed, &provider, app, type_, session_key, iv);
+	parsed
 }
 
 fn encrypt_test_entity_dict_with_provider(
-    entity: &mut ParsedEntity,
-    provider: &TypeModelProvider,
-    app: &str,
-    type_: &str,
-    session_key: &GenericAesKey,
-    iv: &Iv,
+	entity: &mut ParsedEntity,
+	provider: &TypeModelProvider,
+	app: &str,
+	type_: &str,
+	session_key: &GenericAesKey,
+	iv: &Iv,
 ) {
-    let Some(model) = provider.get_type_model(app, type_) else {
-        panic!("Failed to create test entity {app}/{type_}: not in model")
-    };
+	let Some(model) = provider.get_type_model(app, type_) else {
+		panic!("Failed to create test entity {app}/{type_}: not in model")
+	};
 
-    for (&name, value) in &model.values {
-        if !value.encrypted {
-            continue;
-        }
-        let Some(data) = entity.get_mut(name) else {
-            continue;
-        };
-        let encrypt_element_value = |value_to_encrypt: &mut ElementValue| match value_to_encrypt {
-            ElementValue::Bytes(b) => {
-                *b = session_key
-                    .encrypt_data(b, iv.to_owned())
-                    .expect("failed to encrypt bytes");
-            }
-            ElementValue::Bool(b) => {
-                *value_to_encrypt = ElementValue::Bytes(
-                    session_key
-                        .encrypt_data(if *b { b"1" } else { b"0" }, iv.clone())
-                        .expect("failed to encrypt bool"),
-                )
-            }
-            ElementValue::Number(n) => {
-                *value_to_encrypt = ElementValue::Bytes(
-                    session_key
-                        .encrypt_data(n.to_string().as_bytes(), iv.clone())
-                        .expect("failed to encrypt bool"),
-                )
-            }
-            ElementValue::String(s) => {
-                *value_to_encrypt = ElementValue::Bytes(
-                    session_key
-                        .encrypt_data(s.as_bytes(), iv.clone())
-                        .expect("failed to encrypt bool"),
-                )
-            }
-            _ => unimplemented!(
-                "can't encrypt {app}/{type_}.{name} => {:?}/{}",
-                value.value_type,
-                value_to_encrypt.type_variant_name()
-            ),
-        };
-        match data {
-            ElementValue::Null => {}
-            ElementValue::Array(arr) => {
-                for i in arr {
-                    encrypt_element_value(i);
-                }
-            }
-            n => encrypt_element_value(n),
-        }
-    }
+	for (&name, value) in &model.values {
+		if !value.encrypted {
+			continue;
+		}
+		let Some(data) = entity.get_mut(name) else {
+			continue;
+		};
+		let encrypt_element_value = |value_to_encrypt: &mut ElementValue| match value_to_encrypt {
+			ElementValue::Bytes(b) => {
+				*b = session_key
+					.encrypt_data(b, iv.to_owned())
+					.expect("failed to encrypt bytes");
+			},
+			ElementValue::Bool(b) => {
+				*value_to_encrypt = ElementValue::Bytes(
+					session_key
+						.encrypt_data(if *b { b"1" } else { b"0" }, iv.clone())
+						.expect("failed to encrypt bool"),
+				)
+			},
+			ElementValue::Number(n) => {
+				*value_to_encrypt = ElementValue::Bytes(
+					session_key
+						.encrypt_data(n.to_string().as_bytes(), iv.clone())
+						.expect("failed to encrypt bool"),
+				)
+			},
+			ElementValue::String(s) => {
+				*value_to_encrypt = ElementValue::Bytes(
+					session_key
+						.encrypt_data(s.as_bytes(), iv.clone())
+						.expect("failed to encrypt bool"),
+				)
+			},
+			_ => unimplemented!(
+				"can't encrypt {app}/{type_}.{name} => {:?}/{}",
+				value.value_type,
+				value_to_encrypt.type_variant_name()
+			),
+		};
+		match data {
+			ElementValue::Null => {},
+			ElementValue::Array(arr) => {
+				for i in arr {
+					encrypt_element_value(i);
+				}
+			},
+			n => encrypt_element_value(n),
+		}
+	}
 
-    for (&name, association) in &model.associations {
-        let Some(data) = entity.get_mut(name) else {
-            continue;
-        };
-        match data {
-            ElementValue::Null => {}
-            ElementValue::Dict(d) => {
-                encrypt_test_entity_dict_with_provider(
-                    d,
-                    provider,
-                    association.dependency.unwrap_or(app),
-                    association.ref_type,
-                    session_key,
-                    iv,
-                );
-            }
-            ElementValue::Array(a) => {
-                for i in a {
-                    let ElementValue::Dict(d) = i else {
-                        break;
-                    };
-                    encrypt_test_entity_dict_with_provider(
-                        d,
-                        provider,
-                        association.dependency.unwrap_or(app),
-                        association.ref_type,
-                        session_key,
-                        iv,
-                    );
-                }
-            }
-            _ => (),
-        }
-    }
+	for (&name, association) in &model.associations {
+		let Some(data) = entity.get_mut(name) else {
+			continue;
+		};
+		match data {
+			ElementValue::Null => {},
+			ElementValue::Dict(d) => {
+				encrypt_test_entity_dict_with_provider(
+					d,
+					provider,
+					association.dependency.unwrap_or(app),
+					association.ref_type,
+					session_key,
+					iv,
+				);
+			},
+			ElementValue::Array(a) => {
+				for i in a {
+					let ElementValue::Dict(d) = i else {
+						break;
+					};
+					encrypt_test_entity_dict_with_provider(
+						d,
+						provider,
+						association.dependency.unwrap_or(app),
+						association.ref_type,
+						session_key,
+						iv,
+					);
+				}
+			},
+			_ => (),
+		}
+	}
 }

--- a/tuta-sdk/rust/sdk/src/util/mod.rs
+++ b/tuta-sdk/rust/sdk/src/util/mod.rs
@@ -2,50 +2,53 @@ use base64::alphabet::Alphabet;
 use base64::engine::GeneralPurpose;
 
 #[cfg(test)]
-pub mod test_utils;
-#[cfg(test)]
 pub mod entity_test_utils;
+#[cfg(test)]
+pub mod test_utils;
 
 /// A functional style wrapper around `vec.reverse()`
 #[cfg(test)]
 pub fn get_vec_reversed<T: Clone>(vec: Vec<T>) -> Vec<T> {
-    let mut copy = vec.clone();
-    copy.reverse();
-    copy
+	let mut copy = vec.clone();
+	copy.reverse();
+	copy
 }
 
 pub struct Versioned<T> {
-    pub object: T,
-    pub version: i64,
+	pub object: T,
+	pub version: i64,
 }
 
-impl<T> Clone for Versioned<T> where T: Clone {
-    fn clone(&self) -> Self {
-        Versioned { object: self.object.clone(), version: self.version }
-    }
+impl<T> Clone for Versioned<T>
+where
+	T: Clone,
+{
+	fn clone(&self) -> Self {
+		Versioned {
+			object: self.object.clone(),
+			version: self.version,
+		}
+	}
 }
 
 impl<T> Versioned<T> {
-    pub fn new(object: T, version: i64) -> Versioned<T> {
-        Versioned {
-            object,
-            version,
-        }
-    }
+	pub fn new(object: T, version: i64) -> Versioned<T> {
+		Versioned { object, version }
+	}
 }
 
 /// Alphabet for encoding/decoding a base64ext string.
 /// Base64ext uses another character set than base64 in order to make it sortable.
 ///
 /// packages/tutanota-utils/lib/Encoding.ts
-const BASE64EXT_ALPHABET: Alphabet = match Alphabet::new("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz") {
-    Ok(x) => x,
-    Err(_) => panic!("creation of alphabet failed")
-};
+const BASE64EXT_ALPHABET: Alphabet =
+	match Alphabet::new("-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz") {
+		Ok(x) => x,
+		Err(_) => panic!("creation of alphabet failed"),
+	};
 
-pub const BASE64_EXT: GeneralPurpose = GeneralPurpose::new(
-    &BASE64EXT_ALPHABET,
-    base64::engine::general_purpose::PAD);
+pub const BASE64_EXT: GeneralPurpose =
+	GeneralPurpose::new(&BASE64EXT_ALPHABET, base64::engine::general_purpose::PAD);
 
 /// Combine multiple slices into one Vec.
 ///
@@ -69,7 +72,7 @@ macro_rules! join_slices {
 #[derive(thiserror::Error, Debug)]
 #[error("Byte array error: {reason}")]
 pub struct ByteArrayError {
-    reason: String,
+	reason: String,
 }
 
 /// Decode the encoded byte arrays.
@@ -77,31 +80,44 @@ pub struct ByteArrayError {
 /// We encode multiple byte arrays into one by prefixing each byte array with the length as a 16-bit integer (in big endian byte order).
 ///
 /// Returns `Err` if this is invalid.
-pub fn decode_byte_arrays<const SIZE: usize>(arrays: &[u8]) -> Result<[&[u8]; SIZE], ByteArrayError> {
-    let mut result = [[0u8; 0].as_slice(); SIZE];
-    let mut remaining = arrays;
+pub fn decode_byte_arrays<const SIZE: usize>(
+	arrays: &[u8],
+) -> Result<[&[u8]; SIZE], ByteArrayError> {
+	let mut result = [[0u8; 0].as_slice(); SIZE];
+	let mut remaining = arrays;
 
-    for (array_index, array_result) in result.iter_mut().enumerate() {
-        if remaining.len() < 2 {
-            return Err(ByteArrayError { reason: format!("expected more byte arrays (only got {array_index}, expected {SIZE})") });
-        }
-        let (len_bytes, after) = remaining.split_at(2);
+	for (array_index, array_result) in result.iter_mut().enumerate() {
+		if remaining.len() < 2 {
+			return Err(ByteArrayError {
+				reason: format!(
+					"expected more byte arrays (only got {array_index}, expected {SIZE})"
+				),
+			});
+		}
+		let (len_bytes, after) = remaining.split_at(2);
 
-        let length = u16::from_be_bytes(len_bytes.try_into().unwrap()) as usize;
-        if after.len() < length {
-            return Err(ByteArrayError { reason: format!("invalid encoded byte arrays (size {length} is too large)") });
-        }
-        let (arr, new_remaining) = after.split_at(length);
+		let length = u16::from_be_bytes(len_bytes.try_into().unwrap()) as usize;
+		if after.len() < length {
+			return Err(ByteArrayError {
+				reason: format!("invalid encoded byte arrays (size {length} is too large)"),
+			});
+		}
+		let (arr, new_remaining) = after.split_at(length);
 
-        *array_result = arr;
-        remaining = new_remaining;
-    }
+		*array_result = arr;
+		remaining = new_remaining;
+	}
 
-    if !remaining.is_empty() {
-        return Err(ByteArrayError { reason: format!("extraneous {} byte(s) detected - incorrect size?", remaining.len()) });
-    }
+	if !remaining.is_empty() {
+		return Err(ByteArrayError {
+			reason: format!(
+				"extraneous {} byte(s) detected - incorrect size?",
+				remaining.len()
+			),
+		});
+	}
 
-    Ok(result)
+	Ok(result)
 }
 
 /// Encode the byte arrays into one.
@@ -109,43 +125,52 @@ pub fn decode_byte_arrays<const SIZE: usize>(arrays: &[u8]) -> Result<[&[u8]; SI
 /// We encode multiple byte arrays into one by prefixing each byte array with the length as a 16-bit integer (in big endian byte order).
 ///
 /// Returns `Err` if anything is bigger than a 16-bit integer.
-pub fn encode_byte_arrays<const SIZE: usize>(arrays: &[&[u8]; SIZE]) -> Result<Vec<u8>, ByteArrayError> {
-    let mut expected_size = 0usize;
-    for &i in arrays {
-        let len = i.len();
-        if len > u16::MAX as usize {
-            return Err(ByteArrayError { reason: format!("byte array length {len} exceeds 16-bit limit") });
-        }
-        expected_size += 2 + i.len();
-    }
+pub fn encode_byte_arrays<const SIZE: usize>(
+	arrays: &[&[u8]; SIZE],
+) -> Result<Vec<u8>, ByteArrayError> {
+	let mut expected_size = 0usize;
+	for &i in arrays {
+		let len = i.len();
+		if len > u16::MAX as usize {
+			return Err(ByteArrayError {
+				reason: format!("byte array length {len} exceeds 16-bit limit"),
+			});
+		}
+		expected_size += 2 + i.len();
+	}
 
-    let mut v = Vec::with_capacity(expected_size);
-    for &i in arrays {
-        v.extend_from_slice(&(i.len() as u16).to_be_bytes());
-        v.extend_from_slice(i);
-    }
+	let mut v = Vec::with_capacity(expected_size);
+	for &i in arrays {
+		v.extend_from_slice(&(i.len() as u16).to_be_bytes());
+		v.extend_from_slice(i);
+	}
 
-    Ok(v)
+	Ok(v)
 }
-
 
 /// Denotes a failure to convert a slice of size `actual_size` into a newtype `type_name`
 /// containing a fixed size array
 #[derive(thiserror::Error, Debug)]
 #[error("Incorrect {type_name} size: {actual_size}")]
 pub struct ArrayCastingError {
-    pub type_name: &'static str,
-    pub actual_size: usize,
+	pub type_name: &'static str,
+	pub actual_size: usize,
 }
 
 /// Converts a slice into a fixed size array.
 ///
 /// If the size of the slice does not match, it will return an `Err`.
-pub fn array_cast_slice<T: Copy + Clone, const SIZE: usize>(from: &[T], type_name: &'static str) -> Result<[T; SIZE], ArrayCastingError> {
-    match <[T; SIZE]>::try_from(from) {
-        Ok(n) => Ok(n),
-        Err(_) => Err(ArrayCastingError { type_name, actual_size: from.len() })
-    }
+pub fn array_cast_slice<T: Copy + Clone, const SIZE: usize>(
+	from: &[T],
+	type_name: &'static str,
+) -> Result<[T; SIZE], ArrayCastingError> {
+	match <[T; SIZE]>::try_from(from) {
+		Ok(n) => Ok(n),
+		Err(_) => Err(ArrayCastingError {
+			type_name,
+			actual_size: from.len(),
+		}),
+	}
 }
 
 /// Cast the array into an array of a fixed size.
@@ -154,80 +179,80 @@ pub fn array_cast_slice<T: Copy + Clone, const SIZE: usize>(from: &[T], type_nam
 ///
 /// This is used to prove to the compiler that the size is correct, and will generally be optimized
 /// by the compiler to have no runtime cost in release builds.
-pub fn array_cast_size<const SIZE: usize, const ARR_SIZE: usize>(arr: [u8; ARR_SIZE], type_name: &'static str) -> Result<[u8; SIZE], ArrayCastingError> {
-    if arr.len() == SIZE {
-        let mut result: [u8; SIZE] = [0; SIZE];
-        result.copy_from_slice(&arr);
-        Ok(result)
-    } else {
-        Err(ArrayCastingError { type_name, actual_size: ARR_SIZE })
-    }
+pub fn array_cast_size<const SIZE: usize, const ARR_SIZE: usize>(
+	arr: [u8; ARR_SIZE],
+	type_name: &'static str,
+) -> Result<[u8; SIZE], ArrayCastingError> {
+	if arr.len() == SIZE {
+		let mut result: [u8; SIZE] = [0; SIZE];
+		result.copy_from_slice(&arr);
+		Ok(result)
+	} else {
+		Err(ArrayCastingError {
+			type_name,
+			actual_size: ARR_SIZE,
+		})
+	}
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
+	use super::*;
 
-    /// Returns a handwritten encoded byte array and its decoded equivalent
-    const fn get_test_byte_arrays<'a>() -> ([u8; 11], [&'a [u8]; 2]) {
-        let encoded_byte_arrays = [
-            0, 5, 123, 45, 67, 89, 10,
-            0, 2, 22, 23
-        ];
-        let decoded_byte_arrays = [
-            [123, 45, 67, 89, 10].as_slice(),
-            [22, 23].as_slice()
-        ];
-        (encoded_byte_arrays, decoded_byte_arrays)
-    }
+	/// Returns a handwritten encoded byte array and its decoded equivalent
+	const fn get_test_byte_arrays<'a>() -> ([u8; 11], [&'a [u8]; 2]) {
+		let encoded_byte_arrays = [0, 5, 123, 45, 67, 89, 10, 0, 2, 22, 23];
+		let decoded_byte_arrays = [[123, 45, 67, 89, 10].as_slice(), [22, 23].as_slice()];
+		(encoded_byte_arrays, decoded_byte_arrays)
+	}
 
-    #[test]
-    fn combine_slices() {
-        let a = &[0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let b = &[100u8, 101, 102, 103, 104, 105, 106];
-        let c = &[207u8, 208, 209, 210, 211, 212, 213, 214, 215];
+	#[test]
+	fn combine_slices() {
+		let a = &[0u8, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+		let b = &[100u8, 101, 102, 103, 104, 105, 106];
+		let c = &[207u8, 208, 209, 210, 211, 212, 213, 214, 215];
 
-        // Should match a (why would you do this?)
-        let a_a = join_slices!(a);
-        assert_eq!(a, a_a.as_slice());
-        assert_eq!(a.len(), a_a.len());
+		// Should match a (why would you do this?)
+		let a_a = join_slices!(a);
+		assert_eq!(a, a_a.as_slice());
+		assert_eq!(a.len(), a_a.len());
 
-        // Should match a/b
-        let ab = join_slices!(a, b);
-        let (ab_a, ab_b) = ab.split_at(a.len());
-        assert_eq!(a, ab_a);
-        assert_eq!(b, ab_b);
-        assert_eq!(a.len() + b.len(), ab.len());
+		// Should match a/b
+		let ab = join_slices!(a, b);
+		let (ab_a, ab_b) = ab.split_at(a.len());
+		assert_eq!(a, ab_a);
+		assert_eq!(b, ab_b);
+		assert_eq!(a.len() + b.len(), ab.len());
 
-        // Should match a/b/c
-        let abc = join_slices!(a, b, c);
-        let (abc_a, abc_bc) = abc.split_at(a.len());
-        let (abc_b, abc_c) = abc_bc.split_at(b.len());
-        assert_eq!(a, abc_a);
-        assert_eq!(b, abc_b);
-        assert_eq!(c, abc_c);
-        assert_eq!(a.len() + b.len() + c.len(), abc.len());
-    }
+		// Should match a/b/c
+		let abc = join_slices!(a, b, c);
+		let (abc_a, abc_bc) = abc.split_at(a.len());
+		let (abc_b, abc_c) = abc_bc.split_at(b.len());
+		assert_eq!(a, abc_a);
+		assert_eq!(b, abc_b);
+		assert_eq!(c, abc_c);
+		assert_eq!(a.len() + b.len() + c.len(), abc.len());
+	}
 
-    #[test]
-    fn test_encode_byte_arrays() {
-        let (encoded_byte_arrays, decoded_byte_arrays) = get_test_byte_arrays();
-        let encoded = encode_byte_arrays(&decoded_byte_arrays).unwrap();
-        assert_eq!(encoded_byte_arrays, encoded.as_slice());
-    }
+	#[test]
+	fn test_encode_byte_arrays() {
+		let (encoded_byte_arrays, decoded_byte_arrays) = get_test_byte_arrays();
+		let encoded = encode_byte_arrays(&decoded_byte_arrays).unwrap();
+		assert_eq!(encoded_byte_arrays, encoded.as_slice());
+	}
 
-    #[test]
-    fn test_decode_byte_arrays() {
-        let (encoded_byte_arrays, decoded_byte_arrays) = get_test_byte_arrays();
-        let decoded = decode_byte_arrays::<2>(&encoded_byte_arrays).unwrap();
-        assert_eq!(decoded_byte_arrays, decoded);
-    }
+	#[test]
+	fn test_decode_byte_arrays() {
+		let (encoded_byte_arrays, decoded_byte_arrays) = get_test_byte_arrays();
+		let decoded = decode_byte_arrays::<2>(&encoded_byte_arrays).unwrap();
+		assert_eq!(decoded_byte_arrays, decoded);
+	}
 
-    #[test]
-    fn test_byte_arrays_encoding_roundtrip() {
-        let (_, decoded_byte_arrays) = get_test_byte_arrays();
-        let encoded = encode_byte_arrays(&decoded_byte_arrays).unwrap();
-        let decoded = decode_byte_arrays::<2>(&encoded).unwrap();
-        assert_eq!(decoded_byte_arrays, decoded);
-    }
+	#[test]
+	fn test_byte_arrays_encoding_roundtrip() {
+		let (_, decoded_byte_arrays) = get_test_byte_arrays();
+		let encoded = encode_byte_arrays(&decoded_byte_arrays).unwrap();
+		let decoded = decode_byte_arrays::<2>(&encoded).unwrap();
+		assert_eq!(decoded_byte_arrays, decoded);
+	}
 }

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -2,73 +2,76 @@
 
 use rand::random;
 
-use crate::crypto::Aes256Key;
 use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
+use crate::crypto::Aes256Key;
 use crate::custom_id::CustomId;
 use crate::element_value::{ElementValue, ParsedEntity};
-use crate::entities::Entity;
 use crate::entities::sys::{ArchiveRef, ArchiveType, Group, GroupKeysRef, KeyPair, TypeInfo};
+use crate::entities::Entity;
 use crate::generated_id::GeneratedId;
-use crate::IdTuple;
 use crate::instance_mapper::InstanceMapper;
 use crate::metamodel::{AssociationType, Cardinality, ElementType, ValueType};
 use crate::type_model_provider::{init_type_model_provider, TypeModelProvider};
+use crate::IdTuple;
 
 /// Generates a URL-safe random string of length `Size`.
 #[must_use]
 pub fn generate_random_string<const SIZE: usize>() -> String {
-    use base64::engine::Engine;
-    let random_bytes: [u8; SIZE] = make_thread_rng_facade().generate_random_array();
-    base64::engine::general_purpose::URL_SAFE.encode(random_bytes)
+	use base64::engine::Engine;
+	let random_bytes: [u8; SIZE] = make_thread_rng_facade().generate_random_array();
+	base64::engine::general_purpose::URL_SAFE.encode(random_bytes)
 }
 
-pub fn generate_random_group(current_keys: Option<KeyPair>, former_keys: Option<GroupKeysRef>) -> Group {
-    Group {
-        _format: 0,
-        _id: GeneratedId::test_random(),
-        _ownerGroup: None,
-        _permissions: GeneratedId::test_random(),
-        groupInfo: IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random()),
-        administratedGroups: None,
-        archives: vec![ArchiveType {
-            _id: CustomId::test_random(),
-            active: ArchiveRef {
-                _id: CustomId::test_random(),
-                archiveId: GeneratedId::test_random(),
-            },
-            inactive: vec![],
-            r#type: TypeInfo {
-                _id: CustomId::test_random(),
-                application: "app".to_string(),
-                typeId: 1,
-            },
-        }],
-        currentKeys: current_keys,
-        customer: None,
-        formerGroupKeys: former_keys,
-        invitations: GeneratedId::test_random(),
-        members: GeneratedId::test_random(),
-        groupKeyVersion: 1,
-        admin: None,
-        r#type: 46,
-        adminGroupEncGKey: None,
-        adminGroupKeyVersion: None,
-        enabled: true,
-        external: false,
-        pubAdminGroupEncGKey: Some(vec![1, 2, 3]),
-        storageCounter: None,
-        user: None,
-    }
+pub fn generate_random_group(
+	current_keys: Option<KeyPair>,
+	former_keys: Option<GroupKeysRef>,
+) -> Group {
+	Group {
+		_format: 0,
+		_id: GeneratedId::test_random(),
+		_ownerGroup: None,
+		_permissions: GeneratedId::test_random(),
+		groupInfo: IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random()),
+		administratedGroups: None,
+		archives: vec![ArchiveType {
+			_id: CustomId::test_random(),
+			active: ArchiveRef {
+				_id: CustomId::test_random(),
+				archiveId: GeneratedId::test_random(),
+			},
+			inactive: vec![],
+			r#type: TypeInfo {
+				_id: CustomId::test_random(),
+				application: "app".to_string(),
+				typeId: 1,
+			},
+		}],
+		currentKeys: current_keys,
+		customer: None,
+		formerGroupKeys: former_keys,
+		invitations: GeneratedId::test_random(),
+		members: GeneratedId::test_random(),
+		groupKeyVersion: 1,
+		admin: None,
+		r#type: 46,
+		adminGroupEncGKey: None,
+		adminGroupKeyVersion: None,
+		enabled: true,
+		external: false,
+		pubAdminGroupEncGKey: Some(vec![1, 2, 3]),
+		storageCounter: None,
+		user: None,
+	}
 }
 
 pub fn random_aes256_key() -> Aes256Key {
-    Aes256Key::from_bytes(&random::<[u8; 32]>()).unwrap()
+	Aes256Key::from_bytes(&random::<[u8; 32]>()).unwrap()
 }
 
 /// Moves the object T into heap and leaks it.
 #[inline(always)]
 pub fn leak<T>(what: T) -> &'static T {
-    Box::leak(Box::new(what))
+	Box::leak(Box::new(what))
 }
 
 /// Generate a test entity.
@@ -93,13 +96,17 @@ pub fn leak<T>(what: T) -> &'static T {
 /// ```
 #[must_use]
 pub fn create_test_entity<'a, T: Entity + serde::Deserialize<'a>>() -> T {
-    let mapper = InstanceMapper::new();
-    let entity = create_test_entity_dict::<T>();
-    let type_ref = T::type_ref();
-    match mapper.parse_entity(entity) {
-        Ok(n) => n,
-        Err(e) => panic!("Failed to create test entity {app}/{type_}: parse error {e}", app = type_ref.app, type_ = type_ref.type_)
-    }
+	let mapper = InstanceMapper::new();
+	let entity = create_test_entity_dict::<T>();
+	let type_ref = T::type_ref();
+	match mapper.parse_entity(entity) {
+		Ok(n) => n,
+		Err(e) => panic!(
+			"Failed to create test entity {app}/{type_}: parse error {e}",
+			app = type_ref.app,
+			type_ = type_ref.type_
+		),
+	}
 }
 
 /// Generate a test entity as a raw `ParsedEntity` dictionary type.
@@ -112,10 +119,10 @@ pub fn create_test_entity<'a, T: Entity + serde::Deserialize<'a>>() -> T {
 /// **NOTE:** The resulting dictionary is unencrypted.
 #[must_use]
 pub fn create_test_entity_dict<'a, T: Entity + serde::Deserialize<'a>>() -> ParsedEntity {
-    let provider = init_type_model_provider();
-    let type_ref = T::type_ref();
-    let entity = create_test_entity_dict_with_provider(&provider, type_ref.app, type_ref.type_);
-    entity
+	let provider = init_type_model_provider();
+	let type_ref = T::type_ref();
+	let entity = create_test_entity_dict_with_provider(&provider, type_ref.app, type_ref.type_);
+	entity
 }
 
 /// Convert a typed entity into a raw `ParsedEntity` dictionary type.
@@ -125,25 +132,34 @@ pub fn create_test_entity_dict<'a, T: Entity + serde::Deserialize<'a>>() -> Pars
 /// Panics if the resulting entity is invalid and unable to be serialized.
 #[must_use]
 pub fn typed_entity_to_parsed_entity<T: Entity + serde::Serialize>(entity: T) -> ParsedEntity {
-    let mapper = InstanceMapper::new();
-    match mapper.serialize_entity(entity) {
-        Ok(n) => n,
-        Err(e) => panic!("Failed to serialize {}/{}: {:?}", T::type_ref().app, T::type_ref().type_, e)
-    }
+	let mapper = InstanceMapper::new();
+	match mapper.serialize_entity(entity) {
+		Ok(n) => n,
+		Err(e) => panic!(
+			"Failed to serialize {}/{}: {:?}",
+			T::type_ref().app,
+			T::type_ref().type_,
+			e
+		),
+	}
 }
 
-fn create_test_entity_dict_with_provider(provider: &TypeModelProvider, app: &str, type_: &str) -> ParsedEntity {
-    let Some(model) = provider.get_type_model(app, type_) else {
-        panic!("Failed to create test entity {app}/{type_}: not in model")
-    };
-    let mut object = ParsedEntity::new();
+fn create_test_entity_dict_with_provider(
+	provider: &TypeModelProvider,
+	app: &str,
+	type_: &str,
+) -> ParsedEntity {
+	let Some(model) = provider.get_type_model(app, type_) else {
+		panic!("Failed to create test entity {app}/{type_}: not in model")
+	};
+	let mut object = ParsedEntity::new();
 
-    for (&name, value) in &model.values {
-        let element_value = match value.cardinality {
-            Cardinality::ZeroOrOne => ElementValue::Null,
-            Cardinality::Any => ElementValue::Array(Vec::new()),
-            Cardinality::One => {
-                match value.value_type {
+	for (&name, value) in &model.values {
+		let element_value = match value.cardinality {
+			Cardinality::ZeroOrOne => ElementValue::Null,
+			Cardinality::Any => ElementValue::Array(Vec::new()),
+			Cardinality::One => {
+				match value.value_type {
                     ValueType::String => ElementValue::String(Default::default()),
                     ValueType::Number => ElementValue::Number(Default::default()),
                     ValueType::Bytes => ElementValue::Bytes(Default::default()),
@@ -166,34 +182,50 @@ fn create_test_entity_dict_with_provider(provider: &TypeModelProvider, app: &str
                     }
                     ValueType::CompressedString => todo!("Failed to create test entity {app}/{type_}: Compressed strings ({name}) are not yet supported!"),
                 }
-            }
-        };
+			},
+		};
 
-        object.insert(name.to_owned(), element_value);
-    }
+		object.insert(name.to_owned(), element_value);
+	}
 
-    for (&name, value) in &model.associations {
-        let association_value = match value.cardinality {
-            Cardinality::ZeroOrOne => ElementValue::Null,
-            Cardinality::Any => ElementValue::Array(Vec::new()),
-            Cardinality::One => {
-                match value.association_type {
-                    AssociationType::ElementAssociation => ElementValue::IdGeneratedId(GeneratedId::test_random()),
-                    AssociationType::ListAssociation => ElementValue::IdGeneratedId(GeneratedId::test_random()),
-                    AssociationType::ListElementAssociation => ElementValue::IdTupleId(IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random())),
-                    AssociationType::Aggregation => ElementValue::Dict(create_test_entity_dict_with_provider(provider, value.dependency.unwrap_or(app), value.ref_type)),
-                    AssociationType::BlobElementAssociation => ElementValue::IdTupleId(IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random())),
-                }
-            }
-        };
-        object.insert(name.to_owned(), association_value);
-    }
+	for (&name, value) in &model.associations {
+		let association_value =
+			match value.cardinality {
+				Cardinality::ZeroOrOne => ElementValue::Null,
+				Cardinality::Any => ElementValue::Array(Vec::new()),
+				Cardinality::One => match value.association_type {
+					AssociationType::ElementAssociation => {
+						ElementValue::IdGeneratedId(GeneratedId::test_random())
+					},
+					AssociationType::ListAssociation => {
+						ElementValue::IdGeneratedId(GeneratedId::test_random())
+					},
+					AssociationType::ListElementAssociation => ElementValue::IdTupleId(
+						IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random()),
+					),
+					AssociationType::Aggregation => {
+						ElementValue::Dict(create_test_entity_dict_with_provider(
+							provider,
+							value.dependency.unwrap_or(app),
+							value.ref_type,
+						))
+					},
+					AssociationType::BlobElementAssociation => ElementValue::IdTupleId(
+						IdTuple::new(GeneratedId::test_random(), GeneratedId::test_random()),
+					),
+				},
+			};
+		object.insert(name.to_owned(), association_value);
+	}
 
-    if model.is_encrypted() {
-        object.insert("_finalIvs".to_owned(), ElementValue::Dict(Default::default()));
-    }
+	if model.is_encrypted() {
+		object.insert(
+			"_finalIvs".to_owned(),
+			ElementValue::Dict(Default::default()),
+		);
+	}
 
-    object
+	object
 }
 
 #[macro_export]

--- a/tuta-sdk/rust/sdk/tests/download_mail_test.rs
+++ b/tuta-sdk/rust/sdk/tests/download_mail_test.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use base64::Engine;
 use base64::prelude::BASE64_STANDARD;
+use base64::Engine;
 
-use tutasdk::{IdTuple, Sdk};
 use tutasdk::generated_id::GeneratedId;
-use tutasdk::login::{Credentials, CredentialType};
+use tutasdk::login::{CredentialType, Credentials};
 use tutasdk::rest_client::{HttpMethod, RestClient};
+use tutasdk::{IdTuple, Sdk};
 
 use crate::test_rest_client::TestRestClient;
 
@@ -14,63 +14,72 @@ mod test_rest_client;
 
 #[tokio::test]
 async fn test_download_mail() {
-    let rest_client = make_rest_client();
+	let rest_client = make_rest_client();
 
-    // password is qawsedrftgyh
-    let encrypted_passphrase_key = BASE64_STANDARD.decode("AZWEA/KTrHu0bW52CsctsBTTV4U3jrU51TadSxf6Nqs3xbEs3WfoOpPtxUDCNjHNppt6LHCfgTioejjGUJ2cCsXosZAysUiau5Nvyi8mtjLz").unwrap();
+	// password is qawsedrftgyh
+	let encrypted_passphrase_key = BASE64_STANDARD.decode("AZWEA/KTrHu0bW52CsctsBTTV4U3jrU51TadSxf6Nqs3xbEs3WfoOpPtxUDCNjHNppt6LHCfgTioejjGUJ2cCsXosZAysUiau5Nvyi8mtjLz").unwrap();
 
-    let credentials = Credentials {
-        login: "bed-free@tutanota.de".to_string(),
-        user_id: GeneratedId("O1qC700----0".to_owned()),
-        access_token: "ZC2NIBDACUABAdJhibIwclzaPU3fEu-NzQ".to_string(),
-        encrypted_passphrase_key,
-        credential_type: CredentialType::Internal,
-    };
-    let sdk = Sdk::new("http://localhost:9000".to_string(), rest_client, credentials, "");
-    let logged_in_sdk = sdk.login().await.unwrap();
-    let mail_facade = logged_in_sdk.mail_facade();
-    let mail = mail_facade.load_email_by_id_encrypted(
-        &IdTuple { list_id: GeneratedId("O1qC705-17-0".to_string()), element_id: GeneratedId("O1qC7an--3-0".to_string()) }
-    ).await.unwrap();
+	let credentials = Credentials {
+		login: "bed-free@tutanota.de".to_string(),
+		user_id: GeneratedId("O1qC700----0".to_owned()),
+		access_token: "ZC2NIBDACUABAdJhibIwclzaPU3fEu-NzQ".to_string(),
+		encrypted_passphrase_key,
+		credential_type: CredentialType::Internal,
+	};
+	let sdk = Sdk::new(
+		"http://localhost:9000".to_string(),
+		rest_client,
+		credentials,
+		"",
+	);
+	let logged_in_sdk = sdk.login().await.unwrap();
+	let mail_facade = logged_in_sdk.mail_facade();
+	let mail = mail_facade
+		.load_email_by_id_encrypted(&IdTuple {
+			list_id: GeneratedId("O1qC705-17-0".to_string()),
+			element_id: GeneratedId("O1qC7an--3-0".to_string()),
+		})
+		.await
+		.unwrap();
 
-    assert_eq!("Html email features", mail.subject);
-    assert_eq!(1, mail.recipientCount);
-    assert_eq!("bed-free@tutanota.de", mail.firstRecipient.unwrap().address);
-    assert_eq!("map-free@tutanota.de", mail.sender.address);
-    assert_eq!("Matthias", mail.sender.name);
-    assert_eq!(1721043814832, mail.receivedDate.as_millis());
+	assert_eq!("Html email features", mail.subject);
+	assert_eq!(1, mail.recipientCount);
+	assert_eq!("bed-free@tutanota.de", mail.firstRecipient.unwrap().address);
+	assert_eq!("map-free@tutanota.de", mail.sender.address);
+	assert_eq!("Matthias", mail.sender.name);
+	assert_eq!(1721043814832, mail.receivedDate.as_millis());
 }
 
 fn make_rest_client() -> Arc<dyn RestClient> {
-    let mut client = TestRestClient::default();
+	let mut client = TestRestClient::default();
 
-    client.insert_response(
+	client.insert_response(
         "http://localhost:9000/rest/sys/Session/O1qC702-1J-0/3u3i8Lr9_7TnDDdAVw7w3TypTD2k1L00vIUTMF0SIPY",
         HttpMethod::GET,
         200,
         Some(include_bytes!("download_mail_test/session.json"))
     );
 
-    client.insert_response(
-        "http://localhost:9000/rest/sys/User/O1qC700----0",
-        HttpMethod::GET,
-        200,
-        Some(include_bytes!("download_mail_test/session.json"))
-    );
+	client.insert_response(
+		"http://localhost:9000/rest/sys/User/O1qC700----0",
+		HttpMethod::GET,
+		200,
+		Some(include_bytes!("download_mail_test/session.json")),
+	);
 
-    client.insert_response(
-        "http://localhost:9000/rest/sys/User/O1qC700----0",
-        HttpMethod::GET,
-        200,
-        Some(include_bytes!("download_mail_test/user.json"))
-    );
+	client.insert_response(
+		"http://localhost:9000/rest/sys/User/O1qC700----0",
+		HttpMethod::GET,
+		200,
+		Some(include_bytes!("download_mail_test/user.json")),
+	);
 
-    client.insert_response(
-        "http://localhost:9000/rest/tutanota/Mail/O1qC705-17-0/O1qC7an--3-0",
-        HttpMethod::GET,
-        200,
-        Some(include_bytes!("download_mail_test/mail.json"))
-    );
+	client.insert_response(
+		"http://localhost:9000/rest/tutanota/Mail/O1qC705-17-0/O1qC7an--3-0",
+		HttpMethod::GET,
+		200,
+		Some(include_bytes!("download_mail_test/mail.json")),
+	);
 
-    Arc::new(client)
+	Arc::new(client)
 }

--- a/tuta-sdk/rust/sdk/tests/download_mail_test.rs
+++ b/tuta-sdk/rust/sdk/tests/download_mail_test.rs
@@ -29,10 +29,9 @@ async fn test_download_mail() {
 	let sdk = Sdk::new(
 		"http://localhost:9000".to_string(),
 		rest_client,
-		credentials,
-		"",
+		"".to_owned(),
 	);
-	let logged_in_sdk = sdk.login().await.unwrap();
+	let logged_in_sdk = sdk.login(credentials).await.unwrap();
 	let mail_facade = logged_in_sdk.mail_facade();
 	let mail = mail_facade
 		.load_email_by_id_encrypted(&IdTuple {

--- a/tuta-sdk/rust/sdk/tests/test_rest_client.rs
+++ b/tuta-sdk/rust/sdk/tests/test_rest_client.rs
@@ -1,38 +1,54 @@
 use std::collections::HashMap;
-use tutasdk::rest_client::{HttpMethod, RestClient, RestClientError, RestClientOptions, RestResponse};
+use tutasdk::rest_client::{
+	HttpMethod, RestClient, RestClientError, RestClientOptions, RestResponse,
+};
 
 #[derive(Default)]
 pub struct TestRestClient {
-    pub responses: HashMap<TestRestRequest, RestResponse>
+	pub responses: HashMap<TestRestRequest, RestResponse>,
 }
 
 impl TestRestClient {
-    pub fn insert_response(&mut self, url: &str, method: HttpMethod, status: u32, response_body: Option<&[u8]>) {
-        self.responses.insert(
-            TestRestRequest { url: url.to_owned(), method },
-            RestResponse {
-                status,
-                headers: HashMap::new(),
-                body: response_body.map(|v| v.to_vec())
-            }
-        );
-    }
+	pub fn insert_response(
+		&mut self,
+		url: &str,
+		method: HttpMethod,
+		status: u32,
+		response_body: Option<&[u8]>,
+	) {
+		self.responses.insert(
+			TestRestRequest {
+				url: url.to_owned(),
+				method,
+			},
+			RestResponse {
+				status,
+				headers: HashMap::new(),
+				body: response_body.map(|v| v.to_vec()),
+			},
+		);
+	}
 }
 
 #[derive(Hash, PartialEq, Eq)]
 pub struct TestRestRequest {
-    pub url: String,
-    pub method: HttpMethod
+	pub url: String,
+	pub method: HttpMethod,
 }
 
 #[async_trait::async_trait]
 impl RestClient for TestRestClient {
-    async fn request_binary(&self, url: String, method: HttpMethod, _options: RestClientOptions) -> Result<RestResponse, RestClientError> {
-        for i in &self.responses {
-            if i.0.url == url && i.0.method == method {
-                return Ok(i.1.to_owned())
-            }
-        }
-        panic!("TestRestClient - NOT IMPLEMENTED: {url}@{method:?}");
-    }
+	async fn request_binary(
+		&self,
+		url: String,
+		method: HttpMethod,
+		_options: RestClientOptions,
+	) -> Result<RestResponse, RestClientError> {
+		for i in &self.responses {
+			if i.0.url == url && i.0.method == method {
+				return Ok(i.1.to_owned());
+			}
+		}
+		panic!("TestRestClient - NOT IMPLEMENTED: {url}@{method:?}");
+	}
 }

--- a/tuta-sdk/rust/uniffi-bingen/uniffi-bindgen.rs
+++ b/tuta-sdk/rust/uniffi-bingen/uniffi-bindgen.rs
@@ -1,3 +1,3 @@
 fn main() {
-    uniffi::uniffi_bindgen_main()
+	uniffi::uniffi_bindgen_main()
 }


### PR DESCRIPTION
We changed the point at which the credentials are fixed in the sdk. Now they are passed in to login() method and not when creating SDK. This makes for a cleaner separation of a stateless, shared SDK and stateful, account-bound LoggedInSDK. Rest resources are now always bound to a session which allows for parallel logins and prevents accidental bugs