### PR TITLE
Open email from notification on Android

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/MainActivity.kt
@@ -702,7 +702,6 @@ class MainActivity : FragmentActivity() {
 	private suspend fun openMailbox(intent: Intent) {
 		val userId = intent.getStringExtra(OPEN_USER_MAILBOX_USERID_KEY)
 		val address = intent.getStringExtra(OPEN_USER_MAILBOX_MAIL_ADDRESS_KEY)
-		val isSummary = intent.getBooleanExtra(IS_SUMMARY_EXTRA, false)
 		if (userId == null || address == null) {
 			return
 		}
@@ -711,11 +710,16 @@ class MainActivity : FragmentActivity() {
 		startService(
 				notificationDismissedIntent(
 						this, addresses,
-						"MainActivity#openMailbox", isSummary
+						"MainActivity#openMailbox"
 				)
 		)
 
-		commonNativeFacade.openMailBox(userId, address, null)
+		val requestedPath = intent.getStringExtra(OPEN_USER_MAILBOX_MAILID_KEY)?.let {
+			val parts = it.split("/")
+			if (parts.size == 2) "/${parts[0]}/${parts[1]}" else null
+		}
+
+		commonNativeFacade.openMailBox(userId, address, requestedPath)
 	}
 
 	private suspend fun openCalendar(intent: Intent) {
@@ -779,7 +783,7 @@ class MainActivity : FragmentActivity() {
 		const val OPEN_CALENDAR_ACTION = "de.tutao.tutanota.OPEN_CALENDAR_ACTION"
 		const val OPEN_USER_MAILBOX_MAIL_ADDRESS_KEY = "mailAddress"
 		const val OPEN_USER_MAILBOX_USERID_KEY = "userId"
-		const val IS_SUMMARY_EXTRA = "isSummary"
+		const val OPEN_USER_MAILBOX_MAILID_KEY = "mailId"
 		const val ALREADY_HANDLED_INTENT = "alreadyHandledIntent"
 		private const val TAG = "MainActivity"
 		private var requestId = 0

--- a/app-android/app/src/main/java/de/tutao/tutanota/offline/TaggedSqlValue.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/offline/TaggedSqlValue.kt
@@ -29,3 +29,7 @@ fun TaggedSqlValue.unwrap(): Any? = when (this) {
 	is TaggedSqlValue.Num -> this.value
 	is TaggedSqlValue.Bytes -> this.value.data
 }
+
+fun String.sqlTagged() = TaggedSqlValue.Str(this)
+
+fun DataWrapper.sqlTagged() = TaggedSqlValue.Bytes(this)

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/PushNotificationService.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.util.Log
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import de.tutao.tutanota.AndroidNativeCryptoFacade
 import de.tutao.tutanota.LifecycleJobService
@@ -19,6 +18,7 @@ import de.tutao.tutanota.credentials.CredentialsEncryptionFactory
 import de.tutao.tutanota.data.AppDatabase
 import de.tutao.tutanota.data.SseInfo
 import de.tutao.tutanota.ipc.NativeCredentialsFacade
+import de.tutao.tutanota.offline.AndroidSqlCipherFacade
 import de.tutao.tutanota.push.SseClient.SseListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -164,7 +164,11 @@ class PushNotificationService : LifecycleJobService() {
 		if (atLeastQuinceTart() && this.state == State.STARTED && attemptForeground) {
 			Log.d(TAG, "Starting foreground")
 			try {
-				startForeground(1, localNotificationsFacade.makeConnectionNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+				startForeground(
+					1,
+					localNotificationsFacade.makeConnectionNotification(),
+					ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+				)
 			} catch (e: IllegalStateException) {
 				// probably ForegroundServiceStartNotAllowedException
 				Log.w(TAG, "Could not start the service in foreground", e)
@@ -238,7 +242,8 @@ class PushNotificationService : LifecycleJobService() {
 				nativeCredentialsFacade,
 				alarmNotificationsManager,
 				defaultClient,
-				lifecycleScope
+				lifecycleScope,
+				{ AndroidSqlCipherFacade(this@PushNotificationService) }
 			)
 
 		override fun onStartingConnection(): Boolean {

--- a/buildSrc/RustGenerator.js
+++ b/buildSrc/RustGenerator.js
@@ -53,6 +53,7 @@ pub struct ${typeName} {\n`
 
 	if (type.encrypted) {
 		buf += `\tpub errors: Option<Errors>,\n`
+		buf += `\tpub final_ivs: HashMap<String, FinalIv>,\n`
 	}
 	buf += "}"
 

--- a/buildSrc/RustGenerator.js
+++ b/buildSrc/RustGenerator.js
@@ -53,6 +53,10 @@ pub struct ${typeName} {\n`
 
 	if (type.encrypted) {
 		buf += `\tpub _errors: Option<Errors>,\n`
+	}
+
+	// aggregates do not say whether they are encrypted or not. For some reason!
+	if (type.encrypted || Object.values(type.values).some((v) => v.encrypted)) {
 		buf += `\tpub _finalIvs: HashMap<String, FinalIv>,\n`
 	}
 	buf += "}"

--- a/buildSrc/RustGenerator.js
+++ b/buildSrc/RustGenerator.js
@@ -52,8 +52,8 @@ pub struct ${typeName} {\n`
 	}
 
 	if (type.encrypted) {
-		buf += `\tpub errors: Option<Errors>,\n`
-		buf += `\tpub final_ivs: HashMap<String, FinalIv>,\n`
+		buf += `\tpub _errors: Option<Errors>,\n`
+		buf += `\tpub _finalIvs: HashMap<String, FinalIv>,\n`
 	}
 	buf += "}"
 

--- a/src/common/api/worker/crypto/CryptoFacade.ts
+++ b/src/common/api/worker/crypto/CryptoFacade.ts
@@ -296,18 +296,20 @@ export class CryptoFacade {
 	}
 
 	/**
-	 * In case the given bucketKey is a literal the literal will be converted to an instance and return. In case the BucketKey is already an instance the instance is returned.
+	 * In case the given bucketKey is a literal the literal will be converted to an instance and return. In case the BucketKey is already an instance the
+	 * instance is returned.
 	 * @param bucketKeyInstanceOrLiteral The bucket key as literal or instance
 	 */
 	async convertBucketKeyToInstanceIfNecessary(bucketKeyInstanceOrLiteral: Record<string, any>): Promise<BucketKey> {
-		if (!this.isLiteralInstance(bucketKeyInstanceOrLiteral)) {
-			// bucket key was already decoded from base 64
-			return bucketKeyInstanceOrLiteral as BucketKey
-		} else {
-			// decryptAndMapToInstance is misleading here, but we want to map the BucketKey aggregate and its session key from a literal to an instance
-			// to have the encrypted keys in binary format and not as base 64. There is actually no decryption ongoing, just mapToInstance.
+		if (this.isLiteralInstance(bucketKeyInstanceOrLiteral)) {
+			// decryptAndMapToInstance is misleading here (it's not going to be decrypted), but we want to map the BucketKey aggregate and its session key from
+			// a literal to an instance to have the encrypted keys in binary format and not as base 64. There is actually no decryption ongoing, just
+			// mapToInstance.
 			const bucketKeyTypeModel = await resolveTypeReference(BucketKeyTypeRef)
 			return (await this.instanceMapper.decryptAndMapToInstance(bucketKeyTypeModel, bucketKeyInstanceOrLiteral, null)) as BucketKey
+		} else {
+			// bucket key was already decoded
+			return bucketKeyInstanceOrLiteral as BucketKey
 		}
 	}
 
@@ -482,6 +484,9 @@ export class CryptoFacade {
 		instance._ownerKeyVersion = key.encryptingKeyVersion.toString()
 	}
 
+	/**
+	 * @return Whether the {@param elementOrLiteral} is a unmapped type, as used in JSON for transport or if it's a runtime representation of a type.
+	 */
 	private isLiteralInstance(elementOrLiteral: Record<string, any>): boolean {
 		return typeof elementOrLiteral._type === "undefined"
 	}

--- a/src/common/api/worker/crypto/InstanceMapper.ts
+++ b/src/common/api/worker/crypto/InstanceMapper.ts
@@ -46,7 +46,7 @@ export class InstanceMapper {
 				}
 
 				decrypted._errors[key] = JSON.stringify(e)
-				console.log("error when decrypting value on type:", `[${model.app},${model.name}]`, "key:", key)
+				console.log("error when decrypting value on type:", `[${model.app},${model.name}]`, "key:", key, e)
 			} finally {
 				if (valueType.encrypted) {
 					if (valueType.final) {
@@ -90,6 +90,9 @@ export class InstanceMapper {
 	}
 
 	encryptAndMapToLiteral<T>(model: TypeModel, instance: T, sk: AesKey | null): Promise<Record<string, unknown>> {
+		if (model.encrypted && sk == null) {
+			throw new ProgrammingError(`Encrypting ${model.app}/${model.name} requires a session key!`)
+		}
 		let encrypted: Record<string, unknown> = {}
 		let i = instance as any
 

--- a/src/common/api/worker/rest/DefaultEntityRestCache.ts
+++ b/src/common/api/worker/rest/DefaultEntityRestCache.ts
@@ -106,6 +106,8 @@ export type LastUpdateTime = { type: "recorded"; time: number } | { type: "never
  * (mainly password changes)
  */
 export interface ExposedCacheStorage {
+	get<T extends SomeEntity>(typeRef: TypeRef<T>, listId: Id | null, id: Id): Promise<T | null>
+
 	/**
 	 * Load range of entities. Does not include {@param start}.
 	 * If {@param reverse} is false then returns entities newer than {@param start} in ascending order sorted by

--- a/src/common/api/worker/rest/EntityRestClient.ts
+++ b/src/common/api/worker/rest/EntityRestClient.ts
@@ -178,7 +178,7 @@ export class EntityRestClient implements EntityRestInterface {
 			}
 		} catch (e) {
 			if (e instanceof SessionKeyNotFoundError) {
-				console.log(`could not resolve session key for instance of type ${typeModel.app}/${typeModel.name}`)
+				console.log(`could not resolve session key for instance of type ${typeModel.app}/${typeModel.name}`, e)
 				return null
 			} else {
 				throw e

--- a/src/common/native/main/OpenMailboxHandler.ts
+++ b/src/common/native/main/OpenMailboxHandler.ts
@@ -11,13 +11,14 @@ export async function openMailbox(userId: Id, mailAddress: string, requestedPath
 			const inbox = assertSystemFolderOfType(mailboxDetail.folders, MailFolderType.INBOX)
 			m.route.set("/mail/" + inbox.mails)
 		} else {
-			m.route.set("/mail" + requestedPath)
+			m.route.set("/mail" + requestedPath, { focusItem: true })
 		}
 	} else {
 		if (!requestedPath) {
 			m.route.set(`/login?noAutoLogin=false&userId=${userId}&loginWith=${mailAddress}`)
 		} else {
-			m.route.set(`/login?noAutoLogin=false&userId=${userId}&loginWith=${mailAddress}&requestedPath=${encodeURIComponent(requestedPath)}`)
+			const fullRequestedPath = `/mail${requestedPath}?focusItem=true`
+			m.route.set(`/login?noAutoLogin=false&userId=${userId}&loginWith=${mailAddress}&requestedPath=${encodeURIComponent(fullRequestedPath)}`)
 		}
 	}
 }

--- a/src/mail-app/mail/view/ConversationViewModel.ts
+++ b/src/mail-app/mail/view/ConversationViewModel.ts
@@ -194,8 +194,13 @@ export class ConversationViewModel {
 				// otherwise do the error handling
 				this.conversation = await this.entityClient.loadAll(ConversationEntryTypeRef, listIdPart(this.primaryMail.conversationEntry)).then(
 					async (entries) => {
-						const allMails = await this.loadMails(entries)
-						return this.createConversationItems(entries, allMails)
+						// if the primary mail is not along conversation then only display the primary mail
+						if (!entries.some((entry) => isSameId(entry.mail, this.primaryMail._id))) {
+							return this.conversationItemsForSelectedMailOnly()
+						} else {
+							const allMails = await this.loadMails(entries)
+							return this.createConversationItems(entries, allMails)
+						}
 					},
 					async (e) => {
 						if (e instanceof NotAuthorizedError) {

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -641,6 +641,8 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 
 		if (styles.isSingleColumnLayout() && !args.mailId && this.viewSlider.focusedColumn === this.mailColumn) {
 			this.viewSlider.focusPreviousColumn()
+		} else if (args.focusItem) {
+			this.viewSlider.focus(this.mailColumn)
 		}
 
 		this.mailViewModel.showMail(args.listId, args.mailId)

--- a/src/mail-app/mail/view/MailViewModel.ts
+++ b/src/mail-app/mail/view/MailViewModel.ts
@@ -21,8 +21,7 @@ import { Router } from "../../../common/gui/ScopedRouter.js"
 import { ListFetchResult } from "../../../common/gui/base/ListUtils.js"
 import { EntityUpdateData, isUpdateForTypeRef } from "../../../common/api/common/utils/EntityUpdateUtils.js"
 import { EventController } from "../../../common/api/main/EventController.js"
-import { assertSystemFolderOfType, getMailFilterForType, MailFilterType } from "../../../common/mailFunctionality/SharedMailUtils.js"
-import { isOfTypeOrSubfolderOf } from "../../../common/mailFunctionality/SharedMailUtils.js"
+import { assertSystemFolderOfType, getMailFilterForType, isOfTypeOrSubfolderOf, MailFilterType } from "../../../common/mailFunctionality/SharedMailUtils.js"
 import { isSpamOrTrashFolder, isSubfolderOfType } from "../../../common/api/common/CommonMailUtils.js"
 
 export interface MailOpenedListener {
@@ -94,6 +93,14 @@ export class MailViewModel {
 		}
 
 		await this.setListId(listIdToUse)
+
+		if (listId && mailId) {
+			const cached = await this.cacheStorage.get(MailTypeRef, listId, mailId)
+			if (cached) {
+				this.conversationViewModel = this.conversationViewModelFactory({ mail: cached, showFolder: false })
+				this.updateUi()
+			}
+		}
 
 		// if there is a target id and we are not loading for this id already then start loading towards that id
 		if (this.targetMailId && this.targetMailId != this.loadingToTargetId) {

--- a/tuta-sdk/rust/Cargo.lock
+++ b/tuta-sdk/rust/Cargo.lock
@@ -804,6 +804,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f8e213c36148d828083ae01948eed271d03f95f7e72571fa242d78184029af2"
+dependencies = [
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6bdc119b1a405df86a8cde673295114179dbd0ebe18877c26ba89fb080365c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1552,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "log 0.4.22",
+ "minicbor",
  "mockall",
  "mockall_double",
  "oslog",

--- a/tuta-sdk/rust/sdk/Cargo.toml
+++ b/tuta-sdk/rust/sdk/Cargo.toml
@@ -22,7 +22,7 @@ curve25519-dalek = "4.1.2"
 pqcrypto-kyber = { version = "0.7.9", default-features = false, features = ["std"] }
 pqcrypto-traits = "0.3.4"
 rsa = "0.9.6"
-rand_core = "0.6.4"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 serde_bytes = "0.11.14"
 futures = "0.3.30"
 mockall_double = "0.3.1"

--- a/tuta-sdk/rust/sdk/Cargo.toml
+++ b/tuta-sdk/rust/sdk/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 async-trait = "0.1.77"
 serde = { version = "1.0.201", features = ["derive"] }
 serde_json = "1.0.117"
+minicbor = { version = "0.24.2" , features = ["std", "alloc"]}
 thiserror = "1.0.60"
 base64 = "0.22.1"
 aes = { version = "0.8.4", features = ["zeroize"] }

--- a/tuta-sdk/rust/sdk/src/crypto/crypto_facade.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/crypto_facade.rs
@@ -61,7 +61,7 @@ impl CryptoFacade {
     /// Returns the session key from `entity` and resolves the bucket key fields contained inside
     /// if present
     pub async fn resolve_session_key(&self, entity: &mut ParsedEntity, model: &TypeModel) -> Result<Option<ResolvedSessionKey>, SessionKeyResolutionError> {
-        if !model.encrypted {
+        if !model.marked_encrypted() {
             return Ok(None);
         }
 

--- a/tuta-sdk/rust/sdk/src/crypto/crypto_facade.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/crypto_facade.rs
@@ -2,8 +2,10 @@ use std::sync::Arc;
 
 use zeroize::Zeroizing;
 
+use crate::crypto::aes::Iv;
 use crate::crypto::ecc::EccPublicKey;
 use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey, KeyLoadError};
+use crate::crypto::randomizer_facade::RandomizerFacade;
 use crate::crypto::rsa::{RSAEccKeyPair, RSAEncryptionError};
 use crate::crypto::tuta_crypt::{PQError, PQMessage};
 use crate::element_value::{ElementValue, ParsedEntity};
@@ -13,7 +15,6 @@ use crate::IdTuple;
 use crate::instance_mapper::InstanceMapper;
 #[mockall_double::double]
 use crate::key_loader_facade::KeyLoaderFacade;
-use crate::key_loader_facade::VersionedAesKey;
 use crate::metamodel::TypeModel;
 use crate::util::ArrayCastingError;
 
@@ -33,6 +34,14 @@ const BUCKET_KEY_FIELD: &'static str = "bucketKey";
 pub struct CryptoFacade {
     key_loader_facade: Arc<KeyLoaderFacade>,
     instance_mapper: Arc<InstanceMapper>,
+    randomizer_facade: RandomizerFacade,
+}
+
+/// Session key that encrypts an entity and the same key encrypted with the owner group.
+/// owner_enc_session_key is stored on entities to avoid public key encryption on subsequent loads.
+pub struct ResolvedSessionKey {
+    pub session_key: GenericAesKey,
+    pub owner_enc_session_key: Vec<u8>,
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -40,16 +49,18 @@ impl CryptoFacade {
     pub fn new(
         key_loader_facade: Arc<KeyLoaderFacade>,
         instance_mapper: Arc<InstanceMapper>,
+        randomizer_facade: RandomizerFacade,
     ) -> Self {
         Self {
             key_loader_facade,
             instance_mapper,
+            randomizer_facade,
         }
     }
 
     /// Returns the session key from `entity` and resolves the bucket key fields contained inside
     /// if present
-    pub async fn resolve_session_key(&self, entity: &mut ParsedEntity, model: &TypeModel) -> Result<Option<GenericAesKey>, SessionKeyResolutionError> {
+    pub async fn resolve_session_key(&self, entity: &mut ParsedEntity, model: &TypeModel) -> Result<Option<ResolvedSessionKey>, SessionKeyResolutionError> {
         if !model.encrypted {
             return Ok(None);
         }
@@ -77,11 +88,13 @@ impl CryptoFacade {
 
         let group_key: GenericAesKey = self.key_loader_facade.load_sym_group_key(owner_group, owner_key_version, None).await?;
 
-        Ok(group_key.decrypt_aes_key(owner_enc_session_key).map(|k| Some(k))?)
+        let session_key = group_key.decrypt_aes_key(&owner_enc_session_key)?;
+        // TODO: performance: should we reuse owner_enc_session_key?
+        Ok(Some(ResolvedSessionKey { session_key, owner_enc_session_key: owner_enc_session_key.clone() }))
     }
 
     /// Resolves the bucket key fields inside `entity` and returns the session key
-    async fn resolve_bucket_key(&self, entity: &mut ParsedEntity, model: &TypeModel) -> Result<GenericAesKey, SessionKeyResolutionError> {
+    async fn resolve_bucket_key(&self, entity: &mut ParsedEntity, model: &TypeModel) -> Result<ResolvedSessionKey, SessionKeyResolutionError> {
         let Some(ElementValue::Dict(bucket_key_map)) = entity.get(BUCKET_KEY_FIELD) else {
             return Err(SessionKeyResolutionError { reason: format!("{BUCKET_KEY_FIELD} is not a dictionary type") });
         };
@@ -96,7 +109,7 @@ impl CryptoFacade {
             return Err(SessionKeyResolutionError { reason: "entity has no ownerGroup".to_owned() });
         };
 
-        let VersionedAesKey { version: _version, .. } = self.key_loader_facade.get_current_sym_group_key(owner_group).await?;
+        let versioned_key = self.key_loader_facade.get_current_sym_group_key(owner_group).await?;
 
         let ResolvedBucketKey {
             decrypted_bucket_key,
@@ -121,7 +134,8 @@ impl CryptoFacade {
 
         // TODO: authenticate
 
-        Ok(session_key)
+        let owner_enc_session_key = versioned_key.object.encrypt_key(&session_key, Iv::generate(&self.randomizer_facade));
+        Ok(ResolvedSessionKey { session_key, owner_enc_session_key })
     }
 
     /// Decrypts a bucket key, using `owner_group` in the case of secure external.
@@ -269,6 +283,7 @@ impl SessionKeyResolutionErrorSubtype for PQError {}
 
 impl SessionKeyResolutionErrorSubtype for RSAEncryptionError {}
 
+// FIXME: check for returned owner_enc_session_key
 #[cfg(test)]
 mod test {
     use std::sync::Arc;
@@ -300,7 +315,7 @@ mod test {
 
         let ephemeral_keys = EccKeyPair::generate(&randomizer_facade);
         let asymmetric_keypair = PQKeyPairs::generate(&randomizer_facade);
-        let crypto_facade = make_crypto_facade(constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
+        let crypto_facade = make_crypto_facade(randomizer_facade.clone(), constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
 
         let encapsulation_iv = Iv::generate(&randomizer_facade);
         let encapsulation = PQMessage::encapsulate(
@@ -320,7 +335,7 @@ mod test {
             .expect("should not have errored")
             .expect("where is the key");
 
-        assert_eq!(constants.mail_session_key.as_bytes(), key.as_bytes());
+        assert_eq!(constants.mail_session_key.as_bytes(), key.session_key.as_bytes());
     }
 
     #[tokio::test]
@@ -329,7 +344,7 @@ mod test {
 
         let constants = BucketKeyConstants::new(&randomizer_facade);
         let asymmetric_keypair = RSAKeyPair::generate(&randomizer_facade);
-        let crypto_facade = make_crypto_facade(constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
+        let crypto_facade = make_crypto_facade(randomizer_facade.clone(), constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
         let pub_enc_bucket_key = asymmetric_keypair.public_key.encrypt(&randomizer_facade, constants.bucket_key.as_bytes()).unwrap();
 
         let mut raw_mail = make_raw_mail(&constants, pub_enc_bucket_key, CryptoProtocolVersion::RSA as i64);
@@ -339,7 +354,7 @@ mod test {
             .expect("should not have errored")
             .expect("where is the key");
 
-        assert_eq!(constants.mail_session_key.as_bytes(), key.as_bytes());
+        assert_eq!(constants.mail_session_key.as_bytes(), key.session_key.as_bytes());
     }
 
     #[tokio::test]
@@ -348,7 +363,7 @@ mod test {
 
         let constants = BucketKeyConstants::new(&randomizer_facade);
         let asymmetric_keypair = RSAEccKeyPair::generate(&randomizer_facade);
-        let crypto_facade = make_crypto_facade(constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
+        let crypto_facade = make_crypto_facade(randomizer_facade.clone(), constants.group_key.clone(), constants.sender_key_version, asymmetric_keypair.clone());
         let pub_enc_bucket_key = asymmetric_keypair.rsa_key_pair.public_key.encrypt(&randomizer_facade, constants.bucket_key.as_bytes()).unwrap();
 
         let mut raw_mail = make_raw_mail(&constants, pub_enc_bucket_key, CryptoProtocolVersion::RSA as i64);
@@ -358,7 +373,7 @@ mod test {
             .expect("should not have errored")
             .expect("where is the key");
 
-        assert_eq!(constants.mail_session_key.as_bytes(), key.as_bytes());
+        assert_eq!(constants.mail_session_key.as_bytes(), key.session_key.as_bytes());
     }
 
     fn get_mail_type_model() -> TypeModel {
@@ -431,7 +446,7 @@ mod test {
         }
     }
 
-    fn make_crypto_facade<T: Into<AsymmetricKeyPair> + Clone + Send + Sync + 'static>(group_key: GenericAesKey, sender_key_version: i64, asymmetric_keypair: T) -> CryptoFacade {
+    fn make_crypto_facade<T: Into<AsymmetricKeyPair> + Clone + Send + Sync + 'static>(randomizer_facade: RandomizerFacade, group_key: GenericAesKey, sender_key_version: i64, asymmetric_keypair: T) -> CryptoFacade {
         let group_key = group_key.clone();
 
         let mut key_loader = MockKeyLoaderFacade::default();
@@ -445,6 +460,7 @@ mod test {
         CryptoFacade {
             key_loader_facade: Arc::new(key_loader),
             instance_mapper: Arc::new(InstanceMapper::new()),
+            randomizer_facade,
         }
     }
 

--- a/tuta-sdk/rust/sdk/src/crypto/key.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/key.rs
@@ -45,7 +45,7 @@ impl GenericAesKey {
     pub fn decrypt_aes_key(&self, encrypted_key: &[u8]) -> Result<GenericAesKey, KeyLoadError> {
         let decrypted = match self {
             Self::Aes128(key) => aes_128_decrypt_no_padding_fixed_iv(&key, encrypted_key)?,
-            Self::Aes256(key) => aes_256_decrypt_no_padding(&key, encrypted_key)?,
+            Self::Aes256(key) => aes_256_decrypt_no_padding(&key, encrypted_key)?.data,
         };
 
         let decrypted = Zeroizing::new(decrypted);
@@ -56,6 +56,14 @@ impl GenericAesKey {
     ///
     /// The return decrypted data is not zeroized
     pub fn decrypt_data(&self, ciphertext: &[u8]) -> Result<Vec<u8>, AesDecryptError> {
+        let decrypted = match self {
+            Self::Aes128(key) => aes_128_decrypt(&key, ciphertext)?,
+            Self::Aes256(key) => aes_256_decrypt(&key, ciphertext)?,
+        };
+        Ok(decrypted.data)
+    }
+
+    pub fn decrypt_data_and_iv<'a>(&self, ciphertext: &'a [u8]) -> Result<PlaintextAndIv<'a>, AesDecryptError> {
         let decrypted = match self {
             Self::Aes128(key) => aes_128_decrypt(&key, ciphertext)?,
             Self::Aes256(key) => aes_256_decrypt(&key, ciphertext)?,

--- a/tuta-sdk/rust/sdk/src/crypto/key.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/key.rs
@@ -63,7 +63,7 @@ impl GenericAesKey {
         Ok(decrypted.data)
     }
 
-    pub fn decrypt_data_and_iv<'a>(&self, ciphertext: &'a [u8]) -> Result<PlaintextAndIv<'a>, AesDecryptError> {
+    pub fn decrypt_data_and_iv(&self, ciphertext: &[u8]) -> Result<PlaintextAndIv, AesDecryptError> {
         let decrypted = match self {
             Self::Aes128(key) => aes_128_decrypt(&key, ciphertext)?,
             Self::Aes256(key) => aes_256_decrypt(&key, ciphertext)?,

--- a/tuta-sdk/rust/sdk/src/crypto/mod.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/mod.rs
@@ -3,34 +3,31 @@
 // TODO: Remove the above allowance when starting to implement higher level functions
 
 
-mod aes;
-
-#[cfg(test)]
-pub use aes::Iv;
+pub use aes::{Aes256Key, AES_256_KEY_SIZE, IV_BYTE_SIZE};
 #[allow(unused_imports)]
 pub use aes::Aes128Key;
-pub use aes::{Aes256Key, AES_256_KEY_SIZE, IV_BYTE_SIZE};
+#[cfg(test)]
+pub use aes::Iv;
+pub use aes::PlaintextAndIv;
+pub use argon2_id::generate_key_from_passphrase;
+pub use hkdf::hkdf;
+pub use sha::sha256;
+#[allow(unused_imports)]
+pub use tuta_crypt::PQKeyPairs;
+
+mod aes;
 
 mod sha;
 
-pub use sha::sha256;
-
 mod hkdf;
 
-pub use hkdf::hkdf;
-
 pub(crate) mod argon2_id;
-
-pub use argon2_id::generate_key_from_passphrase;
 
 mod ecc;
 pub(crate) mod kyber;
 pub(crate) mod rsa;
 
 mod tuta_crypt;
-
-#[allow(unused_imports)]
-pub use tuta_crypt::PQKeyPairs;
 
 pub mod key_encryption;
 pub mod crypto_facade;

--- a/tuta-sdk/rust/sdk/src/crypto/tuta_crypt.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/tuta_crypt.rs
@@ -71,7 +71,7 @@ impl PQMessage {
             CryptoProtocolVersion::TutaCrypt,
         );
 
-        let bucket_key = aes_256_decrypt(&kek, &self.encapsulation.kek_enc_bucket_key)?;
+        let bucket_key = aes_256_decrypt(&kek, &self.encapsulation.kek_enc_bucket_key)?.data;
         Ok(Aes256Key::try_from(bucket_key)?)
     }
 

--- a/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
@@ -37,7 +37,7 @@ impl CryptoEntityClient {
         let type_model = self.entity_client.get_type_model(&type_ref)?;
         let mut parsed_entity = self.entity_client.load(&type_ref, id).await?;
 
-        if type_model.encrypted {
+        if type_model.marked_encrypted() {
             let possible_session_key = self.crypto_facade
                 .resolve_session_key(&mut parsed_entity, type_model)
                 .await

--- a/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
@@ -53,7 +53,7 @@ impl CryptoEntityClient {
                 )?;
             match possible_session_key {
                 Some(session_key) => {
-                    let decrypted_entity = self.entity_facade.decrypt_and_map(type_model, parsed_entity, &session_key)?;
+                    let decrypted_entity = self.entity_facade.decrypt_and_map(type_model, parsed_entity, session_key)?;
                     let typed_entity = self.instance_mapper.parse_entity::<T>(decrypted_entity)
                         .map_err(|e|
                             ApiCallError::InternalSdkError {
@@ -89,7 +89,7 @@ mod tests {
     use std::sync::Arc;
     use rand::random;
     use crate::crypto::{Aes256Key, Iv};
-    use crate::crypto::crypto_facade::MockCryptoFacade;
+    use crate::crypto::crypto_facade::{MockCryptoFacade, ResolvedSessionKey};
     use crate::crypto::key::GenericAesKey;
     use crate::crypto_entity_client::CryptoEntityClient;
     use crate::date::DateTime;
@@ -142,7 +142,7 @@ mod tests {
 
         // Set up the mock of the crypto facade
         let mut mock_crypto_facade = MockCryptoFacade::default();
-        mock_crypto_facade.expect_resolve_session_key().returning(move |_, _| Ok(Some(sk.clone())));
+        mock_crypto_facade.expect_resolve_session_key().returning(move |_, _| Ok(Some(ResolvedSessionKey { session_key: sk.clone(), owner_enc_session_key: vec![1, 2, 3]})));
 
         // TODO: it would be nice to mock this
         let type_model_provider = Arc::new(init_type_model_provider());

--- a/tuta-sdk/rust/sdk/src/entities/accounting.rs
+++ b/tuta-sdk/rust/sdk/src/entities/accounting.rs
@@ -32,8 +32,8 @@ pub struct CustomerAccountReturn {
     pub balance: i64,
     pub outstandingBookingsPrice: i64,
     pub postings: Vec<CustomerAccountPosting>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerAccountReturn {

--- a/tuta-sdk/rust/sdk/src/entities/accounting.rs
+++ b/tuta-sdk/rust/sdk/src/entities/accounting.rs
@@ -10,6 +10,7 @@ pub struct CustomerAccountPosting {
     #[serde(rename = "type")]
     pub r#type: i64,
     pub valueDate: DateTime,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerAccountPosting {

--- a/tuta-sdk/rust/sdk/src/entities/accounting.rs
+++ b/tuta-sdk/rust/sdk/src/entities/accounting.rs
@@ -33,6 +33,7 @@ pub struct CustomerAccountReturn {
     pub outstandingBookingsPrice: i64,
     pub postings: Vec<CustomerAccountPosting>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerAccountReturn {

--- a/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
+++ b/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
@@ -74,8 +74,8 @@ impl EntityFacade {
         }
 
         if type_model.encrypted {
-            mapped_decrypted.insert("errors".to_string(), ElementValue::Dict(mapped_errors));
-            mapped_decrypted.insert("final_ivs".to_string(), ElementValue::Dict(mapped_ivs));
+            mapped_decrypted.insert("_errors".to_string(), ElementValue::Dict(mapped_errors));
+            mapped_decrypted.insert("_finalIvs".to_string(), ElementValue::Dict(mapped_ivs));
         }
         Ok(mapped_decrypted)
     }
@@ -107,7 +107,7 @@ impl EntityFacade {
 
                                 // Errors should be grouped inside the top-most object, so they should be
                                 // extracted and removed from aggregates
-                                if decrypted_aggregate.get("errors").is_some() {
+                                if decrypted_aggregate.get("_errors").is_some() {
                                     let error_key = &format!("{}_{}", association_name, index);
                                     self.extract_errors(error_key, &mut errors, &mut decrypted_aggregate);
                                 }
@@ -316,7 +316,7 @@ mod tests {
         assert!(decrypted_mail.get("attachments").unwrap().assert_array().is_empty());
         assert_eq!(
             decrypted_mail
-                .get("final_ivs")
+                .get("_finalIvs")
                 .expect("has_final_ivs")
                 .assert_dict()
                 .get("subject")

--- a/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
+++ b/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
@@ -62,8 +62,10 @@ impl EntityFacade {
             }
         }
 
-        mapped_decrypted.insert("errors".to_string(), ElementValue::Dict(mapped_errors));
-        // mapped_decrypted.insert("final_ivs".to_string(), ElementValue::Dict(mapped_ivs));
+        if type_model.encrypted {
+            mapped_decrypted.insert("errors".to_string(), ElementValue::Dict(mapped_errors));
+            mapped_decrypted.insert("final_ivs".to_string(), ElementValue::Dict(mapped_ivs));
+        }
         Ok(mapped_decrypted)
     }
 

--- a/tuta-sdk/rust/sdk/src/entities/mod.rs
+++ b/tuta-sdk/rust/sdk/src/entities/mod.rs
@@ -24,7 +24,7 @@ pub trait Entity: 'static {
     fn type_ref() -> TypeRef;
 }
 
-/// A wrapper for the value in final_ivs map on entities.
+/// A wrapper for the value in _finalIvs map on entities.
 /// Once we decrypt a final field we want to be able to re-encrypt it
 /// to the same exact value. For that we need to use the same initialization
 /// vector.

--- a/tuta-sdk/rust/sdk/src/entities/mod.rs
+++ b/tuta-sdk/rust/sdk/src/entities/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
 pub use crate::IdTuple;
 use crate::TypeRef;
 
@@ -22,6 +23,20 @@ use crate::element_value::ElementValue;
 pub trait Entity: 'static {
     fn type_ref() -> TypeRef;
 }
+
+/// A wrapper for the value in final_ivs map on entities.
+/// Once we decrypt a final field we want to be able to re-encrypt it
+/// to the same exact value. For that we need to use the same initialization
+/// vector.
+/// FinalIv holds such an IV for a specific field.
+#[derive(Clone, Serialize, Deserialize, Debug)]
+#[serde(transparent)]
+pub struct FinalIv(
+    #[serde(with = "serde_bytes")]
+    Vec<u8>
+);
+
+uniffi::custom_newtype!(FinalIv, Vec<u8>);
 
 type Errors = HashMap<String, ElementValue>;
 

--- a/tuta-sdk/rust/sdk/src/entities/sys.rs
+++ b/tuta-sdk/rust/sdk/src/entities/sys.rs
@@ -80,6 +80,7 @@ pub struct AlarmInfo {
     pub alarmIdentifier: String,
     pub trigger: String,
     pub calendarRef: CalendarEventRef,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AlarmInfo {
@@ -103,6 +104,7 @@ pub struct AlarmNotification {
     pub notificationSessionKeys: Vec<NotificationSessionKey>,
     pub repeatRule: Option<RepeatRule>,
     pub user: GeneratedId,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AlarmNotification {
@@ -822,6 +824,7 @@ pub struct CreditCard {
     pub expirationMonth: String,
     pub expirationYear: String,
     pub number: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreditCard {
@@ -1101,6 +1104,7 @@ impl Entity for CustomerServerProperties {
 pub struct DateWrapper {
     pub _id: CustomId,
     pub date: DateTime,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DateWrapper {
@@ -1245,6 +1249,7 @@ pub struct EmailSenderListElement {
     #[serde(rename = "type")]
     pub r#type: i64,
     pub value: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EmailSenderListElement {
@@ -2110,6 +2115,7 @@ pub struct InvoiceItem {
     pub totalPrice: i64,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for InvoiceItem {
@@ -3257,6 +3263,7 @@ pub struct RepeatRule {
     pub interval: i64,
     pub timeZone: String,
     pub excludedDates: Vec<DateWrapper>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for RepeatRule {

--- a/tuta-sdk/rust/sdk/src/entities/sys.rs
+++ b/tuta-sdk/rust/sdk/src/entities/sys.rs
@@ -28,6 +28,7 @@ pub struct AccountingInfo {
     pub appStoreSubscription: Option<IdTuple>,
     pub invoiceInfo: Option<GeneratedId>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AccountingInfo {
@@ -119,6 +120,7 @@ pub struct AlarmServicePost {
     pub _format: i64,
     pub alarmNotifications: Vec<AlarmNotification>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AlarmServicePost {
@@ -183,6 +185,7 @@ pub struct AuditLogEntry {
     pub groupInfo: Option<IdTuple>,
     pub modifiedGroupInfo: Option<IdTuple>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AuditLogEntry {
@@ -1081,6 +1084,7 @@ pub struct CustomerServerProperties {
     pub whitelabelRegistrationDomains: Vec<StringWrapper>,
     pub whitelistedDomains: Option<DomainsRef>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerServerProperties {
@@ -1416,6 +1420,7 @@ pub struct GiftCard {
     pub status: i64,
     pub value: i64,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCard {
@@ -1439,6 +1444,7 @@ pub struct GiftCardCreateData {
     pub ownerKeyVersion: i64,
     pub value: i64,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCardCreateData {
@@ -1543,6 +1549,7 @@ pub struct GiftCardRedeemGetReturn {
     pub value: i64,
     pub giftCard: IdTuple,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCardRedeemGetReturn {
@@ -1630,6 +1637,7 @@ pub struct GroupInfo {
     pub localAdmin: Option<GeneratedId>,
     pub mailAddressAliases: Vec<MailAddressAlias>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupInfo {
@@ -1741,6 +1749,7 @@ pub struct GroupKeyUpdate {
     pub groupKeyVersion: i64,
     pub bucketKey: BucketKey,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupKeyUpdate {
@@ -1980,6 +1989,7 @@ pub struct Invoice {
     pub customer: GeneratedId,
     pub items: Vec<InvoiceItem>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Invoice {
@@ -2402,6 +2412,7 @@ pub struct MissedNotification {
     pub alarmNotifications: Vec<AlarmNotification>,
     pub notificationInfos: Vec<NotificationInfo>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MissedNotification {
@@ -2515,6 +2526,7 @@ pub struct OrderProcessingAgreement {
     pub customer: GeneratedId,
     pub signerUserGroupInfo: IdTuple,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for OrderProcessingAgreement {
@@ -2605,6 +2617,7 @@ pub struct PaymentDataServicePutData {
     pub paymentToken: Option<String>,
     pub creditCard: Option<CreditCard>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for PaymentDataServicePutData {
@@ -2950,6 +2963,7 @@ pub struct PushIdentifier {
     pub lastUsageTime: DateTime,
     pub pushServiceType: i64,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for PushIdentifier {
@@ -2999,6 +3013,7 @@ pub struct ReceivedGroupInvitation {
     pub sentInvitation: IdTuple,
     pub sharedGroup: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ReceivedGroupInvitation {
@@ -3556,6 +3571,7 @@ pub struct Session {
     pub challenges: Vec<Challenge>,
     pub user: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Session {
@@ -3951,6 +3967,7 @@ pub struct UserAlarmInfo {
     pub _permissions: GeneratedId,
     pub alarmInfo: AlarmInfo,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for UserAlarmInfo {
@@ -4356,6 +4373,7 @@ pub struct WhitelabelChild {
     pub mailAddress: String,
     pub customer: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for WhitelabelChild {

--- a/tuta-sdk/rust/sdk/src/entities/sys.rs
+++ b/tuta-sdk/rust/sdk/src/entities/sys.rs
@@ -27,8 +27,8 @@ pub struct AccountingInfo {
     pub secondCountryInfo: i64,
     pub appStoreSubscription: Option<IdTuple>,
     pub invoiceInfo: Option<GeneratedId>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AccountingInfo {
@@ -119,8 +119,8 @@ impl Entity for AlarmNotification {
 pub struct AlarmServicePost {
     pub _format: i64,
     pub alarmNotifications: Vec<AlarmNotification>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AlarmServicePost {
@@ -184,8 +184,8 @@ pub struct AuditLogEntry {
     pub modifiedEntity: String,
     pub groupInfo: Option<IdTuple>,
     pub modifiedGroupInfo: Option<IdTuple>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for AuditLogEntry {
@@ -1083,8 +1083,8 @@ pub struct CustomerServerProperties {
     pub emailSenderList: Vec<EmailSenderListElement>,
     pub whitelabelRegistrationDomains: Vec<StringWrapper>,
     pub whitelistedDomains: Option<DomainsRef>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CustomerServerProperties {
@@ -1419,8 +1419,8 @@ pub struct GiftCard {
     pub orderDate: DateTime,
     pub status: i64,
     pub value: i64,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCard {
@@ -1443,8 +1443,8 @@ pub struct GiftCardCreateData {
     pub ownerEncSessionKey: Vec<u8>,
     pub ownerKeyVersion: i64,
     pub value: i64,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCardCreateData {
@@ -1548,8 +1548,8 @@ pub struct GiftCardRedeemGetReturn {
     pub message: String,
     pub value: i64,
     pub giftCard: IdTuple,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GiftCardRedeemGetReturn {
@@ -1636,8 +1636,8 @@ pub struct GroupInfo {
     pub group: GeneratedId,
     pub localAdmin: Option<GeneratedId>,
     pub mailAddressAliases: Vec<MailAddressAlias>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupInfo {
@@ -1748,8 +1748,8 @@ pub struct GroupKeyUpdate {
     pub groupKey: Vec<u8>,
     pub groupKeyVersion: i64,
     pub bucketKey: BucketKey,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupKeyUpdate {
@@ -1988,8 +1988,8 @@ pub struct Invoice {
     pub bookings: Vec<IdTuple>,
     pub customer: GeneratedId,
     pub items: Vec<InvoiceItem>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Invoice {
@@ -2411,8 +2411,8 @@ pub struct MissedNotification {
     pub lastProcessedNotificationId: Option<GeneratedId>,
     pub alarmNotifications: Vec<AlarmNotification>,
     pub notificationInfos: Vec<NotificationInfo>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MissedNotification {
@@ -2525,8 +2525,8 @@ pub struct OrderProcessingAgreement {
     pub version: String,
     pub customer: GeneratedId,
     pub signerUserGroupInfo: IdTuple,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for OrderProcessingAgreement {
@@ -2616,8 +2616,8 @@ pub struct PaymentDataServicePutData {
     pub paymentMethodInfo: Option<String>,
     pub paymentToken: Option<String>,
     pub creditCard: Option<CreditCard>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for PaymentDataServicePutData {
@@ -2962,8 +2962,8 @@ pub struct PushIdentifier {
     pub lastNotificationDate: Option<DateTime>,
     pub lastUsageTime: DateTime,
     pub pushServiceType: i64,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for PushIdentifier {
@@ -3012,8 +3012,8 @@ pub struct ReceivedGroupInvitation {
     pub sharedGroupName: String,
     pub sentInvitation: IdTuple,
     pub sharedGroup: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ReceivedGroupInvitation {
@@ -3570,8 +3570,8 @@ pub struct Session {
     pub state: i64,
     pub challenges: Vec<Challenge>,
     pub user: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Session {
@@ -3966,8 +3966,8 @@ pub struct UserAlarmInfo {
     pub _ownerKeyVersion: Option<i64>,
     pub _permissions: GeneratedId,
     pub alarmInfo: AlarmInfo,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for UserAlarmInfo {
@@ -4372,8 +4372,8 @@ pub struct WhitelabelChild {
     pub deletedDate: Option<DateTime>,
     pub mailAddress: String,
     pub customer: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for WhitelabelChild {

--- a/tuta-sdk/rust/sdk/src/entities/tutanota.rs
+++ b/tuta-sdk/rust/sdk/src/entities/tutanota.rs
@@ -97,8 +97,8 @@ pub struct CalendarEvent {
     pub attendees: Vec<CalendarEventAttendee>,
     pub organizer: Option<EncryptedMailAddress>,
     pub repeatRule: Option<CalendarRepeatRule>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEvent {
@@ -175,8 +175,8 @@ pub struct CalendarEventUpdate {
     pub _permissions: GeneratedId,
     pub sender: String,
     pub file: IdTuple,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEventUpdate {
@@ -217,8 +217,8 @@ pub struct CalendarGroupRoot {
     pub index: Option<CalendarEventIndexRef>,
     pub longEvents: GeneratedId,
     pub shortEvents: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarGroupRoot {
@@ -288,8 +288,8 @@ pub struct Contact {
     pub relationships: Vec<ContactRelationship>,
     pub socialIds: Vec<ContactSocialId>,
     pub websites: Vec<ContactWebsite>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Contact {
@@ -351,8 +351,8 @@ pub struct ContactList {
     pub _permissions: GeneratedId,
     pub contacts: GeneratedId,
     pub photos: Option<PhotosRef>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactList {
@@ -375,8 +375,8 @@ pub struct ContactListEntry {
     pub _ownerKeyVersion: Option<i64>,
     pub _permissions: GeneratedId,
     pub emailAddress: String,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactListEntry {
@@ -399,8 +399,8 @@ pub struct ContactListGroupRoot {
     pub _ownerKeyVersion: Option<i64>,
     pub _permissions: GeneratedId,
     pub entries: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactListGroupRoot {
@@ -591,8 +591,8 @@ impl Entity for CreateExternalUserGroupData {
 pub struct CreateGroupPostReturn {
     pub _format: i64,
     pub group: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateGroupPostReturn {
@@ -614,8 +614,8 @@ pub struct CreateMailFolderData {
     pub ownerGroup: Option<GeneratedId>,
     pub ownerKeyVersion: i64,
     pub parentFolder: Option<IdTuple>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateMailFolderData {
@@ -632,8 +632,8 @@ impl Entity for CreateMailFolderData {
 pub struct CreateMailFolderReturn {
     pub _format: i64,
     pub newFolder: IdTuple,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateMailFolderReturn {
@@ -741,8 +741,8 @@ impl Entity for DeleteMailData {
 pub struct DeleteMailFolderData {
     pub _format: i64,
     pub folders: Vec<IdTuple>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DeleteMailFolderData {
@@ -784,8 +784,8 @@ pub struct DraftCreateData {
     pub ownerKeyVersion: i64,
     pub previousMessageId: Option<String>,
     pub draftData: DraftData,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftCreateData {
@@ -864,8 +864,8 @@ pub struct DraftUpdateData {
     pub _format: i64,
     pub draft: IdTuple,
     pub draftData: DraftData,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftUpdateData {
@@ -882,8 +882,8 @@ impl Entity for DraftUpdateData {
 pub struct DraftUpdateReturn {
     pub _format: i64,
     pub attachments: Vec<IdTuple>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftUpdateReturn {
@@ -908,8 +908,8 @@ pub struct EmailTemplate {
     pub tag: String,
     pub title: String,
     pub contents: Vec<EmailTemplateContent>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EmailTemplate {
@@ -1045,8 +1045,8 @@ pub struct TutanotaFile {
     pub blobs: Vec<sys::Blob>,
     pub parent: Option<IdTuple>,
     pub subFiles: Option<Subfiles>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TutanotaFile {
@@ -1069,8 +1069,8 @@ pub struct FileSystem {
     pub _ownerKeyVersion: Option<i64>,
     pub _permissions: GeneratedId,
     pub files: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for FileSystem {
@@ -1335,8 +1335,8 @@ pub struct KnowledgeBaseEntry {
     pub description: String,
     pub title: String,
     pub keywords: Vec<KnowledgeBaseEntryKeyword>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for KnowledgeBaseEntry {
@@ -1413,8 +1413,8 @@ pub struct Mail {
     pub mailDetails: Option<IdTuple>,
     pub mailDetailsDraft: Option<IdTuple>,
     pub sender: MailAddress,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Mail {
@@ -1477,8 +1477,8 @@ pub struct MailBox {
     pub receivedAttachments: GeneratedId,
     pub sentAttachments: GeneratedId,
     pub spamResults: Option<SpamResults>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailBox {
@@ -1522,8 +1522,8 @@ pub struct MailDetailsBlob {
     pub _ownerKeyVersion: Option<i64>,
     pub _permissions: GeneratedId,
     pub details: MailDetails,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailDetailsBlob {
@@ -1546,8 +1546,8 @@ pub struct MailDetailsDraft {
     pub _ownerKeyVersion: Option<i64>,
     pub _permissions: GeneratedId,
     pub details: MailDetails,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailDetailsDraft {
@@ -1589,8 +1589,8 @@ pub struct MailFolder {
     pub name: String,
     pub mails: GeneratedId,
     pub parentFolder: Option<IdTuple>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailFolder {
@@ -1655,8 +1655,8 @@ pub struct MailboxProperties {
     pub _permissions: GeneratedId,
     pub reportMovedMails: i64,
     pub mailAddressProperties: Vec<MailAddressProperties>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailboxProperties {
@@ -2147,8 +2147,8 @@ pub struct TemplateGroupRoot {
     pub _permissions: GeneratedId,
     pub knowledgeBase: GeneratedId,
     pub templates: GeneratedId,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TemplateGroupRoot {
@@ -2217,8 +2217,8 @@ pub struct TutanotaProperties {
     pub imapSyncConfig: Vec<ImapSyncConfiguration>,
     pub inboxRules: Vec<InboxRule>,
     pub lastPushedMail: Option<IdTuple>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TutanotaProperties {
@@ -2396,8 +2396,8 @@ pub struct UserSettingsGroupRoot {
     pub timeFormat: i64,
     pub usageDataOptedIn: Option<bool>,
     pub groupSettings: Vec<GroupSettings>,
-	pub errors: Option<Errors>,
-	pub final_ivs: HashMap<String, FinalIv>,
+	pub _errors: Option<Errors>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for UserSettingsGroupRoot {

--- a/tuta-sdk/rust/sdk/src/entities/tutanota.rs
+++ b/tuta-sdk/rust/sdk/src/entities/tutanota.rs
@@ -45,6 +45,7 @@ pub struct Body {
     pub _id: CustomId,
     pub compressedText: Option<Vec<u8>>,
     pub text: Option<String>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Body {
@@ -116,6 +117,7 @@ pub struct CalendarEventAttendee {
     pub _id: CustomId,
     pub status: i64,
     pub address: EncryptedMailAddress,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEventAttendee {
@@ -240,6 +242,7 @@ pub struct CalendarRepeatRule {
     pub interval: i64,
     pub timeZone: String,
     pub excludedDates: Vec<sys::DateWrapper>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarRepeatRule {
@@ -309,6 +312,7 @@ pub struct ContactAddress {
     pub customTypeName: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactAddress {
@@ -328,6 +332,7 @@ pub struct ContactCustomDate {
     pub dateIso: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactCustomDate {
@@ -420,6 +425,7 @@ pub struct ContactMailAddress {
     pub customTypeName: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactMailAddress {
@@ -439,6 +445,7 @@ pub struct ContactMessengerHandle {
     pub handle: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactMessengerHandle {
@@ -458,6 +465,7 @@ pub struct ContactPhoneNumber {
     pub number: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactPhoneNumber {
@@ -475,6 +483,7 @@ pub struct ContactPronouns {
     pub _id: CustomId,
     pub language: String,
     pub pronouns: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactPronouns {
@@ -494,6 +503,7 @@ pub struct ContactRelationship {
     pub person: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactRelationship {
@@ -513,6 +523,7 @@ pub struct ContactSocialId {
     pub socialId: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactSocialId {
@@ -532,6 +543,7 @@ pub struct ContactWebsite {
     #[serde(rename = "type")]
     pub r#type: i64,
     pub url: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactWebsite {
@@ -830,6 +842,7 @@ pub struct DraftData {
     pub removedAttachments: Vec<IdTuple>,
     pub replyTos: Vec<EncryptedMailAddress>,
     pub toRecipients: Vec<DraftRecipient>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftData {
@@ -847,6 +860,7 @@ pub struct DraftRecipient {
     pub _id: CustomId,
     pub mailAddress: String,
     pub name: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftRecipient {
@@ -927,6 +941,7 @@ pub struct EmailTemplateContent {
     pub _id: CustomId,
     pub languageCode: String,
     pub text: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EmailTemplateContent {
@@ -963,6 +978,7 @@ pub struct EncryptedMailAddress {
     pub _id: CustomId,
     pub address: String,
     pub name: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EncryptedMailAddress {
@@ -1162,6 +1178,7 @@ pub struct GroupSettings {
     pub color: String,
     pub name: Option<String>,
     pub group: GeneratedId,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for GroupSettings {
@@ -1179,6 +1196,7 @@ pub struct Header {
     pub _id: CustomId,
     pub compressedHeaders: Option<Vec<u8>>,
     pub headers: Option<String>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Header {
@@ -1256,6 +1274,7 @@ pub struct InboxRule {
     pub r#type: String,
     pub value: String,
     pub targetFolder: IdTuple,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for InboxRule {
@@ -1353,6 +1372,7 @@ impl Entity for KnowledgeBaseEntry {
 pub struct KnowledgeBaseEntryKeyword {
     pub _id: CustomId,
     pub keyword: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for KnowledgeBaseEntryKeyword {
@@ -1433,6 +1453,7 @@ pub struct MailAddress {
     pub address: String,
     pub name: String,
     pub contact: Option<IdTuple>,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailAddress {
@@ -1450,6 +1471,7 @@ pub struct MailAddressProperties {
     pub _id: CustomId,
     pub mailAddress: String,
     pub senderName: String,
+	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailAddressProperties {

--- a/tuta-sdk/rust/sdk/src/entities/tutanota.rs
+++ b/tuta-sdk/rust/sdk/src/entities/tutanota.rs
@@ -98,6 +98,7 @@ pub struct CalendarEvent {
     pub organizer: Option<EncryptedMailAddress>,
     pub repeatRule: Option<CalendarRepeatRule>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEvent {
@@ -175,6 +176,7 @@ pub struct CalendarEventUpdate {
     pub sender: String,
     pub file: IdTuple,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarEventUpdate {
@@ -216,6 +218,7 @@ pub struct CalendarGroupRoot {
     pub longEvents: GeneratedId,
     pub shortEvents: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CalendarGroupRoot {
@@ -286,6 +289,7 @@ pub struct Contact {
     pub socialIds: Vec<ContactSocialId>,
     pub websites: Vec<ContactWebsite>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Contact {
@@ -348,6 +352,7 @@ pub struct ContactList {
     pub contacts: GeneratedId,
     pub photos: Option<PhotosRef>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactList {
@@ -371,6 +376,7 @@ pub struct ContactListEntry {
     pub _permissions: GeneratedId,
     pub emailAddress: String,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactListEntry {
@@ -394,6 +400,7 @@ pub struct ContactListGroupRoot {
     pub _permissions: GeneratedId,
     pub entries: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for ContactListGroupRoot {
@@ -585,6 +592,7 @@ pub struct CreateGroupPostReturn {
     pub _format: i64,
     pub group: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateGroupPostReturn {
@@ -607,6 +615,7 @@ pub struct CreateMailFolderData {
     pub ownerKeyVersion: i64,
     pub parentFolder: Option<IdTuple>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateMailFolderData {
@@ -624,6 +633,7 @@ pub struct CreateMailFolderReturn {
     pub _format: i64,
     pub newFolder: IdTuple,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for CreateMailFolderReturn {
@@ -732,6 +742,7 @@ pub struct DeleteMailFolderData {
     pub _format: i64,
     pub folders: Vec<IdTuple>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DeleteMailFolderData {
@@ -774,6 +785,7 @@ pub struct DraftCreateData {
     pub previousMessageId: Option<String>,
     pub draftData: DraftData,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftCreateData {
@@ -853,6 +865,7 @@ pub struct DraftUpdateData {
     pub draft: IdTuple,
     pub draftData: DraftData,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftUpdateData {
@@ -870,6 +883,7 @@ pub struct DraftUpdateReturn {
     pub _format: i64,
     pub attachments: Vec<IdTuple>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for DraftUpdateReturn {
@@ -895,6 +909,7 @@ pub struct EmailTemplate {
     pub title: String,
     pub contents: Vec<EmailTemplateContent>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for EmailTemplate {
@@ -1031,6 +1046,7 @@ pub struct TutanotaFile {
     pub parent: Option<IdTuple>,
     pub subFiles: Option<Subfiles>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TutanotaFile {
@@ -1054,6 +1070,7 @@ pub struct FileSystem {
     pub _permissions: GeneratedId,
     pub files: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for FileSystem {
@@ -1319,6 +1336,7 @@ pub struct KnowledgeBaseEntry {
     pub title: String,
     pub keywords: Vec<KnowledgeBaseEntryKeyword>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for KnowledgeBaseEntry {
@@ -1396,6 +1414,7 @@ pub struct Mail {
     pub mailDetailsDraft: Option<IdTuple>,
     pub sender: MailAddress,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for Mail {
@@ -1459,6 +1478,7 @@ pub struct MailBox {
     pub sentAttachments: GeneratedId,
     pub spamResults: Option<SpamResults>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailBox {
@@ -1503,6 +1523,7 @@ pub struct MailDetailsBlob {
     pub _permissions: GeneratedId,
     pub details: MailDetails,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailDetailsBlob {
@@ -1526,6 +1547,7 @@ pub struct MailDetailsDraft {
     pub _permissions: GeneratedId,
     pub details: MailDetails,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailDetailsDraft {
@@ -1568,6 +1590,7 @@ pub struct MailFolder {
     pub mails: GeneratedId,
     pub parentFolder: Option<IdTuple>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailFolder {
@@ -1633,6 +1656,7 @@ pub struct MailboxProperties {
     pub reportMovedMails: i64,
     pub mailAddressProperties: Vec<MailAddressProperties>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for MailboxProperties {
@@ -2124,6 +2148,7 @@ pub struct TemplateGroupRoot {
     pub knowledgeBase: GeneratedId,
     pub templates: GeneratedId,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TemplateGroupRoot {
@@ -2193,6 +2218,7 @@ pub struct TutanotaProperties {
     pub inboxRules: Vec<InboxRule>,
     pub lastPushedMail: Option<IdTuple>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for TutanotaProperties {
@@ -2371,6 +2397,7 @@ pub struct UserSettingsGroupRoot {
     pub usageDataOptedIn: Option<bool>,
     pub groupSettings: Vec<GroupSettings>,
 	pub errors: Option<Errors>,
+	pub final_ivs: HashMap<String, FinalIv>,
 }
 
 impl Entity for UserSettingsGroupRoot {

--- a/tuta-sdk/rust/sdk/src/instance_mapper.rs
+++ b/tuta-sdk/rust/sdk/src/instance_mapper.rs
@@ -775,7 +775,7 @@ impl SerializeStruct for ElementValueStructSerializer {
     {
         match self {
             Self::Struct { map } => {
-                if key == "errors" {
+                if key == "_errors" {
                     // Throw decryption errors away since they are not part of the actual type.
                     return Ok(());
                 }
@@ -1123,7 +1123,7 @@ mod tests {
         #[allow(dead_code)]
         #[derive(Deserialize)]
         struct StructWithErrors {
-            errors: HashMap<String, ElementValue>,
+            _errors: HashMap<String, ElementValue>,
         }
 
         impl Entity for StructWithErrors {
@@ -1133,7 +1133,7 @@ mod tests {
         }
 
         let data = HashMap::from_iter([(
-            "errors".to_owned(),
+            "_errors".to_owned(),
             ElementValue::Dict(HashMap::from_iter([
                 (
                     "first".to_owned(),
@@ -1204,8 +1204,8 @@ mod tests {
             group: GeneratedId::test_random(),
             localAdmin: None,
             mailAddressAliases: vec![],
-            errors: Default::default(),
-            final_ivs: Default::default(),
+            _errors: Default::default(),
+            _finalIvs: Default::default(),
         };
         let mapper = InstanceMapper::new();
         let parsed_entity = mapper.serialize_entity(group_info).unwrap();
@@ -1224,7 +1224,7 @@ mod tests {
         let mut parsed_entity = json_serializer.parse(&type_ref, raw_entity).unwrap();
         let type_model = type_model_provider.get_type_model(type_ref.app, type_ref.type_).unwrap();
         if type_model.encrypted {
-            parsed_entity.insert("final_ivs".to_owned(), ElementValue::Dict(Default::default()));
+            parsed_entity.insert("_finalIvs".to_owned(), ElementValue::Dict(Default::default()));
         }
         parsed_entity
     }

--- a/tuta-sdk/rust/sdk/src/instance_mapper.rs
+++ b/tuta-sdk/rust/sdk/src/instance_mapper.rs
@@ -233,7 +233,8 @@ impl<'de, 's> Deserializer<'de> for ElementValueDeserializer<'s> {
     where
         V: Visitor<'de>,
     {
-        Err(de::Error::custom("deserialize_any is not supported!"))
+        let type_name = self.value.type_variant_name();
+        Err(de::Error::custom(format_args!("deserialize_any is not supported! key: {} value: {type_name}", self.key)))
     }
 
     fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/tuta-sdk/rust/sdk/src/lib.rs
+++ b/tuta-sdk/rust/sdk/src/lib.rs
@@ -259,6 +259,9 @@ pub enum ApiCallError {
 }
 
 impl ApiCallError {
+    fn internal(message: String) -> ApiCallError {
+        ApiCallError::InternalSdkError { error_message: message }
+    }
     fn internal_with_err<E: Error>(error: E, message: &str) -> ApiCallError {
         ApiCallError::InternalSdkError { error_message: format!("{}: {}", error, message) }
     }

--- a/tuta-sdk/rust/sdk/src/lib.rs
+++ b/tuta-sdk/rust/sdk/src/lib.rs
@@ -12,6 +12,7 @@ use rest_client::{RestClient, RestClientError};
 
 #[mockall_double::double]
 use crate::crypto::crypto_facade::CryptoFacade;
+use crate::crypto::randomizer_facade::RandomizerFacade;
 #[mockall_double::double]
 use crate::crypto_entity_client::CryptoEntityClient;
 use crate::element_value::ElementValue;
@@ -172,9 +173,11 @@ impl Sdk {
             user_facade.clone(),
             self.typed_entity_client.clone()
         ));
+        let randomizer = RandomizerFacade::from_core(rand_core::OsRng::default());
         let crypto_facade = Arc::new(CryptoFacade::new(
             key_loader.clone(),
             self.instance_mapper.clone(),
+            randomizer,
         ));
         let entity_facade = Arc::new(EntityFacade::new(self.type_model_provider.clone()));
         let crypto_entity_client: Arc<CryptoEntityClient> = Arc::new(CryptoEntityClient::new(

--- a/tuta-sdk/rust/sdk/src/metamodel.rs
+++ b/tuta-sdk/rust/sdk/src/metamodel.rs
@@ -114,8 +114,25 @@ pub struct TypeModel {
     #[serde(rename = "type")]
     pub element_type: ElementType,
     pub versioned: bool,
-    pub encrypted: bool,
+    encrypted: bool,
     pub root_id: &'static str,
     pub values: HashMap<&'static str, ModelValue>,
     pub associations: HashMap<&'static str, ModelAssociation>,
+}
+
+impl TypeModel {
+    /// Whether entity is marked as encrypted in the metamodel.
+    /// This is not the case for aggregates even though they might contain encrypted fields.
+    pub fn marked_encrypted(&self) -> bool {
+        self.encrypted
+    }
+    /// Whether it is expected that the type might contain encrypted fields.
+    pub fn is_encrypted(&self) -> bool {
+        if self.element_type == ElementType::Aggregated {
+            // Aggregates do not track whether they are encrypted
+            self.values.values().any(|v| v.encrypted)
+        } else {
+            self.encrypted
+        }
+    }
 }

--- a/tuta-sdk/rust/sdk/src/typed_entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/typed_entity_client.rs
@@ -31,7 +31,7 @@ impl TypedEntityClient {
         id: &Id,
     ) -> Result<T, ApiCallError> {
         let type_model = self.entity_client.get_type_model(&T::type_ref())?;
-        if type_model.encrypted {
+        if type_model.is_encrypted() {
             return Err(ApiCallError::InternalSdkError {
                 error_message: format!("This client shall not handle encrypted fields! Entity: app: {}, name: {}", &T::type_ref().app, &T::type_ref().type_)
             });

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -190,7 +190,7 @@ fn create_test_entity_dict_with_provider(provider: &TypeModelProvider, app: &str
     }
 
     if model.encrypted {
-        object.insert("final_ivs".to_owned(), ElementValue::Dict(Default::default()));
+        object.insert("_finalIvs".to_owned(), ElementValue::Dict(Default::default()));
     }
 
     object

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -189,7 +189,7 @@ fn create_test_entity_dict_with_provider(provider: &TypeModelProvider, app: &str
         object.insert(name.to_owned(), association_value);
     }
 
-    if model.encrypted {
+    if model.is_encrypted() {
         object.insert("_finalIvs".to_owned(), ElementValue::Dict(Default::default()));
     }
 

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -189,6 +189,10 @@ fn create_test_entity_dict_with_provider(provider: &TypeModelProvider, app: &str
         object.insert(name.to_owned(), association_value);
     }
 
+    if model.encrypted {
+        object.insert("final_ivs".to_owned(), ElementValue::Dict(Default::default()));
+    }
+
     object
 }
 


### PR DESCRIPTION
Our current approach is to store the email in the offline db and load it before network to display the email as soon as possible. Few non-obvious things had to be done:
- implement cbor serialization
- fix `OpenMailboxHandler`
- implement saving owner_enc_session_key

**Done**:
 - Passing the mail id from notification all the way to the mail view
 - Reacting to the mail id and fetching it from offline db
 - Storing emails in offline db in the format that is accepted by the web part
 
**Does not work yet**:
 - Opening email offline. Seems like we are loading the conversation list and then not finding the email that we just got from offline db. Maybe we could ignore the list somehow when the target email is not there
 - Re-encrypting such an email will not work yet. We have some support for storing final IVs but webapp expect final fields instead. We might need to finish final IVs and add support for them in web part. This is important because somebody could try to update such an email (and we have to implement this anyway).
 - Not clear how the rest of the app reacts to the rogue email in offline db
 - Need to check whether switching between mails is still smooth

see #7371