### PR TITLE
[Calendar] Offline Indicator

### DIFF
--- a/src/calendar-app/calendar/search/view/CalendarSearchView.ts
+++ b/src/calendar-app/calendar/search/view/CalendarSearchView.ts
@@ -541,6 +541,7 @@ export class CalendarSearchView extends BaseTopLevelView implements TopLevelView
 						}),
 					...attrs.header,
 				}),
+				offlineIndicatorViewModel: attrs.header.offlineIndicatorModel,
 			}),
 		)
 	}

--- a/src/calendar-app/calendar/settings/CalendarSettingsView.ts
+++ b/src/calendar-app/calendar/settings/CalendarSettingsView.ts
@@ -326,6 +326,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 				header: m(Header, {
 					...attrs.header,
 				}),
+				offlineIndicatorViewModel: attrs.header.offlineIndicatorModel,
 			}),
 		)
 	}

--- a/src/calendar-app/calendar/view/CalendarMobileHeader.ts
+++ b/src/calendar-app/calendar/view/CalendarMobileHeader.ts
@@ -2,7 +2,6 @@ import m, { Children, Component, Vnode } from "mithril"
 import { IconButton } from "../../../common/gui/base/IconButton.js"
 import { ViewSlider } from "../../../common/gui/nav/ViewSlider.js"
 import { BaseMobileHeader } from "../../../common/gui/BaseMobileHeader.js"
-import { OfflineIndicator } from "../../../common/gui/base/OfflineIndicator.js"
 import { ProgressBar } from "../../../common/gui/base/ProgressBar.js"
 import { CalendarNavConfiguration, getIconForViewType } from "../gui/CalendarGuiUtils.js"
 import { MobileHeaderBackButton, MobileHeaderMenuButton, MobileHeaderTitle } from "../../../common/gui/MobileHeader.js"
@@ -58,7 +57,6 @@ export class CalendarMobileHeader implements Component<CalendarMobileHeaderAttrs
 							onExpandedChange: () => {},
 					  })
 					: attrs.navConfiguration.title,
-				bottom: m(OfflineIndicator, attrs.offlineIndicatorModel.getCurrentAttrs()),
 				onTap: attrs.onTap,
 			}),
 			right: [

--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -860,6 +860,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 					...attrs.header,
 				}),
 				bottomNav: attrs.bottomNav?.(),
+				offlineIndicatorViewModel: attrs.header.offlineIndicatorModel,
 			}),
 		)
 	}

--- a/src/common/gui/Header.ts
+++ b/src/common/gui/Header.ts
@@ -5,7 +5,6 @@ import { FeatureType } from "../api/common/TutanotaConstants.js"
 import { BootIcons } from "./base/icons/BootIcons.js"
 import { CALENDAR_PREFIX, CONTACTLIST_PREFIX, CONTACTS_PREFIX, MAIL_PREFIX } from "../misc/RouteChange.js"
 import { assertMainOrNode } from "../api/common/Env.js"
-import { OfflineIndicator } from "./base/OfflineIndicator.js"
 import { OfflineIndicatorViewModel } from "./base/OfflineIndicatorViewModel.js"
 import { NewsModel } from "../misc/news/NewsModel.js"
 import { locator } from "../api/main/CommonLocator.js"
@@ -39,12 +38,7 @@ export class Header implements ClassComponent<HeaderAttrs> {
 	 * @private
 	 */
 	private renderNavigation(attrs: HeaderAttrs): Children {
-		return m(".flex-grow.flex.justify-end.items-center", [
-			attrs.searchBar ? attrs.searchBar() : null,
-			m(OfflineIndicator, attrs.offlineIndicatorModel.getCurrentAttrs()),
-			m(".nav-bar-spacer"),
-			m(NavBar, this.renderButtons()),
-		])
+		return m(".flex-grow.flex.justify-end.items-center", [attrs.searchBar ? attrs.searchBar() : null, m(NavBar, this.renderButtons())])
 	}
 
 	private renderButtons(): Children {

--- a/src/common/gui/MobileHeader.ts
+++ b/src/common/gui/MobileHeader.ts
@@ -6,7 +6,6 @@ import { BaseMobileHeader } from "./BaseMobileHeader.js"
 import { IconButton } from "./base/IconButton.js"
 import { BootIcons } from "./base/icons/BootIcons.js"
 import { styles } from "./styles.js"
-import { OfflineIndicator } from "./base/OfflineIndicator.js"
 import { ProgressBar } from "./base/ProgressBar.js"
 import { CounterBadge } from "./base/CounterBadge.js"
 import { px } from "./size.js"
@@ -49,7 +48,7 @@ export class MobileHeader implements Component<MobileHeaderAttrs> {
 			center: firstVisibleColumn
 				? m(MobileHeaderTitle, {
 						title: attrs.title,
-						bottom: m(OfflineIndicator, attrs.offlineIndicatorModel.getCurrentAttrs()),
+						bottom: null,
 				  })
 				: null,
 			right: [
@@ -72,7 +71,7 @@ export const MobileHeaderBackButton = pureComponent(({ backAction }: { backActio
 	})
 })
 
-export const MobileHeaderTitle = pureComponent(({ title, bottom, onTap }: { title?: string | Children; bottom: Children; onTap?: ClickHandler }) => {
+export const MobileHeaderTitle = pureComponent(({ title, bottom, onTap }: { title?: string | Children; bottom?: Children; onTap?: ClickHandler }) => {
 	// normally min-width: is 0 but inside flex it's auto and we need to teach it how to shrink
 	// align-self: stretch restrict the child to the parent width
 	// text-ellipsis already sets min-width to 0
@@ -82,7 +81,7 @@ export const MobileHeaderTitle = pureComponent(({ title, bottom, onTap }: { titl
 			{ onclick: (event: MouseEvent) => onTap?.(event, event.target as HTMLElement) },
 			title ?? NBSP,
 		),
-		bottom,
+		bottom ?? null,
 	])
 })
 

--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -2560,7 +2560,7 @@ styles.registerStyle("main", () => {
 			"background-color": theme.list_accent_fg,
 		},
 		".status-banner.offline": {
-			"background-color": "#840010",
+			"background-color": "#ca0606", // WARNING_RED from InfoBanner
 		},
 		".status-banner.offline .content-accent-fg": {
 			color: "#ffffff",

--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -2556,5 +2556,20 @@ styles.registerStyle("main", () => {
 		".posr-ml": {
 			right: px(size.vpad_ml),
 		},
+		".status-banner": {
+			"background-color": theme.list_accent_fg,
+		},
+		".status-banner.offline": {
+			"background-color": "#840010",
+		},
+		".status-banner.offline .content-accent-fg": {
+			color: "#ffffff",
+		},
+		".status-banner button": {
+			color: `${theme.list_alternate_bg} !important`,
+		},
+		".status-banner.offline button": {
+			color: "#ffffff !important",
+		},
 	}
 })

--- a/src/common/gui/nav/ViewSlider.ts
+++ b/src/common/gui/nav/ViewSlider.ts
@@ -12,6 +12,8 @@ import { AriaLandmarks } from "../AriaUtils.js"
 import { LayerType } from "../../../RootView.js"
 import { assertMainOrNode } from "../../api/common/Env.js"
 import { client } from "../../misc/ClientDetector.js"
+import { ConnectionStateIndicator } from "../base/OfflineIndicator.js"
+import { OfflineIndicatorViewModel } from "../base/OfflineIndicatorViewModel.js"
 
 assertMainOrNode()
 export type GestureInfo = {
@@ -30,6 +32,7 @@ export const gestureInfoFromTouch = (touch: Touch): GestureInfo => ({
 interface ViewSliderAttrs {
 	header: Children
 	bottomNav?: Children
+	offlineIndicatorViewModel: OfflineIndicatorViewModel
 }
 
 /**
@@ -109,6 +112,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 					},
 				},
 				[
+					m(ConnectionStateIndicator, attrs.offlineIndicatorViewModel.getCurrentAttrs()),
 					styles.isUsingBottomNavigation() ? null : attrs.header,
 					m(
 						".view-columns.flex-grow.rel",

--- a/src/mail-app/contacts/view/ContactView.ts
+++ b/src/mail-app/contacts/view/ContactView.ts
@@ -360,6 +360,7 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 						  this.contactListViewModel.listModel?.state.inMultiselect
 						? m(MobileBottomActionBar, this.detailsViewerActions())
 						: m(BottomNav),
+				offlineIndicatorViewModel: attrs.header.offlineIndicatorModel,
 			}),
 		)
 	}

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -368,6 +368,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 								mailModel: locator.mailModel,
 						  })
 						: m(BottomNav),
+				offlineIndicatorViewModel: attrs.header.offlineIndicatorModel,
 			}),
 		)
 	}

--- a/src/mail-app/search/view/SearchView.ts
+++ b/src/mail-app/search/view/SearchView.ts
@@ -536,6 +536,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 					...attrs.header,
 				}),
 				bottomNav: this.renderBottomNav(),
+				offlineIndicatorViewModel: attrs.header.offlineIndicatorModel,
 			}),
 		)
 	}

--- a/src/mail-app/settings/SettingsView.ts
+++ b/src/mail-app/settings/SettingsView.ts
@@ -462,6 +462,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 					...attrs.header,
 				}),
 				bottomNav: m(BottomNav),
+				offlineIndicatorViewModel: attrs.header.offlineIndicatorModel,
 			}),
 		)
 	}


### PR DESCRIPTION
Removes offline indicator from header and adds a thin status banner on top of the page whenever the app goes offline.
This change is being applied in both apps.

Closes #7211 