### PR TITLE
Adds new App colors

### DIFF
--- a/src/common/gui/builtinThemes.ts
+++ b/src/common/gui/builtinThemes.ts
@@ -4,6 +4,7 @@
 import { getLogoSvg } from "./base/Logo"
 import type { Theme, ThemeId } from "./theme"
 import { assertMainOrNodeBoot } from "../api/common/Env"
+import { client } from "../misc/ClientDetector.js"
 
 assertMainOrNodeBoot()
 
@@ -21,7 +22,8 @@ const grey_darker_0 = "#707070"
 const grey_darker_1 = "#303030"
 const red = "#850122"
 const dunkel = "#410002"
-const blue = "#005885"
+const blue = "#013E85"
+const light_blue = "#4C89FF"
 
 /**
  *      dark theme background
@@ -41,7 +43,7 @@ const dark_lighter_1 = "#363636"
 const dark_lighter_0 = "#232323"
 const dark = "#222222"
 const dark_darker_0 = "#111111"
-const green = "#00d2a7"
+const light_red = "#ff5353"
 const logo_text_bright_grey = "#c5c7c7"
 
 // These are constants that have been chosen because they work across themes
@@ -52,9 +54,10 @@ export const stateBgFocus = "rgba(139,139,139,0.29)"
 export const stateBgActive = "rgba(139,139,139,0.38)"
 
 type Themes = Record<ThemeId, Theme>
-export const themes: Themes = {
-	light: Object.freeze({
-		themeId: "light",
+
+export const themes = (): Themes => {
+	const lightRed = Object.freeze({
+		themeId: !client.isCalendarApp() ? "light" : "light_secondary",
 		logo: getLogoSvg(red, dunkel),
 		button_bubble_bg: grey_lighter_3,
 		button_bubble_fg: grey_darker_1,
@@ -86,29 +89,29 @@ export const themes: Themes = {
 		navigation_button_icon_selected: light_white,
 		navigation_menu_bg: grey_lighter_3,
 		navigation_menu_icon: grey,
-	}),
-	dark: Object.freeze({
-		themeId: "dark",
+	})
+	const darkRed = Object.freeze({
+		themeId: !client.isCalendarApp() ? "dark" : "dark_secondary",
 		logo: getLogoSvg(logo_text_bright_grey, logo_text_bright_grey),
 		button_bubble_bg: dark_lighter_2,
 		button_bubble_fg: light_lighter_1,
 		content_fg: light_lighter_1,
 		content_button: light_lighter_0,
-		content_button_selected: green,
+		content_button_selected: light_red,
 		content_button_icon_bg: dark_lighter_2,
 		content_button_icon: light_lighter_1,
 		content_button_icon_selected: dark_lighter_0,
-		content_accent: green,
+		content_accent: light_red,
 		content_bg: dark_darker_0,
 		content_border: dark_lighter_1,
 		content_message_bg: dark_lighter_2,
 		header_bg: dark,
 		header_box_shadow_bg: dark_darker_0,
 		header_button: light_lighter_0,
-		header_button_selected: green,
+		header_button_selected: light_red,
 		list_bg: dark_darker_0,
 		list_alternate_bg: dark_lighter_0,
-		list_accent_fg: green,
+		list_accent_fg: light_red,
 		list_message_bg: dark_lighter_2,
 		list_border: dark_lighter_1,
 		modal_bg: dark_darker_0,
@@ -118,13 +121,13 @@ export const themes: Themes = {
 		navigation_button: light_lighter_0,
 		navigation_button_icon_bg: dark_lighter_2,
 		navigation_button_icon: light_lighter_1,
-		navigation_button_selected: green,
+		navigation_button_selected: light_red,
 		navigation_button_icon_selected: light_lighter_0,
 		navigation_menu_bg: dark_darker_0,
 		navigation_menu_icon: light_grey,
-	}),
-	blue: Object.freeze({
-		themeId: "blue",
+	})
+	const lightBlue = Object.freeze({
+		themeId: client.isCalendarApp() ? "light" : "light_secondary",
 		// blue is not really our brand color, treat blue like whitelabel color
 		logo: getLogoSvg(grey, grey),
 		button_bubble_bg: grey_lighter_3,
@@ -157,5 +160,48 @@ export const themes: Themes = {
 		navigation_button_icon_selected: light_white,
 		navigation_menu_bg: grey_lighter_3,
 		navigation_menu_icon: grey,
-	}),
+	})
+	const darkBlue = Object.freeze({
+		themeId: client.isCalendarApp() ? "dark" : "dark_secondary",
+		logo: getLogoSvg(logo_text_bright_grey, logo_text_bright_grey),
+		button_bubble_bg: dark_lighter_2,
+		button_bubble_fg: light_lighter_1,
+		content_fg: light_lighter_1,
+		content_button: light_lighter_0,
+		content_button_selected: light_blue,
+		content_button_icon_bg: dark_lighter_2,
+		content_button_icon: light_lighter_1,
+		content_button_icon_selected: dark_lighter_0,
+		content_accent: light_blue,
+		content_bg: dark_darker_0,
+		content_border: dark_lighter_1,
+		content_message_bg: dark_lighter_2,
+		header_bg: dark,
+		header_box_shadow_bg: dark_darker_0,
+		header_button: light_lighter_0,
+		header_button_selected: light_blue,
+		list_bg: dark_darker_0,
+		list_alternate_bg: dark_lighter_0,
+		list_accent_fg: light_blue,
+		list_message_bg: dark_lighter_2,
+		list_border: dark_lighter_1,
+		modal_bg: dark_darker_0,
+		elevated_bg: dark_lighter_0,
+		navigation_bg: dark_lighter_0,
+		navigation_border: dark_lighter_1,
+		navigation_button: light_lighter_0,
+		navigation_button_icon_bg: dark_lighter_2,
+		navigation_button_icon: light_lighter_1,
+		navigation_button_selected: light_blue,
+		navigation_button_icon_selected: light_lighter_0,
+		navigation_menu_bg: dark_darker_0,
+		navigation_menu_icon: light_grey,
+	})
+
+	return {
+		light: client.isCalendarApp() ? lightBlue : lightRed,
+		dark: client.isCalendarApp() ? darkBlue : darkRed,
+		light_secondary: client.isCalendarApp() ? lightRed : lightBlue,
+		dark_secondary: client.isCalendarApp() ? darkRed : darkBlue,
+	}
 }

--- a/src/common/gui/theme.ts
+++ b/src/common/gui/theme.ts
@@ -1,7 +1,4 @@
-import { deviceConfig } from "../misc/DeviceConfig"
-import { assertMainOrNodeBoot, isApp, isDesktop, isTest } from "../api/common/Env"
-import type { HtmlSanitizer } from "../misc/HtmlSanitizer"
-import { NativeThemeFacade, ThemeController, WebThemeFacade } from "./ThemeController"
+import { assertMainOrNodeBoot } from "../api/common/Env"
 import { isColorLight } from "./base/Color"
 import { themes } from "./builtinThemes"
 
@@ -12,7 +9,7 @@ assertMainOrNodeBoot()
  * There are few built-in ones and there are whitelabel ones.
  * Whitelabel themes use domain name as an ID.
  */
-export type ThemeId = "light" | "dark" | "blue" | string
+export type ThemeId = "light" | "dark" | "light_secondary" | "dark_secondary" | string
 export type BaseThemeId = "light" | "dark"
 /**
  * This one is not attached to any single theme but is persisted and is shown to the user as a preference.
@@ -64,24 +61,29 @@ const themeSingleton = {}
 // We keep this singleton available because it is convenient to refer to, and already everywhere in the code before the addition of ThemeController.
 export const theme = themeSingleton as Theme
 
-export const themeOptions = [
-	{
-		name: "systemThemePref_label",
-		value: "auto:light|dark",
-	},
-	{
-		name: "light_label",
-		value: "light",
-	},
-	{
-		name: "dark_label",
-		value: "dark",
-	},
-	{
-		name: "blue_label",
-		value: "blue",
-	},
-] as const
+export const themeOptions = (isCalendarApp: boolean) =>
+	[
+		{
+			name: "systemThemePref_label",
+			value: "auto:light|dark",
+		},
+		{
+			name: "light_label",
+			value: "light",
+		},
+		{
+			name: "dark_label",
+			value: "dark",
+		},
+		{
+			name: isCalendarApp ? "light_red" : "light_blue",
+			value: "light_secondary",
+		},
+		{
+			name: isCalendarApp ? "dark_red" : "dark_blue",
+			value: "dark_secondary",
+		},
+	] as const
 
 export function getContentButtonIconBackground(): string {
 	return theme.content_button_icon_bg || theme.content_button // fallback for the new color content_button_icon_bg
@@ -106,8 +108,8 @@ export function getNavigationMenuIcon(): string {
 export function getLightOrDarkTutanotaLogo(): string {
 	// Use tuta logo with our brand colors
 	if (isColorLight(theme.content_bg)) {
-		return themes.light.logo
+		return themes().light.logo
 	} else {
-		return themes.dark.logo
+		return themes().dark.logo
 	}
 }

--- a/src/common/login/LoginView.ts
+++ b/src/common/login/LoginView.ts
@@ -208,8 +208,12 @@ export class LoginView extends BaseTopLevelView implements TopLevelView<LoginVie
 						click: () => locator.themeController.setThemePreference("dark"),
 					},
 					{
-						label: "blue_label",
-						click: () => locator.themeController.setThemePreference("blue"),
+						label: client.isCalendarApp() ? "light_red" : "light_blue",
+						click: () => locator.themeController.setThemePreference("light_secondary"),
+					},
+					{
+						label: client.isCalendarApp() ? "dark_red" : "dark_blue",
+						click: () => locator.themeController.setThemePreference("dark_secondary"),
 					},
 				]
 				const customButtons = (await locator.themeController.getCustomThemes()).map((themeId) => {

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -1740,3 +1740,7 @@ export type TranslationKeyType =
 	| "calendarImportSelection_label"
 	| "icsInSharingFiles_msg"
 	| "invalidCalendarFile_msg"
+	| "light_blue"
+	| "dark_blue"
+	| "light_red"
+	| "dark_red"

--- a/src/common/native/main/wizard/setupwizardpages/SetupThemePage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupThemePage.ts
@@ -5,6 +5,7 @@ import { RadioSelector, RadioSelectorAttrs, RadioSelectorOption } from "../../..
 import { themeOptions, ThemePreference } from "../../../../gui/theme.js"
 import { SetupPageLayout } from "./SetupPageLayout.js"
 import { locator } from "../../../../api/main/CommonLocator.js"
+import { client } from "../../../../misc/ClientDetector.js"
 
 export class SetupThemePage implements WizardPageN<SetupThemePageAttrs> {
 	// The whitelabel themes formatted as `RadioSelectorOption`s.
@@ -32,7 +33,7 @@ export class SetupThemePage implements WizardPageN<SetupThemePageAttrs> {
 				? null
 				: m(RadioSelector, {
 						name: "theme_label",
-						options: [...themeOptions, ...this.customThemes],
+						options: [...themeOptions(client.isCalendarApp()), ...this.customThemes],
 						class: "mb-s",
 						selectedOption: locator.themeController.themePreference,
 						onOptionSelected: (option) => {

--- a/src/common/settings/AppearanceSettingsViewer.ts
+++ b/src/common/settings/AppearanceSettingsViewer.ts
@@ -14,6 +14,7 @@ import type { UpdatableSettingsViewer } from "./Interfaces.js"
 import { isDesktop } from "../../common/api/common/Env"
 import { locator } from "../../common/api/main/CommonLocator"
 import { EntityUpdateData, isUpdateForTypeRef } from "../../common/api/common/utils/EntityUpdateUtils.js"
+import { client } from "../misc/ClientDetector.js"
 
 export class AppearanceSettingsViewer implements UpdatableSettingsViewer {
 	private _customThemes: Array<ThemeId> | null = null
@@ -137,7 +138,7 @@ export class AppearanceSettingsViewer implements UpdatableSettingsViewer {
 
 		const themeDropDownAttrs: DropDownSelectorAttrs<ThemePreference> = {
 			label: "switchColorTheme_action",
-			items: [...themeOptions.map(({ name, value }) => ({ name: lang.get(name), value: value })), ...customOptions],
+			items: [...themeOptions(client.isCalendarApp()).map(({ name, value }) => ({ name: lang.get(name), value: value })), ...customOptions],
 			selectedValue: locator.themeController.themePreference,
 			selectionChangedHandler: (value) => locator.themeController.setThemePreference(value),
 			dropdownWidth: 300,

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -1758,6 +1758,10 @@ export default {
 		"importEvents_label": "Terminen wird importiert",
 		"calendarImportSelection_label": "Wählen Sie einen Kalender aus, in den Sie Ihre Ereignisse importieren möchten.",
 		"icsInSharingFiles_msg": "Eine oder mehrere Kalenderdateien wurden erkannt. Möchten Sie sie importieren oder anhängen?",
-		"invalidCalendarFile_msg": "Eine oder mehrere Dateien sind keine gültigen Kalenderdateien."
+		"invalidCalendarFile_msg": "Eine oder mehrere Dateien sind keine gültigen Kalenderdateien.",
+		"light_blue": "Hell Blau",
+		"dark_blue": "Dunkel Blau",
+		"light_red": "Hell Rot",
+		"dark_red": "Dunkel Rot"
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -1758,6 +1758,10 @@ export default {
 		"importEvents_label": "Terminen wird importiert",
 		"calendarImportSelection_label": "Wählen Sie einen Kalender aus, in den Sie Ihre Ereignisse importieren möchten.",
 		"icsInSharingFiles_msg": "Eine oder mehrere Kalenderdateien wurden erkannt. Möchten Sie sie importieren oder anhängen?",
-		"invalidCalendarFile_msg": "Eine oder mehrere Dateien sind keine gültigen Kalenderdateien."
+		"invalidCalendarFile_msg": "Eine oder mehrere Dateien sind keine gültigen Kalenderdateien.",
+		"light_blue": "Hell Blau",
+		"dark_blue": "Dunkel Blau",
+		"light_red": "Hell Rot",
+		"dark_red": "Dunkel Rot"
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -1754,6 +1754,10 @@ export default {
 		"importEvents_label": "Import Events",
 		"calendarImportSelection_label": "Select a calendar to import your events into",
 		"icsInSharingFiles_msg": "One or more calendar files were detected. Would you like to import or attach them?",
-		"invalidCalendarFile_msg": "One or more files aren't valid calendar files."
+		"invalidCalendarFile_msg": "One or more files aren't valid calendar files.",
+		"light_blue": "Light Blue",
+		"dark_blue": "Dark Blue",
+		"light_red": "Light Red",
+		"dark_red": "Dark Red"
 	}
 }

--- a/test/tests/gui/ThemeControllerTest.ts
+++ b/test/tests/gui/ThemeControllerTest.ts
@@ -43,7 +43,7 @@ o.spec("ThemeController", function () {
 
 		const captor = matchers.captor()
 		verify(themeFacadeMock.setThemes(captor.capture()))
-		const savedTheme = captor.values![0][3]
+		const savedTheme = captor.values![0][4]
 		o(savedTheme.themeId).equals("HelloFancyId")
 		o(savedTheme.content_bg).equals("#fffeee")
 		o(savedTheme.logo).equals("sanitized")

--- a/test/tests/settings/whitelabel/CustomColorEditorTest.ts
+++ b/test/tests/settings/whitelabel/CustomColorEditorTest.ts
@@ -33,7 +33,7 @@ o.spec("SimpleColorEditor", function () {
 		themeController = {
 			applyCustomizations: spy(),
 			getDefaultTheme: () => {
-				return themes["light"]
+				return themes()["light"]
 			},
 		} as Partial<ThemeController> as ThemeController
 		whitelabelConfig = createTestEntity(WhitelabelConfigTypeRef)


### PR DESCRIPTION
Adds two new colors to Mail and Calendar app and removes the blue theme, replacing it by the new Blue theme using Calendar Colors. Also adapts how the themes are displayed, Light and Dark can be Light Blue/Red and Dark Blue/Red this will depend on which app the user is running.

- Mail App:
  - Light
  - Dark
  - Light Blue
  - Dark Blue

- Calendar App:
   - Light
   - Dark
   - Light Red
   - Dark Red