### PR TITLE
fix offline migrations for tutanota 75

### DIFF
--- a/src/common/api/worker/offline/migrations/tutanota-v74.ts
+++ b/src/common/api/worker/offline/migrations/tutanota-v74.ts
@@ -1,15 +1,7 @@
 import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage } from "../OfflineStorage.js"
 import { addValue, deleteInstancesOfType, migrateAllElements, migrateAllListElements } from "../StandardMigrations.js"
-import {
-	CalendarEventTypeRef,
-	createMail,
-	createMailBox,
-	MailBoxTypeRef,
-	MailFolderTypeRef,
-	MailTypeRef,
-	UserSettingsGroupRootTypeRef,
-} from "../../../entities/tutanota/TypeRefs.js"
+import { CalendarEventTypeRef, createMail, createMailBox, MailBoxTypeRef, MailFolderTypeRef, MailTypeRef } from "../../../entities/tutanota/TypeRefs.js"
 import { GENERATED_MIN_ID } from "../../../common/utils/EntityUtils.js"
 
 export const tutanota74: OfflineMigration = {
@@ -29,8 +21,5 @@ export const tutanota74: OfflineMigration = {
 		// all entities with customIds, that are stored in the offline database (e.g. CalendarEvent, MailSetEntry),
 		// are from now on stored in the offline database using a **base64Ext** encoded id string
 		await deleteInstancesOfType(storage, CalendarEventTypeRef)
-
-		// we need to delete the UserSettingsGroupRoot to download an updated instance
-		await deleteInstancesOfType(storage, UserSettingsGroupRootTypeRef)
 	},
 }

--- a/src/common/api/worker/offline/migrations/tutanota-v75.ts
+++ b/src/common/api/worker/offline/migrations/tutanota-v75.ts
@@ -2,6 +2,9 @@ import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage } from "../OfflineStorage.js"
 import { deleteInstancesOfType } from "../StandardMigrations.js"
 import { UserSettingsGroupRootTypeRef } from "../../../entities/tutanota/TypeRefs.js"
+import { GroupInfoTypeRef } from "../../../entities/sys/TypeRefs.js"
+import { GroupType } from "../../../common/TutanotaConstants.js"
+import { getElementId, getListId } from "../../../common/utils/EntityUtils.js"
 import { AuditLogEntryTypeRef } from "../../../entities/sys/TypeRefs.js"
 
 export const tutanota75: OfflineMigration = {
@@ -9,6 +12,12 @@ export const tutanota75: OfflineMigration = {
 	version: 75,
 	async migrate(storage: OfflineStorage) {
 		await deleteInstancesOfType(storage, UserSettingsGroupRootTypeRef)
+		// required to throw the LoginIncompleteError when trying async login
+		const groupInfos = await storage.getListElementsOfType(GroupInfoTypeRef)
+		for (const groupInfo of groupInfos) {
+			if (groupInfo.groupType !== GroupType.User) continue
+			await storage.deleteIfExists(GroupInfoTypeRef, getListId(groupInfo), getElementId(groupInfo))
+		}
 		await deleteInstancesOfType(storage, AuditLogEntryTypeRef)
 	},
 }


### PR DESCRIPTION
when logging in, the app assumes that the
UserSettingsGroupRoot is cached if the UserGroupInfo is cached.

Deleting UserGroupInfos as well makes sure that we fall back to the sync login to redownload the changed entities