### PR TITLE
Exclude AuditLogEntries from offline cache

### DIFF
--- a/src/common/api/worker/offline/migrations/tutanota-v75.ts
+++ b/src/common/api/worker/offline/migrations/tutanota-v75.ts
@@ -2,11 +2,13 @@ import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage } from "../OfflineStorage.js"
 import { deleteInstancesOfType } from "../StandardMigrations.js"
 import { UserSettingsGroupRootTypeRef } from "../../../entities/tutanota/TypeRefs.js"
+import { AuditLogEntryTypeRef } from "../../../entities/sys/TypeRefs.js"
 
 export const tutanota75: OfflineMigration = {
 	app: "tutanota",
 	version: 75,
 	async migrate(storage: OfflineStorage) {
 		await deleteInstancesOfType(storage, UserSettingsGroupRootTypeRef)
+		await deleteInstancesOfType(storage, AuditLogEntryTypeRef)
 	},
 }

--- a/src/common/api/worker/rest/DefaultEntityRestCache.ts
+++ b/src/common/api/worker/rest/DefaultEntityRestCache.ts
@@ -4,6 +4,7 @@ import { resolveTypeReference } from "../../common/EntityFunctions"
 import { OperationType } from "../../common/TutanotaConstants"
 import { assertNotNull, difference, getFirstOrThrow, getTypeId, groupBy, isEmpty, isSameTypeRef, lastThrow, TypeRef } from "@tutao/tutanota-utils"
 import {
+	AuditLogEntryTypeRef,
 	BucketPermissionTypeRef,
 	EntityEventBatchTypeRef,
 	EntityUpdate,
@@ -56,6 +57,7 @@ const IGNORED_TYPES = [
 	KeyRotationTypeRef,
 	UserGroupRootTypeRef,
 	UserGroupKeyDistributionTypeRef,
+	AuditLogEntryTypeRef, // Should not be part of cached data because there are errors inside entity event processing after rotating the admin group key
 ] as const
 
 export interface EntityRestCache extends EntityRestInterface {


### PR DESCRIPTION
We exclude the audit log entries from the offline cache in order to fix unexpected error after doing the admin group key rotation. #tutadb1855

The admin group with a new key pair is updated in the same batch and as the audit log entry for this update is written. We cannot yet decrypt the audit log with new key at this point.

The simple fix is to exclude it from the offline cache. That way it will only be decrypted later when the new key is available.