### PR TITLE
fix CalendarEvents offline storage migration for TutanotaModeV74

### DIFF
--- a/src/common/api/worker/offline/migrations/tutanota-v74.ts
+++ b/src/common/api/worker/offline/migrations/tutanota-v74.ts
@@ -1,7 +1,15 @@
 import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage } from "../OfflineStorage.js"
 import { addValue, deleteInstancesOfType, migrateAllElements, migrateAllListElements } from "../StandardMigrations.js"
-import { createMail, createMailBox, MailBoxTypeRef, MailFolderTypeRef, MailTypeRef, UserSettingsGroupRootTypeRef } from "../../../entities/tutanota/TypeRefs.js"
+import {
+	CalendarEventTypeRef,
+	createMail,
+	createMailBox,
+	MailBoxTypeRef,
+	MailFolderTypeRef,
+	MailTypeRef,
+	UserSettingsGroupRootTypeRef,
+} from "../../../entities/tutanota/TypeRefs.js"
 import { GENERATED_MIN_ID } from "../../../common/utils/EntityUtils.js"
 
 export const tutanota74: OfflineMigration = {
@@ -16,6 +24,11 @@ export const tutanota74: OfflineMigration = {
 		])
 		await migrateAllElements(MailBoxTypeRef, storage, [createMailBox]) // initialize mailbags
 		await migrateAllListElements(MailTypeRef, storage, [createMail]) // initialize sets
+
+		// we need to delete all CalendarEvents since we changed the format for storing customIds (CalendarEvents use customIds) in the offline database
+		// all entities with customIds, that are stored in the offline database (e.g. CalendarEvent, MailSetEntry),
+		// are from now on stored in the offline database using a **base64Ext** encoded id string
+		await deleteInstancesOfType(storage, CalendarEventTypeRef)
 
 		// we need to delete the UserSettingsGroupRoot to download an updated instance
 		await deleteInstancesOfType(storage, UserSettingsGroupRootTypeRef)


### PR DESCRIPTION
We need to delete all CalendarEvents since we changed the format for storing customIds (CalendarEvents use customIds) in the offline database. All entities with customIds, that are stored in the offline database (e.g. CalendarEvent, MailSetEntry), are from now on stored in the offline database using a **base64Ext** encoded id string.