### PR TITLE
Fix credentials being invalid after changing the password

### DIFF
--- a/src/common/misc/credentials/CredentialsProvider.ts
+++ b/src/common/misc/credentials/CredentialsProvider.ts
@@ -28,13 +28,13 @@ export class CredentialsProvider {
 	/**
 	 * Change the encrypted password for the stored credentials.
 	 */
-	async replacePassword(credentials: CredentialsInfo, encryptedPassword: string): Promise<void> {
+	async replacePassword(credentials: CredentialsInfo, encryptedPassword: string, encryptedPassphraseKey: Uint8Array): Promise<void> {
 		const encryptedCredentials = await this.getCredentialsByUserId(credentials.userId)
 		if (encryptedCredentials == null) {
 			throw new Error(`Trying to replace password for credentials but credentials are not persisted: ${credentials.userId}`)
 		}
 		// Encrypted password is encrypted with the session key and is the same for encrypted and decrypted credentials, no additional logic is needed.
-		const newEncryptedCredentials: PersistedCredentials = { ...encryptedCredentials, encryptedPassword }
+		const newEncryptedCredentials: PersistedCredentials = { ...encryptedCredentials, encryptedPassword, encryptedPassphraseKey }
 		await this.credentialsFacade.storeEncrypted(newEncryptedCredentials)
 	}
 

--- a/test/tests/misc/credentials/CredentialsProviderTest.ts
+++ b/test/tests/misc/credentials/CredentialsProviderTest.ts
@@ -251,12 +251,13 @@ o.spec("CredentialsProvider", function () {
 			encryptedPassphraseKey: null,
 		}
 		const newEncryptedPassword = "uhagre2"
+		const newEncryptedPassphraseKey = new Uint8Array([0x0, 0x0e, 0x9])
 		o.beforeEach(function () {
 			when(nativeCredentialFacadeMock.loadAll()).thenResolve([persistentCredentials])
 		})
 
 		o("replace only", async function () {
-			await credentialsProvider.replacePassword(credentials, newEncryptedPassword)
+			await credentialsProvider.replacePassword(credentials, newEncryptedPassword, newEncryptedPassphraseKey)
 
 			verify(
 				nativeCredentialFacadeMock.storeEncrypted({
@@ -264,7 +265,7 @@ o.spec("CredentialsProvider", function () {
 					accessToken: stringToUtf8Uint8Array("accessToken"),
 					databaseKey: new Uint8Array([1, 2, 3]),
 					encryptedPassword: newEncryptedPassword,
-					encryptedPassphraseKey: null,
+					encryptedPassphraseKey: newEncryptedPassphraseKey,
 				}),
 			)
 		})


### PR DESCRIPTION
After we've added passphraseKey to credentials we forgot to update it in stored credentials on password change.

This commit changes it in a way that both encryptedPassword and encryptedPassphraseKey are updated at the same time.

Fix #7462