### PR TITLE
Fix synchronized contacts not appearing in some contact apps

### DIFF
--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
 	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS"/>
 	<uses-permission android:name="android.permission.USE_CREDENTIALS"/>
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+	<uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS"/>
 	<uses-permission
 			android:name="android.permission.SCHEDULE_EXACT_ALARM"
 			android:maxSdkVersion="32"/>
@@ -148,6 +149,18 @@
 			<meta-data
 					android:name="android.accounts.AccountAuthenticator"
 					android:resource="@xml/authenticator"/>
+		</service>
+
+		<service
+				android:name=".StubSyncService"
+				android:exported="false"
+				android:process=":sync">
+			<intent-filter>
+				<action android:name="android.content.SyncAdapter"/>
+			</intent-filter>
+			<meta-data
+					android:name="android.content.SyncAdapter"
+					android:resource="@xml/syncadapter"/>
 		</service>
 
 

--- a/app-android/app/src/main/java/de/tutao/tutanota/StubSyncService.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/StubSyncService.kt
@@ -1,0 +1,53 @@
+package de.tutao.tutanota
+
+import android.accounts.Account
+import android.app.Service
+import android.content.AbstractThreadedSyncAdapter
+import android.content.ContentProviderClient
+import android.content.Context
+import android.content.Intent
+import android.content.SyncResult
+import android.os.Bundle
+import android.os.IBinder
+import android.util.Log
+
+private const val TAG = "Sync"
+
+/** A stubbed sync service that returns a stubbed sync adapter on `onBind()`.
+ *  It is used to mark Tuta accounts as syncable as a fix for #6568 */
+class StubSyncService : Service() {
+	override fun onCreate() {
+		synchronized(syncAdapterLock) {
+			syncAdapter = syncAdapter ?: StubSyncAdapter(applicationContext, true)
+		}
+	}
+
+	override fun onBind(intent: Intent): IBinder {
+		return syncAdapter?.syncAdapterBinder ?: throw IllegalStateException()
+	}
+
+	companion object {
+		private var syncAdapter: StubSyncAdapter? = null
+		private val syncAdapterLock = Any()
+	}
+}
+
+/** A stubbed sync adapter that does nothing when called. */
+private class StubSyncAdapter @JvmOverloads constructor(
+	context: Context,
+	autoInitialize: Boolean,
+	allowParallelSyncs: Boolean = false,
+) : AbstractThreadedSyncAdapter(context, autoInitialize, allowParallelSyncs) {
+
+	override fun onPerformSync(
+		account: Account,
+		extras: Bundle,
+		authority: String,
+		provider: ContentProviderClient,
+		syncResult: SyncResult
+	) {
+		Log.w(TAG, "Sync requested to stub Sync Adapter!")
+	}
+}
+
+

--- a/app-android/app/src/main/res/xml/syncadapter.xml
+++ b/app-android/app/src/main/res/xml/syncadapter.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Declare the stubbed sync adapter to fix #6568-->
+<sync-adapter
+		xmlns:android="http://schemas.android.com/apk/res/android"
+		android:contentAuthority="com.android.contacts"
+		android:accountType="@string/package_name"
+		android:userVisible="false"
+		android:supportsUploading="false"
+		android:allowParallelSyncs="false"
+		android:isAlwaysSyncable="true"
+		/>


### PR DESCRIPTION
Certain contact apps require the account to be syncable. In order to do this, we implement a stubbed sync service and adapter which does nothing and ask Android not to call it. Preexisting installations of the app will need to turn contact synchronization off and on again to receive this fix.

Closes #6568.