### PR TITLE
Assign correct ownerKeyVersion when updating calendar event

### DIFF
--- a/src/common/api/worker/facades/lazy/CalendarFacade.ts
+++ b/src/common/api/worker/facades/lazy/CalendarFacade.ts
@@ -265,6 +265,7 @@ export class CalendarFacade {
 	async updateCalendarEvent(event: CalendarEvent, newAlarms: ReadonlyArray<AlarmInfoTemplate>, existingEvent: CalendarEvent): Promise<void> {
 		event._id = existingEvent._id
 		event._ownerEncSessionKey = existingEvent._ownerEncSessionKey
+		event._ownerKeyVersion = existingEvent._ownerKeyVersion
 		event._permissions = existingEvent._permissions
 		if (existingEvent.uid == null) throw new Error("no uid set on the existing event")
 		event.uid = existingEvent.uid


### PR DESCRIPTION
Before making the REST request to update a calendar event we assign some technical attributes like _id and _ownerEncSessionKey to the new/updated event. The assignment of the _ownerKeyVersion was missing wich is required if we have another version of the group key. It is suspicious that we have to do this assignement at all because before editing the event we clone the existing entity and all attributes should have been assigned to the new one already. It should probably also not the responsibility of the updateCalendarEvent function to assign these attributes. This commit just fixes this issue itself so the user does not get the error but we should review the clone and update mechanism.

fixes #7533

## Test notes:

- [ ] Execute calendar group key rotation
- [ ] Create new event. Change the title afterwards.