### PR TITLE
Improve mail set migration performance

### DIFF
--- a/src/common/api/worker/offline/OfflineStorage.ts
+++ b/src/common/api/worker/offline/OfflineStorage.ts
@@ -502,6 +502,14 @@ AND NOT(${firstIdBigger("elementId", range.upper)})`
 		}
 	}
 
+	async deleteWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<void> {
+		await this.lockRangesDbAccess(listId)
+		await this.deleteRange(typeRef, listId)
+		const { query, params } = sql`DELETE FROM list_entities WHERE listId = ${listId}`
+		await this.sqlCipherFacade.run(query, params)
+		await this.unlockRangesDbAccess(listId)
+	}
+
 	private async putMetadata<K extends keyof OfflineDbMeta>(key: K, value: OfflineDbMeta[K]): Promise<void> {
 		let encodedValue
 		try {

--- a/src/common/api/worker/rest/CacheStorageProxy.ts
+++ b/src/common/api/worker/rest/CacheStorageProxy.ts
@@ -181,6 +181,10 @@ export class LateInitializedCacheStorageImpl implements CacheStorageLateInitiali
 		return this.inner.deleteAllOwnedBy(owner)
 	}
 
+	async deleteWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<void> {
+		return this.inner.deleteWholeList(typeRef, listId)
+	}
+
 	clearExcludedData(): Promise<void> {
 		return this.inner.clearExcludedData()
 	}

--- a/src/common/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/common/api/worker/rest/EphemeralCacheStorage.ts
@@ -378,6 +378,10 @@ export class EphemeralCacheStorage implements CacheStorage {
 		this.lastBatchIdPerGroup.delete(owner)
 	}
 
+	async deleteWholeList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<void> {
+		this.lists.get(typeRef.type)?.delete(listId)
+	}
+
 	private deleteAllOwnedByFromCache(cacheForType: Map<Id, ListCache | BlobElementCache>, owner: string) {
 		// If we find at least one element in the list that is owned by our target owner, we delete the entire list.
 		// This is OK in most cases because the vast majority of lists are single owner.

--- a/src/common/api/worker/search/SearchFacade.ts
+++ b/src/common/api/worker/search/SearchFacade.ts
@@ -8,6 +8,7 @@ import {
 	downcast,
 	getDayShifted,
 	getStartOfDay,
+	isEmpty,
 	isNotEmpty,
 	isNotNull,
 	isSameTypeRef,
@@ -655,7 +656,7 @@ export class SearchFacade {
 			.then(async (intermediateResults) => {
 				// apply folder restrictions to intermediateResults
 
-				if (!(searchResult.restriction.folderIds.length > 0)) {
+				if (isEmpty(searchResult.restriction.folderIds)) {
 					// no folder restrictions (ALL)
 					return intermediateResults
 				} else {

--- a/test/tests/api/worker/offline/OfflineStorageTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageTest.ts
@@ -203,6 +203,33 @@ o.spec("OfflineStorageDb", function () {
 					o(rangeAfter).equals(null)
 				})
 
+				o("deleteWholeList", async function () {
+					const listOne = "listId1"
+					const listTwo = "listId2"
+					await storage.init({ userId: "user", databaseKey, timeRangeDays, forceNewDatabase: false })
+
+					const listOneMailOne = createTestEntity(MailTypeRef, { _id: [listOne, "id1"] })
+					const listOneMailTwo = createTestEntity(MailTypeRef, { _id: [listOne, "id2"] })
+					const listTwoMail = createTestEntity(MailTypeRef, { _id: [listTwo, "id3"] })
+					await storage.put(listOneMailOne)
+					await storage.put(listOneMailTwo)
+					await storage.put(listTwoMail)
+					await storage.setNewRangeForList(MailTypeRef, listOne, "id1", "id2")
+					await storage.setNewRangeForList(MailTypeRef, listTwo, "id3", "id3")
+
+					await storage.deleteWholeList(MailTypeRef, listOne)
+
+					const mailsInListOne = await storage.getWholeList(MailTypeRef, listOne)
+					const mailsInListTwo = await storage.getWholeList(MailTypeRef, listTwo)
+					const rangeListOne = await storage.getRangeForList(MailTypeRef, listOne)
+					const rangeListTwo = await storage.getRangeForList(MailTypeRef, listTwo)
+
+					o(mailsInListOne).deepEquals([])
+					o(mailsInListTwo).deepEquals([listTwoMail])
+					o(rangeListOne).equals(null)
+					o(rangeListTwo).deepEquals({ lower: "id3", upper: "id3" })
+				})
+
 				o("provideMultiple", async function () {
 					const listId = "listId1"
 					const elementId1 = "id1"


### PR DESCRIPTION
to avoid excessive entity updates and inconsistent offline storage, we don't send entity updates for each mail set migrated mail. instead we detect the mail set migration for each folder and drop its whole mail list from the offline cache.

we could fix up the database when we receive the changed folder, but that would involve re-doing the migration locally and will lead to very long entity event handling that might get interrupted, breaking the offline database anyway.