### PR TITLE
Fixes the logo on desktop and non-red themes

### DIFF
--- a/src/common/gui/builtinThemes.ts
+++ b/src/common/gui/builtinThemes.ts
@@ -1,9 +1,9 @@
 /**
  * @file color/theme definitions for default themes.
  */
-import { getCalendarLogoSvg, getMailLogoSvg } from "./base/Logo"
+import { getCalendarLogoSvg, getMailLogoSvg, getTutaLogoSvg } from "./base/Logo"
 import type { Theme, ThemeId } from "./theme"
-import { assertMainOrNodeBoot } from "../api/common/Env"
+import { assertMainOrNodeBoot, isApp } from "../api/common/Env"
 import { client } from "../misc/ClientDetector.js"
 
 assertMainOrNodeBoot()
@@ -63,12 +63,26 @@ export const tutaDunkel = dunkel
 
 type Themes = Record<ThemeId, Theme>
 
+const getLogo = (isDark: boolean, isDefault: boolean) => {
+	const isDarkOrDefault = isDark || !isDefault
+	if (!isApp()) {
+		return isDarkOrDefault ? getTutaLogoSvg(logo_text_bright_grey, logo_text_bright_grey) : getTutaLogoSvg(red, dunkel)
+	}
+
+	if (client.isCalendarApp()) {
+		return isDarkOrDefault
+			? getCalendarLogoSvg(logo_text_bright_grey, logo_text_bright_grey, logo_text_bright_grey)
+			: getCalendarLogoSvg(blue, secondary_blue, black)
+	}
+
+	return isDarkOrDefault ? getMailLogoSvg(logo_text_bright_grey, logo_text_bright_grey, logo_text_bright_grey) : getMailLogoSvg(red, secondary_red, black)
+}
+
 export const themes = (): Themes => {
+	const isCalendarApp = client.isCalendarApp()
 	const lightRed = Object.freeze({
-		themeId: !client.isCalendarApp() ? "light" : "light_secondary",
-		logo: !client.isCalendarApp()
-			? getMailLogoSvg(red, secondary_red, black)
-			: getCalendarLogoSvg(logo_text_bright_grey, logo_text_bright_grey, logo_text_bright_grey),
+		themeId: !isCalendarApp ? "light" : "light_secondary",
+		logo: getLogo(false, !isCalendarApp),
 		button_bubble_bg: grey_lighter_3,
 		button_bubble_fg: grey_darker_1,
 		content_fg: grey_darker_1,
@@ -101,10 +115,8 @@ export const themes = (): Themes => {
 		navigation_menu_icon: grey,
 	})
 	const darkRed = Object.freeze({
-		themeId: !client.isCalendarApp() ? "dark" : "dark_secondary",
-		logo: !client.isCalendarApp()
-			? getMailLogoSvg(lighter_red, secondary_red, light_white)
-			: getCalendarLogoSvg(logo_text_bright_grey, logo_text_bright_grey, logo_text_bright_grey),
+		themeId: !isCalendarApp ? "dark" : "dark_secondary",
+		logo: getLogo(true, !isCalendarApp),
 		button_bubble_bg: dark_lighter_2,
 		button_bubble_fg: light_lighter_1,
 		content_fg: light_lighter_1,
@@ -139,11 +151,9 @@ export const themes = (): Themes => {
 		navigation_menu_icon: light_grey,
 	})
 	const lightBlue = Object.freeze({
-		themeId: client.isCalendarApp() ? "light" : "light_secondary",
+		themeId: isCalendarApp ? "light" : "light_secondary",
 		// blue is not really our brand color, treat blue like whitelabel color
-		logo: !client.isCalendarApp()
-			? getMailLogoSvg(logo_text_bright_grey, logo_text_bright_grey, logo_text_bright_grey)
-			: getCalendarLogoSvg(blue, secondary_blue, black),
+		logo: getLogo(false, isCalendarApp),
 		button_bubble_bg: grey_lighter_3,
 		button_bubble_fg: grey_darker_1,
 		content_fg: grey_darker_1,
@@ -176,10 +186,8 @@ export const themes = (): Themes => {
 		navigation_menu_icon: grey,
 	})
 	const darkBlue = Object.freeze({
-		themeId: client.isCalendarApp() ? "dark" : "dark_secondary",
-		logo: !client.isCalendarApp()
-			? getMailLogoSvg(logo_text_bright_grey, logo_text_bright_grey, logo_text_bright_grey)
-			: getCalendarLogoSvg(lighter_blue, secondary_blue, light_white),
+		themeId: isCalendarApp ? "dark" : "dark_secondary",
+		logo: getLogo(true, isCalendarApp),
 		button_bubble_bg: dark_lighter_2,
 		button_bubble_fg: light_lighter_1,
 		content_fg: light_lighter_1,
@@ -215,9 +223,9 @@ export const themes = (): Themes => {
 	})
 
 	return {
-		light: client.isCalendarApp() ? lightBlue : lightRed,
-		dark: client.isCalendarApp() ? darkBlue : darkRed,
-		light_secondary: client.isCalendarApp() ? lightRed : lightBlue,
-		dark_secondary: client.isCalendarApp() ? darkRed : darkBlue,
+		light: isCalendarApp ? lightBlue : lightRed,
+		dark: isCalendarApp ? darkBlue : darkRed,
+		light_secondary: isCalendarApp ? lightRed : lightBlue,
+		dark_secondary: isCalendarApp ? darkRed : darkBlue,
 	}
 }

--- a/src/common/gui/theme.ts
+++ b/src/common/gui/theme.ts
@@ -106,9 +106,10 @@ export function getNavigationMenuIcon(): string {
 	return theme.navigation_menu_icon || theme.navigation_button_icon
 }
 
-export function getLightOrDarkTutaLogo(): string {
+export function getLightOrDarkTutaLogo(isCalendarApp: boolean): string {
 	// Use tuta logo with our brand colors
-	if (isColorLight(theme.content_bg)) {
+	const isCalendarTheme = (theme.themeId === "light" && isCalendarApp) || (theme.themeId === "light_secondary" && !isCalendarApp)
+	if (isColorLight(theme.content_bg) && !isCalendarTheme) {
 		return getTutaLogoSvg(tutaRed, tutaDunkel)
 	} else {
 		return getTutaLogoSvg(logoDefaultGrey, logoDefaultGrey)

--- a/src/common/settings/AboutDialog.ts
+++ b/src/common/settings/AboutDialog.ts
@@ -10,6 +10,7 @@ import { clientInfoString, getLogAttachments } from "../misc/ErrorReporter.js"
 import { ExternalLink } from "../gui/base/ExternalLink.js"
 import { isApp } from "../api/common/Env.js"
 import { px, size } from "../gui/size.js"
+import { client } from "../misc/ClientDetector.js"
 
 interface AboutDialogAttrs {
 	onShowSetupWizard: () => unknown
@@ -28,7 +29,7 @@ export class AboutDialog implements Component<AboutDialogAttrs> {
 						margin: px(size.vpad_xl),
 					},
 				},
-				m.trust(getLightOrDarkTutaLogo()),
+				m.trust(getLightOrDarkTutaLogo(client.isCalendarApp())),
 			),
 			m(".flex.justify-center.flex-wrap", [
 				m(ExternalLink, { href: InfoLink.HomePage, text: "Website", isCompanySite: true, specialType: "me", class: "mlr mt" }),


### PR DESCRIPTION
Brings back the brand logo to desktop and webapp and also changes the logo color on about dialog, now it's colored with our red shades just on red light theme.

Fixes #7569