### PR TITLE
[sdk] Use u64 instead of SystemTime for DateTime

### DIFF
--- a/tuta-sdk/rust/sdk/src/custom_id.rs
+++ b/tuta-sdk/rust/sdk/src/custom_id.rs
@@ -3,6 +3,8 @@ use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Debug, Display, Formatter};
 
+pub const CUSTOM_ID_STRUCT_NAME: &str = "CustomId";
+
 /// An ID that uses arbitrary data encoded in base64
 #[derive(Clone, Default, PartialEq, PartialOrd)]
 #[repr(transparent)]
@@ -51,7 +53,7 @@ impl Serialize for CustomId {
 	where
 		S: Serializer,
 	{
-		serializer.serialize_newtype_struct("CustomId", &self.0)
+		serializer.serialize_newtype_struct(CUSTOM_ID_STRUCT_NAME, &self.0)
 	}
 }
 

--- a/tuta-sdk/rust/sdk/src/date.rs
+++ b/tuta-sdk/rust/sdk/src/date.rs
@@ -4,48 +4,45 @@ use std::fmt::Formatter;
 use std::time::{Duration, SystemTime};
 
 /// A wrapper around `SystemTime` so we can change how it is serialised by serde.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
-pub struct DateTime(SystemTime);
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
+pub struct DateTime(u64);
+
+pub const DATETIME_STRUCT_NAME: &str = "DateTime";
 
 impl DateTime {
 	#[must_use]
-	pub fn new(time: SystemTime) -> Self {
-		Self(time)
+	pub fn from_system_time(time: SystemTime) -> Self {
+		Self(
+			time.duration_since(SystemTime::UNIX_EPOCH)
+				.unwrap()
+				.as_millis() as u64,
+		)
 	}
 
 	#[must_use]
 	pub fn from_millis(millis: u64) -> Self {
-		Self(SystemTime::UNIX_EPOCH + Duration::from_millis(millis))
+		Self(millis)
 	}
 
 	#[must_use]
-	pub fn get_time(self) -> SystemTime {
-		self.0
+	pub fn as_system_time(self) -> SystemTime {
+		SystemTime::UNIX_EPOCH + Duration::from_millis(self.as_millis())
 	}
 
 	#[must_use]
 	pub fn as_millis(self) -> u64 {
 		self.0
-			.duration_since(SystemTime::UNIX_EPOCH)
-			.unwrap()
-			.as_millis() as u64
 	}
 }
 
-uniffi::custom_newtype!(DateTime, SystemTime);
-
-impl Default for DateTime {
-	fn default() -> Self {
-		Self(SystemTime::UNIX_EPOCH)
-	}
-}
+uniffi::custom_newtype!(DateTime, u64);
 
 impl Serialize for DateTime {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: Serializer,
 	{
-		serializer.serialize_newtype_struct("Date", &self.as_millis())
+		serializer.serialize_newtype_struct(DATETIME_STRUCT_NAME, &self.as_millis())
 	}
 }
 
@@ -72,5 +69,30 @@ impl Visitor<'_> for DateVisitor {
 		E: Error,
 	{
 		Ok(DateTime::from_millis(v))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::date::DateTime;
+	use std::time::{Duration, SystemTime};
+
+	#[test]
+	fn initializing_datetime_default() {
+		let default = DateTime::default();
+		let epoch = DateTime::from_system_time(SystemTime::UNIX_EPOCH);
+		let zero = DateTime::from_millis(0);
+		assert_eq!(default, epoch);
+		assert_eq!(default, zero);
+	}
+
+	#[test]
+	fn initializing_datetime_timestamp() {
+		// 18 September 2024 @ 10:09 UTC
+		let timestamp = 1726654153555;
+		let systemtime =
+			DateTime::from_system_time(SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp));
+		let millis = DateTime::from_millis(timestamp);
+		assert_eq!(systemtime, millis);
 	}
 }

--- a/tuta-sdk/rust/sdk/src/generated_id.rs
+++ b/tuta-sdk/rust/sdk/src/generated_id.rs
@@ -3,6 +3,7 @@ use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{Debug, Display, Formatter};
 
+pub const GENERATED_ID_STRUCT_NAME: &str = "GeneratedId";
 pub const GENERATED_ID_BYTES_LENGTH: usize = 9;
 
 /// A fixed nine byte length generated ID of an entity/instance
@@ -53,7 +54,7 @@ impl Serialize for GeneratedId {
 	where
 		S: Serializer,
 	{
-		serializer.serialize_newtype_struct("GeneratedId", &self.0)
+		serializer.serialize_newtype_struct(GENERATED_ID_STRUCT_NAME, &self.0)
 	}
 }
 

--- a/tuta-sdk/rust/sdk/src/util/mod.rs
+++ b/tuta-sdk/rust/sdk/src/util/mod.rs
@@ -3,7 +3,6 @@ use crate::element_value::ElementValue;
 use crate::metamodel::ValueType;
 use base64::alphabet::Alphabet;
 use base64::engine::GeneralPurpose;
-use std::time::SystemTime;
 
 #[cfg(test)]
 pub mod entity_test_utils;
@@ -204,7 +203,7 @@ pub(crate) fn resolve_default_value(value_type: &ValueType) -> ElementValue {
 		ValueType::String => ElementValue::String(String::new()),
 		ValueType::Number => ElementValue::Number(0),
 		ValueType::Bytes => ElementValue::Bytes(Vec::new()),
-		ValueType::Date => ElementValue::Date(DateTime::new(SystemTime::UNIX_EPOCH)),
+		ValueType::Date => ElementValue::Date(DateTime::default()),
 		ValueType::Boolean => ElementValue::Bool(false),
 		ValueType::CompressedString => ElementValue::String(String::new()),
 		v => unreachable!("Invalid type {v:?}"),


### PR DESCRIPTION
On Swift, SystemTime will have precision loss due to uniffi internally converting to a floating point number + dividing the number by one billion to get nanoseconds. This leads to dates being off by 1 lower due to conversion back to milliseconds being slightly low and thus rounding down.

For now, we just use u64 so it stays an integer in all implementations.

Fixes #7581