### PR TITLE
Fix build scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,9 @@ jobs:
       - name: build web app
         run: |
           node webapp --disable-minify
+      - name: build calendar web app
+        run: |
+          node webapp --disable-minify --app calendar
       - name: check for FIXMEs
         run: |
           if grep "FIXME\|[fF]ixme" -r src buildSrc test/tests packages/*/lib app-android/app/src app-ios/tutanota/Sources; then

--- a/buildSrc/DevBuild.js
+++ b/buildSrc/DevBuild.js
@@ -99,13 +99,13 @@ async function buildWebPart({ stage, host, version, domainConfigs, app }) {
 	const buildDir = isCalendarBuild ? "build-calendar-app" : "build"
 	const entryFile = isCalendarBuild ? "src/calendar-app/calendar-app.ts" : "src/mail-app/app.ts"
 	const workerFile = isCalendarBuild ? "src/calendar-app/workerUtils/worker/calendar-worker.ts" : "src/mail-app/workerUtils/worker/mail-worker.ts"
-
+	const builtWorkerFile = isCalendarBuild ? "calendar-worker.js" : "mail-worker.js"
 	await runStep("Web: Assets", async () => {
 		await prepareAssets(stage, host, version, domainConfigs, buildDir)
 		await fs.promises.writeFile(
 			`${buildDir}/worker-bootstrap.js`,
 			`importScripts("./polyfill.js")
-importScripts("./worker.js")
+importScripts("./${builtWorkerFile}")
 `,
 		)
 	})

--- a/buildSrc/buildWebapp.js
+++ b/buildSrc/buildWebapp.js
@@ -34,6 +34,7 @@ export async function buildWebapp({ version, stage, host, measure, minify, proje
 	const buildDir = isCalendarApp ? "build-calendar-app" : "build"
 	const entryFile = isCalendarApp ? "src/calendar-app/calendar-app.ts" : "src/mail-app/app.ts"
 	const workerFile = isCalendarApp ? "src/calendar-app/workerUtils/worker/calendar-worker.ts" : "src/mail-app/workerUtils/worker/mail-worker.ts"
+	const builtWorkerFile = isCalendarApp ? "calendar-worker.js" : "mail-worker.js"
 
 	console.log("Building app", app)
 
@@ -146,7 +147,7 @@ export async function buildWebapp({ version, stage, host, measure, minify, proje
 	await fs.promises.writeFile(
 		`${buildDir}/worker-bootstrap.js`,
 		`importScripts("./polyfill.js")
-const importPromise = System.import("./worker.js")
+const importPromise = System.import("./${builtWorkerFile}")
 self.onmessage = function (msg) {
 	importPromise.then(function () {
 		self.onmessage(msg)


### PR DESCRIPTION
After splitting the worker into two, we forgot to set the correct path for the built worker to worker-bootstrap. Now it gets the correct location  depending on which app is being built.

It also adds a new test to the github pipeline to ensure that both apps can be built using the rollup and respect the import rules.