### PR TITLE
Fix text cutoff in external content dropdown

### DIFF
--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -1636,13 +1636,16 @@ styles.registerStyle("main", () => {
 			height: 0,
 			overflow: "hidden", // while the dropdown is slided open we do not want to show the scrollbars. overflow-y is later overwritten to show scrollbars if necessary
 		},
+		".dropdown-panel.fit-content, .dropdown-panel.fit-content .dropdown-content": {
+			"min-width": "fit-content",
+		},
 		".dropdown-content:first-child": {
 			"padding-top": px(size.vpad_small),
 		},
 		".dropdown-content:last-child": {
 			"padding-bottom": px(size.vpad_small),
 		},
-		".dropdown-content > *": {
+		".dropdown-content, .dropdown-content > *": {
 			width: "100%",
 		},
 		".dropdown-shadow": {


### PR DESCRIPTION
In some languages like German or Russian the external content dropdown text doesn't fit and so it gets cutoff with ellipsis. This commit fixes that by shifting the dropdown as needed so the entire text is displayed. When fitting the entire text on screen isn't possible, the dropdown spans the whole width and text is cutoff.

Fixes: #7458