### PR TITLE
[desktop] allow http2 in undici config

### DIFF
--- a/src/common/desktop/net/ProtocolProxy.ts
+++ b/src/common/desktop/net/ProtocolProxy.ts
@@ -32,6 +32,7 @@ export function handleProtocols(session: Session, assetDir: string): void {
 		headersTimeout: READ_TIMEOUT_MS,
 		// this is needed to address issues in some cases where IPv6 does not really work
 		autoSelectFamily: true,
+		allowH2: true,
 	})
 	const customFetch: typeof fetch = (info: UndiciRequestInfo, requestInit?: UndiciRequestInit) => {
 		return fetch(info, {


### PR DESCRIPTION
we still get too many requests from the desktop client when it is rebuilding the search index. Undicis http2 support should have matured enough for us to enable it to see if it is stable enough.

# Test Notes

All of this should work without major hickups on linux, mac and windows:
* [ ] try a signup
* [ ] load mail with external content
* [ ] load mail lists
* [ ] load mails with attachments and download them
* [ ] upload an attachment
* [ ] start clearing a trash folder, suspend your computer while it happens, log back in
* [ ] go offline and back online while using the desktop client
* [ ] do some of this in parallel with multiple windows