### PR TITLE
allow caching of GroupKey entities

### DIFF
--- a/src/common/misc/LanguageViewModel.ts
+++ b/src/common/misc/LanguageViewModel.ts
@@ -221,6 +221,7 @@ export const enum InfoLink {
 	AppStorePayment = "https://tuta.com/support/#appstore-payments",
 	AppStoreDowngrade = "https://tuta.com/support/#appstore-subscription-downgrade",
 	PasswordGenerator = "https://tuta.com/faq#passphrase-generator",
+	HomePageFreeSignup = "https://tuta.com/free-email",
 }
 
 /**

--- a/src/mail-app/mail/signature/Signature.ts
+++ b/src/mail-app/mail/signature/Signature.ts
@@ -14,7 +14,7 @@ export function getDefaultSignature(): string {
 		LINE_BREAK +
 		htmlSanitizer.sanitizeHTML(
 			lang.get("defaultEmailSignature_msg", {
-				"{1}": InfoLink.HomePage,
+				"{1}": `<a href=${InfoLink.HomePageFreeSignup}>${InfoLink.HomePageFreeSignup}</a>`,
 			}),
 		).html
 	)


### PR DESCRIPTION
After rotating group keys we need to access the former group key for previously encrypted instances. Former group keys are stored on the GroupKey LET which use a customId. These instances are not cached by default. But with the recent modification to that cache that allows caching MailSetEntries GroupKey entites can also be cached. With this commit we enable the caching for this type.