### PR TITLE
Remove local admin groups

### DIFF
--- a/src/common/api/common/TutanotaConstants.ts
+++ b/src/common/api/common/TutanotaConstants.ts
@@ -314,7 +314,6 @@ type ConstType = {
 	WEBAUTHN_RP_ID: string
 	U2f_APPID_SUFFIX: string
 	U2F_LEGACY_APPID: string
-	EXECUTE_KDF_MIGRATION: boolean
 }
 
 export const Const: ConstType = {
@@ -335,7 +334,6 @@ export const Const: ConstType = {
 	// we'll still get the contents
 	// because it will be redirected to tuta.com after new domain deploy.
 	U2F_LEGACY_APPID: "https://tutanota.com/u2f-appid.json",
-	EXECUTE_KDF_MIGRATION: false,
 } as const
 
 export const TUTA_MAIL_ADDRESS_DOMAINS: ReadonlyArray<string> = Object.freeze([

--- a/src/common/api/worker/EventBusClient.ts
+++ b/src/common/api/worker/EventBusClient.ts
@@ -39,7 +39,6 @@ import { resolveTypeReference } from "../common/EntityFunctions.js"
 import { PhishingMarkerWebsocketData, PhishingMarkerWebsocketDataTypeRef, ReportedMailFieldMarker } from "../entities/tutanota/TypeRefs"
 import { UserFacade } from "./facades/UserFacade"
 import { ExposedProgressTracker } from "../main/ProgressTracker.js"
-import { typeRefToPath } from "./rest/EntityRestClient.js"
 
 assertWorkerOrNode()
 

--- a/src/common/api/worker/facades/LoginFacade.ts
+++ b/src/common/api/worker/facades/LoginFacade.ts
@@ -26,7 +26,7 @@ import {
 	SessionService,
 	TakeOverDeletedAddressService,
 } from "../../entities/sys/Services"
-import { AccountType, asKdfType, CloseEventBusOption, Const, DEFAULT_KDF_TYPE, KdfType } from "../../common/TutanotaConstants"
+import { AccountType, asKdfType, CloseEventBusOption, DEFAULT_KDF_TYPE, KdfType } from "../../common/TutanotaConstants"
 import {
 	Challenge,
 	createChangeKdfPostIn,
@@ -300,10 +300,6 @@ export class LoginFacade {
 	 * @param user the user we are updating
 	 */
 	public async migrateKdfType(targetKdfType: KdfType, passphrase: string, user: User): Promise<void> {
-		if (!Const.EXECUTE_KDF_MIGRATION) {
-			// Migration is not yet enabled on this version.
-			return
-		}
 		const currentPassphraseKeyData = {
 			passphrase,
 			kdfType: asKdfType(user.kdfVersion),

--- a/src/common/api/worker/facades/lazy/GroupManagementFacade.ts
+++ b/src/common/api/worker/facades/lazy/GroupManagementFacade.ts
@@ -283,7 +283,7 @@ export class GroupManagementFacade {
 			// or I am an admin and I am a member of the target group (eg: shared mailboxes)
 			return this.keyLoaderFacade.getCurrentSymGroupKey(groupId)
 		} else {
-			const group = await this.entityClient.load(GroupTypeRef, groupId)
+			const group = await this.cacheManagementFacade.reloadGroup(groupId)
 			if (!this.hasAdminEncGKey(group)) {
 				throw new ProgrammingError("Group doesn't have adminGroupEncGKey, you can't get group key this way")
 			}

--- a/src/mail-app/workerUtils/worker/WorkerLocator.ts
+++ b/src/mail-app/workerUtils/worker/WorkerLocator.ts
@@ -48,7 +48,7 @@ import { ServiceExecutor } from "../../../common/api/worker/rest/ServiceExecutor
 import type { BookingFacade } from "../../../common/api/worker/facades/lazy/BookingFacade.js"
 import type { BlobFacade } from "../../../common/api/worker/facades/lazy/BlobFacade.js"
 import { UserFacade } from "../../../common/api/worker/facades/UserFacade.js"
-import { OfflineStorage, OfflineStorageCleaner } from "../../../common/api/worker/offline/OfflineStorage.js"
+import { OfflineStorage } from "../../../common/api/worker/offline/OfflineStorage.js"
 import { OFFLINE_STORAGE_MIGRATIONS, OfflineStorageMigrator } from "../../../common/api/worker/offline/OfflineStorageMigrator.js"
 import { modelInfos } from "../../../common/api/common/EntityFunctions.js"
 import { FileFacadeSendDispatcher } from "../../../common/native/common/generatedipc/FileFacadeSendDispatcher.js"

--- a/test/tests/api/worker/facades/GroupManagementFacadeTest.ts
+++ b/test/tests/api/worker/facades/GroupManagementFacadeTest.ts
@@ -88,7 +88,7 @@ o.spec("GroupManagementFacadeTest", function () {
 			})
 			when(userFacade.hasGroup(groupId)).thenReturn(false)
 			when(userFacade.hasGroup(adminGroupId)).thenReturn(true)
-			when(entityClient.load(GroupTypeRef, groupId)).thenResolve(group)
+			when(cacheManagementFacade.reloadGroup(groupId)).thenResolve(group)
 			when(keyLoaderFacade.loadSymGroupKey(adminGroupId, adminGroupKeyVersion)).thenResolve(adminGroupKeyBytes)
 			when(cryptoWrapper.decryptKey(adminGroupKeyBytes, adminGroupEncGKey)).thenReturn(groupKeyBytes)
 			when(keyLoaderFacade.loadKeypair(adminGroupId, adminGroupKeyVersion)).thenResolve(adminGroupKeyPair)
@@ -101,6 +101,14 @@ o.spec("GroupManagementFacadeTest", function () {
 				decryptedAesKey: groupKeyBytes,
 				senderIdentityPubKey: pubUserGroupEccKey,
 			})
+		})
+
+		o("gets a non-cached group instance", async function () {
+			group.adminGroupEncGKey = adminGroupEncGKey
+
+			await groupManagementFacade.getCurrentGroupKeyViaAdminEncGKey(groupId)
+
+			verify(cacheManagementFacade.reloadGroup(groupId))
 		})
 
 		o("symmetric decryption", async function () {

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -22,7 +22,7 @@ import { UserFacade } from "../../../../../src/common/api/worker/facades/UserFac
 import { ChangeKdfService, SaltService, SessionService } from "../../../../../src/common/api/entities/sys/Services"
 import { Credentials } from "../../../../../src/common/misc/credentials/Credentials"
 import { defer, DeferredObject, uint8ArrayToBase64 } from "@tutao/tutanota-utils"
-import { AccountType, Const, DEFAULT_KDF_TYPE, KdfType } from "../../../../../src/common/api/common/TutanotaConstants"
+import { AccountType, DEFAULT_KDF_TYPE, KdfType } from "../../../../../src/common/api/common/TutanotaConstants"
 import { AccessExpiredError, ConnectionError, NotAuthenticatedError } from "../../../../../src/common/api/common/error/RestError"
 import { SessionType } from "../../../../../src/common/api/common/SessionType"
 import { HttpMethod } from "../../../../../src/common/api/common/EntityFunctions"
@@ -783,7 +783,6 @@ o.spec("LoginFacadeTest", function () {
 			user.salt = SALT
 
 			when(userFacade.getCurrentUserGroupKey()).thenReturn({ object: [1, 2, 3, 4], version: 0 })
-			Const.EXECUTE_KDF_MIGRATION = true
 			await facade.migrateKdfType(KdfType.Argon2id, "hunter2", user)
 
 			verify(
@@ -802,9 +801,6 @@ o.spec("LoginFacadeTest", function () {
 					}),
 				),
 			)
-		})
-		o.afterEach(() => {
-			Const.EXECUTE_KDF_MIGRATION = false
 		})
 	})
 })


### PR DESCRIPTION
In order to delete the local admin groups, we need to first re-assign their managed groups to the global admin.

tutadb#1878