### PR TITLE
Remove local admin groups

### DIFF
--- a/src/common/api/common/utils/UserUtils.ts
+++ b/src/common/api/common/utils/UserUtils.ts
@@ -1,0 +1,22 @@
+import { AccountType, GroupType } from "../TutanotaConstants.js"
+import { User } from "../../entities/sys/TypeRefs.js"
+
+/**
+ * Checks if the current user is an admin of the customer.
+ * @return True if the user is an admin
+ */
+export function isGlobalAdmin(user: User): boolean {
+	if (isInternalUser(user)) {
+		return user.memberships.some((m) => m.groupType === GroupType.Admin)
+	} else {
+		return false
+	}
+}
+
+/**
+ * Provides the information if an internal user is logged in.
+ * @return True if an internal user is logged in, false if no user or an external user is logged in.
+ */
+export function isInternalUser(user: User): boolean {
+	return user.accountType !== AccountType.EXTERNAL
+}

--- a/src/common/api/entities/sys/ModelInfo.ts
+++ b/src/common/api/entities/sys/ModelInfo.ts
@@ -1,5 +1,5 @@
 const modelInfo = {
-	version: 112,
+	version: 113,
 	compatibleSince: 112,
 }
 		

--- a/src/common/api/entities/sys/Services.ts
+++ b/src/common/api/entities/sys/Services.ts
@@ -35,6 +35,7 @@ import {GroupKeyRotationInfoGetOutTypeRef} from "./TypeRefs.js"
 import {GroupKeyRotationPostInTypeRef} from "./TypeRefs.js"
 import {InvoiceDataGetInTypeRef} from "./TypeRefs.js"
 import {InvoiceDataGetOutTypeRef} from "./TypeRefs.js"
+import {LocalAdminRemovalPostInTypeRef} from "./TypeRefs.js"
 import {LocationServiceGetReturnTypeRef} from "./TypeRefs.js"
 import {MailAddressAliasGetInTypeRef} from "./TypeRefs.js"
 import {MailAddressAliasServiceReturnTypeRef} from "./TypeRefs.js"
@@ -281,6 +282,15 @@ export const InvoiceDataService = Object.freeze({
 	name: "InvoiceDataService",
 	get: {data: InvoiceDataGetInTypeRef, return: InvoiceDataGetOutTypeRef},
 	post: null,
+	put: null,
+	delete: null,
+} as const)
+
+export const LocalAdminRemovalService = Object.freeze({
+	app: "sys",
+	name: "LocalAdminRemovalService",
+	get: null,
+	post: {data: LocalAdminRemovalPostInTypeRef, return: null},
 	put: null,
 	delete: null,
 } as const)

--- a/src/common/api/entities/sys/TypeModels.js
+++ b/src/common/api/entities/sys/TypeModels.js
@@ -219,7 +219,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AdminGroupKeyAuthenticationData": {
         "name": "AdminGroupKeyAuthenticationData",
@@ -271,7 +271,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AdminGroupKeyRotationPostIn": {
         "name": "AdminGroupKeyRotationPostIn",
@@ -325,7 +325,87 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
+    },
+    "AdministratedGroup": {
+        "name": "AdministratedGroup",
+        "since": 27,
+        "type": "LIST_ELEMENT_TYPE",
+        "id": 1294,
+        "rootId": "A3N5cwAFDg",
+        "versioned": false,
+        "encrypted": false,
+        "values": {
+            "_format": {
+                "final": false,
+                "name": "_format",
+                "id": 1298,
+                "since": 27,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "_id": {
+                "final": true,
+                "name": "_id",
+                "id": 1296,
+                "since": 27,
+                "type": "GeneratedId",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "_ownerGroup": {
+                "final": true,
+                "name": "_ownerGroup",
+                "id": 1299,
+                "since": 27,
+                "type": "GeneratedId",
+                "cardinality": "ZeroOrOne",
+                "encrypted": false
+            },
+            "_permissions": {
+                "final": true,
+                "name": "_permissions",
+                "id": 1297,
+                "since": 27,
+                "type": "GeneratedId",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "groupType": {
+                "final": true,
+                "name": "groupType",
+                "id": 1300,
+                "since": 27,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            }
+        },
+        "associations": {
+            "groupInfo": {
+                "final": false,
+                "name": "groupInfo",
+                "id": 1301,
+                "since": 27,
+                "type": "LIST_ELEMENT_ASSOCIATION",
+                "cardinality": "One",
+                "refType": "GroupInfo",
+                "dependency": null
+            },
+            "localAdminGroup": {
+                "final": false,
+                "name": "localAdminGroup",
+                "id": 1302,
+                "since": 27,
+                "type": "ELEMENT_ASSOCIATION",
+                "cardinality": "One",
+                "refType": "Group",
+                "dependency": null
+            }
+        },
+        "app": "sys",
+        "version": "113"
     },
     "AdministratedGroupsRef": {
         "name": "AdministratedGroupsRef",
@@ -359,7 +439,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AffiliatePartnerKpiMonthSummary": {
         "name": "AffiliatePartnerKpiMonthSummary",
@@ -436,7 +516,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AffiliatePartnerKpiServiceGetOut": {
         "name": "AffiliatePartnerKpiServiceGetOut",
@@ -497,7 +577,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AlarmInfo": {
         "name": "AlarmInfo",
@@ -549,7 +629,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AlarmNotification": {
         "name": "AlarmNotification",
@@ -649,7 +729,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AlarmServicePost": {
         "name": "AlarmServicePost",
@@ -683,7 +763,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ArchiveRef": {
         "name": "ArchiveRef",
@@ -715,7 +795,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ArchiveType": {
         "name": "ArchiveType",
@@ -769,7 +849,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AuditLogEntry": {
         "name": "AuditLogEntry",
@@ -903,7 +983,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AuditLogRef": {
         "name": "AuditLogRef",
@@ -937,7 +1017,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AuthenticatedDevice": {
         "name": "AuthenticatedDevice",
@@ -987,7 +1067,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Authentication": {
         "name": "Authentication",
@@ -1048,7 +1128,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AutoLoginDataDelete": {
         "name": "AutoLoginDataDelete",
@@ -1080,7 +1160,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AutoLoginDataGet": {
         "name": "AutoLoginDataGet",
@@ -1123,7 +1203,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AutoLoginDataReturn": {
         "name": "AutoLoginDataReturn",
@@ -1155,7 +1235,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "AutoLoginPostReturn": {
         "name": "AutoLoginPostReturn",
@@ -1187,7 +1267,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Blob": {
         "name": "Blob",
@@ -1237,7 +1317,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BlobReferenceTokenWrapper": {
         "name": "BlobReferenceTokenWrapper",
@@ -1269,7 +1349,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Booking": {
         "name": "Booking",
@@ -1393,7 +1473,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BookingItem": {
         "name": "BookingItem",
@@ -1479,7 +1559,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BookingsRef": {
         "name": "BookingsRef",
@@ -1513,7 +1593,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BootstrapFeature": {
         "name": "BootstrapFeature",
@@ -1545,7 +1625,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Braintree3ds2Request": {
         "name": "Braintree3ds2Request",
@@ -1595,7 +1675,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Braintree3ds2Response": {
         "name": "Braintree3ds2Response",
@@ -1636,7 +1716,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BrandingDomainData": {
         "name": "BrandingDomainData",
@@ -1713,7 +1793,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BrandingDomainDeleteData": {
         "name": "BrandingDomainDeleteData",
@@ -1745,7 +1825,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BrandingDomainGetReturn": {
         "name": "BrandingDomainGetReturn",
@@ -1779,7 +1859,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Bucket": {
         "name": "Bucket",
@@ -1813,7 +1893,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BucketKey": {
         "name": "BucketKey",
@@ -1902,7 +1982,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "BucketPermission": {
         "name": "BucketPermission",
@@ -2044,7 +2124,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CalendarEventRef": {
         "name": "CalendarEventRef",
@@ -2085,7 +2165,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CertificateInfo": {
         "name": "CertificateInfo",
@@ -2146,7 +2226,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Challenge": {
         "name": "Challenge",
@@ -2199,7 +2279,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ChangeKdfPostIn": {
         "name": "ChangeKdfPostIn",
@@ -2276,7 +2356,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ChangePasswordPostIn": {
         "name": "ChangePasswordPostIn",
@@ -2371,7 +2451,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Chat": {
         "name": "Chat",
@@ -2421,7 +2501,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CloseSessionServicePost": {
         "name": "CloseSessionServicePost",
@@ -2464,7 +2544,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CreateCustomerServerPropertiesData": {
         "name": "CreateCustomerServerPropertiesData",
@@ -2505,7 +2585,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CreateCustomerServerPropertiesReturn": {
         "name": "CreateCustomerServerPropertiesReturn",
@@ -2539,7 +2619,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CreateSessionData": {
         "name": "CreateSessionData",
@@ -2627,7 +2707,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CreateSessionReturn": {
         "name": "CreateSessionReturn",
@@ -2680,7 +2760,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CreditCard": {
         "name": "CreditCard",
@@ -2748,7 +2828,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomDomainCheckGetIn": {
         "name": "CustomDomainCheckGetIn",
@@ -2791,7 +2871,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomDomainCheckGetOut": {
         "name": "CustomDomainCheckGetOut",
@@ -2854,7 +2934,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomDomainData": {
         "name": "CustomDomainData",
@@ -2897,7 +2977,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomDomainReturn": {
         "name": "CustomDomainReturn",
@@ -2940,7 +3020,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Customer": {
         "name": "Customer",
@@ -3197,7 +3277,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomerAccountTerminationPostIn": {
         "name": "CustomerAccountTerminationPostIn",
@@ -3240,7 +3320,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomerAccountTerminationPostOut": {
         "name": "CustomerAccountTerminationPostOut",
@@ -3274,7 +3354,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomerAccountTerminationRequest": {
         "name": "CustomerAccountTerminationRequest",
@@ -3353,7 +3433,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomerInfo": {
         "name": "CustomerInfo",
@@ -3666,7 +3746,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomerProperties": {
         "name": "CustomerProperties",
@@ -3774,7 +3854,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "CustomerServerProperties": {
         "name": "CustomerServerProperties",
@@ -3890,7 +3970,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "DateWrapper": {
         "name": "DateWrapper",
@@ -3922,7 +4002,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "DebitServicePutData": {
         "name": "DebitServicePutData",
@@ -3956,7 +4036,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "DeleteCustomerData": {
         "name": "DeleteCustomerData",
@@ -4036,7 +4116,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "DnsRecord": {
         "name": "DnsRecord",
@@ -4086,7 +4166,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "DomainInfo": {
         "name": "DomainInfo",
@@ -4148,7 +4228,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "DomainMailAddressAvailabilityData": {
         "name": "DomainMailAddressAvailabilityData",
@@ -4180,7 +4260,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "DomainMailAddressAvailabilityReturn": {
         "name": "DomainMailAddressAvailabilityReturn",
@@ -4212,7 +4292,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "EmailSenderListElement": {
         "name": "EmailSenderListElement",
@@ -4271,7 +4351,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "EntityEventBatch": {
         "name": "EntityEventBatch",
@@ -4332,7 +4412,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "EntityUpdate": {
         "name": "EntityUpdate",
@@ -4400,7 +4480,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Exception": {
         "name": "Exception",
@@ -4441,7 +4521,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ExternalPropertiesReturn": {
         "name": "ExternalPropertiesReturn",
@@ -4503,7 +4583,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ExternalUserReference": {
         "name": "ExternalUserReference",
@@ -4574,7 +4654,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Feature": {
         "name": "Feature",
@@ -4606,7 +4686,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "File": {
         "name": "File",
@@ -4656,7 +4736,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GeneratedIdWrapper": {
         "name": "GeneratedIdWrapper",
@@ -4688,7 +4768,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCard": {
         "name": "GiftCard",
@@ -4801,7 +4881,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardCreateData": {
         "name": "GiftCardCreateData",
@@ -4869,7 +4949,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardCreateReturn": {
         "name": "GiftCardCreateReturn",
@@ -4903,7 +4983,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardDeleteData": {
         "name": "GiftCardDeleteData",
@@ -4937,7 +5017,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardGetReturn": {
         "name": "GiftCardGetReturn",
@@ -4989,7 +5069,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardOption": {
         "name": "GiftCardOption",
@@ -5021,7 +5101,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardRedeemData": {
         "name": "GiftCardRedeemData",
@@ -5073,7 +5153,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardRedeemGetReturn": {
         "name": "GiftCardRedeemGetReturn",
@@ -5125,7 +5205,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GiftCardsRef": {
         "name": "GiftCardsRef",
@@ -5159,7 +5239,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Group": {
         "name": "Group",
@@ -5384,7 +5464,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupInfo": {
         "name": "GroupInfo",
@@ -5537,7 +5617,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKey": {
         "name": "GroupKey",
@@ -5644,7 +5724,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKeyRotationData": {
         "name": "GroupKeyRotationData",
@@ -5744,7 +5824,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKeyRotationInfoGetOut": {
         "name": "GroupKeyRotationInfoGetOut",
@@ -5787,7 +5867,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKeyRotationPostIn": {
         "name": "GroupKeyRotationPostIn",
@@ -5821,7 +5901,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKeyUpdate": {
         "name": "GroupKeyUpdate",
@@ -5918,7 +5998,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKeyUpdateData": {
         "name": "GroupKeyUpdateData",
@@ -5979,7 +6059,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKeyUpdatesRef": {
         "name": "GroupKeyUpdatesRef",
@@ -6013,7 +6093,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupKeysRef": {
         "name": "GroupKeysRef",
@@ -6047,7 +6127,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupMember": {
         "name": "GroupMember",
@@ -6137,7 +6217,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupMembership": {
         "name": "GroupMembership",
@@ -6245,7 +6325,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupMembershipKeyData": {
         "name": "GroupMembershipKeyData",
@@ -6306,7 +6386,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupMembershipUpdateData": {
         "name": "GroupMembershipUpdateData",
@@ -6358,7 +6438,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "GroupRoot": {
         "name": "GroupRoot",
@@ -6439,7 +6519,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "IdTupleWrapper": {
         "name": "IdTupleWrapper",
@@ -6480,7 +6560,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "InstanceSessionKey": {
         "name": "InstanceSessionKey",
@@ -6559,7 +6639,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Invoice": {
         "name": "Invoice",
@@ -6775,7 +6855,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "InvoiceDataGetIn": {
         "name": "InvoiceDataGetIn",
@@ -6807,7 +6887,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "InvoiceDataGetOut": {
         "name": "InvoiceDataGetOut",
@@ -6949,7 +7029,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "InvoiceDataItem": {
         "name": "InvoiceDataItem",
@@ -7026,7 +7106,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "InvoiceInfo": {
         "name": "InvoiceInfo",
@@ -7205,7 +7285,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "InvoiceItem": {
         "name": "InvoiceItem",
@@ -7291,7 +7371,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "KeyPair": {
         "name": "KeyPair",
@@ -7368,7 +7448,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "KeyRotation": {
         "name": "KeyRotation",
@@ -7447,7 +7527,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "KeyRotationsRef": {
         "name": "KeyRotationsRef",
@@ -7481,7 +7561,102 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
+    },
+    "LocalAdminGroupReplacementData": {
+        "name": "LocalAdminGroupReplacementData",
+        "since": 113,
+        "type": "AGGREGATED_TYPE",
+        "id": 2484,
+        "rootId": "A3N5cwAJtA",
+        "versioned": false,
+        "encrypted": false,
+        "values": {
+            "_id": {
+                "final": true,
+                "name": "_id",
+                "id": 2485,
+                "since": 113,
+                "type": "CustomId",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "adminGroupEncGKey": {
+                "final": false,
+                "name": "adminGroupEncGKey",
+                "id": 2487,
+                "since": 113,
+                "type": "Bytes",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "adminGroupKeyVersion": {
+                "final": false,
+                "name": "adminGroupKeyVersion",
+                "id": 2489,
+                "since": 113,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            },
+            "groupKeyVersion": {
+                "final": false,
+                "name": "groupKeyVersion",
+                "id": 2488,
+                "since": 113,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            }
+        },
+        "associations": {
+            "groupId": {
+                "final": false,
+                "name": "groupId",
+                "id": 2486,
+                "since": 113,
+                "type": "ELEMENT_ASSOCIATION",
+                "cardinality": "One",
+                "refType": "Group",
+                "dependency": null
+            }
+        },
+        "app": "sys",
+        "version": "113"
+    },
+    "LocalAdminRemovalPostIn": {
+        "name": "LocalAdminRemovalPostIn",
+        "since": 113,
+        "type": "DATA_TRANSFER_TYPE",
+        "id": 2490,
+        "rootId": "A3N5cwAJug",
+        "versioned": false,
+        "encrypted": false,
+        "values": {
+            "_format": {
+                "final": false,
+                "name": "_format",
+                "id": 2491,
+                "since": 113,
+                "type": "Number",
+                "cardinality": "One",
+                "encrypted": false
+            }
+        },
+        "associations": {
+            "groupUpdates": {
+                "final": false,
+                "name": "groupUpdates",
+                "id": 2492,
+                "since": 113,
+                "type": "AGGREGATION",
+                "cardinality": "Any",
+                "refType": "LocalAdminGroupReplacementData",
+                "dependency": null
+            }
+        },
+        "app": "sys",
+        "version": "113"
     },
     "LocationServiceGetReturn": {
         "name": "LocationServiceGetReturn",
@@ -7513,7 +7688,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Login": {
         "name": "Login",
@@ -7572,7 +7747,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MailAddressAlias": {
         "name": "MailAddressAlias",
@@ -7613,7 +7788,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MailAddressAliasGetIn": {
         "name": "MailAddressAliasGetIn",
@@ -7647,7 +7822,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MailAddressAliasServiceData": {
         "name": "MailAddressAliasServiceData",
@@ -7690,7 +7865,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MailAddressAliasServiceDataDelete": {
         "name": "MailAddressAliasServiceDataDelete",
@@ -7742,7 +7917,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MailAddressAliasServiceReturn": {
         "name": "MailAddressAliasServiceReturn",
@@ -7801,7 +7976,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MailAddressAvailability": {
         "name": "MailAddressAvailability",
@@ -7842,7 +8017,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MailAddressToGroup": {
         "name": "MailAddressToGroup",
@@ -7903,7 +8078,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MembershipAddData": {
         "name": "MembershipAddData",
@@ -7974,7 +8149,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MembershipPutIn": {
         "name": "MembershipPutIn",
@@ -8008,7 +8183,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MembershipRemoveData": {
         "name": "MembershipRemoveData",
@@ -8052,7 +8227,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MissedNotification": {
         "name": "MissedNotification",
@@ -8168,7 +8343,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MultipleMailAddressAvailabilityData": {
         "name": "MultipleMailAddressAvailabilityData",
@@ -8202,7 +8377,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "MultipleMailAddressAvailabilityReturn": {
         "name": "MultipleMailAddressAvailabilityReturn",
@@ -8236,7 +8411,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "NotificationInfo": {
         "name": "NotificationInfo",
@@ -8288,7 +8463,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "NotificationMailTemplate": {
         "name": "NotificationMailTemplate",
@@ -8338,7 +8513,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "NotificationSessionKey": {
         "name": "NotificationSessionKey",
@@ -8381,7 +8556,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "OrderProcessingAgreement": {
         "name": "OrderProcessingAgreement",
@@ -8497,7 +8672,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "OtpChallenge": {
         "name": "OtpChallenge",
@@ -8531,7 +8706,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PaymentDataServiceGetData": {
         "name": "PaymentDataServiceGetData",
@@ -8563,7 +8738,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PaymentDataServiceGetReturn": {
         "name": "PaymentDataServiceGetReturn",
@@ -8595,7 +8770,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PaymentDataServicePostData": {
         "name": "PaymentDataServicePostData",
@@ -8629,7 +8804,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PaymentDataServicePutData": {
         "name": "PaymentDataServicePutData",
@@ -8744,7 +8919,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PaymentDataServicePutReturn": {
         "name": "PaymentDataServicePutReturn",
@@ -8787,7 +8962,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PaymentErrorInfo": {
         "name": "PaymentErrorInfo",
@@ -8837,7 +9012,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Permission": {
         "name": "Permission",
@@ -8989,7 +9164,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PlanConfiguration": {
         "name": "PlanConfiguration",
@@ -9102,7 +9277,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PlanPrices": {
         "name": "PlanPrices",
@@ -9244,7 +9419,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PlanServiceGetOut": {
         "name": "PlanServiceGetOut",
@@ -9278,7 +9453,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PriceData": {
         "name": "PriceData",
@@ -9339,7 +9514,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PriceItemData": {
         "name": "PriceItemData",
@@ -9398,7 +9573,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PriceRequestData": {
         "name": "PriceRequestData",
@@ -9475,7 +9650,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PriceServiceData": {
         "name": "PriceServiceData",
@@ -9518,7 +9693,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PriceServiceReturn": {
         "name": "PriceServiceReturn",
@@ -9590,7 +9765,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PubEncKeyData": {
         "name": "PubEncKeyData",
@@ -9667,7 +9842,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PublicKeyGetIn": {
         "name": "PublicKeyGetIn",
@@ -9717,7 +9892,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PublicKeyGetOut": {
         "name": "PublicKeyGetOut",
@@ -9776,7 +9951,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PublicKeyPutIn": {
         "name": "PublicKeyPutIn",
@@ -9828,7 +10003,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PushIdentifier": {
         "name": "PushIdentifier",
@@ -9986,7 +10161,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "PushIdentifierList": {
         "name": "PushIdentifierList",
@@ -10020,7 +10195,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ReceivedGroupInvitation": {
         "name": "ReceivedGroupInvitation",
@@ -10181,7 +10356,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RecoverCode": {
         "name": "RecoverCode",
@@ -10267,7 +10442,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RecoverCodeData": {
         "name": "RecoverCodeData",
@@ -10326,7 +10501,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ReferralCodeGetIn": {
         "name": "ReferralCodeGetIn",
@@ -10360,7 +10535,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ReferralCodePostIn": {
         "name": "ReferralCodePostIn",
@@ -10383,7 +10558,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ReferralCodePostOut": {
         "name": "ReferralCodePostOut",
@@ -10417,7 +10592,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RegistrationCaptchaServiceData": {
         "name": "RegistrationCaptchaServiceData",
@@ -10458,7 +10633,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RegistrationCaptchaServiceGetData": {
         "name": "RegistrationCaptchaServiceGetData",
@@ -10526,7 +10701,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RegistrationCaptchaServiceReturn": {
         "name": "RegistrationCaptchaServiceReturn",
@@ -10567,7 +10742,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RegistrationReturn": {
         "name": "RegistrationReturn",
@@ -10599,7 +10774,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RegistrationServiceData": {
         "name": "RegistrationServiceData",
@@ -10649,7 +10824,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RejectedSender": {
         "name": "RejectedSender",
@@ -10744,7 +10919,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RejectedSendersRef": {
         "name": "RejectedSendersRef",
@@ -10778,7 +10953,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RepeatRule": {
         "name": "RepeatRule",
@@ -10857,7 +11032,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ResetFactorsDeleteData": {
         "name": "ResetFactorsDeleteData",
@@ -10907,7 +11082,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "ResetPasswordPostIn": {
         "name": "ResetPasswordPostIn",
@@ -10986,7 +11161,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "RootInstance": {
         "name": "RootInstance",
@@ -11045,7 +11220,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SaltData": {
         "name": "SaltData",
@@ -11077,7 +11252,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SaltReturn": {
         "name": "SaltReturn",
@@ -11118,7 +11293,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SecondFactor": {
         "name": "SecondFactor",
@@ -11206,7 +11381,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SecondFactorAuthAllowedReturn": {
         "name": "SecondFactorAuthAllowedReturn",
@@ -11238,7 +11413,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SecondFactorAuthData": {
         "name": "SecondFactorAuthData",
@@ -11310,7 +11485,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SecondFactorAuthDeleteData": {
         "name": "SecondFactorAuthDeleteData",
@@ -11344,7 +11519,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SecondFactorAuthGetData": {
         "name": "SecondFactorAuthGetData",
@@ -11376,7 +11551,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SecondFactorAuthGetReturn": {
         "name": "SecondFactorAuthGetReturn",
@@ -11408,7 +11583,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SecondFactorAuthentication": {
         "name": "SecondFactorAuthentication",
@@ -11494,7 +11669,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SendRegistrationCodeData": {
         "name": "SendRegistrationCodeData",
@@ -11553,7 +11728,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SendRegistrationCodeReturn": {
         "name": "SendRegistrationCodeReturn",
@@ -11585,7 +11760,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SentGroupInvitation": {
         "name": "SentGroupInvitation",
@@ -11674,7 +11849,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Session": {
         "name": "Session",
@@ -11817,7 +11992,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SignOrderProcessingAgreementData": {
         "name": "SignOrderProcessingAgreementData",
@@ -11858,7 +12033,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SseConnectData": {
         "name": "SseConnectData",
@@ -11901,7 +12076,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "StringConfigValue": {
         "name": "StringConfigValue",
@@ -11942,7 +12117,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "StringWrapper": {
         "name": "StringWrapper",
@@ -11974,7 +12149,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SurveyData": {
         "name": "SurveyData",
@@ -12033,7 +12208,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SwitchAccountTypePostIn": {
         "name": "SwitchAccountTypePostIn",
@@ -12122,7 +12297,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "SystemKeysReturn": {
         "name": "SystemKeysReturn",
@@ -12238,7 +12413,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "TakeOverDeletedAddressData": {
         "name": "TakeOverDeletedAddressData",
@@ -12297,7 +12472,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "TypeInfo": {
         "name": "TypeInfo",
@@ -12338,7 +12513,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "U2fChallenge": {
         "name": "U2fChallenge",
@@ -12381,7 +12556,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "U2fKey": {
         "name": "U2fKey",
@@ -12433,7 +12608,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "U2fRegisteredDevice": {
         "name": "U2fRegisteredDevice",
@@ -12501,7 +12676,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "U2fResponseData": {
         "name": "U2fResponseData",
@@ -12551,7 +12726,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UpdatePermissionKeyData": {
         "name": "UpdatePermissionKeyData",
@@ -12613,7 +12788,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UpdateSessionKeysPostIn": {
         "name": "UpdateSessionKeysPostIn",
@@ -12647,7 +12822,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UpgradePriceServiceData": {
         "name": "UpgradePriceServiceData",
@@ -12699,7 +12874,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UpgradePriceServiceReturn": {
         "name": "UpgradePriceServiceReturn",
@@ -12870,7 +13045,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "User": {
         "name": "User",
@@ -13085,7 +13260,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserAlarmInfo": {
         "name": "UserAlarmInfo",
@@ -13164,7 +13339,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserAlarmInfoListType": {
         "name": "UserAlarmInfoListType",
@@ -13198,7 +13373,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserAreaGroups": {
         "name": "UserAreaGroups",
@@ -13232,7 +13407,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserAuthentication": {
         "name": "UserAuthentication",
@@ -13286,7 +13461,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserDataDelete": {
         "name": "UserDataDelete",
@@ -13338,7 +13513,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserExternalAuthInfo": {
         "name": "UserExternalAuthInfo",
@@ -13408,7 +13583,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserGroupKeyDistribution": {
         "name": "UserGroupKeyDistribution",
@@ -13476,7 +13651,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserGroupKeyRotationData": {
         "name": "UserGroupKeyRotationData",
@@ -13603,7 +13778,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserGroupKeyRotationPostIn": {
         "name": "UserGroupKeyRotationPostIn",
@@ -13637,7 +13812,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "UserGroupRoot": {
         "name": "UserGroupRoot",
@@ -13718,7 +13893,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "VariableExternalAuthInfo": {
         "name": "VariableExternalAuthInfo",
@@ -13822,7 +13997,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "VerifyRegistrationCodeData": {
         "name": "VerifyRegistrationCodeData",
@@ -13863,7 +14038,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "Version": {
         "name": "Version",
@@ -13934,7 +14109,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "VersionData": {
         "name": "VersionData",
@@ -13993,7 +14168,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "VersionInfo": {
         "name": "VersionInfo",
@@ -14118,7 +14293,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "VersionReturn": {
         "name": "VersionReturn",
@@ -14152,7 +14327,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WebauthnResponseData": {
         "name": "WebauthnResponseData",
@@ -14211,7 +14386,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WebsocketCounterData": {
         "name": "WebsocketCounterData",
@@ -14254,7 +14429,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WebsocketCounterValue": {
         "name": "WebsocketCounterValue",
@@ -14295,7 +14470,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WebsocketEntityData": {
         "name": "WebsocketEntityData",
@@ -14347,7 +14522,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WebsocketLeaderStatus": {
         "name": "WebsocketLeaderStatus",
@@ -14379,7 +14554,7 @@ export const typeModels = {
         },
         "associations": {},
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WhitelabelChild": {
         "name": "WhitelabelChild",
@@ -14494,7 +14669,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WhitelabelChildrenRef": {
         "name": "WhitelabelChildrenRef",
@@ -14528,7 +14703,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WhitelabelConfig": {
         "name": "WhitelabelConfig",
@@ -14663,7 +14838,7 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     },
     "WhitelabelParent": {
         "name": "WhitelabelParent",
@@ -14707,6 +14882,6 @@ export const typeModels = {
             }
         },
         "app": "sys",
-        "version": "112"
+        "version": "113"
     }
 }

--- a/src/common/api/entities/sys/TypeRefs.ts
+++ b/src/common/api/entities/sys/TypeRefs.ts
@@ -67,6 +67,24 @@ export type AdminGroupKeyRotationPostIn = {
 	adminGroupKeyData: GroupKeyRotationData;
 	userGroupKeyData: UserGroupKeyRotationData;
 }
+export const AdministratedGroupTypeRef: TypeRef<AdministratedGroup> = new TypeRef("sys", "AdministratedGroup")
+
+export function createAdministratedGroup(values: StrippedEntity<AdministratedGroup>): AdministratedGroup {
+	return Object.assign(create(typeModels.AdministratedGroup, AdministratedGroupTypeRef), values)
+}
+
+export type AdministratedGroup = {
+	_type: TypeRef<AdministratedGroup>;
+
+	_format: NumberString;
+	_id: IdTuple;
+	_ownerGroup: null | Id;
+	_permissions: Id;
+	groupType: NumberString;
+
+	groupInfo: IdTuple;
+	localAdminGroup: Id;
+}
 export const AdministratedGroupsRefTypeRef: TypeRef<AdministratedGroupsRef> = new TypeRef("sys", "AdministratedGroupsRef")
 
 export function createAdministratedGroupsRef(values: StrippedEntity<AdministratedGroupsRef>): AdministratedGroupsRef {
@@ -1792,6 +1810,35 @@ export type KeyRotationsRef = {
 	_id: Id;
 
 	list: Id;
+}
+export const LocalAdminGroupReplacementDataTypeRef: TypeRef<LocalAdminGroupReplacementData> = new TypeRef("sys", "LocalAdminGroupReplacementData")
+
+export function createLocalAdminGroupReplacementData(values: StrippedEntity<LocalAdminGroupReplacementData>): LocalAdminGroupReplacementData {
+	return Object.assign(create(typeModels.LocalAdminGroupReplacementData, LocalAdminGroupReplacementDataTypeRef), values)
+}
+
+export type LocalAdminGroupReplacementData = {
+	_type: TypeRef<LocalAdminGroupReplacementData>;
+
+	_id: Id;
+	adminGroupEncGKey: Uint8Array;
+	adminGroupKeyVersion: NumberString;
+	groupKeyVersion: NumberString;
+
+	groupId: Id;
+}
+export const LocalAdminRemovalPostInTypeRef: TypeRef<LocalAdminRemovalPostIn> = new TypeRef("sys", "LocalAdminRemovalPostIn")
+
+export function createLocalAdminRemovalPostIn(values: StrippedEntity<LocalAdminRemovalPostIn>): LocalAdminRemovalPostIn {
+	return Object.assign(create(typeModels.LocalAdminRemovalPostIn, LocalAdminRemovalPostInTypeRef), values)
+}
+
+export type LocalAdminRemovalPostIn = {
+	_type: TypeRef<LocalAdminRemovalPostIn>;
+
+	_format: NumberString;
+
+	groupUpdates: LocalAdminGroupReplacementData[];
 }
 export const LocationServiceGetReturnTypeRef: TypeRef<LocationServiceGetReturn> = new TypeRef("sys", "LocationServiceGetReturn")
 

--- a/src/common/api/main/UserController.ts
+++ b/src/common/api/main/UserController.ts
@@ -42,6 +42,7 @@ import { SessionType } from "../common/SessionType"
 import { IServiceExecutor } from "../common/ServiceRequest.js"
 import { isCustomizationEnabledForCustomer } from "../common/utils/CustomerUtils.js"
 import { EntityUpdateData, isUpdateForTypeRef } from "../common/utils/EntityUpdateUtils.js"
+import { isGlobalAdmin, isInternalUser } from "../common/utils/UserUtils.js"
 
 assertMainOrNode()
 
@@ -86,11 +87,7 @@ export class UserController {
 	 * @return True if the user is an admin
 	 */
 	isGlobalAdmin(): boolean {
-		if (this.isInternalUser()) {
-			return this.user.memberships.some((m) => m.groupType === GroupType.Admin)
-		} else {
-			return false
-		}
+		return isGlobalAdmin(this.user)
 	}
 
 	/**
@@ -110,7 +107,7 @@ export class UserController {
 	 * @return True if an internal user is logged in, false if no user or an external user is logged in.
 	 */
 	isInternalUser(): boolean {
-		return this.user.accountType !== AccountType.EXTERNAL
+		return isInternalUser(this.user)
 	}
 
 	loadCustomer(): Promise<Customer> {

--- a/src/mail-app/app.ts
+++ b/src/mail-app/app.ts
@@ -142,6 +142,14 @@ import("./translations/en.js")
 				async onFullLoginSuccess() {},
 			}
 		})
+		mailLocator.logins.addPostLoginAction(async () => {
+			return {
+				async onPartialLoginSuccess() {},
+				async onFullLoginSuccess() {
+					await mailLocator.groupManagementFacade.migrateLocalAdminsToGlobalAdmins()
+				},
+			}
+		})
 
 		if (isOfflineStorageAvailable()) {
 			const { CachePostLoginAction } = await import("../common/offline/CachePostLoginAction.js")

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -137,6 +137,7 @@ import { AppType } from "../common/misc/ClientConstants.js"
 import { ParsedEvent } from "../common/calendar/import/CalendarImporter.js"
 import { lang } from "../common/misc/LanguageViewModel.js"
 import type { CalendarContactPreviewViewModel } from "../calendar-app/calendar/gui/eventpopup/CalendarContactPreviewViewModel.js"
+import { KeyLoaderFacade } from "../common/api/worker/facades/KeyLoaderFacade.js"
 
 assertMainOrNode()
 
@@ -158,6 +159,7 @@ class MailLocator {
 	logins!: LoginController
 	header!: Header
 	customerFacade!: CustomerFacade
+	keyLoaderFacade!: KeyLoaderFacade
 	giftCardFacade!: GiftCardFacade
 	groupManagementFacade!: GroupManagementFacade
 	configFacade!: ConfigurationDatabase

--- a/test/tests/api/worker/facades/GroupManagementFacadeTest.ts
+++ b/test/tests/api/worker/facades/GroupManagementFacadeTest.ts
@@ -11,11 +11,24 @@ import { AsymmetricCryptoFacade } from "../../../../../src/common/api/worker/cry
 import { matchers, object, verify, when } from "testdouble"
 import { AesKey, EccPublicKey, PQKeyPairs } from "@tutao/tutanota-crypto"
 import { createTestEntity } from "../../../TestUtils.js"
-import { Group, GroupTypeRef, PubEncKeyDataTypeRef } from "../../../../../src/common/api/entities/sys/TypeRefs.js"
-import { CryptoWrapper } from "../../../../../src/common/api/worker/crypto/CryptoWrapper.js"
+import {
+	AdministratedGroupsRefTypeRef,
+	AdministratedGroupTypeRef,
+	CustomerTypeRef,
+	Group,
+	GroupInfo,
+	GroupInfoTypeRef,
+	GroupMembershipTypeRef,
+	GroupTypeRef,
+	LocalAdminRemovalPostIn,
+	PubEncKeyDataTypeRef,
+	UserTypeRef,
+} from "../../../../../src/common/api/entities/sys/TypeRefs.js"
+import { CryptoWrapper, VersionedKey } from "../../../../../src/common/api/worker/crypto/CryptoWrapper.js"
 import { assertThrows } from "@tutao/tutanota-test-utils"
 import { ProgrammingError } from "../../../../../src/common/api/common/error/ProgrammingError.js"
-import { CryptoProtocolVersion, PublicKeyIdentifierType } from "../../../../../src/common/api/common/TutanotaConstants.js"
+import { CryptoProtocolVersion, GroupType, PublicKeyIdentifierType } from "../../../../../src/common/api/common/TutanotaConstants.js"
+import { LocalAdminRemovalService } from "../../../../../src/common/api/entities/sys/Services.js"
 
 o.spec("GroupManagementFacadeTest", function () {
 	let userFacade: UserFacade
@@ -164,4 +177,170 @@ o.spec("GroupManagementFacadeTest", function () {
 			await assertThrows(Error, async () => await groupManagementFacade.getCurrentGroupKeyViaAdminEncGKey(groupId))
 		})
 	})
+
+	o("replace local admin enc group key with global admin enc group key", async function () {
+		const symGlobalAdminGroupKey: VersionedKey = {
+			version: 1,
+			object: object(),
+		}
+
+		const symLocalAdminGroupKey: VersionedKey = {
+			version: 0,
+			object: object(),
+		}
+
+		const userGroup: Group = createTestEntity(GroupTypeRef, {
+			type: GroupType.User,
+			adminGroupEncGKey: object(),
+			adminGroupKeyVersion: "0",
+			admin: "localAdmin",
+		})
+
+		const before = createTestEntity(GroupTypeRef, userGroup)
+		const decrypted = object<AesKey>()
+		when(cryptoWrapper.decryptKey(matchers.anything(), matchers.anything())).thenReturn(decrypted)
+		const reencrypted = object<Uint8Array>()
+		when(cryptoWrapper.encryptKey(matchers.anything(), decrypted)).thenReturn(reencrypted)
+
+		const groupUpdate = await groupManagementFacade.replaceLocalAdminEncGroupKeyWithGlobalAdminEncGroupKey(
+			symGlobalAdminGroupKey,
+			symLocalAdminGroupKey.object,
+			userGroup,
+		)
+
+		o(groupUpdate.adminGroupKeyVersion).equals(String(symGlobalAdminGroupKey.version))
+		o(groupUpdate.adminGroupEncGKey).equals(reencrypted)
+
+		o(userGroup).deepEquals(before)
+	})
+
+	o("traverse local admin groups", async function () {
+		// prepare test data...
+		// --------------------
+		const globalAdminGroup = createGroupAndGroupInfo(GroupType.Admin, "adminGroups", "globalAdminId", "globalAdminId", new Uint8Array())
+		const adminGroupKey: VersionedKey = {
+			object: [1, 2, 3],
+			version: 0,
+		}
+		const globalAdminUser = createTestEntity(UserTypeRef, {
+			customer: "someCustomerId",
+			memberships: [
+				createTestEntity(GroupMembershipTypeRef, {
+					group: globalAdminGroup.group._id,
+					groupType: GroupType.Admin,
+				}),
+			],
+		})
+		const customer = createTestEntity(CustomerTypeRef, {
+			_id: "someCustomerId",
+			adminGroup: globalAdminGroup.group._id,
+			teamGroups: "teamGroupsIds",
+		})
+
+		const administratedGroupsRefs = [
+			createTestEntity(AdministratedGroupsRefTypeRef, { items: "xs1" }),
+			createTestEntity(AdministratedGroupsRefTypeRef, { items: "xs2" }),
+		]
+
+		const localAdminGroup1 = createGroupAndGroupInfo(
+			GroupType.LocalAdmin,
+			customer.teamGroups,
+			"localAdminGroup1Id",
+			globalAdminGroup.group._id,
+			new Uint8Array(),
+		)
+		localAdminGroup1.group.administratedGroups = administratedGroupsRefs[0]
+
+		const localAdminGroup2 = createGroupAndGroupInfo(
+			GroupType.LocalAdmin,
+			customer.teamGroups,
+			"localAdminGroup2Id",
+			globalAdminGroup.group._id,
+			new Uint8Array(),
+		)
+		localAdminGroup2.group.administratedGroups = administratedGroupsRefs[1]
+
+		const userGroup1 = createGroupAndGroupInfo(GroupType.User, customer.userGroups, "u1", localAdminGroup1.group._id, new Uint8Array([1]))
+		const userGroup2 = createGroupAndGroupInfo(GroupType.User, customer.userGroups, "u2", localAdminGroup1.group._id, new Uint8Array([1, 2]))
+		const userGroup3 = createGroupAndGroupInfo(GroupType.User, customer.userGroups, "u3", localAdminGroup2.group._id, new Uint8Array([1, 2, 3]))
+
+		const administratedGroupsByLocalAdmins = [
+			createTestEntity(AdministratedGroupTypeRef, {
+				_id: ["xs1", "1"],
+				localAdminGroup: localAdminGroup1.group._id,
+				groupInfo: userGroup1.groupInfo._id,
+			}),
+			createTestEntity(AdministratedGroupTypeRef, {
+				_id: ["xs1", "2"],
+				localAdminGroup: localAdminGroup1.group._id,
+				groupInfo: userGroup2.groupInfo._id,
+			}),
+			createTestEntity(AdministratedGroupTypeRef, {
+				_id: ["xs2", "1"],
+				localAdminGroup: localAdminGroup2.group._id,
+				groupInfo: userGroup3.groupInfo._id,
+			}),
+		]
+
+		// mock body of the function
+		// -------------------------
+		when(userFacade.getLoggedInUser()).thenReturn(globalAdminUser)
+		when(entityClient.load(CustomerTypeRef, "someCustomerId")).thenResolve(customer)
+		when(entityClient.loadAll(GroupInfoTypeRef, "teamGroupsIds")).thenResolve([localAdminGroup1.groupInfo, localAdminGroup2.groupInfo])
+		when(keyLoaderFacade.getCurrentSymGroupKey("globalAdminId")).thenResolve(adminGroupKey) // const adminGroupKey = await this.keyLoaderFacade.getCurrentSymGroupKey(adminGroupId)
+
+		// inner loop loading administrated groups
+		// for the administrated groups of the first local admin
+		when(entityClient.loadAll(AdministratedGroupTypeRef, "xs1")).thenResolve([administratedGroupsByLocalAdmins[0], administratedGroupsByLocalAdmins[1]])
+		// for the administrated groups of the second local admin
+		when(entityClient.loadAll(AdministratedGroupTypeRef, "xs2")).thenResolve([administratedGroupsByLocalAdmins[2]])
+
+		// stubbing
+		const save = groupManagementFacade.getCurrentGroupKeyViaAdminEncGKey
+		groupManagementFacade.getCurrentGroupKeyViaAdminEncGKey = () => {
+			return object()
+		}
+		// when(groupManagementFacade.getCurrentGroupKeyViaAdminEncGKey("localAdminGroup1Id")).thenResolve(object())
+		// when(groupManagementFacade.getCurrentGroupKeyViaAdminEncGKey("localAdminGroup2Id")).thenResolve(object())
+
+		// now run mocked function
+		// -----------------------
+		await groupManagementFacade.migrateLocalAdminsToGlobalAdmins()
+
+		verify(
+			serviceExecutor.post(
+				LocalAdminRemovalService,
+				matchers.argThat((postIn: LocalAdminRemovalPostIn) => {
+					const userWithIds = postIn.groupUpdates.map((user) => user.groupId).sort()
+					o(userWithIds.sort()).deepEquals(["u1", "u2", "u3"])
+					return true
+				}),
+			),
+		)
+
+		groupManagementFacade.getCurrentGroupKeyViaAdminEncGKey = save
+	})
+
+	function createGroupAndGroupInfo(
+		groupType: GroupType,
+		groupInfoListId: string,
+		groupId: string,
+		adminGroup: string,
+		adminGroupEncGroupKey: Uint8Array,
+	): {
+		group: Group
+		groupInfo: GroupInfo
+	} {
+		const groupInfo = createTestEntity(GroupInfoTypeRef, { _id: [groupInfoListId, `groupInfo${groupId}`], groupType: groupType, group: groupId })
+		const group = createTestEntity(GroupTypeRef, {
+			type: groupType,
+			admin: adminGroup,
+			_id: groupId,
+			adminGroupEncGKey: adminGroupEncGroupKey,
+		})
+		when(entityClient.load(GroupTypeRef, groupId)).thenResolve(group)
+		when(entityClient.load(GroupInfoTypeRef, groupInfo._id)).thenResolve(groupInfo)
+
+		return { group, groupInfo }
+	}
 })

--- a/tuta-sdk/rust/sdk/src/entities/sys.rs
+++ b/tuta-sdk/rust/sdk/src/entities/sys.rs
@@ -77,6 +77,26 @@ impl Entity for AdminGroupKeyRotationPostIn {
 
 #[derive(uniffi::Record, Clone, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq, Debug))]
+pub struct AdministratedGroup {
+	pub _format: i64,
+	pub _id: IdTuple,
+	pub _ownerGroup: Option<GeneratedId>,
+	pub _permissions: GeneratedId,
+	pub groupType: i64,
+	pub groupInfo: IdTuple,
+	pub localAdminGroup: GeneratedId,
+}
+impl Entity for AdministratedGroup {
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "AdministratedGroup",
+		}
+	}
+}
+
+#[derive(uniffi::Record, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct AdministratedGroupsRef {
 	pub _id: CustomId,
 	pub items: GeneratedId,
@@ -2122,6 +2142,40 @@ impl Entity for KeyRotationsRef {
 		TypeRef {
 			app: "sys",
 			type_: "KeyRotationsRef",
+		}
+	}
+}
+
+#[derive(uniffi::Record, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub struct LocalAdminGroupReplacementData {
+	pub _id: CustomId,
+	#[serde(with = "serde_bytes")]
+	pub adminGroupEncGKey: Vec<u8>,
+	pub adminGroupKeyVersion: i64,
+	pub groupKeyVersion: i64,
+	pub groupId: GeneratedId,
+}
+impl Entity for LocalAdminGroupReplacementData {
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "LocalAdminGroupReplacementData",
+		}
+	}
+}
+
+#[derive(uniffi::Record, Clone, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq, Debug))]
+pub struct LocalAdminRemovalPostIn {
+	pub _format: i64,
+	pub groupUpdates: Vec<LocalAdminGroupReplacementData>,
+}
+impl Entity for LocalAdminRemovalPostIn {
+	fn type_ref() -> TypeRef {
+		TypeRef {
+			app: "sys",
+			type_: "LocalAdminRemovalPostIn",
 		}
 	}
 }

--- a/tuta-sdk/rust/sdk/src/entities/tutanota.rs
+++ b/tuta-sdk/rust/sdk/src/entities/tutanota.rs
@@ -42,7 +42,7 @@ impl Entity for Birthday {
 #[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct Body {
 	pub _id: CustomId,
-	pub compressedText: Option<Vec<u8>>,
+	pub compressedText: Option<String>,
 	pub text: Option<String>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }
@@ -809,7 +809,7 @@ impl Entity for DraftCreateReturn {
 pub struct DraftData {
 	pub _id: CustomId,
 	pub bodyText: String,
-	pub compressedBodyText: Option<Vec<u8>>,
+	pub compressedBodyText: Option<String>,
 	pub confidential: bool,
 	pub method: i64,
 	pub senderMailAddress: String,
@@ -1158,7 +1158,7 @@ impl Entity for GroupSettings {
 #[cfg_attr(test, derive(PartialEq, Debug))]
 pub struct Header {
 	pub _id: CustomId,
-	pub compressedHeaders: Option<Vec<u8>>,
+	pub compressedHeaders: Option<String>,
 	pub headers: Option<String>,
 	pub _finalIvs: HashMap<String, FinalIv>,
 }

--- a/tuta-sdk/rust/sdk/src/services/monitor.rs
+++ b/tuta-sdk/rust/sdk/src/services/monitor.rs
@@ -12,7 +12,7 @@ use crate::services::{
 use crate::ApiCallError;
 pub struct CounterService;
 
-crate::service_impl!(declare, CounterService, "monitor/counterservice", 28);
+crate::service_impl!(declare, CounterService, "monitor/counterservice", 29);
 crate::service_impl!(POST, CounterService, WriteCounterData, ());
 crate::service_impl!(GET, CounterService, ReadCounterData, ReadCounterReturn);
 
@@ -22,6 +22,6 @@ crate::service_impl!(
 	declare,
 	ReportErrorService,
 	"monitor/reporterrorservice",
-	28
+	29
 );
 crate::service_impl!(POST, ReportErrorService, ReportErrorIn, ());

--- a/tuta-sdk/rust/sdk/src/services/sys.rs
+++ b/tuta-sdk/rust/sdk/src/services/sys.rs
@@ -37,6 +37,7 @@ use crate::entities::sys::GroupKeyRotationInfoGetOut;
 use crate::entities::sys::GroupKeyRotationPostIn;
 use crate::entities::sys::InvoiceDataGetIn;
 use crate::entities::sys::InvoiceDataGetOut;
+use crate::entities::sys::LocalAdminRemovalPostIn;
 use crate::entities::sys::LocationServiceGetReturn;
 use crate::entities::sys::MailAddressAliasGetIn;
 use crate::entities::sys::MailAddressAliasServiceData;
@@ -100,7 +101,7 @@ crate::service_impl!(
 	declare,
 	AdminGroupKeyRotationService,
 	"sys/admingroupkeyrotationservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -115,7 +116,7 @@ crate::service_impl!(
 	declare,
 	AffiliatePartnerKpiService,
 	"sys/affiliatepartnerkpiservice",
-	111
+	113
 );
 crate::service_impl!(
 	GET,
@@ -126,12 +127,12 @@ crate::service_impl!(
 
 pub struct AlarmService;
 
-crate::service_impl!(declare, AlarmService, "sys/alarmservice", 111);
+crate::service_impl!(declare, AlarmService, "sys/alarmservice", 113);
 crate::service_impl!(POST, AlarmService, AlarmServicePost, ());
 
 pub struct AutoLoginService;
 
-crate::service_impl!(declare, AutoLoginService, "sys/autologinservice", 111);
+crate::service_impl!(declare, AutoLoginService, "sys/autologinservice", 113);
 crate::service_impl!(
 	POST,
 	AutoLoginService,
@@ -147,7 +148,7 @@ crate::service_impl!(
 	declare,
 	BrandingDomainService,
 	"sys/brandingdomainservice",
-	111
+	113
 );
 crate::service_impl!(POST, BrandingDomainService, BrandingDomainData, ());
 crate::service_impl!(GET, BrandingDomainService, (), BrandingDomainGetReturn);
@@ -156,7 +157,7 @@ crate::service_impl!(DELETE, BrandingDomainService, BrandingDomainDeleteData, ()
 
 pub struct ChangeKdfService;
 
-crate::service_impl!(declare, ChangeKdfService, "sys/changekdfservice", 111);
+crate::service_impl!(declare, ChangeKdfService, "sys/changekdfservice", 113);
 crate::service_impl!(POST, ChangeKdfService, ChangeKdfPostIn, ());
 
 pub struct ChangePasswordService;
@@ -165,13 +166,13 @@ crate::service_impl!(
 	declare,
 	ChangePasswordService,
 	"sys/changepasswordservice",
-	111
+	113
 );
 crate::service_impl!(POST, ChangePasswordService, ChangePasswordPostIn, ());
 
 pub struct CloseSessionService;
 
-crate::service_impl!(declare, CloseSessionService, "sys/closesessionservice", 111);
+crate::service_impl!(declare, CloseSessionService, "sys/closesessionservice", 113);
 crate::service_impl!(POST, CloseSessionService, CloseSessionServicePost, ());
 
 pub struct CreateCustomerServerProperties;
@@ -180,7 +181,7 @@ crate::service_impl!(
 	declare,
 	CreateCustomerServerProperties,
 	"sys/createcustomerserverproperties",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -195,7 +196,7 @@ crate::service_impl!(
 	declare,
 	CustomDomainCheckService,
 	"sys/customdomaincheckservice",
-	111
+	113
 );
 crate::service_impl!(
 	GET,
@@ -206,7 +207,7 @@ crate::service_impl!(
 
 pub struct CustomDomainService;
 
-crate::service_impl!(declare, CustomDomainService, "sys/customdomainservice", 111);
+crate::service_impl!(declare, CustomDomainService, "sys/customdomainservice", 113);
 crate::service_impl!(
 	POST,
 	CustomDomainService,
@@ -222,7 +223,7 @@ crate::service_impl!(
 	declare,
 	CustomerAccountTerminationService,
 	"sys/customeraccountterminationservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -237,18 +238,18 @@ crate::service_impl!(
 	declare,
 	CustomerPublicKeyService,
 	"sys/customerpublickeyservice",
-	111
+	113
 );
 crate::service_impl!(GET, CustomerPublicKeyService, (), PublicKeyGetOut);
 
 pub struct CustomerService;
 
-crate::service_impl!(declare, CustomerService, "sys/customerservice", 111);
+crate::service_impl!(declare, CustomerService, "sys/customerservice", 113);
 crate::service_impl!(DELETE, CustomerService, DeleteCustomerData, ());
 
 pub struct DebitService;
 
-crate::service_impl!(declare, DebitService, "sys/debitservice", 111);
+crate::service_impl!(declare, DebitService, "sys/debitservice", 113);
 crate::service_impl!(PUT, DebitService, DebitServicePutData, ());
 
 pub struct DomainMailAddressAvailabilityService;
@@ -257,7 +258,7 @@ crate::service_impl!(
 	declare,
 	DomainMailAddressAvailabilityService,
 	"sys/domainmailaddressavailabilityservice",
-	111
+	113
 );
 crate::service_impl!(
 	GET,
@@ -272,7 +273,7 @@ crate::service_impl!(
 	declare,
 	ExternalPropertiesService,
 	"sys/externalpropertiesservice",
-	111
+	113
 );
 crate::service_impl!(GET, ExternalPropertiesService, (), ExternalPropertiesReturn);
 
@@ -282,7 +283,7 @@ crate::service_impl!(
 	declare,
 	GiftCardRedeemService,
 	"sys/giftcardredeemservice",
-	111
+	113
 );
 crate::service_impl!(POST, GiftCardRedeemService, GiftCardRedeemData, ());
 crate::service_impl!(
@@ -294,7 +295,7 @@ crate::service_impl!(
 
 pub struct GiftCardService;
 
-crate::service_impl!(declare, GiftCardService, "sys/giftcardservice", 111);
+crate::service_impl!(declare, GiftCardService, "sys/giftcardservice", 113);
 crate::service_impl!(
 	POST,
 	GiftCardService,
@@ -310,7 +311,7 @@ crate::service_impl!(
 	declare,
 	GroupKeyRotationInfoService,
 	"sys/groupkeyrotationinfoservice",
-	111
+	113
 );
 crate::service_impl!(
 	GET,
@@ -325,18 +326,28 @@ crate::service_impl!(
 	declare,
 	GroupKeyRotationService,
 	"sys/groupkeyrotationservice",
-	111
+	113
 );
 crate::service_impl!(POST, GroupKeyRotationService, GroupKeyRotationPostIn, ());
 
 pub struct InvoiceDataService;
 
-crate::service_impl!(declare, InvoiceDataService, "sys/invoicedataservice", 111);
+crate::service_impl!(declare, InvoiceDataService, "sys/invoicedataservice", 113);
 crate::service_impl!(GET, InvoiceDataService, InvoiceDataGetIn, InvoiceDataGetOut);
+
+pub struct LocalAdminRemovalService;
+
+crate::service_impl!(
+	declare,
+	LocalAdminRemovalService,
+	"sys/localadminremovalservice",
+	113
+);
+crate::service_impl!(POST, LocalAdminRemovalService, LocalAdminRemovalPostIn, ());
 
 pub struct LocationService;
 
-crate::service_impl!(declare, LocationService, "sys/locationservice", 111);
+crate::service_impl!(declare, LocationService, "sys/locationservice", 113);
 crate::service_impl!(GET, LocationService, (), LocationServiceGetReturn);
 
 pub struct MailAddressAliasService;
@@ -345,7 +356,7 @@ crate::service_impl!(
 	declare,
 	MailAddressAliasService,
 	"sys/mailaddressaliasservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -368,7 +379,7 @@ crate::service_impl!(
 
 pub struct MembershipService;
 
-crate::service_impl!(declare, MembershipService, "sys/membershipservice", 111);
+crate::service_impl!(declare, MembershipService, "sys/membershipservice", 113);
 crate::service_impl!(POST, MembershipService, MembershipAddData, ());
 crate::service_impl!(PUT, MembershipService, MembershipPutIn, ());
 crate::service_impl!(DELETE, MembershipService, MembershipRemoveData, ());
@@ -379,7 +390,7 @@ crate::service_impl!(
 	declare,
 	MultipleMailAddressAvailabilityService,
 	"sys/multiplemailaddressavailabilityservice",
-	111
+	113
 );
 crate::service_impl!(
 	GET,
@@ -390,7 +401,7 @@ crate::service_impl!(
 
 pub struct PaymentDataService;
 
-crate::service_impl!(declare, PaymentDataService, "sys/paymentdataservice", 111);
+crate::service_impl!(declare, PaymentDataService, "sys/paymentdataservice", 113);
 crate::service_impl!(POST, PaymentDataService, PaymentDataServicePostData, ());
 crate::service_impl!(
 	GET,
@@ -407,23 +418,23 @@ crate::service_impl!(
 
 pub struct PlanService;
 
-crate::service_impl!(declare, PlanService, "sys/planservice", 111);
+crate::service_impl!(declare, PlanService, "sys/planservice", 113);
 crate::service_impl!(GET, PlanService, (), PlanServiceGetOut);
 
 pub struct PriceService;
 
-crate::service_impl!(declare, PriceService, "sys/priceservice", 111);
+crate::service_impl!(declare, PriceService, "sys/priceservice", 113);
 crate::service_impl!(GET, PriceService, PriceServiceData, PriceServiceReturn);
 
 pub struct PublicKeyService;
 
-crate::service_impl!(declare, PublicKeyService, "sys/publickeyservice", 111);
+crate::service_impl!(declare, PublicKeyService, "sys/publickeyservice", 113);
 crate::service_impl!(GET, PublicKeyService, PublicKeyGetIn, PublicKeyGetOut);
 crate::service_impl!(PUT, PublicKeyService, PublicKeyPutIn, ());
 
 pub struct ReferralCodeService;
 
-crate::service_impl!(declare, ReferralCodeService, "sys/referralcodeservice", 111);
+crate::service_impl!(declare, ReferralCodeService, "sys/referralcodeservice", 113);
 crate::service_impl!(
 	POST,
 	ReferralCodeService,
@@ -438,7 +449,7 @@ crate::service_impl!(
 	declare,
 	RegistrationCaptchaService,
 	"sys/registrationcaptchaservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -455,7 +466,7 @@ crate::service_impl!(
 
 pub struct RegistrationService;
 
-crate::service_impl!(declare, RegistrationService, "sys/registrationservice", 111);
+crate::service_impl!(declare, RegistrationService, "sys/registrationservice", 113);
 crate::service_impl!(
 	POST,
 	RegistrationService,
@@ -466,7 +477,7 @@ crate::service_impl!(GET, RegistrationService, (), RegistrationServiceData);
 
 pub struct ResetFactorsService;
 
-crate::service_impl!(declare, ResetFactorsService, "sys/resetfactorsservice", 111);
+crate::service_impl!(declare, ResetFactorsService, "sys/resetfactorsservice", 113);
 crate::service_impl!(DELETE, ResetFactorsService, ResetFactorsDeleteData, ());
 
 pub struct ResetPasswordService;
@@ -475,13 +486,13 @@ crate::service_impl!(
 	declare,
 	ResetPasswordService,
 	"sys/resetpasswordservice",
-	111
+	113
 );
 crate::service_impl!(POST, ResetPasswordService, ResetPasswordPostIn, ());
 
 pub struct SaltService;
 
-crate::service_impl!(declare, SaltService, "sys/saltservice", 111);
+crate::service_impl!(declare, SaltService, "sys/saltservice", 113);
 crate::service_impl!(GET, SaltService, SaltData, SaltReturn);
 
 pub struct SecondFactorAuthAllowedService;
@@ -490,7 +501,7 @@ crate::service_impl!(
 	declare,
 	SecondFactorAuthAllowedService,
 	"sys/secondfactorauthallowedservice",
-	111
+	113
 );
 crate::service_impl!(
 	GET,
@@ -505,7 +516,7 @@ crate::service_impl!(
 	declare,
 	SecondFactorAuthService,
 	"sys/secondfactorauthservice",
-	111
+	113
 );
 crate::service_impl!(POST, SecondFactorAuthService, SecondFactorAuthData, ());
 crate::service_impl!(
@@ -523,7 +534,7 @@ crate::service_impl!(
 
 pub struct SessionService;
 
-crate::service_impl!(declare, SessionService, "sys/sessionservice", 111);
+crate::service_impl!(declare, SessionService, "sys/sessionservice", 113);
 crate::service_impl!(POST, SessionService, CreateSessionData, CreateSessionReturn);
 
 pub struct SignOrderProcessingAgreementService;
@@ -532,7 +543,7 @@ crate::service_impl!(
 	declare,
 	SignOrderProcessingAgreementService,
 	"sys/signorderprocessingagreementservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -547,13 +558,13 @@ crate::service_impl!(
 	declare,
 	SwitchAccountTypeService,
 	"sys/switchaccounttypeservice",
-	111
+	113
 );
 crate::service_impl!(POST, SwitchAccountTypeService, SwitchAccountTypePostIn, ());
 
 pub struct SystemKeysService;
 
-crate::service_impl!(declare, SystemKeysService, "sys/systemkeysservice", 111);
+crate::service_impl!(declare, SystemKeysService, "sys/systemkeysservice", 113);
 crate::service_impl!(GET, SystemKeysService, (), SystemKeysReturn);
 
 pub struct TakeOverDeletedAddressService;
@@ -562,7 +573,7 @@ crate::service_impl!(
 	declare,
 	TakeOverDeletedAddressService,
 	"sys/takeoverdeletedaddressservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -577,7 +588,7 @@ crate::service_impl!(
 	declare,
 	UpdatePermissionKeyService,
 	"sys/updatepermissionkeyservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -592,13 +603,13 @@ crate::service_impl!(
 	declare,
 	UpdateSessionKeysService,
 	"sys/updatesessionkeysservice",
-	111
+	113
 );
 crate::service_impl!(POST, UpdateSessionKeysService, UpdateSessionKeysPostIn, ());
 
 pub struct UpgradePriceService;
 
-crate::service_impl!(declare, UpgradePriceService, "sys/upgradepriceservice", 111);
+crate::service_impl!(declare, UpgradePriceService, "sys/upgradepriceservice", 113);
 crate::service_impl!(
 	GET,
 	UpgradePriceService,
@@ -612,7 +623,7 @@ crate::service_impl!(
 	declare,
 	UserGroupKeyRotationService,
 	"sys/usergroupkeyrotationservice",
-	111
+	113
 );
 crate::service_impl!(
 	POST,
@@ -623,10 +634,10 @@ crate::service_impl!(
 
 pub struct UserService;
 
-crate::service_impl!(declare, UserService, "sys/userservice", 111);
+crate::service_impl!(declare, UserService, "sys/userservice", 113);
 crate::service_impl!(DELETE, UserService, UserDataDelete, ());
 
 pub struct VersionService;
 
-crate::service_impl!(declare, VersionService, "sys/versionservice", 111);
+crate::service_impl!(declare, VersionService, "sys/versionservice", 113);
 crate::service_impl!(GET, VersionService, VersionData, VersionReturn);

--- a/tuta-sdk/rust/sdk/src/services/tutanota.rs
+++ b/tuta-sdk/rust/sdk/src/services/tutanota.rs
@@ -1,4 +1,5 @@
 #![allow(unused_imports, dead_code, unused_variables)]
+use crate::entities::tutanota::CalendarDeleteData;
 use crate::entities::tutanota::CreateGroupPostReturn;
 use crate::entities::tutanota::CreateMailFolderData;
 use crate::entities::tutanota::CreateMailFolderReturn;
@@ -26,13 +27,14 @@ use crate::entities::tutanota::ReceiveInfoServiceData;
 use crate::entities::tutanota::ReportMailPostData;
 use crate::entities::tutanota::SendDraftData;
 use crate::entities::tutanota::SendDraftReturn;
+use crate::entities::tutanota::SimpleMoveMailPostIn;
 use crate::entities::tutanota::TranslationGetIn;
 use crate::entities::tutanota::TranslationGetOut;
+use crate::entities::tutanota::UnreadMailStatePostIn;
 use crate::entities::tutanota::UpdateMailFolderData;
 use crate::entities::tutanota::UserAccountCreateData;
 use crate::entities::tutanota::UserAreaGroupDeleteData;
 use crate::entities::tutanota::UserAreaGroupPostData;
-use crate::entities::tutanota::{CalendarDeleteData, SimpleMoveMailPostIn, UnreadMailStatePostIn};
 use crate::entities::Entity;
 use crate::rest_client::HttpMethod;
 use crate::services::hidden::Nothing;
@@ -42,7 +44,7 @@ use crate::services::{
 use crate::ApiCallError;
 pub struct CalendarService;
 
-crate::service_impl!(declare, CalendarService, "tutanota/calendarservice", 75);
+crate::service_impl!(declare, CalendarService, "tutanota/calendarservice", 76);
 crate::service_impl!(
 	POST,
 	CalendarService,
@@ -57,7 +59,7 @@ crate::service_impl!(
 	declare,
 	ContactListGroupService,
 	"tutanota/contactlistgroupservice",
-	75
+	76
 );
 crate::service_impl!(
 	POST,
@@ -73,13 +75,13 @@ crate::service_impl!(
 	declare,
 	CustomerAccountService,
 	"tutanota/customeraccountservice",
-	75
+	76
 );
 crate::service_impl!(POST, CustomerAccountService, CustomerAccountCreateData, ());
 
 pub struct DraftService;
 
-crate::service_impl!(declare, DraftService, "tutanota/draftservice", 75);
+crate::service_impl!(declare, DraftService, "tutanota/draftservice", 76);
 crate::service_impl!(POST, DraftService, DraftCreateData, DraftCreateReturn);
 crate::service_impl!(PUT, DraftService, DraftUpdateData, DraftUpdateReturn);
 
@@ -89,7 +91,7 @@ crate::service_impl!(
 	declare,
 	EncryptTutanotaPropertiesService,
 	"tutanota/encrypttutanotapropertiesservice",
-	75
+	76
 );
 crate::service_impl!(
 	POST,
@@ -100,7 +102,7 @@ crate::service_impl!(
 
 pub struct EntropyService;
 
-crate::service_impl!(declare, EntropyService, "tutanota/entropyservice", 75);
+crate::service_impl!(declare, EntropyService, "tutanota/entropyservice", 76);
 crate::service_impl!(PUT, EntropyService, EntropyData, ());
 
 pub struct ExternalUserService;
@@ -109,7 +111,7 @@ crate::service_impl!(
 	declare,
 	ExternalUserService,
 	"tutanota/externaluserservice",
-	75
+	76
 );
 crate::service_impl!(POST, ExternalUserService, ExternalUserData, ());
 
@@ -119,7 +121,7 @@ crate::service_impl!(
 	declare,
 	GroupInvitationService,
 	"tutanota/groupinvitationservice",
-	75
+	76
 );
 crate::service_impl!(
 	POST,
@@ -141,13 +143,13 @@ crate::service_impl!(
 	declare,
 	ListUnsubscribeService,
 	"tutanota/listunsubscribeservice",
-	75
+	76
 );
 crate::service_impl!(POST, ListUnsubscribeService, ListUnsubscribeData, ());
 
 pub struct MailFolderService;
 
-crate::service_impl!(declare, MailFolderService, "tutanota/mailfolderservice", 75);
+crate::service_impl!(declare, MailFolderService, "tutanota/mailfolderservice", 76);
 crate::service_impl!(
 	POST,
 	MailFolderService,
@@ -159,23 +161,23 @@ crate::service_impl!(DELETE, MailFolderService, DeleteMailFolderData, ());
 
 pub struct MailGroupService;
 
-crate::service_impl!(declare, MailGroupService, "tutanota/mailgroupservice", 75);
+crate::service_impl!(declare, MailGroupService, "tutanota/mailgroupservice", 76);
 crate::service_impl!(POST, MailGroupService, CreateMailGroupData, ());
 crate::service_impl!(DELETE, MailGroupService, DeleteGroupData, ());
 
 pub struct MailService;
 
-crate::service_impl!(declare, MailService, "tutanota/mailservice", 75);
+crate::service_impl!(declare, MailService, "tutanota/mailservice", 76);
 crate::service_impl!(DELETE, MailService, DeleteMailData, ());
 
 pub struct MoveMailService;
 
-crate::service_impl!(declare, MoveMailService, "tutanota/movemailservice", 75);
+crate::service_impl!(declare, MoveMailService, "tutanota/movemailservice", 76);
 crate::service_impl!(POST, MoveMailService, MoveMailData, ());
 
 pub struct NewsService;
 
-crate::service_impl!(declare, NewsService, "tutanota/newsservice", 75);
+crate::service_impl!(declare, NewsService, "tutanota/newsservice", 76);
 crate::service_impl!(POST, NewsService, NewsIn, ());
 crate::service_impl!(GET, NewsService, (), NewsOut);
 
@@ -185,19 +187,29 @@ crate::service_impl!(
 	declare,
 	ReceiveInfoService,
 	"tutanota/receiveinfoservice",
-	75
+	76
 );
 crate::service_impl!(POST, ReceiveInfoService, ReceiveInfoServiceData, ());
 
 pub struct ReportMailService;
 
-crate::service_impl!(declare, ReportMailService, "tutanota/reportmailservice", 75);
+crate::service_impl!(declare, ReportMailService, "tutanota/reportmailservice", 76);
 crate::service_impl!(POST, ReportMailService, ReportMailPostData, ());
 
 pub struct SendDraftService;
 
-crate::service_impl!(declare, SendDraftService, "tutanota/senddraftservice", 75);
+crate::service_impl!(declare, SendDraftService, "tutanota/senddraftservice", 76);
 crate::service_impl!(POST, SendDraftService, SendDraftData, SendDraftReturn);
+
+pub struct SimpleMoveMailService;
+
+crate::service_impl!(
+	declare,
+	SimpleMoveMailService,
+	"tutanota/simplemovemailservice",
+	76
+);
+crate::service_impl!(POST, SimpleMoveMailService, SimpleMoveMailPostIn, ());
 
 pub struct TemplateGroupService;
 
@@ -205,7 +217,7 @@ crate::service_impl!(
 	declare,
 	TemplateGroupService,
 	"tutanota/templategroupservice",
-	75
+	76
 );
 crate::service_impl!(
 	POST,
@@ -221,29 +233,9 @@ crate::service_impl!(
 	declare,
 	TranslationService,
 	"tutanota/translationservice",
-	75
-);
-crate::service_impl!(GET, TranslationService, TranslationGetIn, TranslationGetOut);
-
-pub struct UserAccountService;
-
-crate::service_impl!(
-	declare,
-	UserAccountService,
-	"tutanota/useraccountservice",
-	75
-);
-crate::service_impl!(POST, UserAccountService, UserAccountCreateData, ());
-
-pub struct SimpleMoveMailService;
-
-crate::service_impl!(
-	declare,
-	SimpleMoveMailService,
-	"tutanota/simplemovemailservice",
 	76
 );
-crate::service_impl!(POST, SimpleMoveMailService, SimpleMoveMailPostIn, ());
+crate::service_impl!(GET, TranslationService, TranslationGetIn, TranslationGetOut);
 
 pub struct UnreadMailStateService;
 
@@ -254,3 +246,13 @@ crate::service_impl!(
 	76
 );
 crate::service_impl!(POST, UnreadMailStateService, UnreadMailStatePostIn, ());
+
+pub struct UserAccountService;
+
+crate::service_impl!(
+	declare,
+	UserAccountService,
+	"tutanota/useraccountservice",
+	76
+);
+crate::service_impl!(POST, UserAccountService, UserAccountCreateData, ());

--- a/tuta-sdk/rust/sdk/src/type_models/sys.json
+++ b/tuta-sdk/rust/sdk/src/type_models/sys.json
@@ -212,7 +212,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AdminGroupKeyAuthenticationData": {
 		"name": "AdminGroupKeyAuthenticationData",
@@ -264,7 +264,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AdminGroupKeyRotationPostIn": {
 		"name": "AdminGroupKeyRotationPostIn",
@@ -318,7 +318,87 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
+	},
+	"AdministratedGroup": {
+		"name": "AdministratedGroup",
+		"since": 27,
+		"type": "LIST_ELEMENT_TYPE",
+		"id": 1294,
+		"rootId": "A3N5cwAFDg",
+		"versioned": false,
+		"encrypted": false,
+		"values": {
+			"_format": {
+				"final": false,
+				"name": "_format",
+				"id": 1298,
+				"since": 27,
+				"type": "Number",
+				"cardinality": "One",
+				"encrypted": false
+			},
+			"_id": {
+				"final": true,
+				"name": "_id",
+				"id": 1296,
+				"since": 27,
+				"type": "GeneratedId",
+				"cardinality": "One",
+				"encrypted": false
+			},
+			"_ownerGroup": {
+				"final": true,
+				"name": "_ownerGroup",
+				"id": 1299,
+				"since": 27,
+				"type": "GeneratedId",
+				"cardinality": "ZeroOrOne",
+				"encrypted": false
+			},
+			"_permissions": {
+				"final": true,
+				"name": "_permissions",
+				"id": 1297,
+				"since": 27,
+				"type": "GeneratedId",
+				"cardinality": "One",
+				"encrypted": false
+			},
+			"groupType": {
+				"final": true,
+				"name": "groupType",
+				"id": 1300,
+				"since": 27,
+				"type": "Number",
+				"cardinality": "One",
+				"encrypted": false
+			}
+		},
+		"associations": {
+			"groupInfo": {
+				"final": false,
+				"name": "groupInfo",
+				"id": 1301,
+				"since": 27,
+				"type": "LIST_ELEMENT_ASSOCIATION",
+				"cardinality": "One",
+				"refType": "GroupInfo",
+				"dependency": null
+			},
+			"localAdminGroup": {
+				"final": false,
+				"name": "localAdminGroup",
+				"id": 1302,
+				"since": 27,
+				"type": "ELEMENT_ASSOCIATION",
+				"cardinality": "One",
+				"refType": "Group",
+				"dependency": null
+			}
+		},
+		"app": "sys",
+		"version": "113"
 	},
 	"AdministratedGroupsRef": {
 		"name": "AdministratedGroupsRef",
@@ -352,7 +432,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AffiliatePartnerKpiMonthSummary": {
 		"name": "AffiliatePartnerKpiMonthSummary",
@@ -429,7 +509,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AffiliatePartnerKpiServiceGetOut": {
 		"name": "AffiliatePartnerKpiServiceGetOut",
@@ -490,7 +570,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AlarmInfo": {
 		"name": "AlarmInfo",
@@ -542,7 +622,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AlarmNotification": {
 		"name": "AlarmNotification",
@@ -642,7 +722,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AlarmServicePost": {
 		"name": "AlarmServicePost",
@@ -676,7 +756,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ArchiveRef": {
 		"name": "ArchiveRef",
@@ -708,7 +788,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ArchiveType": {
 		"name": "ArchiveType",
@@ -762,7 +842,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AuditLogEntry": {
 		"name": "AuditLogEntry",
@@ -896,7 +976,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AuditLogRef": {
 		"name": "AuditLogRef",
@@ -930,7 +1010,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AuthenticatedDevice": {
 		"name": "AuthenticatedDevice",
@@ -980,7 +1060,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Authentication": {
 		"name": "Authentication",
@@ -1041,7 +1121,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AutoLoginDataDelete": {
 		"name": "AutoLoginDataDelete",
@@ -1073,7 +1153,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AutoLoginDataGet": {
 		"name": "AutoLoginDataGet",
@@ -1116,7 +1196,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AutoLoginDataReturn": {
 		"name": "AutoLoginDataReturn",
@@ -1148,7 +1228,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"AutoLoginPostReturn": {
 		"name": "AutoLoginPostReturn",
@@ -1180,7 +1260,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Blob": {
 		"name": "Blob",
@@ -1230,7 +1310,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BlobReferenceTokenWrapper": {
 		"name": "BlobReferenceTokenWrapper",
@@ -1262,7 +1342,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Booking": {
 		"name": "Booking",
@@ -1386,7 +1466,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BookingItem": {
 		"name": "BookingItem",
@@ -1472,7 +1552,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BookingsRef": {
 		"name": "BookingsRef",
@@ -1506,7 +1586,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BootstrapFeature": {
 		"name": "BootstrapFeature",
@@ -1538,7 +1618,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Braintree3ds2Request": {
 		"name": "Braintree3ds2Request",
@@ -1588,7 +1668,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Braintree3ds2Response": {
 		"name": "Braintree3ds2Response",
@@ -1629,7 +1709,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BrandingDomainData": {
 		"name": "BrandingDomainData",
@@ -1706,7 +1786,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BrandingDomainDeleteData": {
 		"name": "BrandingDomainDeleteData",
@@ -1738,7 +1818,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BrandingDomainGetReturn": {
 		"name": "BrandingDomainGetReturn",
@@ -1772,7 +1852,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Bucket": {
 		"name": "Bucket",
@@ -1806,7 +1886,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BucketKey": {
 		"name": "BucketKey",
@@ -1895,7 +1975,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"BucketPermission": {
 		"name": "BucketPermission",
@@ -2037,7 +2117,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CalendarEventRef": {
 		"name": "CalendarEventRef",
@@ -2078,7 +2158,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CertificateInfo": {
 		"name": "CertificateInfo",
@@ -2139,7 +2219,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Challenge": {
 		"name": "Challenge",
@@ -2192,7 +2272,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ChangeKdfPostIn": {
 		"name": "ChangeKdfPostIn",
@@ -2269,7 +2349,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ChangePasswordPostIn": {
 		"name": "ChangePasswordPostIn",
@@ -2364,7 +2444,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Chat": {
 		"name": "Chat",
@@ -2414,7 +2494,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CloseSessionServicePost": {
 		"name": "CloseSessionServicePost",
@@ -2457,7 +2537,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CreateCustomerServerPropertiesData": {
 		"name": "CreateCustomerServerPropertiesData",
@@ -2498,7 +2578,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CreateCustomerServerPropertiesReturn": {
 		"name": "CreateCustomerServerPropertiesReturn",
@@ -2532,7 +2612,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CreateSessionData": {
 		"name": "CreateSessionData",
@@ -2620,7 +2700,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CreateSessionReturn": {
 		"name": "CreateSessionReturn",
@@ -2673,7 +2753,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CreditCard": {
 		"name": "CreditCard",
@@ -2741,7 +2821,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomDomainCheckGetIn": {
 		"name": "CustomDomainCheckGetIn",
@@ -2784,7 +2864,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomDomainCheckGetOut": {
 		"name": "CustomDomainCheckGetOut",
@@ -2847,7 +2927,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomDomainData": {
 		"name": "CustomDomainData",
@@ -2890,7 +2970,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomDomainReturn": {
 		"name": "CustomDomainReturn",
@@ -2933,7 +3013,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Customer": {
 		"name": "Customer",
@@ -3190,7 +3270,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomerAccountTerminationPostIn": {
 		"name": "CustomerAccountTerminationPostIn",
@@ -3233,7 +3313,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomerAccountTerminationPostOut": {
 		"name": "CustomerAccountTerminationPostOut",
@@ -3267,7 +3347,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomerAccountTerminationRequest": {
 		"name": "CustomerAccountTerminationRequest",
@@ -3346,7 +3426,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomerInfo": {
 		"name": "CustomerInfo",
@@ -3659,7 +3739,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomerProperties": {
 		"name": "CustomerProperties",
@@ -3767,7 +3847,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"CustomerServerProperties": {
 		"name": "CustomerServerProperties",
@@ -3883,7 +3963,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"DateWrapper": {
 		"name": "DateWrapper",
@@ -3915,7 +3995,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"DebitServicePutData": {
 		"name": "DebitServicePutData",
@@ -3949,7 +4029,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"DeleteCustomerData": {
 		"name": "DeleteCustomerData",
@@ -4029,7 +4109,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"DnsRecord": {
 		"name": "DnsRecord",
@@ -4079,7 +4159,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"DomainInfo": {
 		"name": "DomainInfo",
@@ -4141,7 +4221,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"DomainMailAddressAvailabilityData": {
 		"name": "DomainMailAddressAvailabilityData",
@@ -4173,7 +4253,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"DomainMailAddressAvailabilityReturn": {
 		"name": "DomainMailAddressAvailabilityReturn",
@@ -4205,7 +4285,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"EmailSenderListElement": {
 		"name": "EmailSenderListElement",
@@ -4264,7 +4344,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"EntityEventBatch": {
 		"name": "EntityEventBatch",
@@ -4325,7 +4405,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"EntityUpdate": {
 		"name": "EntityUpdate",
@@ -4393,7 +4473,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Exception": {
 		"name": "Exception",
@@ -4434,7 +4514,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ExternalPropertiesReturn": {
 		"name": "ExternalPropertiesReturn",
@@ -4496,7 +4576,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ExternalUserReference": {
 		"name": "ExternalUserReference",
@@ -4567,7 +4647,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Feature": {
 		"name": "Feature",
@@ -4599,7 +4679,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"File": {
 		"name": "File",
@@ -4649,7 +4729,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GeneratedIdWrapper": {
 		"name": "GeneratedIdWrapper",
@@ -4681,7 +4761,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCard": {
 		"name": "GiftCard",
@@ -4794,7 +4874,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardCreateData": {
 		"name": "GiftCardCreateData",
@@ -4862,7 +4942,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardCreateReturn": {
 		"name": "GiftCardCreateReturn",
@@ -4896,7 +4976,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardDeleteData": {
 		"name": "GiftCardDeleteData",
@@ -4930,7 +5010,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardGetReturn": {
 		"name": "GiftCardGetReturn",
@@ -4982,7 +5062,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardOption": {
 		"name": "GiftCardOption",
@@ -5014,7 +5094,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardRedeemData": {
 		"name": "GiftCardRedeemData",
@@ -5066,7 +5146,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardRedeemGetReturn": {
 		"name": "GiftCardRedeemGetReturn",
@@ -5118,7 +5198,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GiftCardsRef": {
 		"name": "GiftCardsRef",
@@ -5152,7 +5232,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Group": {
 		"name": "Group",
@@ -5377,7 +5457,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupInfo": {
 		"name": "GroupInfo",
@@ -5530,7 +5610,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKey": {
 		"name": "GroupKey",
@@ -5637,7 +5717,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKeyRotationData": {
 		"name": "GroupKeyRotationData",
@@ -5737,7 +5817,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKeyRotationInfoGetOut": {
 		"name": "GroupKeyRotationInfoGetOut",
@@ -5780,7 +5860,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKeyRotationPostIn": {
 		"name": "GroupKeyRotationPostIn",
@@ -5814,7 +5894,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKeyUpdate": {
 		"name": "GroupKeyUpdate",
@@ -5911,7 +5991,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKeyUpdateData": {
 		"name": "GroupKeyUpdateData",
@@ -5972,7 +6052,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKeyUpdatesRef": {
 		"name": "GroupKeyUpdatesRef",
@@ -6006,7 +6086,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupKeysRef": {
 		"name": "GroupKeysRef",
@@ -6040,7 +6120,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupMember": {
 		"name": "GroupMember",
@@ -6130,7 +6210,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupMembership": {
 		"name": "GroupMembership",
@@ -6238,7 +6318,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupMembershipKeyData": {
 		"name": "GroupMembershipKeyData",
@@ -6299,7 +6379,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupMembershipUpdateData": {
 		"name": "GroupMembershipUpdateData",
@@ -6351,7 +6431,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"GroupRoot": {
 		"name": "GroupRoot",
@@ -6432,7 +6512,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"IdTupleWrapper": {
 		"name": "IdTupleWrapper",
@@ -6473,7 +6553,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"InstanceSessionKey": {
 		"name": "InstanceSessionKey",
@@ -6552,7 +6632,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Invoice": {
 		"name": "Invoice",
@@ -6768,7 +6848,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"InvoiceDataGetIn": {
 		"name": "InvoiceDataGetIn",
@@ -6800,7 +6880,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"InvoiceDataGetOut": {
 		"name": "InvoiceDataGetOut",
@@ -6942,7 +7022,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"InvoiceDataItem": {
 		"name": "InvoiceDataItem",
@@ -7019,7 +7099,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"InvoiceInfo": {
 		"name": "InvoiceInfo",
@@ -7198,7 +7278,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"InvoiceItem": {
 		"name": "InvoiceItem",
@@ -7284,7 +7364,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"KeyPair": {
 		"name": "KeyPair",
@@ -7361,7 +7441,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"KeyRotation": {
 		"name": "KeyRotation",
@@ -7440,7 +7520,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"KeyRotationsRef": {
 		"name": "KeyRotationsRef",
@@ -7474,7 +7554,102 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
+	},
+	"LocalAdminGroupReplacementData": {
+		"name": "LocalAdminGroupReplacementData",
+		"since": 113,
+		"type": "AGGREGATED_TYPE",
+		"id": 2484,
+		"rootId": "A3N5cwAJtA",
+		"versioned": false,
+		"encrypted": false,
+		"values": {
+			"_id": {
+				"final": true,
+				"name": "_id",
+				"id": 2485,
+				"since": 113,
+				"type": "CustomId",
+				"cardinality": "One",
+				"encrypted": false
+			},
+			"adminGroupEncGKey": {
+				"final": false,
+				"name": "adminGroupEncGKey",
+				"id": 2487,
+				"since": 113,
+				"type": "Bytes",
+				"cardinality": "One",
+				"encrypted": false
+			},
+			"adminGroupKeyVersion": {
+				"final": false,
+				"name": "adminGroupKeyVersion",
+				"id": 2489,
+				"since": 113,
+				"type": "Number",
+				"cardinality": "One",
+				"encrypted": false
+			},
+			"groupKeyVersion": {
+				"final": false,
+				"name": "groupKeyVersion",
+				"id": 2488,
+				"since": 113,
+				"type": "Number",
+				"cardinality": "One",
+				"encrypted": false
+			}
+		},
+		"associations": {
+			"groupId": {
+				"final": false,
+				"name": "groupId",
+				"id": 2486,
+				"since": 113,
+				"type": "ELEMENT_ASSOCIATION",
+				"cardinality": "One",
+				"refType": "Group",
+				"dependency": null
+			}
+		},
+		"app": "sys",
+		"version": "113"
+	},
+	"LocalAdminRemovalPostIn": {
+		"name": "LocalAdminRemovalPostIn",
+		"since": 113,
+		"type": "DATA_TRANSFER_TYPE",
+		"id": 2490,
+		"rootId": "A3N5cwAJug",
+		"versioned": false,
+		"encrypted": false,
+		"values": {
+			"_format": {
+				"final": false,
+				"name": "_format",
+				"id": 2491,
+				"since": 113,
+				"type": "Number",
+				"cardinality": "One",
+				"encrypted": false
+			}
+		},
+		"associations": {
+			"groupUpdates": {
+				"final": false,
+				"name": "groupUpdates",
+				"id": 2492,
+				"since": 113,
+				"type": "AGGREGATION",
+				"cardinality": "Any",
+				"refType": "LocalAdminGroupReplacementData",
+				"dependency": null
+			}
+		},
+		"app": "sys",
+		"version": "113"
 	},
 	"LocationServiceGetReturn": {
 		"name": "LocationServiceGetReturn",
@@ -7506,7 +7681,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Login": {
 		"name": "Login",
@@ -7565,7 +7740,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MailAddressAlias": {
 		"name": "MailAddressAlias",
@@ -7606,7 +7781,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MailAddressAliasGetIn": {
 		"name": "MailAddressAliasGetIn",
@@ -7640,7 +7815,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MailAddressAliasServiceData": {
 		"name": "MailAddressAliasServiceData",
@@ -7683,7 +7858,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MailAddressAliasServiceDataDelete": {
 		"name": "MailAddressAliasServiceDataDelete",
@@ -7735,7 +7910,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MailAddressAliasServiceReturn": {
 		"name": "MailAddressAliasServiceReturn",
@@ -7794,7 +7969,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MailAddressAvailability": {
 		"name": "MailAddressAvailability",
@@ -7835,7 +8010,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MailAddressToGroup": {
 		"name": "MailAddressToGroup",
@@ -7896,7 +8071,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MembershipAddData": {
 		"name": "MembershipAddData",
@@ -7967,7 +8142,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MembershipPutIn": {
 		"name": "MembershipPutIn",
@@ -8001,7 +8176,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MembershipRemoveData": {
 		"name": "MembershipRemoveData",
@@ -8045,7 +8220,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MissedNotification": {
 		"name": "MissedNotification",
@@ -8161,7 +8336,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MultipleMailAddressAvailabilityData": {
 		"name": "MultipleMailAddressAvailabilityData",
@@ -8195,7 +8370,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"MultipleMailAddressAvailabilityReturn": {
 		"name": "MultipleMailAddressAvailabilityReturn",
@@ -8229,7 +8404,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"NotificationInfo": {
 		"name": "NotificationInfo",
@@ -8281,7 +8456,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"NotificationMailTemplate": {
 		"name": "NotificationMailTemplate",
@@ -8331,7 +8506,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"NotificationSessionKey": {
 		"name": "NotificationSessionKey",
@@ -8374,7 +8549,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"OrderProcessingAgreement": {
 		"name": "OrderProcessingAgreement",
@@ -8490,7 +8665,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"OtpChallenge": {
 		"name": "OtpChallenge",
@@ -8524,7 +8699,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PaymentDataServiceGetData": {
 		"name": "PaymentDataServiceGetData",
@@ -8556,7 +8731,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PaymentDataServiceGetReturn": {
 		"name": "PaymentDataServiceGetReturn",
@@ -8588,7 +8763,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PaymentDataServicePostData": {
 		"name": "PaymentDataServicePostData",
@@ -8622,7 +8797,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PaymentDataServicePutData": {
 		"name": "PaymentDataServicePutData",
@@ -8737,7 +8912,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PaymentDataServicePutReturn": {
 		"name": "PaymentDataServicePutReturn",
@@ -8780,7 +8955,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PaymentErrorInfo": {
 		"name": "PaymentErrorInfo",
@@ -8830,7 +9005,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Permission": {
 		"name": "Permission",
@@ -8982,7 +9157,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PlanConfiguration": {
 		"name": "PlanConfiguration",
@@ -9095,7 +9270,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PlanPrices": {
 		"name": "PlanPrices",
@@ -9237,7 +9412,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PlanServiceGetOut": {
 		"name": "PlanServiceGetOut",
@@ -9271,7 +9446,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PriceData": {
 		"name": "PriceData",
@@ -9332,7 +9507,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PriceItemData": {
 		"name": "PriceItemData",
@@ -9391,7 +9566,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PriceRequestData": {
 		"name": "PriceRequestData",
@@ -9468,7 +9643,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PriceServiceData": {
 		"name": "PriceServiceData",
@@ -9511,7 +9686,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PriceServiceReturn": {
 		"name": "PriceServiceReturn",
@@ -9583,7 +9758,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PubEncKeyData": {
 		"name": "PubEncKeyData",
@@ -9660,7 +9835,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PublicKeyGetIn": {
 		"name": "PublicKeyGetIn",
@@ -9710,7 +9885,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PublicKeyGetOut": {
 		"name": "PublicKeyGetOut",
@@ -9769,7 +9944,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PublicKeyPutIn": {
 		"name": "PublicKeyPutIn",
@@ -9821,7 +9996,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PushIdentifier": {
 		"name": "PushIdentifier",
@@ -9979,7 +10154,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"PushIdentifierList": {
 		"name": "PushIdentifierList",
@@ -10013,7 +10188,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ReceivedGroupInvitation": {
 		"name": "ReceivedGroupInvitation",
@@ -10174,7 +10349,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RecoverCode": {
 		"name": "RecoverCode",
@@ -10260,7 +10435,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RecoverCodeData": {
 		"name": "RecoverCodeData",
@@ -10319,7 +10494,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ReferralCodeGetIn": {
 		"name": "ReferralCodeGetIn",
@@ -10353,7 +10528,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ReferralCodePostIn": {
 		"name": "ReferralCodePostIn",
@@ -10376,7 +10551,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ReferralCodePostOut": {
 		"name": "ReferralCodePostOut",
@@ -10410,7 +10585,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RegistrationCaptchaServiceData": {
 		"name": "RegistrationCaptchaServiceData",
@@ -10451,7 +10626,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RegistrationCaptchaServiceGetData": {
 		"name": "RegistrationCaptchaServiceGetData",
@@ -10519,7 +10694,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RegistrationCaptchaServiceReturn": {
 		"name": "RegistrationCaptchaServiceReturn",
@@ -10560,7 +10735,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RegistrationReturn": {
 		"name": "RegistrationReturn",
@@ -10592,7 +10767,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RegistrationServiceData": {
 		"name": "RegistrationServiceData",
@@ -10642,7 +10817,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RejectedSender": {
 		"name": "RejectedSender",
@@ -10737,7 +10912,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RejectedSendersRef": {
 		"name": "RejectedSendersRef",
@@ -10771,7 +10946,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RepeatRule": {
 		"name": "RepeatRule",
@@ -10850,7 +11025,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ResetFactorsDeleteData": {
 		"name": "ResetFactorsDeleteData",
@@ -10900,7 +11075,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"ResetPasswordPostIn": {
 		"name": "ResetPasswordPostIn",
@@ -10979,7 +11154,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"RootInstance": {
 		"name": "RootInstance",
@@ -11038,7 +11213,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SaltData": {
 		"name": "SaltData",
@@ -11070,7 +11245,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SaltReturn": {
 		"name": "SaltReturn",
@@ -11111,7 +11286,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SecondFactor": {
 		"name": "SecondFactor",
@@ -11199,7 +11374,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SecondFactorAuthAllowedReturn": {
 		"name": "SecondFactorAuthAllowedReturn",
@@ -11231,7 +11406,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SecondFactorAuthData": {
 		"name": "SecondFactorAuthData",
@@ -11303,7 +11478,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SecondFactorAuthDeleteData": {
 		"name": "SecondFactorAuthDeleteData",
@@ -11337,7 +11512,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SecondFactorAuthGetData": {
 		"name": "SecondFactorAuthGetData",
@@ -11369,7 +11544,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SecondFactorAuthGetReturn": {
 		"name": "SecondFactorAuthGetReturn",
@@ -11401,7 +11576,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SecondFactorAuthentication": {
 		"name": "SecondFactorAuthentication",
@@ -11487,7 +11662,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SendRegistrationCodeData": {
 		"name": "SendRegistrationCodeData",
@@ -11546,7 +11721,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SendRegistrationCodeReturn": {
 		"name": "SendRegistrationCodeReturn",
@@ -11578,7 +11753,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SentGroupInvitation": {
 		"name": "SentGroupInvitation",
@@ -11667,7 +11842,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Session": {
 		"name": "Session",
@@ -11810,7 +11985,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SignOrderProcessingAgreementData": {
 		"name": "SignOrderProcessingAgreementData",
@@ -11851,7 +12026,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SseConnectData": {
 		"name": "SseConnectData",
@@ -11894,7 +12069,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"StringConfigValue": {
 		"name": "StringConfigValue",
@@ -11935,7 +12110,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"StringWrapper": {
 		"name": "StringWrapper",
@@ -11967,7 +12142,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SurveyData": {
 		"name": "SurveyData",
@@ -12026,7 +12201,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SwitchAccountTypePostIn": {
 		"name": "SwitchAccountTypePostIn",
@@ -12115,7 +12290,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"SystemKeysReturn": {
 		"name": "SystemKeysReturn",
@@ -12231,7 +12406,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"TakeOverDeletedAddressData": {
 		"name": "TakeOverDeletedAddressData",
@@ -12290,7 +12465,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"TypeInfo": {
 		"name": "TypeInfo",
@@ -12331,7 +12506,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"U2fChallenge": {
 		"name": "U2fChallenge",
@@ -12374,7 +12549,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"U2fKey": {
 		"name": "U2fKey",
@@ -12426,7 +12601,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"U2fRegisteredDevice": {
 		"name": "U2fRegisteredDevice",
@@ -12494,7 +12669,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"U2fResponseData": {
 		"name": "U2fResponseData",
@@ -12544,7 +12719,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UpdatePermissionKeyData": {
 		"name": "UpdatePermissionKeyData",
@@ -12606,7 +12781,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UpdateSessionKeysPostIn": {
 		"name": "UpdateSessionKeysPostIn",
@@ -12640,7 +12815,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UpgradePriceServiceData": {
 		"name": "UpgradePriceServiceData",
@@ -12692,7 +12867,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UpgradePriceServiceReturn": {
 		"name": "UpgradePriceServiceReturn",
@@ -12863,7 +13038,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"User": {
 		"name": "User",
@@ -13078,7 +13253,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserAlarmInfo": {
 		"name": "UserAlarmInfo",
@@ -13157,7 +13332,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserAlarmInfoListType": {
 		"name": "UserAlarmInfoListType",
@@ -13191,7 +13366,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserAreaGroups": {
 		"name": "UserAreaGroups",
@@ -13225,7 +13400,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserAuthentication": {
 		"name": "UserAuthentication",
@@ -13279,7 +13454,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserDataDelete": {
 		"name": "UserDataDelete",
@@ -13331,7 +13506,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserExternalAuthInfo": {
 		"name": "UserExternalAuthInfo",
@@ -13401,7 +13576,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserGroupKeyDistribution": {
 		"name": "UserGroupKeyDistribution",
@@ -13469,7 +13644,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserGroupKeyRotationData": {
 		"name": "UserGroupKeyRotationData",
@@ -13596,7 +13771,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserGroupKeyRotationPostIn": {
 		"name": "UserGroupKeyRotationPostIn",
@@ -13630,7 +13805,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"UserGroupRoot": {
 		"name": "UserGroupRoot",
@@ -13711,7 +13886,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"VariableExternalAuthInfo": {
 		"name": "VariableExternalAuthInfo",
@@ -13815,7 +13990,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"VerifyRegistrationCodeData": {
 		"name": "VerifyRegistrationCodeData",
@@ -13856,7 +14031,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"Version": {
 		"name": "Version",
@@ -13927,7 +14102,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"VersionData": {
 		"name": "VersionData",
@@ -13986,7 +14161,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"VersionInfo": {
 		"name": "VersionInfo",
@@ -14111,7 +14286,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"VersionReturn": {
 		"name": "VersionReturn",
@@ -14145,7 +14320,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WebauthnResponseData": {
 		"name": "WebauthnResponseData",
@@ -14204,7 +14379,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WebsocketCounterData": {
 		"name": "WebsocketCounterData",
@@ -14247,7 +14422,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WebsocketCounterValue": {
 		"name": "WebsocketCounterValue",
@@ -14288,7 +14463,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WebsocketEntityData": {
 		"name": "WebsocketEntityData",
@@ -14340,7 +14515,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WebsocketLeaderStatus": {
 		"name": "WebsocketLeaderStatus",
@@ -14372,7 +14547,7 @@
 		},
 		"associations": {},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WhitelabelChild": {
 		"name": "WhitelabelChild",
@@ -14487,7 +14662,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WhitelabelChildrenRef": {
 		"name": "WhitelabelChildrenRef",
@@ -14521,7 +14696,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WhitelabelConfig": {
 		"name": "WhitelabelConfig",
@@ -14656,7 +14831,7 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	},
 	"WhitelabelParent": {
 		"name": "WhitelabelParent",
@@ -14700,6 +14875,6 @@
 			}
 		},
 		"app": "sys",
-		"version": "112"
+		"version": "113"
 	}
 }


### PR DESCRIPTION
In order to delete the local admin groups, we need to first re-assign their managed groups to the global admin.

tutadb#1878