### PR TITLE
[Calendar] Birthdays preview shows contact information

### DIFF
--- a/buildSrc/RollupConfig.js
+++ b/buildSrc/RollupConfig.js
@@ -33,13 +33,13 @@ export const allowedImports = {
 	main: ["polyfill-helpers", "common-min", "common", "boot", "gui-base"],
 	sanitizer: ["polyfill-helpers", "common-min", "common", "boot", "gui-base"],
 	date: ["polyfill-helpers", "common-min", "common"],
-	"date-gui": ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main", "sharing", "date"],
+	"date-gui": ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main", "sharing", "date", "contacts"],
 	"mail-view": ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main"],
 	"mail-editor": ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main", "mail-view", "sanitizer", "sharing"],
 	search: ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main", "mail-view", "calendar-view", "contacts", "date", "date-gui", "sharing"],
 	// ContactMergeView needs HtmlEditor even though ContactEditor doesn't?
 	contacts: ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main", "mail-view", "date", "date-gui", "mail-editor"],
-	"calendar-view": ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main", "date", "date-gui", "sharing"],
+	"calendar-view": ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main", "date", "date-gui", "sharing", "contacts"],
 	login: ["polyfill-helpers", "common-min", "common", "boot", "gui-base", "main"],
 	worker: ["polyfill-helpers", "common-min", "common", "native-common", "native-worker", "wasm", "wasm-fallback"],
 	settings: [

--- a/src/calendar-app/calendar/gui/eventpopup/CalendarContactPopup.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/CalendarContactPopup.ts
@@ -1,0 +1,147 @@
+import type { Shortcut } from "../../../../common/misc/KeyManager.js"
+import m, { Children } from "mithril"
+import { px } from "../../../../common/gui/size.js"
+import { Icons } from "../../../../common/gui/base/icons/Icons.js"
+import type { ModalComponent } from "../../../../common/gui/base/Modal.js"
+import { modal } from "../../../../common/gui/base/Modal.js"
+import { DROPDOWN_MARGIN, PosRect, showDropdown } from "../../../../common/gui/base/Dropdown.js"
+import { Keys } from "../../../../common/api/common/TutanotaConstants.js"
+import { IconButton } from "../../../../common/gui/base/IconButton.js"
+import { CalendarContactPreviewViewModel } from "./CalendarContactPreviewViewModel.js"
+import { ContactPreviewView } from "./ContactPreviewView.js"
+import { client } from "../../../../common/misc/ClientDetector.js"
+import { ContactEditor } from "../../../../mail-app/contacts/ContactEditor.js"
+import { locator } from "../../../../common/api/main/CommonLocator.js"
+import { listIdPart } from "../../../../common/api/common/utils/EntityUtils.js"
+import { stringToBase64 } from "@tutao/tutanota-utils"
+import { calendarLocator } from "../../../calendarLocator.js"
+
+/**
+ * small modal displaying all relevant information about a contact in a compact fashion. offers limited editing capabilities to participants in the
+ * form with quick action buttons such as edit contact.
+ */
+export class ContactEventPopup implements ModalComponent {
+	private readonly _shortcuts: Shortcut[] = []
+	private dom: HTMLElement | null = null
+	private focusedBeforeShown: HTMLElement | null = null
+
+	/**
+	 * @param model
+	 * @param eventBubbleRect the rect where the event bubble was displayed that was clicked (if any)
+	 */
+	constructor(private readonly model: CalendarContactPreviewViewModel, private readonly eventBubbleRect: PosRect) {
+		this.setupShortcuts()
+		this.view = this.view.bind(this)
+	}
+
+	private readonly handleEditButtonClick: (ev: MouseEvent, receiver: HTMLElement) => void = (ev: MouseEvent, receiver: HTMLElement) => {
+		if (client.isCalendarApp()) {
+			const query = `contactId=${stringToBase64(this.model.contact._id.join("/"))}`
+			calendarLocator.systemFacade.openMailApp(stringToBase64(query))
+			return
+		}
+		new ContactEditor(locator.entityClient, this.model.contact, listIdPart(this.model.contact._id), m.redraw).show()
+	}
+
+	view(): Children {
+		return m(
+			".abs.elevated-bg.plr.pb.border-radius.dropdown-shadow.flex.flex-column",
+			{
+				style: {
+					// minus margin, need to apply it now to not overflow later
+					width: px(Math.min(window.innerWidth - DROPDOWN_MARGIN * 2, 400)),
+					// see hack description below
+					opacity: "0",
+					// because calendar event bubbles have 1px border, we want to align
+					margin: "1px",
+				},
+				oncreate: (vnode) => {
+					this.dom = vnode.dom as HTMLElement
+					// This is a hack to get "natural" view size but render it without opacity first and then show dropdown with inferred
+					// size.
+					setTimeout(() => {
+						showDropdown(this.eventBubbleRect, this.dom!, this.dom!.offsetHeight, 400)
+						// Move the keyboard focus into the popup's buttons when it is shown
+						const firstButton = vnode.dom.firstElementChild?.firstElementChild as HTMLInputElement | null
+						firstButton?.focus()
+					}, 24)
+				},
+			},
+			[
+				m(".flex.flex-end", [this.renderEditButton(), this.renderCloseButton()]),
+				m(".flex-grow.scroll.visible-scrollbar", [
+					m(ContactPreviewView, {
+						event: this.model.event,
+						contact: this.model.contact,
+					}),
+				]),
+			],
+		)
+	}
+
+	private renderEditButton(): Children {
+		if (!this.model.canEdit) return null
+		return m(IconButton, { title: "edit_action", icon: Icons.Edit, click: this.handleEditButtonClick })
+	}
+
+	private renderCloseButton(): Children {
+		return m(IconButton, {
+			title: "close_alt",
+			click: () => this.close(),
+			icon: Icons.Cancel,
+		})
+	}
+
+	show() {
+		this.focusedBeforeShown = document.activeElement as HTMLElement
+		modal.display(this, false)
+	}
+
+	private close() {
+		modal.remove(this)
+	}
+
+	backgroundClick(e: MouseEvent): void {
+		modal.remove(this)
+	}
+
+	hideAnimation(): Promise<void> {
+		return Promise.resolve()
+	}
+
+	onClose(): void {
+		this.close()
+	}
+
+	shortcuts(): Shortcut[] {
+		return this._shortcuts
+	}
+
+	popState(e: Event): boolean {
+		modal.remove(this)
+		return false
+	}
+
+	callingElement(): HTMLElement | null {
+		return this.focusedBeforeShown
+	}
+
+	private setupShortcuts() {
+		const close: Shortcut = {
+			key: Keys.ESC,
+			exec: () => this.close(),
+			help: "close_alt",
+		}
+		const edit: Shortcut = {
+			key: Keys.E,
+			exec: () => this.handleEditButtonClick(new MouseEvent("click", {}), this.dom!),
+			help: "edit_action",
+		}
+
+		this._shortcuts.push(close)
+
+		if (this.model.canEdit) {
+			this._shortcuts.push(edit)
+		}
+	}
+}

--- a/src/calendar-app/calendar/gui/eventpopup/CalendarContactPreviewViewModel.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/CalendarContactPreviewViewModel.ts
@@ -1,0 +1,19 @@
+import { CalendarEvent, Contact } from "../../../../common/api/entities/tutanota/TypeRefs.js"
+import { isNotNull } from "@tutao/tutanota-utils"
+
+/**
+ * makes decisions about which operations are available from the popup and knows how to implement them depending on the event's type.
+ */
+export class CalendarContactPreviewViewModel {
+	/**
+	 *
+	 * @param event the event that was interacted with
+	 * @param contact the contact to display in the popup
+	 * @param _canEdit allow editing the contact if available
+	 */
+	constructor(readonly event: Readonly<CalendarEvent>, readonly contact: Readonly<Contact>, private readonly _canEdit: boolean = false) {}
+
+	get canEdit(): boolean {
+		return this._canEdit && isNotNull(this.contact)
+	}
+}

--- a/src/calendar-app/calendar/gui/eventpopup/ContactPreviewView.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/ContactPreviewView.ts
@@ -1,0 +1,185 @@
+import type { CalendarEvent, Contact } from "../../../../common/api/entities/tutanota/TypeRefs.js"
+import m, { Children, Component, Vnode } from "mithril"
+import { AllIcons, Icon, IconSize } from "../../../../common/gui/base/Icon.js"
+import { theme } from "../../../../common/gui/theme.js"
+import { BootIcons } from "../../../../common/gui/base/icons/BootIcons.js"
+import { Icons } from "../../../../common/gui/base/icons/Icons.js"
+import { calculateContactsAge, getTimeZone } from "../../../../common/calendar/date/CalendarUtils.js"
+import { memoized, noOp } from "@tutao/tutanota-utils"
+import { lang, TranslationKey } from "../../../../common/misc/LanguageViewModel.js"
+import { BannerButton, BannerButtonAttrs } from "../../../../common/gui/base/buttons/BannerButton.js"
+import { pureComponent } from "../../../../common/gui/base/PureComponent.js"
+import { formatEventDuration } from "../CalendarGuiUtils.js"
+import { getLocationUrl } from "./EventPreviewView.js"
+import { getContactTitle } from "../../../../common/gui/base/GuiUtils.js"
+import { isoDateToBirthday } from "../../../../common/api/common/utils/BirthdayUtils.js"
+import { createDropdown } from "../../../../common/gui/base/Dropdown.js"
+import { writeMail } from "../../../../mail-app/contacts/view/ContactView.js"
+import { client } from "../../../../common/misc/ClientDetector.js"
+
+export type ContactPreviewViewAttrs = {
+	event: CalendarEvent
+	contact: Contact
+}
+
+export class ContactPreviewView implements Component<ContactPreviewViewAttrs> {
+	// Cache the parsed URL, so we don't parse the URL on every single view call
+	private readonly getLocationUrl: typeof getLocationUrl
+
+	constructor() {
+		this.getLocationUrl = memoized(getLocationUrl)
+	}
+
+	view(vnode: Vnode<ContactPreviewViewAttrs>): Children {
+		const { event, contact } = vnode.attrs
+		const eventTitle = getContactTitle(contact)
+
+		const birthYear = contact.birthdayIso && isoDateToBirthday(contact.birthdayIso).year
+		const age = birthYear && calculateContactsAge(new Date(birthYear).getFullYear(), event.startTime.getFullYear())
+		const ageString = age ? lang.get("birthdayEventAge_title", { "{age}": age }) : ""
+
+		return m(".flex.col.smaller.scroll.visible-scrollbar", [
+			this.renderRow(BootIcons.Calendar, [m("span.h3", eventTitle)]),
+			this.renderRow(Icons.Time, [formatEventDuration(event, getTimeZone(), false)]),
+			age ? this.renderRow(Icons.Gift, ageString) : null,
+			this.renderActions(contact),
+		])
+	}
+
+	private renderRow(headerIcon: AllIcons, children: Children, isAlignedLeft?: boolean): Children {
+		return m(
+			".flex.pb-s",
+			{
+				class: isAlignedLeft ? "items-start" : "items-center",
+			},
+			[this.renderSectionIndicator(headerIcon, isAlignedLeft ? { marginTop: "2px" } : undefined), m(".selectable.text-break.full-width", children)],
+		)
+	}
+
+	private renderSectionIndicator(icon: AllIcons, style: Record<string, any> = {}): Children {
+		return m(Icon, {
+			icon,
+			class: "pr",
+			size: IconSize.Medium,
+			style: Object.assign(
+				{
+					fill: theme.content_button,
+					display: "block",
+				},
+				style,
+			),
+		})
+	}
+
+	private renderActions(contact: Contact): Children {
+		return m(".flex.pb-s", m(ActionButtons, contact))
+	}
+}
+
+export function simulateMailToClick(mailAddress: string) {
+	const anchorElement: HTMLAnchorElement = document.createElement("a")
+	anchorElement.href = `mailto:${mailAddress}`
+	anchorElement.target = "_blank"
+	anchorElement.click()
+}
+
+const ActionButtons = pureComponent((contact: Contact) => {
+	interface ButtonColors {
+		borderColor: string
+		color: string
+	}
+
+	const makeActionButtonAttrs = (onClick: (e: any, dom: any) => unknown, text: TranslationKey, colors: ButtonColors, icon?: Children): BannerButtonAttrs => ({
+		text,
+		class: "width-min-content flex items-center",
+		click: onClick,
+		icon,
+		...colors,
+	})
+
+	const renderIcon = (icon: AllIcons, fillColor: string) =>
+		m(Icon, {
+			icon,
+			class: "flex-center items-center mr-xs",
+			style: {
+				fill: fillColor,
+			},
+		})
+
+	const renderSuffix = (text: string) => (text !== "" ? `(${text}) ` : "")
+
+	const showMailDropdown = createDropdown({
+		lazyButtons: () =>
+			contact.mailAddresses.map((mailAddress, index) => ({
+				label: () => `${renderSuffix(mailAddress.customTypeName)}${mailAddress.address}`,
+				click: () => {
+					if (client.isCalendarApp()) {
+						simulateMailToClick(mailAddress.address)
+						return
+					}
+					return writeMail(
+						{
+							name: `${contact.firstName} ${contact.lastName}`.trim(),
+							address: mailAddress.address,
+							contact: contact,
+						},
+						"Happy birthday!",
+					)
+				},
+			})),
+	})
+	const showPhoneDropdown = createDropdown({
+		lazyButtons: () =>
+			contact.phoneNumbers.map((contactPhone, index) => ({
+				label: () => `${renderSuffix(contactPhone.customTypeName)}${contactPhone.number}`,
+				click: () => {
+					const element: HTMLAnchorElement = document.createElement("a")
+					element.href = `tel:${contactPhone.number}`
+					element.target = "_blank"
+					element.click()
+				},
+			})),
+	})
+
+	const emailButtonColors = {
+		borderColor: theme.content_accent,
+		color: theme.content_accent,
+	}
+	const phoneButtonColors = {
+		borderColor: theme.content_button,
+		color: theme.content_button,
+	}
+
+	const singleEmailAdress = contact.mailAddresses.length === 1
+	const singlePhoneNumber = contact.phoneNumbers.length === 1
+	return m(".full-width.flex.items-center.flex-end.mt-s", [
+		contact.mailAddresses.length
+			? m(
+					singleEmailAdress ? `a[href="mailto:${contact.addresses[0].address}"][target=_blank]` : "",
+					m(
+						BannerButton,
+						makeActionButtonAttrs(
+							singleEmailAdress ? noOp : showMailDropdown,
+							"sendMail_label",
+							emailButtonColors,
+							renderIcon(BootIcons.Mail, emailButtonColors.color),
+						),
+					),
+			  )
+			: null,
+		contact.phoneNumbers.length
+			? m(
+					singlePhoneNumber ? `a[href="tel:${contact.phoneNumbers[0].number}"][target=_blank]` : "",
+					m(
+						BannerButton,
+						makeActionButtonAttrs(
+							singlePhoneNumber ? noOp : showPhoneDropdown,
+							"callNumber_label",
+							phoneButtonColors,
+							renderIcon(Icons.Call, phoneButtonColors.color),
+						),
+					),
+			  )
+			: null,
+	])
+})

--- a/src/calendar-app/calendar/gui/eventpopup/EventPreviewView.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/EventPreviewView.ts
@@ -210,7 +210,7 @@ export class EventPreviewView implements Component<EventPreviewViewAttrs> {
  * @param text
  * @returns {*}
  */
-function getLocationUrl(text: string): URL {
+export function getLocationUrl(text: string): URL {
 	const osmHref = `https://www.openstreetmap.org/search?query=${text}`
 	let url
 

--- a/src/calendar-app/calendar/view/EventDetailsView.ts
+++ b/src/calendar-app/calendar/view/EventDetailsView.ts
@@ -8,6 +8,7 @@ import { createAsyncDropdown } from "../../../common/gui/base/Dropdown.js"
 import { Dialog } from "../../../common/gui/base/Dialog.js"
 import { CalendarEventPreviewViewModel } from "../gui/eventpopup/CalendarEventPreviewViewModel.js"
 import { styles } from "../../../common/gui/styles.js"
+import { CalendarPreviewModels } from "./CalendarViewModel.js"
 
 export interface EventDetailsViewAttrs {
 	eventPreviewModel: CalendarEventPreviewViewModel
@@ -18,7 +19,6 @@ export class EventDetailsView implements Component<EventDetailsViewAttrs> {
 
 	view({ attrs }: Vnode<EventDetailsViewAttrs>) {
 		this.model = attrs.eventPreviewModel
-
 		return m(".content-bg.border-radius-big.pl-l.pb-s.flex.pr", [
 			m(
 				".flex-grow",

--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -49,7 +49,7 @@ import { SqlCipherFacade } from "../common/native/common/generatedipc/SqlCipherF
 import { assertNotNull, defer, DeferredObject, lazy, lazyAsync, LazyLoaded, lazyMemoized, noOp, ofClass } from "@tutao/tutanota-utils"
 import { RecipientsModel } from "../common/api/main/RecipientsModel.js"
 import { NoZoneDateProvider } from "../common/api/common/utils/NoZoneDateProvider.js"
-import { CalendarEvent, CalendarEventAttendee, Mail, MailboxProperties } from "../common/api/entities/tutanota/TypeRefs.js"
+import { CalendarEvent, CalendarEventAttendee, Contact, Mail, MailboxProperties } from "../common/api/entities/tutanota/TypeRefs.js"
 import { SendMailModel } from "../common/mailFunctionality/SendMailModel.js"
 import { OfflineIndicatorViewModel } from "../common/gui/base/OfflineIndicatorViewModel.js"
 import { Router, ScopedRouter, ThrottledRouter } from "../common/gui/ScopedRouter.js"
@@ -91,7 +91,7 @@ import { CalendarInfo, CalendarModel } from "./calendar/model/CalendarModel.js"
 import { CalendarInviteHandler } from "./calendar/view/CalendarInvites.js"
 import { AlarmScheduler } from "../common/calendar/date/AlarmScheduler.js"
 import { SchedulerImpl } from "../common/api/common/utils/Scheduler.js"
-import { CalendarEventPreviewViewModel } from "./calendar/gui/eventpopup/CalendarEventPreviewViewModel.js"
+import type { CalendarEventPreviewViewModel } from "./calendar/gui/eventpopup/CalendarEventPreviewViewModel.js"
 import { isCustomizationEnabledForCustomer } from "../common/api/common/utils/CustomerUtils.js"
 import { PostLoginActions } from "../common/login/PostLoginActions.js"
 import { CredentialFormatMigrator } from "../common/misc/credentials/CredentialFormatMigrator.js"
@@ -111,6 +111,7 @@ import { showSnackBar } from "../common/gui/base/SnackBar.js"
 import { DbError } from "../common/api/common/error/DbError.js"
 import { WorkerRandomizer } from "../common/api/worker/workerInterfaces.js"
 import { lang } from "../common/misc/LanguageViewModel.js"
+import type { CalendarContactPreviewViewModel } from "./calendar/gui/eventpopup/CalendarContactPreviewViewModel.js"
 
 assertMainOrNode()
 
@@ -277,6 +278,7 @@ class CalendarLocator {
 				return await this.calendarEventModel(mode, event, mailboxDetail, mailboxProperties, null)
 			},
 			(...args) => this.calendarEventPreviewModel(...args),
+			(...args) => this.calendarContactPreviewModel(...args),
 			await this.calendarModel(),
 			await this.calendarEventsRepository(),
 			this.entityClient,
@@ -848,6 +850,11 @@ class CalendarLocator {
 		await popupModel.sanitizeDescription()
 
 		return popupModel
+	}
+
+	async calendarContactPreviewModel(event: CalendarEvent, contact: Contact, canEdit: boolean): Promise<CalendarContactPreviewViewModel> {
+		const { CalendarContactPreviewViewModel } = await import("./calendar/gui/eventpopup/CalendarContactPreviewViewModel.js")
+		return new CalendarContactPreviewViewModel(event, contact, canEdit)
 	}
 
 	postLoginActions: () => Promise<PostLoginActions> = lazyMemoized(async () => {

--- a/src/common/api/main/CommonLocator.ts
+++ b/src/common/api/main/CommonLocator.ts
@@ -55,12 +55,12 @@ import { NativeFileApp } from "../../native/common/FileApp.js"
 import { MobileSystemFacade } from "../../native/common/generatedipc/MobileSystemFacade.js"
 import { MobileContactsFacade } from "../../native/common/generatedipc/MobileContactsFacade.js"
 import { NativeCredentialsFacade } from "../../native/common/generatedipc/NativeCredentialsFacade.js"
-import { CalendarEvent, Mail, MailboxProperties } from "../entities/tutanota/TypeRefs.js"
+import { CalendarEvent, Contact, Mail, MailboxProperties } from "../entities/tutanota/TypeRefs.js"
 import { SendMailModel } from "../../mailFunctionality/SendMailModel.js"
 import { RecipientsSearchModel } from "../../misc/RecipientsSearchModel.js"
 import { CalendarInfo, CalendarModel } from "../../../calendar-app/calendar/model/CalendarModel.js"
 import { CalendarEventModel, CalendarOperation } from "../../../calendar-app/calendar/gui/eventeditor-model/CalendarEventModel.js"
-import { CalendarEventPreviewViewModel } from "../../../calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.js"
+import type { CalendarEventPreviewViewModel } from "../../../calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.js"
 import { RecipientsModel } from "./RecipientsModel.js"
 import { ThemeController } from "../../gui/ThemeController.js"
 import { MobilePaymentsFacade } from "../../native/common/generatedipc/MobilePaymentsFacade.js"
@@ -68,6 +68,7 @@ import { AppStorePaymentPicker } from "../../misc/AppStorePaymentPicker.js"
 import { WorkerRandomizer } from "../worker/workerInterfaces.js"
 import { CommonSearchModel } from "../../search/CommonSearchModel.js"
 import { DeviceConfig } from "../../misc/DeviceConfig.js"
+import type { CalendarContactPreviewViewModel } from "../../../calendar-app/calendar/gui/eventpopup/CalendarContactPreviewViewModel.js"
 
 export interface CommonLocator {
 	worker: WorkerClient
@@ -151,6 +152,8 @@ export interface CommonLocator {
 	): Promise<CalendarEventModel | null>
 
 	calendarEventPreviewModel(selectedEvent: CalendarEvent, calendars: ReadonlyMap<string, CalendarInfo>): Promise<CalendarEventPreviewViewModel>
+
+	calendarContactPreviewModel(event: CalendarEvent, contact: Contact, canEdit: boolean): Promise<CalendarContactPreviewViewModel>
 
 	// native
 	native: NativeInterfaceMain

--- a/src/common/calendar/date/CalendarUtils.ts
+++ b/src/common/calendar/date/CalendarUtils.ts
@@ -1,6 +1,7 @@
 import {
 	assert,
 	clone,
+	decodeBase64,
 	downcast,
 	filterInt,
 	findAllAndRemove,
@@ -45,7 +46,7 @@ import { EntityClient } from "../../api/common/EntityClient.js"
 import { CalendarEventUidIndexEntry } from "../../api/worker/facades/lazy/CalendarFacade.js"
 import { ParserError } from "../../misc/parsing/ParserCombinator.js"
 import { LoginController } from "../../api/main/LoginController.js"
-import { BirthdayEvent } from "./CalendarEventsRepository.js"
+import { BirthdayEventRegistry } from "./CalendarEventsRepository.js"
 
 export type CalendarTimeRange = {
 	start: number
@@ -1050,7 +1051,7 @@ export function extractYearFromBirthday(birthday: string | null): number | null 
 	return Number.parseInt(dateParts[0])
 }
 
-export async function retrieveClientOnlyEventsForUser(logins: LoginController, events: IdTuple[], localEvents: Map<number, BirthdayEvent[]>) {
+export async function retrieveClientOnlyEventsForUser(logins: LoginController, events: IdTuple[], localEvents: Map<number, BirthdayEventRegistry[]>) {
 	if (!(await logins.getUserController().isNewPaidPlan())) {
 		return []
 	}
@@ -1065,4 +1066,20 @@ export async function retrieveClientOnlyEventsForUser(logins: LoginController, e
 	}
 
 	return retrievedEvents
+}
+
+export function calculateContactsAge(birthYear: number | null, currentYear: number): number | null {
+	if (!birthYear) {
+		return null
+	}
+
+	return currentYear - birthYear
+}
+
+export function extractContactIdFromEvent(id: string | null | undefined): string | null {
+	if (id == null) {
+		return null
+	}
+
+	return decodeBase64("utf-8", id)
 }

--- a/src/common/gui/base/GuiUtils.ts
+++ b/src/common/gui/base/GuiUtils.ts
@@ -15,6 +15,7 @@ import { DropDownSelector } from "./DropDownSelector.js"
 import { IconButtonAttrs } from "./IconButton.js"
 import { LoginController } from "../../api/main/LoginController.js"
 import { client } from "../../misc/ClientDetector.js"
+import type { Contact } from "../../api/entities/tutanota/TypeRefs.js"
 
 export type dropHandler = (dragData: string) => void
 // not all browsers have the actual button as e.currentTarget, but all of them send it as a second argument (see https://github.com/tutao/tutanota/issues/1110)
@@ -232,4 +233,12 @@ export function getIfLargeScroll(oldPosition: number | null, newPosition: number
 	if (oldPosition === null || newPosition === null) return false
 	const difference = Math.abs(oldPosition - newPosition)
 	return difference > 10
+}
+
+export function getContactTitle(contact: Contact) {
+	const title = contact.title ? `${contact.title} ` : ""
+	const middleName = contact.middleName != null ? ` ${contact.middleName} ` : " "
+	const fullName = `${contact.firstName}${middleName}${contact.lastName} `
+	const suffix = contact.nameSuffix ?? ""
+	return (title + fullName + suffix).trim()
 }

--- a/src/common/gui/base/buttons/BannerButton.ts
+++ b/src/common/gui/base/buttons/BannerButton.ts
@@ -5,6 +5,7 @@ import { px, size } from "../../size.js"
 import { BaseButton } from "./BaseButton.js"
 import { theme } from "../../theme.js"
 import { ClickHandler } from "../GuiUtils.js"
+import { Icon } from "../Icon.js"
 
 export type BannerButtonAttrs = {
 	borderColor: string
@@ -13,6 +14,7 @@ export type BannerButtonAttrs = {
 	disabled?: boolean
 	click: ClickHandler
 	text: TranslationKey | lazy<string>
+	icon?: Children
 }
 
 export class BannerButton implements Component<BannerButtonAttrs> {
@@ -30,6 +32,7 @@ export class BannerButton implements Component<BannerButtonAttrs> {
 			},
 			disabled: attrs.disabled,
 			onclick: attrs.click,
+			icon: attrs.icon,
 		})
 	}
 }

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -1786,3 +1786,5 @@ export type TranslationKeyType =
 	| "birthdayEventAge_title"
 	| "birthdayCalendar_label"
 	| "contactNotFound_msg"
+	| "sendMail_label"
+	| "callNumber_label"

--- a/src/mail-app/contacts/view/ContactCardViewer.ts
+++ b/src/mail-app/contacts/view/ContactCardViewer.ts
@@ -11,6 +11,7 @@ export interface ContactCardAttrs {
 	editAction?: (contact: Contact) => unknown
 	deleteAction?: (contacts: Contact[]) => unknown
 	extendedActions?: boolean
+	style?: Record<string, any>
 }
 
 /** Wraps contact viewer in a nice card. */
@@ -24,6 +25,7 @@ export class ContactCardViewer implements Component<ContactCardAttrs> {
 					class: responsiveCardHMargin(),
 					style: {
 						backgroundColor: theme.content_bg,
+						...attrs.style,
 					},
 				},
 				m(ContactViewer, {

--- a/src/mail-app/contacts/view/ContactViewer.ts
+++ b/src/mail-app/contacts/view/ContactViewer.ts
@@ -35,6 +35,8 @@ import { PartialRecipient } from "../../../common/api/common/recipients/Recipien
 import { attachDropdown } from "../../../common/gui/base/Dropdown.js"
 import type { AllIcons } from "../../../common/gui/base/Icon.js"
 
+import { getContactTitle } from "../../../common/gui/base/GuiUtils.js"
+
 assertMainOrNode()
 
 export interface ContactViewerAttrs {
@@ -49,13 +51,7 @@ export interface ContactViewerAttrs {
  *  Displays information about a single contact
  */
 export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
-	private readonly contactAppellation = memoized((contact: Contact) => {
-		const title = contact.title ? `${contact.title} ` : ""
-		const middleName = contact.middleName != null ? ` ${contact.middleName} ` : " "
-		const fullName = `${contact.firstName}${middleName}${contact.lastName} `
-		const suffix = contact.nameSuffix ?? ""
-		return (title + fullName + suffix).trim()
-	})
+	private readonly contactAppellation = memoized(getContactTitle)
 
 	private readonly contactPhoneticName = memoized((contact: Contact): string | null => {
 		const firstName = contact.phoneticFirst ?? ""

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -53,7 +53,7 @@ import { SqlCipherFacade } from "../common/native/common/generatedipc/SqlCipherF
 import { assert, assertNotNull, defer, DeferredObject, lazy, lazyAsync, LazyLoaded, lazyMemoized, noOp, ofClass } from "@tutao/tutanota-utils"
 import { RecipientsModel } from "../common/api/main/RecipientsModel.js"
 import { NoZoneDateProvider } from "../common/api/common/utils/NoZoneDateProvider.js"
-import { CalendarEvent, CalendarEventAttendee, Mail, MailboxProperties } from "../common/api/entities/tutanota/TypeRefs.js"
+import { CalendarEvent, CalendarEventAttendee, Contact, Mail, MailboxProperties } from "../common/api/entities/tutanota/TypeRefs.js"
 import { SendMailModel } from "../common/mailFunctionality/SendMailModel.js"
 import { OfflineIndicatorViewModel } from "../common/gui/base/OfflineIndicatorViewModel.js"
 import { Router, ScopedRouter, ThrottledRouter } from "../common/gui/ScopedRouter.js"
@@ -109,7 +109,7 @@ import { CalendarInfo, CalendarModel } from "../calendar-app/calendar/model/Cale
 import { CalendarInviteHandler } from "../calendar-app/calendar/view/CalendarInvites.js"
 import { AlarmScheduler } from "../common/calendar/date/AlarmScheduler.js"
 import { SchedulerImpl } from "../common/api/common/utils/Scheduler.js"
-import { CalendarEventPreviewViewModel } from "../calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.js"
+import type { CalendarEventPreviewViewModel } from "../calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.js"
 import { isCustomizationEnabledForCustomer } from "../common/api/common/utils/CustomerUtils.js"
 import { NativeContactsSyncManager } from "./contacts/model/NativeContactsSyncManager.js"
 import { PostLoginActions } from "../common/login/PostLoginActions.js"
@@ -136,6 +136,7 @@ import { ExternalCalendarFacade } from "../common/native/common/generatedipc/Ext
 import { AppType } from "../common/misc/ClientConstants.js"
 import { ParsedEvent } from "../common/calendar/import/CalendarImporter.js"
 import { lang } from "../common/misc/LanguageViewModel.js"
+import type { CalendarContactPreviewViewModel } from "../calendar-app/calendar/gui/eventpopup/CalendarContactPreviewViewModel.js"
 
 assertMainOrNode()
 
@@ -350,6 +351,7 @@ class MailLocator {
 				return await this.calendarEventModel(mode, event, mailboxDetail, mailboxProperties, null)
 			},
 			(...args) => this.calendarEventPreviewModel(...args),
+			(...args) => this.calendarContactPreviewModel(...args),
 			await this.calendarModel(),
 			await this.calendarEventsRepository(),
 			this.entityClient,
@@ -1050,6 +1052,11 @@ class MailLocator {
 		await popupModel.sanitizeDescription()
 
 		return popupModel
+	}
+
+	async calendarContactPreviewModel(event: CalendarEvent, contact: Contact, canEdit: boolean): Promise<CalendarContactPreviewViewModel> {
+		const { CalendarContactPreviewViewModel } = await import("../calendar-app/calendar/gui/eventpopup/CalendarContactPreviewViewModel.js")
+		return new CalendarContactPreviewViewModel(event, contact, canEdit)
 	}
 
 	readonly nativeContactsSyncManager: () => NativeContactsSyncManager = lazyMemoized(() => {

--- a/src/mail-app/search/view/SearchView.ts
+++ b/src/mail-app/search/view/SearchView.ts
@@ -107,7 +107,7 @@ import { BottomNav } from "../../gui/BottomNav.js"
 import { mailLocator } from "../../mailLocator.js"
 import { getIndentedFolderNameForDropdown } from "../../mail/model/MailUtils.js"
 import { ContactModel } from "../../../common/contactsFunctionality/ContactModel.js"
-import { isBirthdayEvent } from "../../../common/calendar/date/CalendarUtils.js"
+import { extractContactIdFromEvent, isBirthdayEvent } from "../../../common/calendar/date/CalendarUtils.js"
 
 assertMainOrNode()
 
@@ -501,7 +501,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 								color: theme.content_message_bg,
 								backgroundColor: theme.navigation_bg,
 						  })
-						: this.handleEventPreview(selectedEvent),
+						: this.renderEventPreview(selectedEvent),
 			})
 		} else {
 			return m(
@@ -531,7 +531,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 		}
 
 		const idParts = selectedEvent._id[1].split("#")
-		const contactId = this.extractContactIdFromEvent(last(idParts))
+		const contactId = extractContactIdFromEvent(last(idParts))
 		if (!contactId) {
 			return
 		}
@@ -539,11 +539,11 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 		this.getContactPreviewData(contactId).reload().then(m.redraw)
 	}
 
-	private handleEventPreview(event: CalendarEvent) {
+	private renderEventPreview(event: CalendarEvent) {
 		if (isBirthdayEvent(event.uid)) {
 			const idParts = event._id[1].split("#")
 
-			const contactId = this.extractContactIdFromEvent(last(idParts))
+			const contactId = extractContactIdFromEvent(last(idParts))
 			if (contactId != null && this.getContactPreviewData(contactId).isLoaded()) {
 				return this.renderContactPreview(this.getContactPreviewData(contactId).getSync()!)
 			}
@@ -554,14 +554,6 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 		}
 
 		return null
-	}
-
-	private extractContactIdFromEvent(id: string | null | undefined): string | null {
-		if (id == null) {
-			return null
-		}
-
-		return decodeBase64("utf-8", id)
 	}
 
 	private renderContactPreview(contact: Contact) {

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -1801,9 +1801,11 @@ export default {
 		"yourMessage_label": "Deine Nachricht",
 		"you_label": "Du",
 		"birthdayEvent_title": `{name} Geburtstag`,
-		"birthdayEventAge_title": "({age} Jahre alt)",
+		"birthdayEventAge_title": "{age} Jahre alt",
 		"birthdayCalendar_label": "Geburtstage",
 		"contactNotFound_msg": "Kontakt nicht gefunden",
-		"makeAdminPendingUserGroupKeyRotationError_msg": "Der Benutzer kann zur Zeit keine Admin-Rechte erhalten. Der Benutzer muss sich von all seinen Geräten ausloggen und neu einloggen. Anschließend kann die Aktion ausgeführt werden."
+		"makeAdminPendingUserGroupKeyRotationError_msg": "Der Benutzer kann zur Zeit keine Admin-Rechte erhalten. Der Benutzer muss sich von all seinen Geräten ausloggen und neu einloggen. Anschließend kann die Aktion ausgeführt werden.",
+		"sendMail_label": "Eine E-Mail senden",
+		"callNumber_label": "Rufnummer"
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -1802,8 +1802,10 @@ export default {
 		"you_label": "Sie",
 		"makeAdminPendingUserGroupKeyRotationError_msg": "Der Benutzer kann zur Zeit keine Admin-Rechte erhalten. Der Benutzer muss sich von all seinen Geräten ausloggen und neu einloggen. Anschließend kann die Aktion ausgeführt werden.",
 		"birthdayEvent_title": `{name} Geburtstag`,
-		"birthdayEventAge_title": "({age} Jahre alt)",
+		"birthdayEventAge_title": "{age} Jahre alt",
 		"birthdayCalendar_label": "Geburtstage",
-		"contactNotFound_msg": "Kontakt nicht gefunden"
+		"contactNotFound_msg": "Kontakt nicht gefunden",
+		"sendMail_label": "Eine E-Mail senden",
+		"callNumber_label": "Rufnummer"
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -1797,9 +1797,11 @@ export default {
 		"yourMessage_label": "Your message",
 		"you_label": "You",
 		"birthdayEvent_title": `{name}'s birthday`,
-		"birthdayEventAge_title": `({age} years old)`,
+		"birthdayEventAge_title": `{age} years old`,
 		"birthdayCalendar_label": "Birthdays",
 		"contactNotFound_msg": "Contact not found",
-		"makeAdminPendingUserGroupKeyRotationError_msg": "The user currently cannot become admin. Please ask the user to logout with all their devices and then login again. Afterwards try again."
+		"makeAdminPendingUserGroupKeyRotationError_msg": "The user currently cannot become admin. Please ask the user to logout with all their devices and then login again. Afterwards try again.",
+		"sendMail_label": "Send an email",
+		"callNumber_label": "Call number"
 	}
 }

--- a/test/tests/calendar/CalendarViewModelTest.ts
+++ b/test/tests/calendar/CalendarViewModelTest.ts
@@ -18,6 +18,7 @@ import { EntityUpdateData } from "../../../src/common/api/common/utils/EntityUpd
 import stream from "mithril/stream"
 import Stream from "mithril/stream"
 import {
+	CalendarContactPreviewModelFactory,
 	CalendarEventEditModelsFactory,
 	CalendarEventPreviewModelFactory,
 	CalendarViewModel,
@@ -77,10 +78,12 @@ o.spec("CalendarViewModel", function () {
 		})
 		const mailboxModel: MailboxModel = object()
 		const previewModelFactory: CalendarEventPreviewModelFactory = async () => object()
+		const contactPreviewModelFactory: CalendarContactPreviewModelFactory = async () => object()
 		const viewModel = new CalendarViewModel(
 			loginController,
 			makeViewModelCallback,
 			previewModelFactory,
+			contactPreviewModelFactory,
 			calendarModel,
 			eventsRepository,
 			new EntityClient(entityClientMock),


### PR DESCRIPTION
This commit makes birthday events preview show contact info as a pop-up with pre-defined actions such as send email and call phone number.

Closes #7672 