### PR TITLE
[a11y] Make dark theme accent colors AA-accessible

### DIFF
--- a/src/common/gui/builtinThemes.ts
+++ b/src/common/gui/builtinThemes.ts
@@ -25,8 +25,7 @@ const secondary_red = "#FF2222"
 const dunkel = "#410002"
 const blue = "#013E85"
 const secondary_blue = "#4282FF"
-const light_blue = "#4C89FF"
-const lighter_blue = "#A1C1FF"
+const light_blue = "#ACC7FF"
 
 /**
  *      dark theme background
@@ -46,8 +45,7 @@ const dark_lighter_1 = "#363636"
 const dark_lighter_0 = "#232323"
 const dark = "#222222"
 const dark_darker_0 = "#111111"
-const light_red = "#ff5353"
-const lighter_red = "#FF6C6C"
+const light_red = "#E99497"
 const logo_text_bright_grey = "#c5c7c7"
 const black = "#000000"
 


### PR DESCRIPTION
![Screenshot from 2024-10-17 17-38-04](https://github.com/user-attachments/assets/ca0c840a-b2e9-44e8-9a41-f1f9e24d2f1f)
![Screenshot from 2024-10-17 17-33-21](https://github.com/user-attachments/assets/5add60e2-40b3-431b-ac70-33700e8273b5)
