### PR TITLE
Make default email signature clickable

### DIFF
--- a/src/common/misc/LanguageViewModel.ts
+++ b/src/common/misc/LanguageViewModel.ts
@@ -221,6 +221,7 @@ export const enum InfoLink {
 	AppStorePayment = "https://tuta.com/support/#appstore-payments",
 	AppStoreDowngrade = "https://tuta.com/support/#appstore-subscription-downgrade",
 	PasswordGenerator = "https://tuta.com/faq#passphrase-generator",
+	HomePageFreeSignup = "https://tuta.com/free-email",
 }
 
 /**

--- a/src/mail-app/mail/signature/Signature.ts
+++ b/src/mail-app/mail/signature/Signature.ts
@@ -14,7 +14,7 @@ export function getDefaultSignature(): string {
 		LINE_BREAK +
 		htmlSanitizer.sanitizeHTML(
 			lang.get("defaultEmailSignature_msg", {
-				"{1}": InfoLink.HomePage,
+				"{1}": `<a href=${InfoLink.HomePageFreeSignup}>${InfoLink.HomePageFreeSignup}</a>`,
 			}),
 		).html
 	)


### PR DESCRIPTION
The default email signature should have a clickable link so users don't have to copy and paste the link into the browser. The link itself is added ass a parameter into the translation text. As we don't detect links in email content and make them clickable automatically, I decided to surround the replacement with an anchor tag. I also introduced a new link, that was requested by marketing.