### PR TITLE
Make theme default to system on initial launch on iOS

### DIFF
--- a/src/common/gui/ThemeController.ts
+++ b/src/common/gui/ThemeController.ts
@@ -61,12 +61,11 @@ export class ThemeController {
 
 				// We also don't need to save anything in this case
 				await this.applyCustomizations(parsedTheme, false)
-				// If it's a first start we might get a fallback theme from native. We can apply it for a short time but we should switch to the full, resolved
-				// theme after that.
-				await this.setThemePreference((await this.themeFacade.getThemePreference()) ?? this._themePreference)
-			} else {
-				await this.reloadTheme()
 			}
+
+			// If it's a first start we might get a fallback theme from native. We can apply it for a short time but we should switch to the full, resolved
+			// theme after that.
+			await this.setThemePreference((await this.themeFacade.getThemePreference()) ?? this._themePreference)
 		}
 	}
 


### PR DESCRIPTION
On iOS the app defaults to light theme on initial launch, even if the system theme is dark.

This is a result of iOS initialUrl not containing a theme param causing it to miss initial theme setting logic branch.

Co-authored-by: hrb-hub <181954414+hrb-hub@users.noreply.github.com>

Close: #7045