### PR TITLE
fix: delete wrong cached type

### DIFF
--- a/src/common/api/worker/facades/lazy/CacheManagementFacade.ts
+++ b/src/common/api/worker/facades/lazy/CacheManagementFacade.ts
@@ -36,7 +36,7 @@ export class CacheManagementFacade {
 	 * @param groupId
 	 */
 	async reloadGroup(groupId: Id): Promise<Group> {
-		await this.entityRestCache.deleteFromCacheIfExists(GroupKeyTypeRef, null, groupId)
+		await this.entityRestCache.deleteFromCacheIfExists(GroupTypeRef, null, groupId)
 		return await this.cachingEntityClient.load(GroupTypeRef, groupId)
 	}
 


### PR DESCRIPTION
When asking to remove a cached type, there is a mismatch between the type asking to be removed and the one in the cache.  This causes the client to throw when the admin was logging in

tutadb#1883