### PR TITLE
Fix sort order of mails with mailSet in MailViewModel

### DIFF
--- a/src/mail-app/mail/view/MailViewModel.ts
+++ b/src/mail-app/mail/view/MailViewModel.ts
@@ -56,12 +56,12 @@ export interface MailOpenedListener {
 }
 
 /** sort mail set mails in descending order (**reversed**: newest to oldest) according to their receivedDate, not their elementId */
-function sortCompareMailSetMails(firstMail: Mail, secondMail: Mail): number {
+export function sortCompareMailSetMailsReversed(firstMail: Mail, secondMail: Mail): number {
 	const firstMailReceivedTimestamp = firstMail.receivedDate.getTime()
 	const secondMailReceivedTimestamp = secondMail.receivedDate.getTime()
 	if (firstMailReceivedTimestamp > secondMailReceivedTimestamp) {
 		return -1
-	} else if (secondMailReceivedTimestamp < firstMailReceivedTimestamp) {
+	} else if (firstMailReceivedTimestamp < secondMailReceivedTimestamp) {
 		return 1
 	} else {
 		if (firstBiggerThanSecond(getElementId(firstMail), getElementId(secondMail))) {
@@ -378,7 +378,7 @@ export class MailViewModel {
 					}),
 				)
 			},
-			sortCompare: folder.isMailSet ? sortCompareMailSetMails : sortCompareByReverseId,
+			sortCompare: folder.isMailSet ? sortCompareMailSetMailsReversed : sortCompareByReverseId,
 			autoSelectBehavior: () => this.conversationPrefProvider.getMailAutoSelectBehavior(),
 		})
 	})
@@ -454,7 +454,14 @@ export class MailViewModel {
 		const mailId = this.loadingTargetId ?? (folderId ? this.getMailFolderToSelectedMail().get(folderId) : null)
 		const stickyMail = this.stickyMailId
 		if (mailId != null) {
-			this.router.routeTo("/mail/:folderId/:mailId", this.addStickyMailParam({ folderId, mailId, mail: stickyMail }))
+			this.router.routeTo(
+				"/mail/:folderId/:mailId",
+				this.addStickyMailParam({
+					folderId,
+					mailId,
+					mail: stickyMail,
+				}),
+			)
 		} else {
 			this.router.routeTo("/mail/:folderId", this.addStickyMailParam({ folderId: folderId ?? "" }))
 		}

--- a/test/tests/Suite.ts
+++ b/test/tests/Suite.ts
@@ -131,6 +131,7 @@ import "./api/worker/facades/KeyRotationFacadeTest.js"
 import "./mail/view/ConversationViewModelTest.js"
 import "./mail/view/MailViewerViewModelTest.js"
 import "./api/worker/facades/KeyCacheTest.js"
+import "./mail/view/MailViewModelTest.js"
 
 import * as td from "testdouble"
 import { random } from "@tutao/tutanota-crypto"

--- a/test/tests/mail/view/MailViewModelTest.ts
+++ b/test/tests/mail/view/MailViewModelTest.ts
@@ -1,0 +1,91 @@
+import o from "@tutao/otest"
+import { createTestEntity } from "../../TestUtils"
+import { MailTypeRef } from "../../../../src/common/api/entities/tutanota/TypeRefs"
+import { sortCompareMailSetMailsReversed } from "../../../../src/mail-app/mail/view/MailViewModel"
+import { arrayEquals } from "@tutao/tutanota-utils"
+
+o.spec("MailViewModel", function () {
+	o.spec("sortCompareMailSetMailsReversed sorts mails first by receivedDate and than mailId", function () {
+		o("when mailId of mail1 is newer (i.e. larger) than mailId of mail2, still sort by receivedDate", async function () {
+			let mail1 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "b"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 0, 0),
+			})
+			let mail2 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "a"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 1, 0),
+			})
+
+			let result = [mail2, mail1].sort(sortCompareMailSetMailsReversed)
+			o(arrayEquals(result, [mail2, mail1])).equals(true)(`Wrong sort order! Mails should sort by receivedDate.`)
+			o(sortCompareMailSetMailsReversed(mail1, mail2)).equals(1)
+			o(sortCompareMailSetMailsReversed(mail2, mail1)).equals(-1)
+		})
+
+		o("when mailIds are same, still sort by receivedDate", async function () {
+			let mail1 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "mailId"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 0, 0),
+			})
+			let mail2 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "mailId"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 1, 0),
+			})
+
+			let result = [mail1, mail2].sort(sortCompareMailSetMailsReversed)
+			o(arrayEquals(result, [mail2, mail1])).equals(true)(`Wrong sort order! Mails should sort by receivedDate.`)
+			o(sortCompareMailSetMailsReversed(mail1, mail2)).equals(1)
+			o(sortCompareMailSetMailsReversed(mail2, mail1)).equals(-1)
+		})
+
+		o("still sort by receivedDate, even though mailIds would sort differently with three mails", async function () {
+			let mail1 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "b"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 0, 0),
+			})
+			let mail2 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "a"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 2, 0),
+			})
+			let mail3 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "c"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 1, 0),
+			})
+
+			let result = [mail2, mail1, mail3].sort(sortCompareMailSetMailsReversed)
+			o(arrayEquals(result, [mail2, mail3, mail1])).equals(true)(`Wrong sort order! Mails should sort by receivedDate.`)
+		})
+
+		o("when receivedDate same, then sort by mailId", async function () {
+			let mail1 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "b"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 0, 0),
+			})
+			let mail2 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "a"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 0, 0),
+			})
+
+			o("a" > "b").equals(false)
+			o("a" < "b").equals(true)
+			let result = [mail2, mail1].sort(sortCompareMailSetMailsReversed)
+			o(arrayEquals(result, [mail1, mail2])).equals(true)(`Wrong sort order! Mails should sort by mailId in this case.`)
+			o(sortCompareMailSetMailsReversed(mail1, mail2)).equals(-1)
+			o(sortCompareMailSetMailsReversed(mail2, mail1)).equals(1)
+		})
+
+		o("when both receivedDates and mailIds are the same, then return 0", async function () {
+			let mail1 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "mailId"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 0, 0),
+			})
+			let mail2 = createTestEntity(MailTypeRef, {
+				_id: ["mailListId", "mailId"],
+				receivedDate: new Date(2024, 10, 1, 0, 0, 0, 0),
+			})
+
+			o(sortCompareMailSetMailsReversed(mail2, mail1)).equals(0)
+			o(sortCompareMailSetMailsReversed(mail1, mail2)).equals(0)(`Wrong return value! Should return 0.`)
+		})
+	})
+})


### PR DESCRIPTION
By mistake we executed the same condition twice:

firstMailReceivedTimestamp > secondReceivedTimeStamp & secondReceivedTimestamp < firstReceivedTimestamp

The above condition is apparently checking the same thing twice, and therefore, resulted in possibly random sort orders. This only happened in case of mailSet folders, and if sorting by `mail.receivedDate` is leading to a different sort order, than sorting by `mail.id`.