### PR TITLE
7246 fix calendar nav tooltip

### DIFF
--- a/src/calendar-app/calendar/gui/CalendarGuiUtils.ts
+++ b/src/calendar-app/calendar/gui/CalendarGuiUtils.ts
@@ -169,8 +169,8 @@ export function calendarNavConfiguration(
 			}
 		case CalendarViewType.AGENDA:
 			return {
-				back: renderCalendarSwitchLeftButton("prevWeek_label", onBack),
-				forward: renderCalendarSwitchRightButton("nextWeek_label", onForward),
+				back: renderCalendarSwitchLeftButton("prevDay_label", onBack),
+				forward: renderCalendarSwitchRightButton("nextDay_label", onForward),
 				title: titleType === "short" ? formatMonthWithFullYear(date) : formatDateWithWeekday(date),
 			}
 	}

--- a/src/common/gui/base/Icon.ts
+++ b/src/common/gui/base/Icon.ts
@@ -53,7 +53,7 @@ export class Icon implements Component<IconAttrs> {
 		return m(
 			containerClasses,
 			{
-				title: vnode.attrs.title ?? "",
+				title: vnode.attrs.title ?? null,
 				"aria-hidden": "true",
 				class: this.getClass(vnode.attrs),
 				style: this.getStyle(vnode.attrs.style ?? null),


### PR DESCRIPTION
When hovering the Previous/Next Day IconButton in the Agenda view, the tooltip text displayed was incorrect, showing the text to navigate to the previous/next week instead of the day.

Also fixes an issue with hovering IconButtons and not displaying the tooltip.

Co-authored-by: André Dias <and@tutao.de>