### PR TITLE
Hide more button once clicked for labels/mails

### DIFF
--- a/src/common/gui/base/SidebarSectionRow.ts
+++ b/src/common/gui/base/SidebarSectionRow.ts
@@ -23,7 +23,6 @@ export interface SidebarSectionRowAttrs {
  * Selectable navigation row, typically used in the sidebar, like contact list or labels.
  */
 export class SidebarSectionRow implements Component<SidebarSectionRowAttrs> {
-	private rightButtonClicked: boolean = false
 	private hovered: boolean = false
 
 	view({ attrs }: Vnode<SidebarSectionRowAttrs>): Children {
@@ -57,9 +56,7 @@ export class SidebarSectionRow implements Component<SidebarSectionRowAttrs> {
 				style: { background: isNavButtonSelected(navButtonAttrs) ? stateBgHover : "" },
 				onmouseenter: onHover,
 				onmouseleave: () => {
-					if (!this.rightButtonClicked) {
-						this.hovered = false
-					}
+					this.hovered = false
 				},
 			},
 			[
@@ -79,12 +76,7 @@ export class SidebarSectionRow implements Component<SidebarSectionRowAttrs> {
 					? m(IconButton, {
 							...attrs.moreButton,
 							click: (event, dom) => {
-								// Don't ask me why, but you need to set this to true twice
-								// to have hovering off the folder row work correctly on web
-								// certified JavaScript moment™
-								this.rightButtonClicked = true
 								attrs.moreButton.click(event, dom)
-								this.rightButtonClicked = true
 							},
 							onkeydown: handleForwardsTab,
 					  })

--- a/src/mail-app/mail/view/MailFolderRow.ts
+++ b/src/mail-app/mail/view/MailFolderRow.ts
@@ -28,7 +28,6 @@ export type MailFolderRowAttrs = {
 }
 
 export class MailFolderRow implements Component<MailFolderRowAttrs> {
-	private rightButtonClicked: boolean = false
 	private hovered: boolean = false
 
 	onupdate(vnode: Vnode<MailFolderRowAttrs>): any {
@@ -68,9 +67,7 @@ export class MailFolderRow implements Component<MailFolderRowAttrs> {
 				title: lang.getMaybeLazy(button.label),
 				onmouseenter: onHover,
 				onmouseleave: () => {
-					if (!this.rightButtonClicked) {
-						this.hovered = false
-					}
+					this.hovered = false
 				},
 			},
 			[
@@ -125,12 +122,7 @@ export class MailFolderRow implements Component<MailFolderRowAttrs> {
 					? m(IconButton, {
 							...rightButton,
 							click: (event, dom) => {
-								// Don't ask me why, but you need to set this to true twice
-								// to have hovering off the folder row work correctly on web
-								// certified JavaScript moment™
-								this.rightButtonClicked = true
 								rightButton.click(event, dom)
-								this.rightButtonClicked = true
 							},
 							onkeydown: handleForwardsTab,
 					  })


### PR DESCRIPTION
Remove the right click hack. The dots don't need to be visible once the more button has been clicked, and trying to make it work with the dots still visible would be far more trouble than it's worth.

Closes #7886