### PR TITLE
Fix inline image being removed in mail viewer on reply

### DIFF
--- a/src/mail-app/mail/view/MailViewerViewModel.ts
+++ b/src/mail-app/mail/view/MailViewerViewModel.ts
@@ -908,7 +908,10 @@ export class MailViewerViewModel {
 			const { prependEmailSignature } = await import("../signature/Signature.js")
 			const { newMailEditorAsResponse } = await import("../editor/MailEditor")
 
-			await this.loadAll(Promise.resolve(), { notify: false })
+			const isReloadNeeded = !this.sanitizeResult || this.mail.attachments.length !== this.attachments.length
+			if (isReloadNeeded) {
+				await this.loadAll(Promise.resolve(), { notify: true })
+			}
 			// It should be there after loadAll() but if not we just give up
 			const inlineImageCids = this.sanitizeResult?.inlineImageCids ?? []
 


### PR DESCRIPTION
Issue caused by inline images not being replaced after a loadAll call (without notify) which sanitizes mail body.
This is due to the replaceInlineImages call being inside a loadCompleteNotification listener.

Fixed by calling loadAll *with* notify in reply. loadAll is also now only called when necessary.

Close #6523