### PR TITLE
Hide keyboard in calendar search after clicking Go Button in Mobile

### DIFF
--- a/src/calendar-app/calendar/search/CalendarSearchBar.ts
+++ b/src/calendar-app/calendar/search/CalendarSearchBar.ts
@@ -148,6 +148,8 @@ export class CalendarSearchBar implements Component<CalendarSearchBarAttrs> {
 					} else {
 						this.search()
 					}
+					// blur() is used to hide keyboard on return button click
+					this.domInput.blur()
 				},
 			},
 			{


### PR DESCRIPTION
close: #7898