### PR TITLE
Support entry language not change on switching language

### DIFF
--- a/src/common/support/FaqModel.ts
+++ b/src/common/support/FaqModel.ts
@@ -53,6 +53,10 @@ export class FaqModel {
 	}
 
 	async init(websiteBaseUrl: string): Promise<void> {
+		//resetting the lazy reload whenever the language preference change to clear caching.
+		if (this.currentLanguageCode !== lang.code) {
+			this.lazyLoaded.reset()
+		}
 		this.websiteBaseUrl = websiteBaseUrl
 		await this.lazyLoaded.getAsync()
 		this.getList()


### PR DESCRIPTION
Issue caused by caching the initially selected language and not changing current language while switching language. Resolved by resetting lazyloaded when switching the system language.

close: #7335