### PR TITLE
Fix text appearing grey while printing in dark mode

### DIFF
--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/MobilePlanPrice.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/MobilePlanPrice.kt
@@ -10,7 +10,10 @@ import kotlinx.serialization.json.*
 @Serializable
 data class MobilePlanPrice(
 	val name: String,
-	val monthlyPerMonth: String,
-	val yearlyPerYear: String,
-	val yearlyPerMonth: String,
+	val rawMonthlyPerMonth: String,
+	val rawYearlyPerYear: String,
+	val rawYearlyPerMonth: String,
+	val displayMonthlyPerMonth: String,
+	val displayYearlyPerYear: String,
+	val displayYearlyPerMonth: String,
 )

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/MobilePlanPrice.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/MobilePlanPrice.swift
@@ -4,17 +4,26 @@
 public struct MobilePlanPrice : Codable {
 	public init(
 		name: String,
-		monthlyPerMonth: String,
-		yearlyPerYear: String,
-		yearlyPerMonth: String
+		rawMonthlyPerMonth: String,
+		rawYearlyPerYear: String,
+		rawYearlyPerMonth: String,
+		displayMonthlyPerMonth: String,
+		displayYearlyPerYear: String,
+		displayYearlyPerMonth: String
 	) {
 		self.name = name
-		self.monthlyPerMonth = monthlyPerMonth
-		self.yearlyPerYear = yearlyPerYear
-		self.yearlyPerMonth = yearlyPerMonth
+		self.rawMonthlyPerMonth = rawMonthlyPerMonth
+		self.rawYearlyPerYear = rawYearlyPerYear
+		self.rawYearlyPerMonth = rawYearlyPerMonth
+		self.displayMonthlyPerMonth = displayMonthlyPerMonth
+		self.displayYearlyPerYear = displayYearlyPerYear
+		self.displayYearlyPerMonth = displayYearlyPerMonth
 	}
 	public let name: String
-	public let monthlyPerMonth: String
-	public let yearlyPerYear: String
-	public let yearlyPerMonth: String
+	public let rawMonthlyPerMonth: String
+	public let rawYearlyPerYear: String
+	public let rawYearlyPerMonth: String
+	public let displayMonthlyPerMonth: String
+	public let displayYearlyPerYear: String
+	public let displayYearlyPerMonth: String
 }

--- a/app-ios/tutanota/Sources/Payment/IosMobilePaymentsFacade.swift
+++ b/app-ios/tutanota/Sources/Payment/IosMobilePaymentsFacade.swift
@@ -28,10 +28,14 @@ public class IosMobilePaymentsFacade: MobilePaymentsFacade {
 	}
 
 	public func getPlanPrices() async throws -> [MobilePlanPrice] {
+		// TODO: Handle promotions (first year discount etc.)
 		struct TempMobilePlanPrice {
-			var monthlyPerMonth: String?
-			var yearlyPerYear: String?
-			var yearlyPerMonth: String?
+			var rawMonthlyPerMonth: String?
+			var rawYearlyPerYear: String?
+			var rawYearlyPerMonth: String?
+			var displayMonthlyPerMonth: String?
+			var displayYearlyPerYear: String?
+			var displayYearlyPerMonth: String?
 		}
 		let plans: [String] = ALL_PURCHASEABLE_PLANS.flatMap { plan in
 			[self.formatPlanType(plan, withInterval: 1), self.formatPlanType(plan, withInterval: 12)]
@@ -40,7 +44,16 @@ public class IosMobilePaymentsFacade: MobilePaymentsFacade {
 		var result = [String: TempMobilePlanPrice]()
 		for product in products {
 			let productName = String(product.id.split(separator: ".")[1])
-			var plan = result[productName] ?? TempMobilePlanPrice(monthlyPerMonth: nil, yearlyPerYear: nil, yearlyPerMonth: nil)
+			var plan =
+				result[productName]
+				?? TempMobilePlanPrice(
+					rawMonthlyPerMonth: nil,
+					rawYearlyPerYear: nil,
+					rawYearlyPerMonth: nil,
+					displayMonthlyPerMonth: nil,
+					displayYearlyPerYear: nil,
+					displayYearlyPerMonth: nil
+				)
 
 			let unit = product.subscription!.subscriptionPeriod.unit
 			switch unit {
@@ -49,15 +62,27 @@ public class IosMobilePaymentsFacade: MobilePaymentsFacade {
 				let priceDivided = product.price / 12
 				let yearlyPerMonthPrice = priceDivided.formatted(formatStyle)
 				let yearlyPerYearPrice = product.displayPrice
-				plan.yearlyPerYear = yearlyPerYearPrice
-				plan.yearlyPerMonth = yearlyPerMonthPrice
-			case .month: plan.monthlyPerMonth = product.displayPrice
+				plan.rawYearlyPerYear = String(describing: product.price)
+				plan.rawYearlyPerMonth = String(describing: priceDivided)
+				plan.displayYearlyPerYear = yearlyPerYearPrice
+				plan.displayYearlyPerMonth = yearlyPerMonthPrice
+			case .month:
+				plan.rawMonthlyPerMonth = String(describing: product.price)
+				plan.displayMonthlyPerMonth = product.displayPrice
 			default: fatalError("unexpected subscription period unit \(unit)")
 			}
 			result[productName] = plan
 		}
 		return result.map { name, prices in
-			MobilePlanPrice(name: name, monthlyPerMonth: prices.monthlyPerMonth!, yearlyPerYear: prices.yearlyPerYear!, yearlyPerMonth: prices.yearlyPerMonth!)
+			MobilePlanPrice(
+				name: name,
+				rawMonthlyPerMonth: prices.rawMonthlyPerMonth!,
+				rawYearlyPerYear: prices.rawYearlyPerYear!,
+				rawYearlyPerMonth: prices.rawYearlyPerMonth!,
+				displayMonthlyPerMonth: prices.displayMonthlyPerMonth!,
+				displayYearlyPerYear: prices.displayYearlyPerYear!,
+				displayYearlyPerMonth: prices.displayYearlyPerMonth!
+			)
 		}
 	}
 	public func showSubscriptionConfigView() async throws {

--- a/buildSrc/LaunchHtml.js
+++ b/buildSrc/LaunchHtml.js
@@ -58,7 +58,7 @@ export async function renderHtml(scripts, env) {
 	<meta itemprop="name" content="Turn ON Privacy">
 	<meta itemprop="description" content="Get a free email account with quantum-safe encryption and best privacy on all your devices. Green, secure &amp; no ads!">
 	<meta itemprop="image" content="https://tuta.com/images/share_image.png">
-	<meta name="apple-itunes-app" content="app-id=id922429609, affiliate-data=10lSfb">
+	<meta name="apple-itunes-app" content="app-id=922429609, app-argument=https://app.tuta.com">
 </head>
 <body style="background-color:transparent">
 <noscript>This site requires javascript to be enabled. Please activate it in the settings of your browser.</noscript>

--- a/ipc-schema/types/MobilePlanPrice.json
+++ b/ipc-schema/types/MobilePlanPrice.json
@@ -3,8 +3,11 @@
 	"type": "struct",
 	"fields": {
 		"name": "string",
-		"monthlyPerMonth": "string",
-		"yearlyPerYear": "string",
-		"yearlyPerMonth": "string"
+		"rawMonthlyPerMonth": "string",
+		"rawYearlyPerYear": "string",
+		"rawYearlyPerMonth": "string",
+		"displayMonthlyPerMonth": "string",
+		"displayYearlyPerYear": "string",
+		"displayYearlyPerMonth": "string"
 	}
 }

--- a/src/common/api/worker/invoicegen/InvoiceTexts.ts
+++ b/src/common/api/worker/invoicegen/InvoiceTexts.ts
@@ -34,6 +34,7 @@ export default {
 		yourVatId: "Your VAT identification number:",
 		netPricesNoVatInGermany: "All prices are net prices and not subject to value added tax in Germany.",
 		noVatInGermany: "Prices are not subject to value added tax in Germany.",
+		reverseChargeAffiliate: "All prices are net prices. We are liable for VAT under the reverse charge mechanism",
 
 		paymentInvoiceDue1: "The payment is due 7 days after the invoice date without any deduction. Please",
 		paymentInvoiceDue2: "transfer the grand total with reference to the invoice number to our account:",
@@ -102,6 +103,7 @@ export default {
 		yourVatId: "Ihre Umsatzsteuer-Identifikationsnummer:",
 		netPricesNoVatInGermany: "Alle Beträge sind netto und werden nicht in Deutschland versteuert.",
 		noVatInGermany: "Beträge werden nicht in Deutschland versteuert.",
+		reverseChargeAffiliate: "Alle Beträge sind netto. Die Steuerschuldnerschaft geht auf uns als Leistungsempfänger über.",
 
 		quantity: "Menge",
 		item: "Item",

--- a/src/common/api/worker/invoicegen/PdfInvoiceGenerator.ts
+++ b/src/common/api/worker/invoicegen/PdfInvoiceGenerator.ts
@@ -8,7 +8,7 @@ const enum VatType {
 	ADD_VAT = "1",
 	VAT_INCLUDED_SHOWN = "2",
 	VAT_INCLUDED_HIDDEN = "3",
-	NO_VAT_REVERSE_CHARGE = "4",
+	NO_VAT_CHARGE_TUTAO = "4",
 }
 
 const enum InvoiceType {
@@ -223,7 +223,8 @@ export class PdfInvoiceGenerator {
 			"",
 			"",
 			InvoiceTexts[this.languageCode].grandTotal,
-			this.formatInvoiceCurrency(this.invoice.grandTotal),
+			// in case of NO_VAT_CHARGE_TUTAO we must not show the VAT in the invoice, but we pay the taxes ourselves, so they need to be existing on the invoice
+			this.formatInvoiceCurrency(this.invoice.vatType == VatType.NO_VAT_CHARGE_TUTAO ? this.invoice.subTotal : this.invoice.grandTotal),
 		])
 	}
 
@@ -239,7 +240,6 @@ export class PdfInvoiceGenerator {
 			case VatType.VAT_INCLUDED_SHOWN:
 				break
 			case VatType.NO_VAT:
-			case VatType.NO_VAT_REVERSE_CHARGE:
 				if (this.invoice.vatIdNumber != null) {
 					this.doc
 						.addText(InvoiceTexts[this.languageCode].reverseChargeVatIdNumber1)
@@ -251,6 +251,19 @@ export class PdfInvoiceGenerator {
 						.addText(`${this.invoice.vatIdNumber}`)
 				} else {
 					this.doc.addText(InvoiceTexts[this.languageCode].netPricesNoVatInGermany)
+				}
+				break
+			case VatType.NO_VAT_CHARGE_TUTAO:
+				this.doc
+					.addText(InvoiceTexts[this.languageCode].reverseChargeAffiliate)
+					.addLineBreak()
+					.addText(InvoiceTexts[this.languageCode].reverseChargeVatIdNumber2)
+				if (this.invoice.vatIdNumber != null) {
+					this.doc
+						.addLineBreak()
+						.addText(`${InvoiceTexts[this.languageCode].yourVatId} `)
+						.changeFont(PDF_FONTS.BOLD, 11)
+						.addText(`${this.invoice.vatIdNumber}`)
 				}
 				break
 			case VatType.VAT_INCLUDED_HIDDEN:

--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -8,6 +8,7 @@ import { getContentButtonIconBackground, getElevatedBackground, getNavigationMen
 import { stateBgActive, stateBgFocus, stateBgHover, stateBgLike } from "./builtinThemes.js"
 import { FontIcons } from "./base/icons/FontIcons.js"
 import { DefaultAnimationTime } from "./animation/Animations.js"
+import { locator } from "../api/main/CommonLocator.js"
 
 assertMainOrNode()
 
@@ -35,6 +36,7 @@ const searchBarShadow = "0px 2px 4px rgb(0, 0, 0, 0.12)"
 
 const scrollbarWidthHeight = px(18)
 styles.registerStyle("main", () => {
+	const lightTheme = locator.themeController.getBaseTheme("light")
 	return {
 		"#link-tt": isElectronClient()
 			? {
@@ -2506,6 +2508,8 @@ styles.registerStyle("main", () => {
 			"html, body": {
 				position: "initial",
 				overflow: "visible !important",
+				color: lightTheme.content_fg,
+				"background-color": `${lightTheme.content_bg} !important`,
 			},
 			// overwrite position "fixed" otherwise only one page will be printed.
 			".header-nav": {

--- a/src/common/native/common/generatedipc/MobilePlanPrice.ts
+++ b/src/common/native/common/generatedipc/MobilePlanPrice.ts
@@ -2,7 +2,10 @@
 
 export interface MobilePlanPrice {
 	readonly name: string
-	readonly monthlyPerMonth: string
-	readonly yearlyPerYear: string
-	readonly yearlyPerMonth: string
+	readonly rawMonthlyPerMonth: string
+	readonly rawYearlyPerYear: string
+	readonly rawYearlyPerMonth: string
+	readonly displayMonthlyPerMonth: string
+	readonly displayYearlyPerYear: string
+	readonly displayYearlyPerMonth: string
 }

--- a/src/common/subscription/InvoiceAndPaymentDataPage.ts
+++ b/src/common/subscription/InvoiceAndPaymentDataPage.ts
@@ -159,7 +159,7 @@ export class InvoiceAndPaymentDataPage implements WizardPageN<UpgradeSubscriptio
 								a.data.paymentData,
 								null,
 								a.data.upgradeType === UpgradeType.Signup,
-								a.data.price,
+								neverNull(a.data.price?.rawPrice),
 								neverNull(a.data.accountingInfo),
 							).then((success) => {
 								if (success) {

--- a/src/common/subscription/PriceUtils.ts
+++ b/src/common/subscription/PriceUtils.ts
@@ -121,7 +121,7 @@ export function getPriceFromPriceData(priceData: PriceData | null, featureType: 
 export type SubscriptionPrice = {
 	// The locale formatted price of a description in the local currency on iOS and in Euro elsewhere
 	displayPrice: string
-	// The raw price in Euro as a float
+	// The raw price in the local currency on iOS and in Euro elsewhere as a float
 	rawPrice: string
 }
 
@@ -173,7 +173,9 @@ export class PriceAndConfigProvider {
 			: this.getMonthlySubscriptionPrice(subscription, type)
 	}
 
-	// Returns the subscription price with the currency formatting on iOS and as a plain period seperated number on other platforms
+	/**
+	 * Returns the subscription price with the currency formatting on iOS and as a plain period seperated number on other platforms
+	 */
 	getSubscriptionPriceWithCurrency(paymentInterval: PaymentInterval, subscription: PlanType, type: UpgradePriceType): SubscriptionPrice {
 		const price = this.getSubscriptionPrice(paymentInterval, subscription, type)
 		const rawPrice = price.toString()
@@ -181,8 +183,8 @@ export class PriceAndConfigProvider {
 		if (isIOSApp()) {
 			return this.getAppStorePaymentsSubscriptionPrice(subscription, paymentInterval, rawPrice, type)
 		} else {
-			const displayPrice = formatPrice(price, true)
-			return { displayPrice, rawPrice }
+			const price = this.getSubscriptionPrice(paymentInterval, subscription, type)
+			return { displayPrice: formatPrice(price, true), rawPrice: price.toString() }
 		}
 	}
 
@@ -198,15 +200,9 @@ export class PriceAndConfigProvider {
 
 		switch (paymentInterval) {
 			case PaymentInterval.Monthly:
-				return { displayPrice: applePrices.monthlyPerMonth, rawPrice }
+				return { displayPrice: applePrices.displayMonthlyPerMonth, rawPrice: applePrices.rawMonthlyPerMonth }
 			case PaymentInterval.Yearly:
-				if (isCyberMonday && subscription === PlanType.Legend && type === UpgradePriceType.PlanActualPrice) {
-					const revolutionaryYearlyPerYear = this.getMobilePrices().get(PlanTypeToName[PlanType.Revolutionary].toLowerCase())?.yearlyPerYear ?? NBSP
-
-					return { displayPrice: revolutionaryYearlyPerYear, rawPrice }
-				}
-
-				return { displayPrice: applePrices.yearlyPerYear, rawPrice }
+				return { displayPrice: applePrices.displayYearlyPerYear, rawPrice: applePrices.rawYearlyPerYear }
 		}
 	}
 

--- a/src/common/subscription/SubscriptionSelector.ts
+++ b/src/common/subscription/SubscriptionSelector.ts
@@ -264,19 +264,19 @@ export class SubscriptionSelector implements Component<SubscriptionSelectorAttr>
 			if (prices != null) {
 				if (isCyberMonday && targetSubscription === PlanType.Legend && interval == PaymentInterval.Yearly) {
 					const revolutionaryPrice = priceAndConfigProvider.getMobilePrices().get(PlanTypeToName[PlanType.Revolutionary].toLowerCase())
-					priceStr = revolutionaryPrice?.yearlyPerMonth ?? NBSP
+					priceStr = revolutionaryPrice?.displayYearlyPerMonth ?? NBSP
 					// if there is a discount for this plan we show the original price as reference
-					referencePriceStr = prices?.yearlyPerMonth
+					referencePriceStr = prices?.displayYearlyPerMonth
 				} else {
 					switch (interval) {
 						case PaymentInterval.Monthly:
-							priceStr = prices.monthlyPerMonth
+							priceStr = prices.displayMonthlyPerMonth
 							break
 						case PaymentInterval.Yearly:
-							priceStr = prices.yearlyPerMonth
+							priceStr = prices.displayYearlyPerMonth
 							if (!isCyberMonday) {
 								// if there is no discount for any plan then we show the monthly price as reference
-								referencePriceStr = prices.monthlyPerMonth
+								referencePriceStr = prices.displayMonthlyPerMonth
 							}
 							break
 					}

--- a/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
+++ b/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
@@ -168,8 +168,8 @@ export class UpgradeConfirmSubscriptionPage implements WizardPageN<UpgradeSubscr
 					isReadOnly: true,
 				}),
 				m(TextField, {
-					label: isYearly ? "priceFirstYear_label" : "price_label",
-					value: buildPriceString(attrs.data.displayPrice, attrs.data.options),
+					label: isYearly && attrs.data.nextYearPrice ? "priceFirstYear_label" : "price_label",
+					value: buildPriceString(attrs.data.price?.displayPrice ?? "0", attrs.data.options),
 					isReadOnly: true,
 				}),
 				this.renderPriceNextYear(attrs),
@@ -204,10 +204,10 @@ export class UpgradeConfirmSubscriptionPage implements WizardPageN<UpgradeSubscr
 	}
 
 	private renderPriceNextYear(attrs: WizardPageAttrs<UpgradeSubscriptionData>) {
-		return attrs.data.priceNextYear
+		return attrs.data.nextYearPrice
 			? m(TextField, {
 					label: "priceForNextYear_label",
-					value: buildPriceString(attrs.data.priceNextYear, attrs.data.options),
+					value: buildPriceString(attrs.data.nextYearPrice.displayPrice, attrs.data.options),
 					isReadOnly: true,
 			  })
 			: null

--- a/src/common/subscription/UpgradeSubscriptionPage.ts
+++ b/src/common/subscription/UpgradeSubscriptionPage.ts
@@ -127,8 +127,8 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 				// Confirmation of free/business dialog (click on ok)
 				this.__signupFreeTest?.getStage(1).complete()
 				data.type = PlanType.Free
-				data.price = "0"
-				data.priceNextYear = "0"
+				data.price = null
+				data.nextYearPrice = null
 				this.showNextPage()
 			}
 		})
@@ -207,12 +207,10 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 		data.type = planType
 		const { planPrices, options } = data
 		try {
-			// `data.price` is used for the amount parameter in the Braintree credit card verification call, so we do not include currency locale outside iOS.
-			const subscriptionPrice = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanActualPrice)
-			data.price = subscriptionPrice.rawPrice
-			data.displayPrice = subscriptionPrice.displayPrice
-			const nextYear = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanNextYearsPrice).displayPrice
-			data.priceNextYear = data.price !== nextYear ? nextYear : null
+			// `data.price.rawPrice` is used for the amount parameter in the Braintree credit card verification call, so we do not include currency locale outside iOS.
+			data.price = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanActualPrice)
+			const nextYear = planPrices.getSubscriptionPriceWithCurrency(options.paymentInterval(), data.type, UpgradePriceType.PlanNextYearsPrice)
+			data.nextYearPrice = data.price.rawPrice !== nextYear.rawPrice ? nextYear : null
 		} catch (e) {
 			console.error(e)
 			Dialog.message("appStoreNotAvailable_msg")

--- a/src/common/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/common/subscription/UpgradeSubscriptionWizard.ts
@@ -26,7 +26,7 @@ import { StorageBehavior } from "../misc/UsageTestModel"
 import { FeatureListProvider, SelectedSubscriptionOptions } from "./FeatureListProvider"
 import { queryAppStoreSubscriptionOwnership, UpgradeType } from "./SubscriptionUtils"
 import { UpgradeConfirmSubscriptionPage } from "./UpgradeConfirmSubscriptionPage.js"
-import { asPaymentInterval, PaymentInterval, PriceAndConfigProvider } from "./PriceUtils"
+import { asPaymentInterval, PaymentInterval, PriceAndConfigProvider, SubscriptionPrice } from "./PriceUtils"
 import { formatNameAndAddress } from "../api/common/utils/CommonFormatter.js"
 import { LoginController } from "../api/main/LoginController.js"
 import { MobilePaymentSubscriptionOwnership } from "../native/common/generatedipc/MobilePaymentSubscriptionOwnership.js"
@@ -49,13 +49,8 @@ export type UpgradeSubscriptionData = {
 	invoiceData: InvoiceData
 	paymentData: PaymentData
 	type: PlanType
-	// Subscription price as a float
-	price: string
-	// Subscription price as a formatted string with the currency symbol and with decimal separator from local
-	// On iOS: in the local currency
-	// Else: in Euro
-	displayPrice: string
-	priceNextYear: string | null
+	price: SubscriptionPrice | null
+	nextYearPrice: SubscriptionPrice | null
 	accountingInfo: AccountingInfo | null
 	// not initially set for signup but loaded in InvoiceAndPaymentDataPage
 	customer: Customer | null
@@ -96,10 +91,9 @@ export async function showUpgradeWizard(logins: LoginController, acceptedPlans: 
 			paymentMethod: getPaymentMethodType(accountingInfo) || (await getDefaultPaymentMethod()),
 			creditCardData: null,
 		},
-		price: "",
-		displayPrice: "",
+		price: null,
 		type: PlanType.Revolutionary,
-		priceNextYear: null,
+		nextYearPrice: null,
 		accountingInfo: accountingInfo,
 		customer: customer,
 		newAccountData: null,
@@ -184,9 +178,8 @@ export async function loadSignupWizard(
 			paymentMethod: await getDefaultPaymentMethod(),
 			creditCardData: null,
 		},
-		price: "",
-		displayPrice: "",
-		priceNextYear: null,
+		price: null,
+		nextYearPrice: null,
 		type: PlanType.Free,
 		accountingInfo: null,
 		customer: null,


### PR DESCRIPTION
It was the caused by the different foreground and background contrast between the light mode and dark mode.
This PR forces the light mode foreground and background to be used when printing.
Closes #5781.