### PR TITLE
Use UIApplication.open instead of UIApplication.openURL on share

### DIFF
--- a/app-ios/TutanotaShareExtension/ShareViewController.swift
+++ b/app-ios/TutanotaShareExtension/ShareViewController.swift
@@ -100,8 +100,8 @@ import WebKit
 		var responder: UIResponder? = self
 		while responder != nil {
 			if let application = responder as? UIApplication {
-				let result = application.perform(#selector(openURL(_:)), with: url)
-				return result != nil
+				application.open(url)
+				return true
 			}
 			responder = responder?.next
 		}


### PR DESCRIPTION
"Calling this method has no effect." according to Apple docs. This was changed recently according to wayback machine.

https://developer.apple.com/documentation/uikit/uiapplication/1622961-openurl

Fixes #7944