### PR TITLE
Show long Url properly in mobile view.

### DIFF
--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -602,7 +602,7 @@ styles.registerStyle("main", () => {
 			"word-break": "break-all",
 		},
 		".break-word-links a": {
-			"word-wrap": "break-word",
+			"overflow-wrap": "anywhere",
 		},
 		".text-prewrap": {
 			"white-space": "pre-wrap",


### PR DESCRIPTION
very long Url in mobile app showing in small text which is not readable. Resolved by breaking overflow text in url to multiple lines which will make link readable to user.

close: #7972