### PR TITLE
Correct error names in ErrorNameToType map

### DIFF
--- a/app-ios/TutanotaSharedFramework/Contacts/ContactStoreError.swift
+++ b/app-ios/TutanotaSharedFramework/Contacts/ContactStoreError.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-public class ContactStoreError: TutanotaError { public override var name: String { get { "de.tutao.ContactStoreError" } } }
+public class ContactStoreError: TutanotaError { public override var name: String { get { "de.tutao.tutashared.ContactStoreError" } } }

--- a/app-ios/TutanotaSharedFramework/Keychain/KeychainManager.swift
+++ b/app-ios/TutanotaSharedFramework/Keychain/KeychainManager.swift
@@ -6,8 +6,8 @@ import LocalAuthentication
 #endif
 
 private let TAG = "de.tutao.tutanota.notificationkey."
-private let KEY_PERMANENTLY_INVALIDATED_ERROR_DOMAIN = "de.tutao.tutanota.KeyPermanentlyInvalidatedError"
-private let CREDENTIAL_AUTHENTICATION_ERROR_DOMAIN = "de.tutao.tutanota.CredentialAuthenticationError"
+private let KEY_PERMANENTLY_INVALIDATED_ERROR_DOMAIN = "de.tutao.tutashared.KeyPermanentlyInvalidatedError"
+private let CREDENTIAL_AUTHENTICATION_ERROR_DOMAIN = "de.tutao.tutashared.CredentialAuthenticationError"
 
 class KeyPermanentlyInvalidatedError: TutanotaError {
 	init(underlyingError: Error) { super.init(message: underlyingError.localizedDescription, underlyingError: underlyingError) }

--- a/app-ios/TutanotaSharedFramework/Offline/IosSqlCipherFade.swift
+++ b/app-ios/TutanotaSharedFramework/Offline/IosSqlCipherFade.swift
@@ -5,7 +5,7 @@ enum ListIdLockState {
 	case listIdUnlocked
 }
 
-let OFFLINE_DB_CLOSED_DOMAIN = "de.tutao.tutanota.offline.OfflineDbClosedError"
+let OFFLINE_DB_CLOSED_DOMAIN = "de.tutao.tutashared.offline.OfflineDbClosedError"
 
 public actor IosSqlCipherFacade: SqlCipherFacade {
 	private var db: SqlCipherDb?

--- a/app-ios/TutanotaSharedFramework/Utils/CancelledError.swift
+++ b/app-ios/TutanotaSharedFramework/Utils/CancelledError.swift
@@ -1,5 +1,5 @@
 public class CancelledError: TutanotaError {
 	public override init(message: String, underlyingError: Error?) { super.init(message: message, underlyingError: underlyingError) }
 
-	public override var name: String { get { "de.tutao.tutanota.CancelledError" } }
+	public override var name: String { get { "de.tutao.tutashared.CancelledError" } }
 }

--- a/app-ios/TutanotaSharedFramework/Utils/PermissionError.swift
+++ b/app-ios/TutanotaSharedFramework/Utils/PermissionError.swift
@@ -4,5 +4,5 @@ public class PermissionError: TutanotaError {
 
 	init(message: String) { super.init(message: message, underlyingError: nil) }
 
-	public override var name: String { get { "de.tutao.tutanota.PermissionError" } }
+	public override var name: String { get { "de.tutao.tutashared.PermissionError" } }
 }

--- a/app-ios/TutanotaSharedFramework/Utils/TUTErrorFactory.m
+++ b/app-ios/TutanotaSharedFramework/Utils/TUTErrorFactory.m
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import "TUTErrorFactory.h"
 
-NSString *const TUT_ERROR_DOMAIN = @"de.tutao.tutanota";
-NSString *const TUT_CRYPTO_ERROR = @"de.tutao.tutanota.TutCrypto";
-NSString *const TUT_FILEVIEWER_ERROR = @"de.tutao.tutanota.TutFileViewer";
-NSString *const TUT_NETWORK_ERROR = @"de.tutao.tutanota.network";
+NSString *const TUT_ERROR_DOMAIN = @"de.tutao.tutashared";
+NSString *const TUT_CRYPTO_ERROR = @"de.tutao.tutashared.TutCrypto";
+NSString *const TUT_FILEVIEWER_ERROR = @"de.tutao.tutashared.TutFileViewer";
+NSString *const TUT_NETWORK_ERROR = @"de.tutao.tutashared.network";
 
 @implementation TUTErrorFactory
 

--- a/src/common/api/common/utils/ErrorUtils.ts
+++ b/src/common/api/common/utils/ErrorUtils.ts
@@ -78,7 +78,7 @@ export function isOfflineError(e: Error) {
 
 /**
  * This maps the errors from their names to their constructors.
- * This is needed generally when errros cross IPC boundaries and more specifically when we want to map native errors to
+ * This is needed generally when errors cross IPC boundaries and more specifically when we want to map native errors to
  * our error classes.
  *
  * All errors that cross IPC boundaries should be added here.
@@ -138,23 +138,23 @@ const ErrorNameToType = {
 	"java.net.UnknownHostException": ConnectionError,
 	"java.lang.SecurityException": PermissionError,
 	"java.io.FileNotFoundException": FileNotFoundError,
-	"de.tutao.tutanota.CryptoError": CryptoError,
+	"de.tutao.tutashared.CryptoError": CryptoError,
 	// Android app exception class name
-	"de.tutao.tutanota.TutCrypto": CryptoError,
+	"de.tutao.tutashared.TutCrypto": CryptoError,
 	// iOS app crypto error domain
 	"android.content.ActivityNotFoundException": FileOpenError,
-	"de.tutao.tutanota.TutFileViewer": FileOpenError,
+	"de.tutao.tutashared.TutFileViewer": FileOpenError,
 	NSURLErrorDomain: ConnectionError,
 	"de.tutao.tutashared.CredentialAuthenticationException": CredentialAuthenticationError,
 	"android.security.keystore.KeyPermanentlyInvalidatedException": KeyPermanentlyInvalidatedError,
-	"de.tutao.tutanota.KeyPermanentlyInvalidatedError": KeyPermanentlyInvalidatedError,
-	"de.tutao.tutanota.CredentialAuthenticationError": CredentialAuthenticationError,
-	"de.tutao.tutanota.offline.OfflineDbClosedError": OfflineDbClosedError,
-	"de.tutao.tutanota.CancelledError": CancelledError,
+	"de.tutao.tutashared.KeyPermanentlyInvalidatedError": KeyPermanentlyInvalidatedError,
+	"de.tutao.tutashared.CredentialAuthenticationError": CredentialAuthenticationError,
+	"de.tutao.tutashared.offline.OfflineDbClosedError": OfflineDbClosedError,
+	"de.tutao.tutashared.CancelledError": CancelledError,
 	"de.tutao.tutanota.webauthn.WebauthnError": WebauthnError,
 	"de.tutao.tutanota.Webauthn": WebauthnError,
-	"de.tutao.tutanota.PermissionError": PermissionError,
-	"de.tutao.ContactStoreError": ContactStoreError,
+	"de.tutao.tutashared.PermissionError": PermissionError,
+	"de.tutao.tutashared.ContactStoreError": ContactStoreError,
 	"de.tutao.tutanota.MobilePayment": MobilePaymentError,
 }
 

--- a/src/common/api/common/utils/ErrorUtils.ts
+++ b/src/common/api/common/utils/ErrorUtils.ts
@@ -145,7 +145,7 @@ const ErrorNameToType = {
 	"android.content.ActivityNotFoundException": FileOpenError,
 	"de.tutao.tutanota.TutFileViewer": FileOpenError,
 	NSURLErrorDomain: ConnectionError,
-	"de.tutao.tutanota.CredentialAuthenticationException": CredentialAuthenticationError,
+	"de.tutao.tutashared.CredentialAuthenticationException": CredentialAuthenticationError,
 	"android.security.keystore.KeyPermanentlyInvalidatedException": KeyPermanentlyInvalidatedError,
 	"de.tutao.tutanota.KeyPermanentlyInvalidatedError": KeyPermanentlyInvalidatedError,
 	"de.tutao.tutanota.CredentialAuthenticationError": CredentialAuthenticationError,


### PR DESCRIPTION
Some errors names contain tutanota package when it should have been tutashared. Caught because the incorrect CredentialAuthenticationException name was causing the error banner to show on Authentication cancelled due the error not being handled correctly.

Close #7977 

Co-authored-by: ivk <ivk@tutao.de>