### PR TITLE
fix opening mail preview from notification on mobile after key rotation

### DIFF
--- a/app-android/.run/app-debug-emulator.run.xml
+++ b/app-android/.run/app-debug-emulator.run.xml
@@ -10,11 +10,10 @@
     <option name="ALWAYS_INSTALL_WITH_PM" value="false" />
     <option name="CLEAR_APP_STORAGE" value="false" />
     <option name="DYNAMIC_FEATURES_DISABLED_LIST" value="" />
-    <option name="ACTIVITY_EXTRA_FLAGS" value="" />
+    <option name="ACTIVITY_EXTRA_FLAGS" value="-dns-server 127.0.0.1" />
     <option name="MODE" value="default_activity" />
     <option name="CLEAR_LOGCAT" value="true" />
     <option name="SHOW_LOGCAT_AUTOMATICALLY" value="true" />
-    <option name="INSPECTION_WITHOUT_ACTIVITY_RESTART" value="false" />
     <option name="TARGET_SELECTION_MODE" value="DEVICE_AND_SNAPSHOT_COMBO_BOX" />
     <option name="SELECTED_CLOUD_MATRIX_CONFIGURATION_ID" value="-1" />
     <option name="SELECTED_CLOUD_MATRIX_PROJECT_ID" value="" />

--- a/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
@@ -1,7 +1,7 @@
 #[cfg_attr(test, mockall_double::double)]
 use crate::crypto::crypto_facade::CryptoFacade;
 use crate::element_value::ParsedEntity;
-use crate::entities::entity_facade::EntityFacade;
+use crate::entities::entity_facade::{EntityFacade, ID_FIELD};
 use crate::entities::Entity;
 #[cfg_attr(test, mockall_double::double)]
 use crate::entity_client::EntityClient;
@@ -74,7 +74,7 @@ impl CryptoEntityClient {
 			.resolve_session_key(&mut parsed_entity, type_model)
 			.await
 			.map_err(|error| {
-				let id = parsed_entity.get("_id");
+				let id = parsed_entity.get(ID_FIELD);
 				ApiCallError::InternalSdkError {
 					error_message: format!(
 						"Failed to resolve session key for entity '{}' with ID: {:?}; {}",
@@ -153,7 +153,7 @@ mod tests {
 	use crate::crypto::{aes::Iv, Aes256Key};
 	use crate::crypto_entity_client::CryptoEntityClient;
 	use crate::date::DateTime;
-	use crate::entities::entity_facade::EntityFacadeImpl;
+	use crate::entities::entity_facade::{EntityFacadeImpl, ID_FIELD};
 	use crate::entities::generated::tutanota::Mail;
 	use crate::entity_client::MockEntityClient;
 	use crate::instance_mapper::InstanceMapper;
@@ -188,7 +188,7 @@ mod tests {
 		let my_favorite_leak: &'static TypeModelProvider = leak(init_type_model_provider());
 
 		let raw_mail_id = encrypted_mail
-			.get("_id")
+			.get(ID_FIELD)
 			.unwrap()
 			.assert_tuple_id_generated();
 		let mail_id =
@@ -218,6 +218,7 @@ mod tests {
 				Ok(Some(ResolvedSessionKey {
 					session_key: sk.clone(),
 					owner_enc_session_key: vec![1, 2, 3],
+					owner_key_version: 0i64,
 				}))
 			});
 

--- a/tuta-sdk/rust/sdk/src/entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/entity_client.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::element_value::{ElementValue, ParsedEntity};
+use crate::entities::entity_facade::ID_FIELD;
 use crate::id::id_tuple::{BaseIdType, IdTupleType, IdType};
 use crate::json_element::RawEntity;
 use crate::json_serializer::JsonSerializer;
@@ -142,7 +143,7 @@ impl EntityClient {
 		entity: ParsedEntity,
 		model_version: u32,
 	) -> Result<(), ApiCallError> {
-		let id = match &entity.get("_id").unwrap() {
+		let id = match &entity.get(ID_FIELD).unwrap() {
 			ElementValue::IdTupleGeneratedElementId(ref id_tuple) => id_tuple.to_string(),
 			ElementValue::IdTupleCustomElementId(ref id_tuple) => id_tuple.to_string(),
 			_ => panic!("id is not string or array"),
@@ -310,7 +311,7 @@ mod tests {
 
 		let list_id = GeneratedId("list_id".to_owned());
 		let entity_map: HashMap<String, ElementValue> = collection! {
-			"_id" => ElementValue::IdTupleGeneratedElementId(IdTupleGenerated::new(list_id.clone(), GeneratedId("element_id".to_owned()))),
+			ID_FIELD => ElementValue::IdTupleGeneratedElementId(IdTupleGenerated::new(list_id.clone(), GeneratedId("element_id".to_owned()))),
 			"field" => ElementValue::Bytes(vec![1, 2, 3])
 		};
 		let mut rest_client = MockRestClient::new();
@@ -360,7 +361,7 @@ mod tests {
 
 		let list_id = GeneratedId("list_id".to_owned());
 		let entity_map: HashMap<String, ElementValue> = collection! {
-			"_id" => ElementValue::IdTupleCustomElementId(IdTupleCustom::new(list_id.clone(), CustomId("element_id".to_owned()))),
+			ID_FIELD => ElementValue::IdTupleCustomElementId(IdTupleCustom::new(list_id.clone(), CustomId("element_id".to_owned()))),
 			"field" => ElementValue::Bytes(vec![1, 2, 3])
 		};
 		let mut rest_client = MockRestClient::new();
@@ -410,7 +411,7 @@ mod tests {
 
 		let list_id = GeneratedId("list_id".to_owned());
 		let entity_map: HashMap<String, ElementValue> = collection! {
-			"_id" => ElementValue::IdTupleGeneratedElementId(IdTupleGenerated::new(list_id.clone(), GeneratedId("element_id".to_owned()))),
+			ID_FIELD => ElementValue::IdTupleGeneratedElementId(IdTupleGenerated::new(list_id.clone(), GeneratedId("element_id".to_owned()))),
 			"field" => ElementValue::Bytes(vec![1, 2, 3])
 		};
 		let mut rest_client = MockRestClient::new();
@@ -460,7 +461,7 @@ mod tests {
 
 		let list_id = GeneratedId("list_id".to_owned());
 		let entity_map: HashMap<String, ElementValue> = collection! {
-			"_id" => ElementValue::IdTupleCustomElementId(IdTupleCustom::new(list_id.clone(), CustomId("element_id".to_owned()))),
+			ID_FIELD => ElementValue::IdTupleCustomElementId(IdTupleCustom::new(list_id.clone(), CustomId("element_id".to_owned()))),
 			"field" => ElementValue::Bytes(vec![1, 2, 3])
 		};
 		let mut rest_client = MockRestClient::new();
@@ -516,7 +517,7 @@ mod tests {
 			encrypted: true,
 			root_id: "",
 			values: str_map! {
-				"_id" => ModelValue {
+				ID_FIELD => ModelValue {
 						id: 1,
 						value_type: ValueType::GeneratedId,
 						cardinality: Cardinality::One,
@@ -546,7 +547,7 @@ mod tests {
 			encrypted: true,
 			root_id: "",
 			values: str_map! {
-				"_id" => ModelValue {
+				ID_FIELD => ModelValue {
 						id: 1,
 						value_type: ValueType::CustomId,
 						cardinality: Cardinality::One,

--- a/tuta-sdk/rust/sdk/src/instance_mapper.rs
+++ b/tuta-sdk/rust/sdk/src/instance_mapper.rs
@@ -1107,6 +1107,9 @@ impl Serializer for MapKeySerializer {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::entities::entity_facade::{
+		FORMAT_FIELD, ID_FIELD, OWNER_GROUP_FIELD, PERMISSIONS_FIELD,
+	};
 	use crate::entities::generated::sys::{Group, GroupInfo};
 	use crate::entities::generated::tutanota::{
 		CalendarEventUidIndex, Mail, MailDetailsBlob, MailboxGroupRoot, OutOfOfficeNotification,
@@ -1179,12 +1182,12 @@ mod tests {
 
 	#[test]
 	fn test_de_error_wrong_type() {
-		let parsed_entity = [("_id".to_owned(), ElementValue::Number(2))].into();
+		let parsed_entity = [(ID_FIELD.to_owned(), ElementValue::Number(2))].into();
 		let mapper = InstanceMapper::new();
 		let group_result = mapper.parse_entity::<Group>(parsed_entity);
 		let err = group_result.unwrap_err();
 		assert!(
-			err.to_string().contains("_id"),
+			err.to_string().contains(ID_FIELD),
 			"error message should contain _id"
 		)
 	}
@@ -1192,7 +1195,7 @@ mod tests {
 	#[test]
 	fn test_de_error_missing_key() {
 		let parsed_entity = [(
-			"_id".to_owned(),
+			ID_FIELD.to_owned(),
 			ElementValue::IdGeneratedId(GeneratedId("id".to_owned())),
 		)]
 		.into();
@@ -1218,14 +1221,14 @@ mod tests {
 	fn test_de_out_of_office_notification() {
 		let parsed_entity: ParsedEntity = HashMap::from_iter(
 			[
-				("_format", ElementValue::Number(0)),
+				(FORMAT_FIELD, ElementValue::Number(0)),
 				(
-					"_id",
+					ID_FIELD,
 					ElementValue::IdGeneratedId(GeneratedId("id".to_owned())),
 				),
-				("_ownerGroup", ElementValue::Null),
+				(OWNER_GROUP_FIELD, ElementValue::Null),
 				(
-					"_permissions",
+					PERMISSIONS_FIELD,
 					ElementValue::IdGeneratedId(GeneratedId("permissions".to_owned())),
 				),
 				("enabled", ElementValue::Bool(true)),
@@ -1296,7 +1299,7 @@ mod tests {
 		};
 		let mapper = InstanceMapper::new();
 		let result = mapper.serialize_entity(group_root.clone()).unwrap();
-		assert_eq!(&ElementValue::Number(0), result.get("_format").unwrap());
+		assert_eq!(&ElementValue::Number(0), result.get(FORMAT_FIELD).unwrap());
 	}
 
 	#[test]
@@ -1308,7 +1311,7 @@ mod tests {
 			&group.groupInfo,
 			result.get("groupInfo").unwrap().assert_tuple_id_generated()
 		);
-		assert_eq!(&ElementValue::Number(0), result.get("_format").unwrap());
+		assert_eq!(&ElementValue::Number(0), result.get(FORMAT_FIELD).unwrap());
 		assert_eq!(
 			&ElementValue::Bytes(vec![1, 2, 3]),
 			result
@@ -1355,7 +1358,7 @@ mod tests {
 
 		assert_eq!(
 			ElementValue::IdTupleCustomElementId(_id),
-			*parsed_entity.get("_id").unwrap()
+			*parsed_entity.get(ID_FIELD).unwrap()
 		);
 		assert_eq!(
 			ElementValue::IdTupleCustomElementId(progenitor),
@@ -1390,7 +1393,7 @@ mod tests {
 
 		assert_eq!(
 			ElementValue::IdTupleGeneratedElementId(_id),
-			*parsed_entity.get("_id").unwrap()
+			*parsed_entity.get(ID_FIELD).unwrap()
 		);
 		assert_eq!(
 			ElementValue::Date(DateTime::from_millis(1533116004052)),
@@ -1416,7 +1419,10 @@ mod tests {
 		let serialized = mapper.serialize_entity(mail).unwrap();
 		assert_eq!(
 			&_id,
-			serialized.get("_id").unwrap().assert_tuple_id_generated()
+			serialized
+				.get(ID_FIELD)
+				.unwrap()
+				.assert_tuple_id_generated()
 		);
 		assert_eq!(
 			&mail_details_id,
@@ -1456,7 +1462,10 @@ mod tests {
 		let serialized = mapper.serialize_entity(mail_details_blob).unwrap();
 		assert_eq!(
 			&_id,
-			serialized.get("_id").unwrap().assert_tuple_id_generated()
+			serialized
+				.get(ID_FIELD)
+				.unwrap()
+				.assert_tuple_id_generated()
 		);
 
 		let deserialized: MailDetailsBlob = mapper.parse_entity(serialized).unwrap();

--- a/tuta-sdk/rust/sdk/src/json_serializer.rs
+++ b/tuta-sdk/rust/sdk/src/json_serializer.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 use crate::date::DateTime;
 use crate::element_value::{ElementValue, ParsedEntity};
+use crate::entities::entity_facade::ID_FIELD;
 use crate::json_element::{JsonElement, RawEntity};
 use crate::json_serializer::InstanceMapperError::InvalidValue;
 use crate::metamodel::{
@@ -492,7 +493,7 @@ impl JsonSerializer {
 			return Ok(JsonElement::Null);
 		}
 
-		if value_name == "_id" {
+		if value_name == ID_FIELD {
 			return match (
 				&model_value.value_type,
 				element_value,
@@ -615,7 +616,7 @@ impl JsonSerializer {
 		// Type models for ids are special.
 		// The actual type depends on the type of the Element.
 		// e.g. for ListElementType the GeneratedId actually means IdTuple.-
-		if value_name == "_id" {
+		if value_name == ID_FIELD {
 			return match (
 				&model_value.value_type,
 				json_value,

--- a/tuta-sdk/rust/sdk/src/services/service_executor.rs
+++ b/tuta-sdk/rust/sdk/src/services/service_executor.rs
@@ -661,6 +661,7 @@ mod tests {
 				.unwrap();
 		}
 		let owner_enc_session_key = [rand::random(); 32].to_vec();
+		let owner_key_version = 0i64;
 
 		rest_client
 			.expect_request_binary()
@@ -706,6 +707,7 @@ mod tests {
 				Ok(Some(ResolvedSessionKey {
 					session_key: session_key_clone.clone(),
 					owner_enc_session_key: owner_enc_session_key.clone(),
+					owner_key_version,
 				}))
 			});
 

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -5,6 +5,7 @@ use rand::random;
 use crate::crypto::randomizer_facade::test_util::make_thread_rng_facade;
 use crate::crypto::Aes256Key;
 use crate::element_value::{ElementValue, ParsedEntity};
+use crate::entities::entity_facade::ID_FIELD;
 use crate::entities::generated::sys::{
 	ArchiveRef, ArchiveType, Group, GroupKeysRef, KeyPair, PubEncKeyData, TypeInfo,
 };
@@ -199,7 +200,7 @@ fn create_test_entity_dict_with_provider(
 				ValueType::Date => ElementValue::Date(Default::default()),
 				ValueType::Boolean => ElementValue::Bool(Default::default()),
 				ValueType::GeneratedId => {
-					if name == "_id"
+					if name == ID_FIELD
 						&& (model.element_type == ElementType::ListElement
 							|| model.element_type == ElementType::BlobElement)
 					{
@@ -212,12 +213,12 @@ fn create_test_entity_dict_with_provider(
 					}
 				},
 				ValueType::CustomId => {
-					if name == "_id" && (model.element_type == ElementType::ListElement) {
+					if name == ID_FIELD && (model.element_type == ElementType::ListElement) {
 						ElementValue::IdTupleCustomElementId(IdTupleCustom::new(
 							GeneratedId::test_random(),
 							CustomId::test_random(),
 						))
-					} else if name == "_id" && model.element_type == Aggregated {
+					} else if name == ID_FIELD && model.element_type == Aggregated {
 						ElementValue::IdCustomId(CustomId::test_random_aggregate())
 					} else {
 						ElementValue::IdCustomId(CustomId::test_random())
@@ -304,7 +305,7 @@ fn create_encrypted_test_entity_dict_with_provider(
 						ValueType::Date => ElementValue::Date(Default::default()),
 						ValueType::Boolean => ElementValue::Bool(Default::default()),
 						ValueType::GeneratedId => {
-							if name == "_id"
+							if name == ID_FIELD
 								&& (model.element_type == ElementType::ListElement
 									|| model.element_type == ElementType::BlobElement)
 							{
@@ -317,7 +318,7 @@ fn create_encrypted_test_entity_dict_with_provider(
 							}
 						},
 						ValueType::CustomId => {
-							if name == "_id"
+							if name == ID_FIELD
 								&& (model.element_type == ElementType::ListElement
 									|| model.element_type == ElementType::BlobElement)
 							{


### PR DESCRIPTION
#tutadb1915

We did not set the owner key version properly on an instance when decrypting it. This was fine for owner key version 0 which is the default fallback but it does not work after a key rotation. We now set this properly, so that we can preview the mail without loading it from the server again when opening the app by tapping the notification.