### PR TITLE
Prevent adding new admin when rotating admin group

### DIFF
--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -220,6 +220,7 @@ export type TranslationKeyType =
 	| "cancelSharedMailbox_label"
 	| "cancelUserAccounts_label"
 	| "cancel_action"
+	| "cannotAddAdminWhenMultiAdminKeyRotationScheduled_msg"
 	| "cannotEditEvent_msg"
 	| "cannotEditFullEvent_msg"
 	| "cannotEditNotOrganizer_msg"

--- a/src/common/settings/UserViewer.ts
+++ b/src/common/settings/UserViewer.ts
@@ -194,6 +194,9 @@ export class UserViewer implements UpdatableSettingsDetailsViewer {
 								ofClass(PreconditionFailedError, (e) => {
 									if (e.data && e.data === "usergroup.pending-key-rotation") {
 										Dialog.message("makeAdminPendingUserGroupKeyRotationError_msg")
+									} else if (e.data === "multiadmingroup.pending-key-rotation") {
+										// when a multi admin key rotation is scheduled we do not want to introduce new members into the admin group
+										Dialog.message("cannotAddAdminWhenMultiAdminKeyRotationScheduled_msg")
 									} else {
 										throw e
 									}

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -241,6 +241,7 @@ export default {
 		"cancelSharedMailbox_label": "Abbestellung von geteilter Mailbox",
 		"cancelUserAccounts_label": "Abbestellung von {1} Benutzer",
 		"cancel_action": "Abbrechen",
+		"cannotAddAdminWhenMultiAdminKeyRotationScheduled_msg": "Du versuchst, einen neuen Admin hinzuzufügen, aber wir warten derzeit darauf, dass alle aktuellen Admins eine Verbindung herstellen, damit wir die Sicherheitsverbesserung deines Kontos abschließen können.",
 		"cannotEditEvent_msg": "Du kannst nur Teile dieses Ereignisses bearbeiten.",
 		"cannotEditFullEvent_msg": "Du kannst nur Teile dieses Termins bearbeiten, weil er nicht in deinem Kalender erstellt wurde.",
 		"cannotEditNotOrganizer_msg": "Du kannst diesen Termin nicht bearbeiten, da du nicht der Organisator bist.",

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -241,6 +241,7 @@ export default {
 		"cancelSharedMailbox_label": "Abbestellung von geteilter Mailbox",
 		"cancelUserAccounts_label": "Abbestellung von {1} Benutzer",
 		"cancel_action": "Abbrechen",
+		"cannotAddAdminWhenMultiAdminKeyRotationScheduled_msg": "Sie versuchen, einen neuen Admin hinzuzufügen, aber wir warten derzeit darauf, dass alle aktuellen Admins eine Verbindung herstellen, damit wir die Sicherheitsverbesserung Ihres Kontos abschließen können.",
 		"cannotEditEvent_msg": "Sie können nur Teile dieses Termins bearbeiten.",
 		"cannotEditFullEvent_msg": "Sie können nur Teile dieses Termins bearbeiten, weil er nicht in Ihrem Kalender erstellt wurde.",
 		"cannotEditNotOrganizer_msg": "Sie können diesen Termin nicht bearbeiten, da Sie nicht der Organisator sind.",

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -237,6 +237,7 @@ export default {
 		"cancelSharedMailbox_label": "Cancel shared mailbox",
 		"cancelUserAccounts_label": "Cancel {1} user(s)",
 		"cancel_action": "Cancel",
+		"cannotAddAdminWhenMultiAdminKeyRotationScheduled_msg": "You are trying to add a new admin but we are currently waiting for all current admins to connect so we can finish upgrading the security of your account.",
 		"cannotEditEvent_msg": "You can only edit parts of this event.",
 		"cannotEditFullEvent_msg": "You can only edit parts of this event because it was not created in your calendar.",
 		"cannotEditNotOrganizer_msg": "You cannot edit this event because you are not its organizer.",


### PR DESCRIPTION
When adding a new admin and an admin key rotation is pending we inform the admin that he must wait the rotation to finish first.

tutadb#1905