### PR TITLE
Respect the correct RFC standard

### DIFF
--- a/src/mail-app/mail/export/Exporter.ts
+++ b/src/mail-app/mail/export/Exporter.ts
@@ -202,10 +202,10 @@ export function mailToEml(mail: MailBundle): string {
 		lines.push(
 			"--------------79Bu5A16qPEYcVIZL@tutanota",
 			"Content-Type: " + getCleanedMimeType(attachment.mimeType) + ";",
-			" name=" + base64Filename + "",
+			" name=\"" + base64Filename + "\"",
 			"Content-Transfer-Encoding: base64",
 			"Content-Disposition: attachment;",
-			" filename=" + base64Filename + "",
+			" filename=\"" + base64Filename + "\"",
 		)
 
 		if (attachment.cid) {


### PR DESCRIPTION
name und filename must be escaped, otherwise some MIME parsers are not able to read the .eml file