### PR TITLE
Fix inline image being removed in mail viewer on forward

### DIFF
--- a/src/mail-app/mail/view/MailViewerViewModel.ts
+++ b/src/mail-app/mail/view/MailViewerViewModel.ts
@@ -791,8 +791,12 @@ export class MailViewerViewModel {
 			if (mailboxDetails == null) {
 				return
 			}
-			// Call this again to make sure everything is loaded, including inline images because this can be called earlier than all the parts are loaded.
-			await this.loadAll(Promise.resolve(), { notify: false })
+
+			const isReloadNeeded = !this.sanitizeResult || this.mail.attachments.length !== this.attachments.length
+			if (isReloadNeeded) {
+				// Call this again to make sure everything is loaded, including inline images because this can be called earlier than all the parts are loaded.
+				await this.loadAll(Promise.resolve(), { notify: true })
+			}
 			const editor = await newMailEditorAsResponse(args, this.isBlockingExternalImages(), this.getLoadedInlineImages(), mailboxDetails)
 			editor.show()
 		}


### PR DESCRIPTION
Issue caused by inline images not being replaced after a loadAll call (without notify) which sanitizes mail body.
This is due to the replaceInlineImages call being inside a loadCompleteNotification listener.

Fixed by calling loadAll *with* notify in reply. loadAll is also now only called when necessary.

Related to #6523
Fix #8003