### PR TITLE
Enable argon2 migration

### DIFF
--- a/src/common/api/common/TutanotaConstants.ts
+++ b/src/common/api/common/TutanotaConstants.ts
@@ -348,7 +348,7 @@ export const Const: ConstType = {
 	// we'll still get the contents
 	// because it will be redirected to tuta.com after new domain deploy.
 	U2F_LEGACY_APPID: "https://tutanota.com/u2f-appid.json",
-	EXECUTE_KDF_MIGRATION: false,
+	EXECUTE_KDF_MIGRATION: true,
 } as const
 
 export const TUTA_MAIL_ADDRESS_DOMAINS: ReadonlyArray<string> = Object.freeze([


### PR DESCRIPTION
We enable the argon2 migration for every user that is still using bycrypt to derive the password key. During the login process we derive a new password key from the existing password and encrypt the user group key with it. This step is a requirement for upgrading to quantum safe key material.

## Test notes
see  #tutadb1896 