### PR TITLE
fix luxon import in InAppRatingUtils.ts

### DIFF
--- a/src/common/ratings/InAppRatingUtils.ts
+++ b/src/common/ratings/InAppRatingUtils.ts
@@ -1,5 +1,5 @@
 import { DeviceConfig } from "../misc/DeviceConfig.js"
-import { DateTime } from "../../../libs/luxon.js"
+import { DateTime } from "luxon"
 import { locator } from "../api/main/CommonLocator.js"
 
 export function createEvent(deviceConfig: DeviceConfig): void {


### PR DESCRIPTION
importing the file directly breaks builds that depend on tutanota-3 the bundlers are configured to resolve the actual file to use