### PR TITLE
Remove extra spacing between items in Menu bar.

### DIFF
--- a/src/common/gui/SidebarSection.ts
+++ b/src/common/gui/SidebarSection.ts
@@ -20,7 +20,7 @@ export class SidebarSection implements Component<SidebarSectionAttrs> {
 		const content = vnode.children
 		if (hideIfEmpty && content == false) return null // Using loose equality to check if children has any contents
 		return m(
-			".sidebar-section.mb",
+			".sidebar-section",
 			{
 				style: {
 					color: theme.navigation_button,


### PR DESCRIPTION
Removed extra spacing (margin bottom) between sidebar heading and AddItem button

close #8112