### PR TITLE
[ci] Fix iOS jobs

### DIFF
--- a/ci/Ios.Jenkinsfile
+++ b/ci/Ios.Jenkinsfile
@@ -75,6 +75,7 @@ pipeline {
 					when { expression { return params.STAGING } }
 					environment {
 						PATH="${env.NODE_MAC_PATH}:${env.PATH}:${env.HOME}/emsdk:${env.HOME}/emsdk/upstream/emscripten:${env.HOME}/emsdk/upstream/bin"
+						EM_CACHE="${env.HOME}/emcache"
 					}
 					agent {
 						label 'mac-intel'
@@ -97,6 +98,7 @@ pipeline {
 					when { expression { return params.PROD } }
 					environment {
 						PATH="${env.NODE_MAC_PATH}:${env.PATH}:${env.HOME}/emsdk:${env.HOME}/emsdk/upstream/emscripten:${env.HOME}/emsdk/upstream/bin"
+						EM_CACHE="${env.HOME}/emcache"
 					}
 					agent {
 						label 'mac-intel'

--- a/ci/IosRenewCerts.Jenkinsfile
+++ b/ci/IosRenewCerts.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 		LANG = "en_US.UTF-8"
 	}
 	agent {
-		label 'mac'
+		label 'mac-intel'
 	}
 
 	parameters {
@@ -31,7 +31,7 @@ pipeline {
 	stages {
 		stage("Renew prod certs") {
 			agent {
-				label 'mac'
+				label 'mac-intel'
 			}
 			when {
 				expression{ return params.prod }
@@ -88,7 +88,7 @@ pipeline {
 
 		stage("Renew staging certs") {
 			agent {
-				label 'mac'
+				label 'mac-intel'
 			}
 			when {
 				expression { return params.staging }


### PR DESCRIPTION
Set emscripten cache location explicitly.
Only run renew certs on the intel mac until the new one is ready.