### PR TITLE
Fix being able to open Labels dropdown even if there are no labels

### DIFF
--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -575,12 +575,13 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	 */
 	private labels() {
 		const mailList = this.mailViewModel.listModel
-		if (mailList == null) {
+		if (mailList == null || !mailLocator.mailModel.canAssignLabels()) {
 			return
 		}
-
+		const labels = mailLocator.mailModel.getLabelStatesForMails(mailList.getSelectedAsArray())
 		const selectedMails = mailList.getSelectedAsArray()
-		if (isEmpty(selectedMails)) {
+
+		if (isEmpty(labels) || isEmpty(selectedMails)) {
 			return
 		}
 


### PR DESCRIPTION
The issue is being able to open labels dropdown even if there are no labels.
Resolved by only showing dropdown if there are any labels found.

close #8141