### PR TITLE
Fixes iOS yearly full price being displayed as per month

### DIFF
--- a/src/common/subscription/SubscriptionSelector.ts
+++ b/src/common/subscription/SubscriptionSelector.ts
@@ -273,11 +273,7 @@ export class SubscriptionSelector implements Component<SubscriptionSelectorAttr>
 							priceStr = prices.displayMonthlyPerMonth
 							break
 						case PaymentInterval.Yearly:
-							priceStr = prices.displayYearlyPerMonth
-							if (!isCyberMonday) {
-								// if there is no discount for any plan then we show the monthly price as reference
-								referencePriceStr = prices.displayMonthlyPerMonth
-							}
+							priceStr = prices.displayYearlyPerYear
 							break
 					}
 				}


### PR DESCRIPTION
Yearly Prices on iOS must be displayed as full price according to Apple's subscription policies, so this commit reverts the changes made for Cyber Monday and displays the full price when booking a new subscription