### PR TITLE
Fix ViewColumn still tabbable when off-screen in single-column layout

### DIFF
--- a/src/common/gui/base/ViewColumn.ts
+++ b/src/common/gui/base/ViewColumn.ts
@@ -82,7 +82,7 @@ export class ViewColumn implements Component<Attrs> {
 			".view-column.fill-absolute",
 			{
 				...landmark,
-				"aria-hidden": this.isVisible || this.isInForeground ? "false" : "true",
+				inert: !this.isVisible && !this.isInForeground,
 				oncreate: (vnode) => {
 					this.domColumn = vnode.dom as HTMLElement
 					this.domColumn.style.transform =


### PR DESCRIPTION
While setting ViewColumn's `aria-hidden` to `true` when not visible works for mobile screen readers. The ViewColumn can still be tabbed into. To make sure the ViewColumn is ignored, we use `inert` instead.

Close #7054