### PR TITLE
Fix export facade tests

### DIFF
--- a/test/tests/api/worker/facades/MailExportFacadeTest.ts
+++ b/test/tests/api/worker/facades/MailExportFacadeTest.ts
@@ -38,10 +38,12 @@ o.spec("MailExportFacade", () => {
 	})
 
 	o.test("loadFixedNumberOfMailsWithCache", async () => {
-		when(bulkMailLoader.loadFixedNumberOfMailsWithCache("mailListId", "startId", { baseUrl: "baseUrl", extraHeaders: tokenHeaders })).thenResolve([
-			mail1,
-			mail2,
-		])
+		when(
+			bulkMailLoader.loadFixedNumberOfMailsWithCache("mailListId", "startId", {
+				baseUrl: "baseUrl",
+				extraHeaders: tokenHeaders,
+			}),
+		).thenResolve([mail1, mail2])
 
 		const result = await facade.loadFixedNumberOfMailsWithCache("mailListId", "startId", "baseUrl")
 
@@ -62,7 +64,12 @@ o.spec("MailExportFacade", () => {
 
 	o.test("loadAttachments", async () => {
 		const expected = [createTestEntity(FileTypeRef), createTestEntity(FileTypeRef)]
-		when(bulkMailLoader.loadAttachments([mail1, mail2], { baseUrl: "baseUrl", extraHeaders: tokenHeaders })).thenResolve(expected)
+		when(
+			bulkMailLoader.loadAttachments([mail1, mail2], {
+				baseUrl: "baseUrl",
+				extraHeaders: tokenHeaders,
+			}),
+		).thenResolve(expected)
 
 		const result = await facade.loadAttachments([mail1, mail2], "baseUrl")
 
@@ -73,7 +80,12 @@ o.spec("MailExportFacade", () => {
 		const dataByteMail1 = new Uint8Array([1, 2, 3])
 		const dataByteMail2 = new Uint8Array([4, 5, 6])
 		const mailAttachments = [
-			createTestEntity(FileTypeRef, { name: "mail1", mimeType: "img/png", cid: "12345", _id: ["attachment", "id1"] }),
+			createTestEntity(FileTypeRef, {
+				name: "mail1",
+				mimeType: "img/png",
+				cid: "12345",
+				_id: ["attachment", "id1"],
+			}),
 			createTestEntity(FileTypeRef, { name: "mail2", mimeType: "pdf", cid: "12345", _id: ["attachment", "id2"] }),
 		]
 
@@ -83,7 +95,6 @@ o.spec("MailExportFacade", () => {
 				ArchiveDataType.Attachments,
 				[createReferencingInstance(mailAttachments[0]), createReferencingInstance(mailAttachments[1])],
 				{
-					baseUrl: "baseUrl",
 					extraHeaders: tokenHeaders,
 				},
 			),
@@ -94,11 +105,27 @@ o.spec("MailExportFacade", () => {
 			]),
 		)
 
-		const result = await facade.loadAttachmentData(mail1, mailAttachments, "baseUrl")
+		const result = await facade.loadAttachmentData(mail1, mailAttachments)
 
 		o(result).deepEquals([
-			{ _type: "DataFile", name: "mail1", mimeType: "img/png", data: dataByteMail1, cid: "12345", size: 3, id: ["attachment", "id1"] },
-			{ _type: "DataFile", name: "mail2", mimeType: "pdf", data: dataByteMail2, cid: "12345", size: 3, id: ["attachment", "id2"] },
+			{
+				_type: "DataFile",
+				name: "mail1",
+				mimeType: "img/png",
+				data: dataByteMail1,
+				cid: "12345",
+				size: 3,
+				id: ["attachment", "id1"],
+			},
+			{
+				_type: "DataFile",
+				name: "mail2",
+				mimeType: "pdf",
+				data: dataByteMail2,
+				cid: "12345",
+				size: 3,
+				id: ["attachment", "id2"],
+			},
 		])
 	})
 })

--- a/test/tests/native/main/MailExportControllerTest.ts
+++ b/test/tests/native/main/MailExportControllerTest.ts
@@ -98,7 +98,7 @@ o.spec("MailExportController", function () {
 		when(mailExportFacade.loadFixedNumberOfMailsWithCache(mailBag.mails, startId, matchers.anything())).thenResolve([mail])
 		when(mailExportFacade.loadMailDetails([mail])).thenResolve([{ mail, mailDetails }])
 		when(mailExportFacade.loadAttachments([mail], matchers.anything())).thenResolve([attachmentInfo])
-		when(mailExportFacade.loadAttachmentData(mail, [attachmentInfo], matchers.anything())).thenResolve([dataFile])
+		when(mailExportFacade.loadAttachmentData(mail, [attachmentInfo])).thenResolve([dataFile])
 
 		const mailBundle = makeMailBundle(sanitizer, mail, mailDetails, [dataFile])
 		return { mail, mailBundle, mailDetails }
@@ -242,7 +242,7 @@ o.spec("MailExportController", function () {
 
 			verify(mailExportFacade.loadFixedNumberOfMailsWithCache(currentMailBag.mails, GENERATED_MAX_ID, "baseUrl2"))
 			verify(mailExportFacade.loadAttachments([mail1], "baseUrl3"))
-			verify(mailExportFacade.loadAttachmentData(mail1, matchers.anything(), "baseUrl1"))
+			verify(mailExportFacade.loadAttachmentData(mail1, matchers.anything()))
 		})
 	})
 


### PR DESCRIPTION
We stopped using baseUrl when getting attachment data, as we have exact servers the blobs are stored on to retrieve from.