### PR TITLE
Fix unsafe mutable static warnings

### DIFF
--- a/packages/node-mimimi/Cargo.lock
+++ b/packages/node-mimimi/Cargo.lock
@@ -2242,7 +2242,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuta-sdk"
-version = "259.250102.0"
+version = "259.250106.0"
 dependencies = [
  "aes",
  "android_log",

--- a/packages/node-mimimi/src/importer_api.rs
+++ b/packages/node-mimimi/src/importer_api.rs
@@ -202,13 +202,13 @@ impl ImporterApi {
 	}
 
 	#[napi]
-	pub unsafe fn init_log(env: Env) {
+	pub fn init_log(env: Env) {
 		// this is in a separate fn because Env isn't Send, so can't be used in async fn.
 		crate::logging::console::Console::init(env)
 	}
 
 	#[napi]
-	pub unsafe fn deinit_log() {
+	pub fn deinit_log() {
 		crate::logging::console::Console::deinit();
 	}
 }

--- a/packages/node-mimimi/src/logging/console.rs
+++ b/packages/node-mimimi/src/logging/console.rs
@@ -1,18 +1,22 @@
 use crate::logging::logger::{LogLevel, LogMessage, Logger};
 use log::{Level, LevelFilter, Log, Metadata, Record};
-use napi::sys::{napi_async_work, napi_cancel_async_work};
-use napi::{AsyncWorkPromise, Env, Task};
-use std::sync::OnceLock;
+use napi::Env;
+use std::sync::mpsc::Sender;
+use std::sync::Once;
+use std::sync::RwLock;
 
 const TAG: &str = file!();
 
-pub static mut GLOBAL_CONSOLE: OnceLock<Console> = OnceLock::new();
+/// Maintain one instance of the logger, as the log crate can only have the logger be set exactly
+/// once.
+static GLOBAL_CONSOLE: Console = Console {
+	sender: RwLock::new(None),
+};
 
 /// A way for the rust code to log messages to the main applications log files
 /// without having to deal with obtaining a reference to console each time.
-#[derive(Clone)]
 pub struct Console {
-	tx: std::sync::mpsc::Sender<LogMessage>,
+	sender: RwLock<Option<Sender<LogMessage>>>,
 }
 
 impl Log for Console {
@@ -28,56 +32,58 @@ impl Log for Console {
 
 		let tag = record.file().unwrap_or("<unknown>").to_string();
 
-		let _ = self.tx.send(LogMessage {
-			level: record.metadata().level().into(),
-			message: format!("{}", record.args()),
-			tag,
-		});
+		let lock = self.sender.read().expect("poisoned");
+		if let Some(sender) = lock.as_ref() {
+			let _ = sender.send(LogMessage {
+				level: record.metadata().level().into(),
+				message: format!("{}", record.args()),
+				tag,
+			});
+		}
 	}
 
 	fn flush(&self) {}
 }
 
 impl Console {
-	pub unsafe fn init(env: Env) {
-		if GLOBAL_CONSOLE.get().is_some() {
+	pub fn init(env: Env) {
+		Self::init_global_state();
+
+		let mut current_sender = GLOBAL_CONSOLE.sender.write().expect("poisoned");
+		if current_sender.is_some() {
 			// some other thread already initialized the cell, we don't need to set up the logger.
 			return;
 		}
+
 		let (tx, rx) = std::sync::mpsc::channel::<LogMessage>();
-		let console = Console { tx };
 		let logger = Logger::new(rx);
 		let maybe_async_task = env.spawn(logger);
 
 		match maybe_async_task {
 			Ok(_logger_task) => {
-				console.log(
+				*current_sender = Some(tx);
+				GLOBAL_CONSOLE.log(
 					&Record::builder()
 						.level(Level::Info)
 						.file(Some(TAG))
 						.args(format_args!("{}", "spawned logger"))
 						.build(),
 				);
-
-				GLOBAL_CONSOLE
-					.set(console)
-					.map_err(|_| "can not set")
-					.unwrap();
-
-				let console = GLOBAL_CONSOLE.get().unwrap();
-				set_panic_hook(&console);
-				log::set_logger(console).unwrap_or_else(|e| eprintln!("failed to set logger: {e}"));
-				log::set_max_level(LevelFilter::Info);
 			},
 			Err(e) => {
 				eprintln!("failed to spawn logger: {e}");
 			},
 		}
 	}
-	pub unsafe fn deinit() {
-		let console = GLOBAL_CONSOLE.take().expect("cannot deinit logger before initializing");
-		console
-			.tx
+
+	pub fn deinit() {
+		let sender = GLOBAL_CONSOLE
+			.sender
+			.write()
+			.expect("poisoned")
+			.take()
+			.expect("cannot deinit logger before initializing");
+		sender
 			.send(LogMessage {
 				level: LogLevel::Finish,
 				message: "called deinit".to_string(),
@@ -85,42 +91,59 @@ impl Console {
 			})
 			.expect("Can not send finish log message. Receiver already disconnected");
 	}
-}
 
-/// set a panic hook that tries to log the panic to the JS side before continuing
-/// a normal unwind. should work unless the panicking thread is the main thread.
-fn set_panic_hook(console: &'static Console) {
-	let logger_thread_id = std::thread::current().id();
-	let panic_console = console.clone();
-	let old_panic_hook = std::panic::take_hook();
-	std::panic::set_hook(Box::new(move |panic_info| {
-		let formatted_info = panic_info.to_string();
-		let formatted_stack = std::backtrace::Backtrace::force_capture().to_string();
-		if logger_thread_id == std::thread::current().id() {
-			// logger is (probably) running on the currently panicking thread,
-			// so we can't use it to log to JS. this at least shows up in stderr.
-			eprintln!("PANIC MAIN {}", formatted_info);
-			eprintln!("PANIC MAIN {}", formatted_stack);
-		} else {
-			panic_console.log(
-				&Record::builder()
-					.level(Level::Error)
-					.file(Some("PANIC"))
-					.args(format_args!(
-						"thread {} {}",
-						std::thread::current().name().unwrap_or("<unknown>"),
-						formatted_info
-					))
-					.build(),
-			);
-			panic_console.log(
-				&Record::builder()
-					.level(Level::Error)
-					.file(Some("PANIC"))
-					.args(format_args!("{}", formatted_stack.as_str()))
-					.build(),
-			);
-		}
-		old_panic_hook(panic_info)
-	}));
+	/// Sets the panic hook and global logger.
+	///
+	/// This function must be called once before the console can be used, but it can be safely
+	/// called multiple times, and it is thread-safe.
+	fn init_global_state() {
+		// Limit scope to this function only.
+		static GLOBAL_CONSOLE_SETUP: Once = Once::new();
+
+		GLOBAL_CONSOLE_SETUP.call_once(|| {
+			// Sets the logger to the static instance and sets up the panic hook.
+			// This can fail if the logger was set somewhere else.
+			if let Err(e) = log::set_logger(&GLOBAL_CONSOLE) {
+				eprintln!("failed to set logger: {e}");
+			} else {
+				log::set_max_level(LevelFilter::Info);
+			}
+
+			// set a panic hook that tries to log the panic to the JS side before continuing
+			// a normal unwind. should work unless the panicking thread is the main thread.
+			let logger_thread_id = std::thread::current().id();
+			let old_panic_hook = std::panic::take_hook();
+
+			std::panic::set_hook(Box::new(move |panic_info| {
+				let formatted_info = panic_info.to_string();
+				let formatted_stack = std::backtrace::Backtrace::force_capture().to_string();
+				if logger_thread_id == std::thread::current().id() {
+					// logger is (probably) running on the currently panicking thread,
+					// so we can't use it to log to JS. this at least shows up in stderr.
+					eprintln!("PANIC MAIN {}", formatted_info);
+					eprintln!("PANIC MAIN {}", formatted_stack);
+				} else {
+					GLOBAL_CONSOLE.log(
+						&Record::builder()
+							.level(Level::Error)
+							.file(Some("PANIC"))
+							.args(format_args!(
+								"thread {} {}",
+								std::thread::current().name().unwrap_or("<unknown>"),
+								formatted_info
+							))
+							.build(),
+					);
+					GLOBAL_CONSOLE.log(
+						&Record::builder()
+							.level(Level::Error)
+							.file(Some("PANIC"))
+							.args(format_args!("{}", formatted_stack.as_str()))
+							.build(),
+					);
+				}
+				old_panic_hook(panic_info)
+			}));
+		});
+	}
 }


### PR DESCRIPTION
Keep a Console always in existence, but make it so the sender can be set/unset. We can do this by using Once to ensure that our panic hook and logger are set once, and then having Console be pre-initialized with the sender set to None.

This ensures we do not need any static mutables, thus Console can be inited and deinited safely.