### PR TITLE
set the ownerGroup on unmapped instances in client-side migrations

### DIFF
--- a/src/common/api/worker/crypto/CryptoFacade.ts
+++ b/src/common/api/worker/crypto/CryptoFacade.ts
@@ -398,7 +398,7 @@ export class CryptoFacade {
 		unmappedInstance._ownerEncSessionKey = uint8ArrayToBase64(key.key)
 		unmappedInstance._ownerKeyVersion = key.encryptingKeyVersion.toString()
 		if (ownerGroup) {
-			unmappedInstance._ownerGroup
+			unmappedInstance._ownerGroup = ownerGroup
 		}
 	}
 


### PR DESCRIPTION
fixes a bug introduced with a6d6d26d1a04a244fd2d238495b362118032aa89 the bug most likely is not triggered