### PR TITLE
Fix not authorized error after login

### DIFF
--- a/src/calendar-app/calendar/model/CalendarModel.ts
+++ b/src/calendar-app/calendar/model/CalendarModel.ts
@@ -386,7 +386,13 @@ export class CalendarModel {
 				(existingEvent) => !parsedExternalEvents.some((externalEvent) => externalEvent.event.uid === existingEvent.uid),
 			)
 			for (const event of eventsToRemove) {
-				this.deleteEvent(event)
+				this.deleteEvent(event).catch((err) => {
+					if (err instanceof NotFoundError) {
+						return console.log(`Already deleted event`, event)
+					}
+
+					throw err
+				})
 				operationsLog.deleted.push(event)
 			}
 			console.log(TAG, `${operationsLog.deleted.length} events removed`)


### PR DESCRIPTION
After login a client might try to process group events but the entity related to these events might have already been deleted by another client which raise an exception. In our case the client loses its group membership (shared calendar has been deleted) and try to load members of this deleted shared calendar. This commit handles errors happening while initializing the calendar model.

Co-authored-by: bedhub
fix #8254

tutadb#1942