### PR TITLE
Fix unexpected error during signup for paid account

### DIFF
--- a/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
+++ b/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
@@ -207,15 +207,7 @@ export class UpgradeConfirmSubscriptionPage implements WizardPageN<UpgradeSubscr
 	}
 
 	private close(data: UpgradeSubscriptionData, dom: HTMLElement) {
-		let promise = Promise.resolve()
-
-		if (data.newAccountData && locator.logins.isUserLoggedIn()) {
-			promise = locator.logins.logout(false)
-		}
-
-		promise.then(() => {
-			emitWizardEvent(dom, WizardEventType.SHOW_NEXT_PAGE)
-		})
+		emitWizardEvent(dom, WizardEventType.SHOW_NEXT_PAGE)
 	}
 }
 

--- a/src/common/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/common/subscription/UpgradeSubscriptionWizard.ts
@@ -202,8 +202,8 @@ export async function loadSignupWizard(
 	const wizardPages = [
 		wizardPageWrapper(UpgradeSubscriptionPage, new UpgradeSubscriptionPageAttrs(signupData)),
 		wizardPageWrapper(SignupPage, new SignupPageAttrs(signupData)),
-		wizardPageWrapper(InvoiceAndPaymentDataPage, invoiceAttrs),
-		wizardPageWrapper(UpgradeConfirmSubscriptionPage, invoiceAttrs),
+		wizardPageWrapper(InvoiceAndPaymentDataPage, invoiceAttrs), // this page will login the user after signing up with newaccount data
+		wizardPageWrapper(UpgradeConfirmSubscriptionPage, invoiceAttrs), // this page will login the user if they are not login for iOS payment through AppStore
 		wizardPageWrapper(UpgradeCongratulationsPage, new UpgradeCongratulationsPageAttrs(signupData)),
 	]
 
@@ -216,6 +216,8 @@ export async function loadSignupWizard(
 		wizardPages,
 		async () => {
 			if (locator.logins.isUserLoggedIn()) {
+				// this ensures that all created sessions during signup process are closed
+				// either by clicking on `cancel`, closing the window, or confirm on the UpgradeCongratulationsPage
 				await locator.logins.logout(false)
 			}
 


### PR DESCRIPTION
After subscription to a paid account and using PayPal, the SignupWizard would logout the user before showing the CongratulationPage which cause some backgorund actions to fail and raise exceptions (no user found, no user group key required for initialization of the db). This commit removes this unecessary logout and resolve a bunch of error related to this race condition.

Co-authored-by: bedhub

tutadb#1805