### PR TITLE
Fix all-day events spanning two days when created at the end of the day

### DIFF
--- a/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventWhenModel.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventWhenModel.ts
@@ -1,4 +1,10 @@
-import { CalendarEventTimes, getAllDayDateUTC, getEventWithDefaultTimes, isAllDayEvent } from "../../../../common/api/common/utils/CommonCalendarUtils.js"
+import {
+	CalendarEventTimes,
+	getAllDayDateUTC,
+	getEventWithDefaultTimes,
+	isAllDayEvent,
+	isBefore,
+} from "../../../../common/api/common/utils/CommonCalendarUtils.js"
 import { Time } from "../../../../common/calendar/date/Time.js"
 import { DateTime, DurationLikeObject } from "luxon"
 import {
@@ -236,10 +242,12 @@ export class CalendarEventWhenModel {
 		const endTime = this._endTime ?? new Time(0, 0)
 		const currentStart = startTime.toDate(this._startDate)
 		const newEnd = endTime.toDate(value)
-		if (newEnd < currentStart) {
+
+		if (isBefore(newEnd, currentStart, "date")) {
 			console.log("tried to set the end date to before the start date")
 			return
 		}
+
 		this._endDate = DateTime.fromJSDate(value, this).set({ hour: 0, minute: 0, second: 0, millisecond: 0 }).toJSDate()
 		this.uiUpdateCallback()
 	}

--- a/src/common/api/common/utils/CommonCalendarUtils.ts
+++ b/src/common/api/common/utils/CommonCalendarUtils.ts
@@ -180,3 +180,25 @@ export enum CalendarViewType {
 	MONTH = "month",
 	AGENDA = "agenda",
 }
+
+/**
+ * Checks if dateA occurs before dateB based on the specified comparison type.
+ *
+ * @param {Date} dateA - The first date to compare.
+ * @param {Date} dateB - The second date to compare.
+ * @param {string} comparisonType - The type of comparison to perform.
+ *                              "full" = compare date and time,
+ *                              "dayMonthYear" = compare only day, month, and year.
+ * @returns {boolean} - Returns true if dateA is before dateB according to the comparison type, false otherwise.
+ */
+export function isBefore(dateA: Date, dateB: Date, comparisonType: "dateTime" | "date" = "dateTime"): boolean {
+	switch (comparisonType) {
+		case "dateTime":
+			return dateA.getTime() < dateB.getTime()
+		case "date": {
+			return dateA.setHours(0, 0, 0, 0) < dateB.setHours(0, 0, 0, 0)
+		}
+		default:
+			throw new Error("Unknown comparison method")
+	}
+}


### PR DESCRIPTION
Fixed the issue by allowing users to change the end date back to the same date as the initial date.
Closes #7723