### PR TITLE
Use invisible address as displayed sender when sender name is empty

### DIFF
--- a/src/mail-app/mail/view/MailViewerHeader.ts
+++ b/src/mail-app/mail/view/MailViewerHeader.ts
@@ -192,10 +192,12 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 	private renderSubjectActionsLine(attrs: MailViewerHeaderAttrs) {
 		const { viewModel } = attrs
 		const classes = this.makeSubjectActionsLineClasses()
+		const senderName = viewModel.getDisplayedSender()?.name?.trim() ?? ""
+		const displayAddressForSender = senderName === ""
 
 		return m(classes, [
 			m(
-				".flex.flex-grow.align-self-start.items-start",
+				".flex.flex-grow.align-self-start.items-start.overflow-hidden",
 				{
 					class: styles.isSingleColumnLayout() ? "mt-m" : "mt",
 					role: "button",
@@ -230,7 +232,10 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 						  )
 						: null,
 					this.tutaoBadge(viewModel),
-					m("span.text-break" + (viewModel.isUnread() ? ".font-weight-600" : ""), viewModel.getDisplayedSender()?.name ?? ""),
+					m(
+						"span" + (displayAddressForSender ? ".invisible.overflow-hidden" : ".text-break") + (viewModel.isUnread() ? ".font-weight-600" : ""),
+						displayAddressForSender ? viewModel.getDisplayedSender()?.address ?? "" : senderName,
+					),
 				],
 			),
 			m(


### PR DESCRIPTION
Because the sender's name is used as a fold mail button. An empty sender name results in an element with a height of zero, making it impossible to click to fold mails.

VoiceOver also does not focus the fold mail button when the sender name is empty.

Close https://github.com/tutao/tutanota/issues/8266
Close https://github.com/tutao/tutanota/issues/8309

Co-authored-by: paw <paw-hub@users.noreply.github.com>
Co-authored-by: ivk <ivk@tutao.de>