### PR TITLE
refactor LanguageViewModel to use new translation types

### DIFF
--- a/src/calendar-app/calendar/gui/EditCalendarDialog.ts
+++ b/src/calendar-app/calendar/gui/EditCalendarDialog.ts
@@ -183,7 +183,7 @@ export function showCreateEditCalendarDialog({
 									}
 									doAction(dialog)
 								})
-								.catch((e) => Dialog.message(() => e.message))
+								.catch((e) => Dialog.message(lang.makeTranslation("error_message", e.message)))
 						},
 						class: errorMessageStream().trim() !== "" ? "mt-s no-hover button-bg" : "mt-s",
 						disabled: errorMessageStream().trim() !== "",
@@ -198,7 +198,7 @@ export function showCreateEditCalendarDialog({
 			{
 				allowOkWithReturn: true,
 				okActionTextId: okTextId,
-				title: lang.get(titleTextId),
+				title: titleTextId,
 				child: {
 					view: () =>
 						m(".flex.col", [

--- a/src/calendar-app/calendar/gui/RemindersEditor.ts
+++ b/src/calendar-app/calendar/gui/RemindersEditor.ts
@@ -71,11 +71,11 @@ export class RemindersEditor implements Component<RemindersEditorAttrs> {
 						},
 						childAttrs: () => [
 							...createAlarmIntervalItems(lang.languageTag).map((i) => ({
-								label: () => i.name,
+								label: lang.makeTranslation(i.name, i.name),
 								click: () => addNewAlarm(i.value),
 							})),
 							{
-								label: () => lang.get("calendarReminderIntervalDropdownCustomItem_label"),
+								label: "calendarReminderIntervalDropdownCustomItem_label",
 								click: () => {
 									this.showCustomReminderIntervalDialog((value, unit) => {
 										addNewAlarm({
@@ -133,7 +133,10 @@ export class RemindersEditor implements Component<RemindersEditorAttrs> {
 						BaseButton,
 						{
 							//This might not make sense in other languages, but is better than what we have now
-							label: `${lang.get("delete_action")} ${humanDescriptionForAlarmInterval(alarm, lang.languageTag)}`,
+							label: lang.makeTranslation(
+								"delete_action",
+								`${lang.get("delete_action")} ${humanDescriptionForAlarmInterval(alarm, lang.languageTag)}`,
+							),
 							onclick: () => removeAlarm(alarm),
 							class: "flex items-center",
 						},
@@ -193,7 +196,7 @@ export class RemindersEditor implements Component<RemindersEditorAttrs> {
 		let timeReminderUnit: AlarmIntervalUnit = AlarmIntervalUnit.MINUTE
 
 		Dialog.showActionDialog({
-			title: () => lang.get("calendarReminderIntervalCustomDialog_title"),
+			title: "calendarReminderIntervalCustomDialog_title",
 			allowOkWithReturn: true,
 			child: {
 				view: () => {

--- a/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventWhoModel.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventWhoModel.ts
@@ -27,6 +27,7 @@ import { CalendarNotificationSendModels } from "./CalendarNotificationModel.js"
 import { getContactDisplayName } from "../../../../common/contactsFunctionality/ContactUtils.js"
 import { RecipientField } from "../../../../common/mailFunctionality/SharedMailUtils.js"
 import { hasSourceUrl } from "../../../../common/calendar/date/CalendarUtils"
+import { lang } from "../../../../common/misc/LanguageViewModel.js"
 
 /** there is no point in returning recipients, the SendMailModel will re-resolve them anyway. */
 type AttendanceModelResult = {
@@ -409,7 +410,7 @@ export class CalendarEventWhoModel {
 	 */
 	addAttendee(address: string, contact: Contact | null = null): void {
 		if (!this.canModifyGuests) {
-			throw new UserError(() => "cannotAddAttendees_msg")
+			throw new UserError(lang.makeTranslation("cannotAddAttendees_msg", "Cannot add attendees"))
 		}
 		const cleanAddress = cleanMailAddress(address)
 		// We don't add an attendee if they are already an attendee

--- a/src/calendar-app/calendar/gui/eventeditor-view/AttendeeListEditor.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-view/AttendeeListEditor.ts
@@ -131,7 +131,7 @@ export class AttendeeListEditor implements Component<AttendeeListEditorAttrs> {
 									// the user could have, but did not upgrade.
 									if (!this.hasPlanWithInvites) return
 								} else {
-									Dialog.message(() => lang.get("contactAdmin_msg"))
+									Dialog.message("contactAdmin_msg")
 								}
 							} else {
 								whoModel.addAttendee(address, contact)

--- a/src/calendar-app/calendar/gui/eventeditor-view/CalendarEventEditDialog.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-view/CalendarEventEditDialog.ts
@@ -7,7 +7,7 @@
  */
 
 import { Dialog } from "../../../../common/gui/base/Dialog.js"
-import { lang } from "../../../../common/misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../../../common/misc/LanguageViewModel.js"
 import { ButtonAttrs, ButtonType } from "../../../../common/gui/base/Button.js"
 import { Keys } from "../../../../common/api/common/TutanotaConstants.js"
 import { AlarmInterval, getStartOfTheWeekOffsetForUser, getTimeFormatForUser, parseAlarmInterval } from "../../../../common/calendar/date/CalendarUtils.js"
@@ -114,10 +114,8 @@ export class EventEditorDialog {
 			handler(dom.getBoundingClientRect(), () => dialog.close())
 		}
 
-		const heading = () => {
-			const summary = model.editModels.summary.content
-			return summary.trim().length > 0 ? summary : lang.get("createEvent_label")
-		}
+		const summary = model.editModels.summary.content
+		const heading = summary.trim().length > 0 ? lang.makeTranslation("summary", summary) : "createEvent_label"
 
 		const navigationCallback = (targetPage: EditorPages) => {
 			this.currentPage(targetPage)

--- a/src/calendar-app/calendar/gui/eventpopup/ContactPreviewView.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/ContactPreviewView.ts
@@ -111,7 +111,7 @@ const ActionButtons = pureComponent((contact: Contact) => {
 	const showMailDropdown = createDropdown({
 		lazyButtons: () =>
 			contact.mailAddresses.map((mailAddress, index) => ({
-				label: () => `${renderSuffix(mailAddress.customTypeName)}${mailAddress.address}`,
+				label: lang.makeTranslation("mailAddress_label", `${renderSuffix(mailAddress.customTypeName)}${mailAddress.address}`),
 				click: () => {
 					if (client.isCalendarApp()) {
 						simulateMailToClick(mailAddress.address)
@@ -128,7 +128,7 @@ const ActionButtons = pureComponent((contact: Contact) => {
 	const showPhoneDropdown = createDropdown({
 		lazyButtons: () =>
 			contact.phoneNumbers.map((contactPhone, index) => ({
-				label: () => `${renderSuffix(contactPhone.customTypeName)}${contactPhone.number}`,
+				label: lang.makeTranslation("phoneNumber", `${renderSuffix(contactPhone.customTypeName)}${contactPhone.number}`),
 				click: () => {
 					const element: HTMLAnchorElement = document.createElement("a")
 					element.href = `tel:${contactPhone.number}`

--- a/src/calendar-app/calendar/gui/pickers/DatePicker.ts
+++ b/src/calendar-app/calendar/gui/pickers/DatePicker.ts
@@ -1,7 +1,7 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { client } from "../../../../common/misc/ClientDetector.js"
 import { formatDate, formatDateWithWeekdayAndYear, formatMonthWithFullYear } from "../../../../common/misc/Formatter.js"
-import type { TranslationText } from "../../../../common/misc/LanguageViewModel.js"
+import type { TranslationKey, MaybeTranslation } from "../../../../common/misc/LanguageViewModel.js"
 import { lang } from "../../../../common/misc/LanguageViewModel.js"
 import { px } from "../../../../common/gui/size.js"
 import { theme } from "../../../../common/gui/theme.js"
@@ -29,8 +29,8 @@ export interface DatePickerAttrs {
 	date?: Date
 	onDateSelected: (date: Date) => unknown
 	startOfTheWeekOffset: number
-	label: TranslationText
-	nullSelectionText?: TranslationText
+	label: TranslationKey
+	nullSelectionText?: MaybeTranslation
 	disabled?: boolean
 	rightAlignDropdown?: boolean
 	useInputButton?: boolean
@@ -107,7 +107,7 @@ export class DatePicker implements Component<DatePickerAttrs> {
 				: null,
 			m(InputButton, {
 				tabIndex: Number(isApp() ? TabIndex.Programmatic : TabIndex.Default),
-				ariaLabel: lang.getMaybeLazy(label),
+				ariaLabel: lang.getTranslationText(label),
 				inputValue: this.inputText,
 				oninput: (newValue: string) => (this.inputText = newValue),
 				display: formatDateWithWeekdayAndYear(date ?? new Date()),
@@ -199,13 +199,13 @@ export class DatePicker implements Component<DatePickerAttrs> {
 		return true
 	}
 
-	private renderHelpLabel(date: Date | null | undefined, nullSelectionText: TranslationText | null): Children {
+	private renderHelpLabel(date: Date | null | undefined, nullSelectionText: MaybeTranslation | null): Children {
 		if (this.showingDropdown) {
 			return null
 		} else if (date != null) {
-			return [m("", formatDateWithWeekdayAndYear(date)), nullSelectionText ? m("", lang.getMaybeLazy(nullSelectionText)) : null]
+			return [m("", formatDateWithWeekdayAndYear(date)), nullSelectionText ? m("", lang.getTranslationText(nullSelectionText)) : null]
 		} else {
-			return lang.getMaybeLazy(nullSelectionText ?? "emptyString_msg")
+			return lang.getTranslationText(nullSelectionText ?? "emptyString_msg")
 		}
 	}
 
@@ -216,7 +216,7 @@ export class DatePicker implements Component<DatePickerAttrs> {
 			".content-bg.z3.menu-shadow.plr.pb-s",
 			{
 				"aria-modal": "true",
-				"aria-label": lang.getMaybeLazy(label),
+				"aria-label": lang.get(label),
 				style: {
 					width: "240px",
 					right: rightAlignDropdown ? "0" : null,

--- a/src/calendar-app/calendar/gui/pickers/DatePickerDialog.ts
+++ b/src/calendar-app/calendar/gui/pickers/DatePickerDialog.ts
@@ -1,6 +1,6 @@
 import m, { Component } from "mithril"
 import { Dialog, DialogType } from "../../../../common/gui/base/Dialog.js"
-import { lang } from "../../../../common/misc/LanguageViewModel.js"
+import { lang, Translation } from "../../../../common/misc/LanguageViewModel.js"
 import { DatePicker } from "./DatePicker.js"
 import { px, size } from "../../../../common/gui/size.js"
 import { client } from "../../../../common/misc/ClientDetector.js"
@@ -22,7 +22,8 @@ export function showDateRangeSelectionDialog<T>(
 	start: Date
 	end: Date
 }> {
-	const helpLabel = (date: Date | null) => (date != null ? () => formatDateWithWeekdayAndYear(date) : "unlimited_label")
+	const helpLabel = (date: Date | null): Translation =>
+		date != null ? lang.makeTranslation("date", formatDateWithWeekdayAndYear(date)) : lang.getTranslation("unlimited_label")
 
 	const validateDates = debounceStart(750, (startDate, endDate) => {
 		warning = dateValidator(startDate, endDate)
@@ -71,7 +72,7 @@ export function showDateRangeSelectionDialog<T>(
 	}
 	return new Promise((resolve) => {
 		let dialog = Dialog.showActionDialog({
-			title: lang.get("selectPeriodOfTime_label"),
+			title: "selectPeriodOfTime_label",
 			child: form,
 			allowOkWithReturn: true,
 			okAction: () =>

--- a/src/calendar-app/calendar/gui/pickers/GuestPicker.ts
+++ b/src/calendar-app/calendar/gui/pickers/GuestPicker.ts
@@ -140,7 +140,7 @@ export class GuestPicker implements ClassComponent<GuestPickerAttrs> {
 					this.value = getFirstOrThrow(errors)
 				} else {
 					if (errors.length > 0) {
-						Dialog.message(() => `${lang.get("invalidPastedRecipients_msg")}\n\n${errors.join("\n")}`)
+						Dialog.message(lang.makeTranslation("error_message", `${lang.get("invalidPastedRecipients_msg")}\n\n${errors.join("\n")}`))
 					}
 					this.value = remainingText
 				}

--- a/src/calendar-app/calendar/search/view/CalendarSearchListView.ts
+++ b/src/calendar-app/calendar/search/view/CalendarSearchListView.ts
@@ -45,7 +45,7 @@ export class CalendarSearchListView implements Component<CalendarSearchListViewA
 		return attrs.listModel.isEmptyAndDone()
 			? m(ColumnEmptyMessageBox, {
 					icon,
-					message: () => lang.get("searchNoResults_msg"),
+					message: "searchNoResults_msg",
 					color: theme.list_message_bg,
 			  })
 			: m(List, {

--- a/src/calendar-app/calendar/search/view/CalendarSearchView.ts
+++ b/src/calendar-app/calendar/search/view/CalendarSearchView.ts
@@ -12,7 +12,7 @@ import { SidebarSection } from "../../../../common/gui/SidebarSection.js"
 import { NavButton } from "../../../../common/gui/base/NavButton.js"
 import { BootIcons } from "../../../../common/gui/base/icons/BootIcons.js"
 import { px, size } from "../../../../common/gui/size.js"
-import { lang, type TranslationText } from "../../../../common/misc/LanguageViewModel.js"
+import { lang, type MaybeTranslation } from "../../../../common/misc/LanguageViewModel.js"
 import { BackgroundColumnLayout } from "../../../../common/gui/BackgroundColumnLayout.js"
 import { theme } from "../../../../common/gui/theme.js"
 import { DesktopListToolbar, DesktopViewerToolbar } from "../../../../common/gui/DesktopToolbars.js"
@@ -76,7 +76,7 @@ export class CalendarSearchView extends BaseTopLevelView implements TopLevelView
 	private readonly searchViewModel: CalendarSearchViewModel
 	private readonly contactModel: ContactModel
 	private readonly startOfTheWeekOffset: number
-	private datePickerWarning: TranslationText | null = null
+	private datePickerWarning: MaybeTranslation | null = null
 
 	private getSanitizedPreviewData: (event: CalendarEvent) => LazyLoaded<CalendarEventPreviewViewModel> = memoized((event: CalendarEvent) =>
 		new LazyLoaded(async () => {
@@ -117,7 +117,7 @@ export class CalendarSearchView extends BaseTopLevelView implements TopLevelView
 			{
 				minWidth: size.second_col_min_width,
 				maxWidth: size.second_col_max_width,
-				headerCenter: () => lang.get("searchResult_label"),
+				headerCenter: "searchResult_label",
 			},
 		)
 		this.resultDetailsColumn = new ViewColumn(
@@ -215,7 +215,7 @@ export class CalendarSearchView extends BaseTopLevelView implements TopLevelView
 					...header,
 					backAction: () => this.viewSlider.focusPreviousColumn(),
 					columnType: "other",
-					title: lang.get("search_label"),
+					title: "search_label",
 					actions: null,
 					multicolumnActions: () => [],
 					primaryAction: () => this.renderHeaderRightView(),
@@ -362,7 +362,7 @@ export class CalendarSearchView extends BaseTopLevelView implements TopLevelView
 					click: () => {
 						const dialog = Dialog.editSmallDialog(
 							{
-								middle: () => lang.get("filter_label"),
+								middle: "filter_label",
 								right: [
 									{
 										label: "ok_action",
@@ -384,7 +384,7 @@ export class CalendarSearchView extends BaseTopLevelView implements TopLevelView
 	}
 
 	private renderDateRangeSelection(): Children {
-		const renderedHelpText: TranslationText | undefined =
+		const renderedHelpText: MaybeTranslation | undefined =
 			this.searchViewModel.warning === "startafterend"
 				? "startAfterEnd_label"
 				: this.searchViewModel.warning === "long"

--- a/src/calendar-app/calendar/settings/CalendarSettingsView.ts
+++ b/src/calendar-app/calendar/settings/CalendarSettingsView.ts
@@ -16,7 +16,7 @@ import { LoginSettingsViewer } from "../../../common/settings/login/LoginSetting
 import { Icons } from "../../../common/gui/base/icons/Icons.js"
 import { AppearanceSettingsViewer } from "../../../common/settings/AppearanceSettingsViewer.js"
 import { px, size } from "../../../common/gui/size.js"
-import { lang, TranslationText } from "../../../common/misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../../common/misc/LanguageViewModel.js"
 import { BackgroundColumnLayout } from "../../../common/gui/BackgroundColumnLayout.js"
 import { theme } from "../../../common/gui/theme.js"
 import { styles } from "../../../common/gui/styles.js"
@@ -140,7 +140,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 											this.viewSlider.focusPreviousColumn()
 										},
 										columnType: "first",
-										title: lang.getMaybeLazy(this.selectedFolder.name),
+										title: this.selectedFolder.name,
 										actions: [],
 										useBackButton: true,
 										primaryAction: () => null,
@@ -153,7 +153,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 			{
 				minWidth: size.second_col_min_width,
 				maxWidth: size.third_col_max_width,
-				headerCenter: () => lang.getMaybeLazy(this.selectedFolder.name),
+				headerCenter: this.selectedFolder.name,
 			},
 		)
 	}
@@ -174,7 +174,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 								...vnode.attrs.header,
 								backAction: () => m.route.set(CALENDAR_PREFIX),
 								columnType: "first",
-								title: lang.getMaybeLazy("settings_label"),
+								title: "settings_label",
 								actions: [],
 								useBackButton: true,
 								primaryAction: () => null,
@@ -187,7 +187,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 			{
 				minWidth: size.first_col_min_width,
 				maxWidth: size.first_col_max_width,
-				headerCenter: () => lang.get("settings_label"),
+				headerCenter: "settings_label",
 			},
 		)
 	}
@@ -317,7 +317,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 		}
 	}
 
-	renderSettingsNavigation(folders: SettingsFolder<unknown>[], title: TranslationText): Children {
+	renderSettingsNavigation(folders: SettingsFolder<unknown>[], title: MaybeTranslation): Children {
 		if (folders.length === 0) {
 			return null
 		}
@@ -328,7 +328,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 				class: styles.isSingleColumnLayout() ? "pr-m" : "pr-vpad-s",
 			},
 			[
-				m("small.uppercase.pb-s.b.text-ellipsis", { style: { color: theme.navigation_button } }, lang.getMaybeLazy(title)),
+				m("small.uppercase.pb-s.b.text-ellipsis", { style: { color: theme.navigation_button } }, lang.getTranslationText(title)),
 				m(
 					".flex.col.border-radius-m.list-bg",
 					folders
@@ -467,7 +467,7 @@ export class CalendarSettingsView extends BaseTopLevelView implements TopLevelVi
 						onclick: () => {
 							setTimeout(() => {
 								const dialog = Dialog.showActionDialog({
-									title: () => lang.get("about_label"),
+									title: "about_label",
 									child: () =>
 										m(AboutDialog, {
 											onShowSetupWizard: () => {

--- a/src/calendar-app/calendar/view/CalendarAgendaView.ts
+++ b/src/calendar-app/calendar/view/CalendarAgendaView.ts
@@ -262,7 +262,7 @@ export class CalendarAgendaView implements Component<CalendarAgendaViewAttrs> {
 							".rel.flex-grow.height-100p",
 							m(ColumnEmptyMessageBox, {
 								icon: BootIcons.Calendar,
-								message: () => lang.get("noEventSelect_msg"),
+								message: "noEventSelect_msg",
 								color: theme.list_message_bg,
 							}),
 					  )

--- a/src/calendar-app/calendar/view/CalendarDesktopToolbar.ts
+++ b/src/calendar-app/calendar/view/CalendarDesktopToolbar.ts
@@ -1,7 +1,7 @@
 import { CalendarNavConfiguration, getIconForViewType } from "../gui/CalendarGuiUtils.js"
 import m, { Children, Component, Vnode } from "mithril"
 import { px, size } from "../../../common/gui/size.js"
-import { lang, TranslationText } from "../../../common/misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../../common/misc/LanguageViewModel.js"
 import { IconSegmentControl } from "../../../common/gui/base/IconSegmentControl.js"
 import { AllIcons } from "../../../common/gui/base/Icon.js"
 import { TodayIconButton } from "./TodayIconButton.js"
@@ -43,7 +43,7 @@ export class CalendarDesktopToolbar implements Component<CalendarDesktopToolbarA
 	}
 
 	private renderViewSelector(attrs: CalendarDesktopToolbarAttrs): Children {
-		const calendarViewValues: Array<{ icon: AllIcons; label: TranslationText; value: CalendarViewType }> = [
+		const calendarViewValues: Array<{ icon: AllIcons; label: MaybeTranslation; value: CalendarViewType }> = [
 			{
 				icon: getIconForViewType(CalendarViewType.AGENDA),
 				label: "agenda_label",

--- a/src/calendar-app/calendar/view/CalendarInvites.ts
+++ b/src/calendar-app/calendar/view/CalendarInvites.ts
@@ -20,6 +20,7 @@ import { LoginController } from "../../../common/api/main/LoginController.js"
 import type { MailboxDetail, MailboxModel } from "../../../common/mailFunctionality/MailboxModel.js"
 import { SendMailModel } from "../../../common/mailFunctionality/SendMailModel.js"
 import { RecipientField } from "../../../common/mailFunctionality/SharedMailUtils.js"
+import { lang } from "../../../common/misc/LanguageViewModel.js"
 
 // not picking the status directly from CalendarEventAttendee because it's a NumberString
 export type Guest = Recipient & { status: CalendarAttendeeStatus }
@@ -173,7 +174,7 @@ export class CalendarInviteHandler {
 			await notificationModel.send(eventClone, [], { responseModel, inviteModel: null, cancelModel: null, updateModel: null })
 		} catch (e) {
 			if (e instanceof UserError) {
-				await Dialog.message(() => e.message)
+				await Dialog.message(lang.makeTranslation("confirm_msg", e.message))
 				return ReplyResult.ReplyNotSent
 			} else {
 				throw e

--- a/src/calendar-app/calendar/view/CalendarMobileHeader.ts
+++ b/src/calendar-app/calendar/view/CalendarMobileHeader.ts
@@ -8,7 +8,7 @@ import { CalendarNavConfiguration, getIconForViewType } from "../gui/CalendarGui
 import { MobileHeaderBackButton, MobileHeaderMenuButton, MobileHeaderTitle } from "../../../common/gui/MobileHeader.js"
 import { AppHeaderAttrs } from "../../../common/gui/Header.js"
 import { attachDropdown } from "../../../common/gui/base/Dropdown.js"
-import { TranslationKey } from "../../../common/misc/LanguageViewModel.js"
+import { lang, TranslationKey } from "../../../common/misc/LanguageViewModel.js"
 import { styles } from "../../../common/gui/styles.js"
 import { theme } from "../../../common/gui/theme.js"
 import { ClickHandler } from "../../../common/gui/base/GuiUtils.js"
@@ -44,7 +44,7 @@ export class CalendarMobileHeader implements Component<CalendarMobileHeaderAttrs
 			center: m(MobileHeaderTitle, {
 				title: attrs.showExpandIcon
 					? m(ExpanderButton, {
-							label: () => attrs.navConfiguration.title,
+							label: lang.makeTranslation(attrs.navConfiguration.title, attrs.navConfiguration.title),
 							isUnformattedLabel: true,
 							style: {
 								"padding-top": "inherit",

--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -237,7 +237,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			{
 				minWidth: size.calendar_first_col_min_width,
 				maxWidth: size.first_col_max_width,
-				headerCenter: () => (this.currentViewType === CalendarViewType.WEEK ? lang.get("month_label") : lang.get("calendar_label")),
+				headerCenter: this.currentViewType === CalendarViewType.WEEK ? "month_label" : "calendar_label",
 			},
 		)
 
@@ -938,12 +938,12 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 						: null,
 					(isApp() || isDesktop()) && isExternal
 						? {
-								label: () => "Sync",
+								label: lang.makeTranslation("sync_action", "Sync"),
 								icon: Icons.Sync,
 								size: ButtonSize.Compact,
 								click: () => {
 									this.viewModel.forceSyncExternal(existingGroupSettings, true)?.catch(async (e) => {
-										await Dialog.message(() => e.message)
+										await Dialog.message(lang.makeTranslation("confirm_msg", e.message))
 									})
 								},
 						  }
@@ -975,15 +975,17 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			const ownerMail = locator.logins.getUserController().userGroupInfo.mailAddress
 			const otherMembers = members.filter((member) => member.info.mailAddress !== ownerMail)
 			Dialog.confirm(
-				() =>
+				lang.makeTranslation(
+					"confirm_msg",
 					(otherMembers.length > 0
 						? lang.get("deleteSharedCalendarConfirm_msg", {
 								"{calendar}": calendarName,
 						  }) + " "
 						: "") +
-					lang.get("deleteCalendarConfirm_msg", {
-						"{calendar}": calendarName,
-					}),
+						lang.get("deleteCalendarConfirm_msg", {
+							"{calendar}": calendarName,
+						}),
+				),
 			).then((confirmed) => {
 				if (confirmed) {
 					this.viewModel.deleteCalendar(calendarInfo).catch(ofClass(NotFoundError, () => console.log("Calendar to be deleted was not found.")))
@@ -1064,7 +1066,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			if (shouldSyncExternal)
 				this.viewModel.forceSyncExternal(existingGroupSettings)?.catch(async (e) => {
 					showSnackBar({
-						message: () => e.message,
+						message: lang.makeTranslation("exception_msg", e.message),
 						button: {
 							label: "ok_action",
 							click: noOp,

--- a/src/calendar-app/calendar/view/TodayIconButton.ts
+++ b/src/calendar-app/calendar/view/TodayIconButton.ts
@@ -4,7 +4,6 @@ import { Icons } from "../../../common/gui/base/icons/Icons.js"
 import { BaseButton } from "../../../common/gui/base/buttons/BaseButton.js"
 import { Icon, IconSize } from "../../../common/gui/base/Icon.js"
 import { theme } from "../../../common/gui/theme.js"
-import { lang } from "../../../common/misc/LanguageViewModel.js"
 
 type TodayIconButtonAttrs = Pick<IconButtonAttrs, "click">
 
@@ -14,7 +13,7 @@ type TodayIconButtonAttrs = Pick<IconButtonAttrs, "click">
 export class TodayIconButton implements Component<TodayIconButtonAttrs> {
 	view({ attrs }: Vnode<TodayIconButtonAttrs>): Children {
 		return m(BaseButton, {
-			label: lang.get("today_label"),
+			label: "today_label",
 			onclick: attrs.click,
 			icon: m(Icon, {
 				container: "div",

--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -917,7 +917,7 @@ class CalendarLocator {
 		if (isApp() || isDesktop()) {
 			calendarModel.syncExternalCalendars().catch(async (e) => {
 				showSnackBar({
-					message: () => e.message,
+					message: lang.makeTranslation("exception_msg", e.message),
 					button: {
 						label: "ok_action",
 						click: noOp,

--- a/src/calendar-app/gui/FloatingActionButton.ts
+++ b/src/calendar-app/gui/FloatingActionButton.ts
@@ -3,11 +3,11 @@ import { IconButton } from "../../common/gui/base/IconButton.js"
 import { Icons } from "../../common/gui/base/icons/Icons.js"
 import { ButtonColor } from "../../common/gui/base/Button.js"
 import { BootIcons } from "../../common/gui/base/icons/BootIcons.js"
-import type { TranslationText } from "../../common/misc/LanguageViewModel.js"
+import type { MaybeTranslation } from "../../common/misc/LanguageViewModel.js"
 import { ButtonSize } from "../../common/gui/base/ButtonSize.js"
 
 export type FloatingActionButtonAttrs = {
-	title: TranslationText
+	title: MaybeTranslation
 	colors: ButtonColor
 	icon: Icons | BootIcons
 	action: () => unknown

--- a/src/calendar-app/gui/SettingsNavButton.ts
+++ b/src/calendar-app/gui/SettingsNavButton.ts
@@ -1,5 +1,5 @@
 import { Icon, IconSize, lazyIcon } from "../../common/gui/base/Icon.js"
-import { lang, TranslationText } from "../../common/misc/LanguageViewModel.js"
+import { lang, Translation, MaybeTranslation } from "../../common/misc/LanguageViewModel.js"
 import { ClickHandler } from "../../common/gui/base/GuiUtils.js"
 import m, { Children, Component, Vnode } from "mithril"
 import { BaseButton } from "../../common/gui/base/buttons/BaseButton.js"
@@ -8,7 +8,7 @@ import { lazyStringValue } from "@tutao/tutanota-utils"
 
 export interface SettingsNavButtonAttrs {
 	icon?: lazyIcon
-	label: TranslationText
+	label: MaybeTranslation
 	click: ClickHandler
 	href?: string
 	class?: string
@@ -19,8 +19,8 @@ export class SettingsNavButton implements Component<SettingsNavButtonAttrs> {
 		const child = m(
 			BaseButton,
 			{
-				label: lang.getMaybeLazy(attrs.label),
-				text: m("span.flex-grow", lang.getMaybeLazy(attrs.label)),
+				label: attrs.label,
+				text: m("span.flex-grow", lang.getTranslationText(attrs.label)),
 				icon: attrs.icon
 					? m(Icon, {
 							icon: attrs.icon?.(),

--- a/src/common/api/common/utils/GroupUtils.ts
+++ b/src/common/api/common/utils/GroupUtils.ts
@@ -1,5 +1,6 @@
 import type { GroupInfo, GroupMembership, User } from "../../entities/sys/TypeRefs.js"
 import { GroupType } from "../TutanotaConstants"
+import { lang, Translation } from "../../../misc/LanguageViewModel.js"
 
 export function getEnabledMailAddressesForGroupInfo(groupInfo: GroupInfo): string[] {
 	let aliases = groupInfo.mailAddressAliases.filter((alias) => alias.enabled).map((alias) => alias.mailAddress)

--- a/src/common/api/main/UserError.ts
+++ b/src/common/api/main/UserError.ts
@@ -1,13 +1,12 @@
-import type { TranslationKeyType } from "../../misc/TranslationKey"
-import { lang } from "../../misc/LanguageViewModel"
-import type { lazy } from "@tutao/tutanota-utils"
+import { lang, TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
+import { MaybeLazy, resolveMaybeLazy } from "@tutao/tutanota-utils"
 import { assertMainOrNode } from "../common/Env"
 import { TutanotaError } from "@tutao/tutanota-error"
 
 assertMainOrNode()
 
 export class UserError extends TutanotaError {
-	constructor(message: TranslationKeyType | lazy<string>) {
-		super("UserError", lang.getMaybeLazy(message))
+	constructor(message: MaybeLazy<MaybeTranslation>) {
+		super("UserError", lang.getTranslationText(resolveMaybeLazy(message)))
 	}
 }

--- a/src/common/calendar/import/CalendarImporter.ts
+++ b/src/common/calendar/import/CalendarImporter.ts
@@ -5,7 +5,7 @@ import { ParserError } from "../../misc/parsing/ParserCombinator.js"
 import { CalendarEvent } from "../../api/entities/tutanota/TypeRefs.js"
 import { AlarmInfoTemplate } from "../../api/worker/facades/lazy/CalendarFacade.js"
 import { Dialog, DialogType } from "../../gui/base/Dialog.js"
-import { lang, TranslationText } from "../../misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../misc/LanguageViewModel.js"
 import { List, ListAttrs, ListLoadingState, MultiselectMode, RenderConfig } from "../../gui/base/List.js"
 import { KindaCalendarRow } from "../../../calendar-app/calendar/gui/CalendarRow.js"
 import { size } from "../../gui/size.js"
@@ -52,7 +52,7 @@ export function parseCalendarFile(file: DataFile): ParsedCalendarData {
  * @param okAction The action to be executed when the user press the ok or continue button
  * @param title
  */
-export function showEventsImportDialog(events: CalendarEvent[], okAction: (dialog: Dialog) => unknown, title: TranslationText) {
+export function showEventsImportDialog(events: CalendarEvent[], okAction: (dialog: Dialog) => unknown, title: MaybeTranslation) {
 	const renderConfig: RenderConfig<CalendarEvent, KindaCalendarRow> = {
 		itemHeight: size.list_row_height,
 		multiselectionAllowed: MultiselectMode.Disabled,
@@ -74,7 +74,7 @@ export function showEventsImportDialog(events: CalendarEvent[], okAction: (dialo
 						},
 					},
 				],
-				middle: () => lang.getMaybeLazy(title),
+				middle: title,
 				right: [
 					{
 						type: ButtonType.Primary,
@@ -165,7 +165,7 @@ export function calendarSelectionDialog(
 						},
 					},
 				],
-				middle: () => lang.getMaybeLazy("calendar_label"),
+				middle: "calendar_label",
 				right: [
 					{
 						type: ButtonType.Primary,

--- a/src/common/calendar/import/CalendarImporterDialog.ts
+++ b/src/common/calendar/import/CalendarImporterDialog.ts
@@ -26,11 +26,14 @@ import { EventImportRejectionReason, EventWrapper, sortOutParsedEvents } from ".
 async function partialImportConfirmation(skippedEvents: CalendarEvent[], confirmationText: TranslationKeyType, total: number): Promise<boolean> {
 	return (
 		skippedEvents.length === 0 ||
-		(await Dialog.confirm(() =>
-			lang.get(confirmationText, {
-				"{amount}": skippedEvents.length + "",
-				"{total}": total + "",
-			}),
+		(await Dialog.confirm(
+			lang.makeTranslation(
+				"confirm_msg",
+				lang.get(confirmationText, {
+					"{amount}": skippedEvents.length + "",
+					"{total}": total + "",
+				}),
+			),
 		))
 	)
 }
@@ -75,10 +78,13 @@ async function selectAndParseIcalFile(): Promise<ParsedEvent[]> {
 	} catch (e) {
 		if (e instanceof ParserError) {
 			console.log("Failed to parse file", e)
-			Dialog.message(() =>
-				lang.get("importReadFileError_msg", {
-					"{filename}": e.filename ?? "",
-				}),
+			Dialog.message(
+				lang.makeTranslation(
+					"confirm_msg",
+					lang.get("importReadFileError_msg", {
+						"{filename}": e.filename ?? "",
+					}),
+				),
 			)
 			return []
 		} else {
@@ -92,11 +98,14 @@ async function importEvents(eventsForCreation: Array<EventWrapper>): Promise<voi
 	return showProgressDialog("importCalendar_label", locator.calendarFacade.saveImportedCalendarEvents(eventsForCreation, operation.id), operation.progress)
 		.catch(
 			ofClass(ImportError, (e) =>
-				Dialog.message(() =>
-					lang.get("importEventsError_msg", {
-						"{amount}": e.numFailed + "",
-						"{total}": eventsForCreation.length.toString(),
-					}),
+				Dialog.message(
+					lang.makeTranslation(
+						"confirm_msg",
+						lang.get("importEventsError_msg", {
+							"{amount}": e.numFailed + "",
+							"{total}": eventsForCreation.length.toString(),
+						}),
+					),
 				),
 			),
 		)

--- a/src/common/desktop/mailimport/MailImporter.ts
+++ b/src/common/desktop/mailimport/MailImporter.ts
@@ -29,7 +29,7 @@ export function folderSelectionDialog(indentedFolders: IndentedFolder[], okActio
 						},
 					},
 				],
-				middle: () => lang.getMaybeLazy("mailFolder_label"),
+				middle: "mailFolder_label",
 				right: [
 					{
 						type: ButtonType.Primary,

--- a/src/common/file/FileController.ts
+++ b/src/common/file/FileController.ts
@@ -31,6 +31,7 @@ export enum VCARD_MIME_TYPES {
 	X_VCARD = "text/x-vcard",
 	VCARD = "text/vcard",
 }
+
 export enum MAIL_MIME_TYPES {
 	EML = "message/rfc822",
 	MBOX = "application/mbox",
@@ -65,7 +66,7 @@ export abstract class FileController {
 						if (msg === "couldNotAttachFile_msg") {
 							isOffline = true
 						} else {
-							Dialog.message(() => lang.get(msg) + " " + file.name)
+							Dialog.message(lang.makeTranslation("error_msg", lang.get(msg) + " " + file.name))
 						}
 					})
 					if (isOffline) break // don't try to download more files, but the previous ones (if any) will still be downloaded

--- a/src/common/gui/AriaUtils.ts
+++ b/src/common/gui/AriaUtils.ts
@@ -9,6 +9,7 @@ import { assertMainOrNodeBoot } from "../api/common/Env"
  *
  */
 import { TabIndex } from "../api/common/TutanotaConstants"
+import { lang, MaybeTranslation } from "../misc/LanguageViewModel.js"
 
 assertMainOrNodeBoot()
 

--- a/src/common/gui/AttachmentBubble.ts
+++ b/src/common/gui/AttachmentBubble.ts
@@ -19,6 +19,7 @@ import { hasError } from "../api/common/utils/ErrorUtils.js"
 import { BubbleButton, bubbleButtonHeight, bubbleButtonPadding } from "./base/buttons/BubbleButton.js"
 import { BootIcons } from "./base/icons/BootIcons.js"
 import { CALENDAR_MIME_TYPE, MAIL_MIME_TYPES, VCARD_MIME_TYPES } from "../file/FileController.js"
+import { lang } from "../misc/LanguageViewModel.js"
 
 export enum AttachmentType {
 	GENERIC,
@@ -54,8 +55,8 @@ export class AttachmentBubble implements Component<AttachmentBubbleAttrs> {
 			return m(
 				BubbleButton,
 				{
-					label: () => attachment.name,
-					text: () => rest,
+					label: lang.makeTranslation("attachment_name", attachment.name),
+					text: lang.makeTranslation("attachment_base_name", rest),
 					icon: getAttachmentIcon(vnode.attrs.type),
 					onclick: () => {
 						showAttachmentDetailsPopup(this.dom!, vnode.attrs).then(() => this.dom?.focus())

--- a/src/common/gui/FolderColumnView.ts
+++ b/src/common/gui/FolderColumnView.ts
@@ -1,7 +1,7 @@
 import { DrawerMenu, DrawerMenuAttrs } from "./nav/DrawerMenu.js"
 import { theme } from "./theme.js"
 import m, { Children, Component, Vnode } from "mithril"
-import type { TranslationKey } from "../misc/LanguageViewModel.js"
+import type { TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { lang } from "../misc/LanguageViewModel.js"
 import { AriaLandmarks, landmarkAttrs } from "./AriaUtils.js"
 import type { ClickHandler } from "./base/GuiUtils.js"
@@ -12,7 +12,7 @@ export type Attrs = {
 	/** Button to be displayed on top of the column*/
 	button: { label: TranslationKey; click: ClickHandler } | null | undefined
 	content: Children
-	ariaLabel: TranslationKey | lazy<string>
+	ariaLabel: MaybeTranslation
 	drawer: DrawerMenuAttrs
 }
 
@@ -20,7 +20,7 @@ export class FolderColumnView implements Component<Attrs> {
 	view({ attrs }: Vnode<Attrs>): Children {
 		return m(".flex.height-100p.nav-bg", [
 			m(DrawerMenu, attrs.drawer),
-			m(".folder-column.flex-grow.overflow-x-hidden.flex.col", landmarkAttrs(AriaLandmarks.Navigation, lang.getMaybeLazy(attrs.ariaLabel)), [
+			m(".folder-column.flex-grow.overflow-x-hidden.flex.col", landmarkAttrs(AriaLandmarks.Navigation, lang.getTranslationText(attrs.ariaLabel)), [
 				this.renderMainButton(attrs),
 				m(
 					".scroll.scrollbar-gutter-stable-or-fallback.visible-scrollbar.overflow-x-hidden.flex.col.flex-grow",

--- a/src/common/gui/MailRecipientsTextField.ts
+++ b/src/common/gui/MailRecipientsTextField.ts
@@ -66,7 +66,9 @@ export class MailRecipientsTextField implements ClassComponent<MailRecipientsTex
 					attrs.onTextChanged(getFirstOrThrow(errors))
 				} else {
 					if (errors.length > 0) {
-						Dialog.message(() => `${lang.get("invalidPastedRecipients_msg")}\n\n${errors.join("\n")}`)
+						Dialog.message(
+							lang.makeTranslation("invalidPastedRecipients_msg", `${lang.get("invalidPastedRecipients_msg")}\n\n${errors.join("\n")}`),
+						)
 					}
 					attrs.onTextChanged(remainingText)
 				}
@@ -74,7 +76,7 @@ export class MailRecipientsTextField implements ClassComponent<MailRecipientsTex
 			items: attrs.recipients.map((recipient) => recipient.address),
 			renderBubbleText: (address: string) => {
 				const name = findRecipientWithAddress(attrs.recipients, address)?.name ?? null
-				return getMailAddressDisplayText(name, address, false)
+				return lang.makeTranslation(address, getMailAddressDisplayText(name, address, false))
 			},
 			getBubbleDropdownAttrs: async (address) => (await attrs.getRecipientClickedDropdownAttrs?.(address)) ?? [],
 			onBackspace: () => {

--- a/src/common/gui/MainCreateButton.ts
+++ b/src/common/gui/MainCreateButton.ts
@@ -16,10 +16,9 @@ export interface MainCreateButtonAttrs {
  */
 export class MainCreateButton implements Component<MainCreateButtonAttrs> {
 	view(vnode: Vnode<MainCreateButtonAttrs>): Children {
-		const label = lang.get(vnode.attrs.label)
 		return m(BaseButton, {
-			label,
-			text: label,
+			label: vnode.attrs.label,
+			text: lang.get(vnode.attrs.label),
 			onclick: vnode.attrs.click,
 			class: `full-width border-radius-big center b flash ${vnode.attrs.class}`,
 			style: {

--- a/src/common/gui/MobileHeader.ts
+++ b/src/common/gui/MobileHeader.ts
@@ -13,6 +13,7 @@ import { px } from "./size.js"
 import { theme } from "./theme.js"
 import { NewsModel } from "../misc/news/NewsModel.js"
 import { ClickHandler } from "./base/GuiUtils.js"
+import { lang, MaybeTranslation } from "../misc/LanguageViewModel.js"
 
 export interface MobileHeaderAttrs extends AppHeaderAttrs {
 	columnType: "first" | "other"
@@ -25,7 +26,7 @@ export interface MobileHeaderAttrs extends AppHeaderAttrs {
 	 * in the second column in two column layout.
 	 */
 	primaryAction: () => Children
-	title?: string
+	title?: MaybeTranslation
 	backAction: () => unknown
 	useBackButton?: boolean
 }
@@ -44,7 +45,7 @@ export class MobileHeader implements Component<MobileHeaderAttrs> {
 			left: this.renderLeftAction(attrs),
 			center: firstVisibleColumn
 				? m(MobileHeaderTitle, {
-						title: attrs.title,
+						title: attrs.title ? lang.getTranslationText(attrs.title) : undefined,
 						bottom: m(OfflineIndicator, attrs.offlineIndicatorModel.getCurrentAttrs()),
 				  })
 				: null,

--- a/src/common/gui/MultiselectMobileHeader.ts
+++ b/src/common/gui/MultiselectMobileHeader.ts
@@ -4,16 +4,17 @@ import m from "mithril"
 import { BaseMobileHeader } from "./BaseMobileHeader.js"
 import { IconButton } from "./base/IconButton.js"
 import { Icons } from "./base/icons/Icons.js"
+import { lang, MaybeTranslation } from "../misc/LanguageViewModel.js"
 
 type MultiselectMobileHeaderAttrs = SelectAllCheckboxAttrs & {
-	message: string
+	message: MaybeTranslation
 }
 /** A special header that is used for multiselect state on mobile. */
 export const MultiselectMobileHeader = pureComponent((attrs: MultiselectMobileHeaderAttrs) => {
 	const { selectAll, selectNone, selected, message } = attrs
 	return m(BaseMobileHeader, {
 		left: m(SelectAllCheckbox, { selectNone, selectAll, selected }),
-		center: m(".font-weight-600", message),
+		center: m(".font-weight-600", lang.getTranslationText(message)),
 		right: m(IconButton, {
 			icon: Icons.Cancel,
 			title: "cancel_action",

--- a/src/common/gui/RenderLoginInfoLinks.ts
+++ b/src/common/gui/RenderLoginInfoLinks.ts
@@ -63,7 +63,7 @@ function showVersionDropdown(e: MouseEvent) {
 	createDropdown({
 		lazyButtons: () => [
 			{
-				label: () => "Get logs",
+				label: lang.makeTranslation("get_logs", "Get logs"),
 				click: () => showLogsDialog(),
 			},
 		],
@@ -75,7 +75,7 @@ async function showLogsDialog() {
 
 	const dialog: Dialog = Dialog.editDialog(
 		{
-			middle: () => "Logs",
+			middle: lang.makeTranslation("logs", "Logs"),
 			right: () => [
 				{
 					type: ButtonType.Secondary,

--- a/src/common/gui/SidebarSection.ts
+++ b/src/common/gui/SidebarSection.ts
@@ -1,5 +1,5 @@
 import m, { Child, Children, Component, Vnode } from "mithril"
-import type { TranslationKey } from "../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel"
 import { lang } from "../misc/LanguageViewModel"
 import { theme } from "./theme"
 import { lazy } from "@tutao/tutanota-utils"
@@ -7,7 +7,7 @@ import Stream from "mithril/stream"
 import stream from "mithril/stream"
 
 export type SidebarSectionAttrs = {
-	name: TranslationKey | lazy<string>
+	name: MaybeTranslation
 	button?: Child
 	hideIfEmpty?: true
 }
@@ -28,7 +28,7 @@ export class SidebarSection implements Component<SidebarSectionAttrs> {
 			},
 			[
 				m(".folder-row.flex-space-between.plr-button.pt-s.button-height", [
-					m("small.b.align-self-center.text-ellipsis.plr-button", lang.getMaybeLazy(name).toLocaleUpperCase()),
+					m("small.b.align-self-center.text-ellipsis.plr-button", lang.getTranslationText(name).toLocaleUpperCase()),
 					button ?? null,
 				]),
 				content,

--- a/src/common/gui/base/BaseSearchBar.ts
+++ b/src/common/gui/base/BaseSearchBar.ts
@@ -81,7 +81,7 @@ export class BaseSearchBar implements ClassComponent<BaseSearchBarAttrs> {
 				),
 				attrs.busy || attrs.text
 					? m(BaseButton, {
-							label: lang.get(attrs.busy ? "loading_msg" : "close_alt"),
+							label: attrs.busy ? "loading_msg" : "close_alt",
 							icon: m(Icon, {
 								container: "div",
 								size: IconSize.Medium,

--- a/src/common/gui/base/BubbleTextField.ts
+++ b/src/common/gui/base/BubbleTextField.ts
@@ -1,15 +1,15 @@
 import m, { Children, ClassComponent, Vnode } from "mithril"
 import { Autocomplete, TextField, TextFieldType } from "./TextField.js"
-import { TranslationText } from "../../misc/LanguageViewModel"
+import { Translation, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { Keys } from "../../api/common/TutanotaConstants"
 import { createAsyncDropdown, DropdownChildAttrs } from "./Dropdown.js"
 import { lazy } from "@tutao/tutanota-utils"
 import { BaseButton } from "./buttons/BaseButton.js"
 
 export interface BubbleTextFieldAttrs {
-	label: TranslationText
+	label: MaybeTranslation
 	items: Array<string>
-	renderBubbleText: (item: string) => string
+	renderBubbleText: (item: string) => Translation
 	getBubbleDropdownAttrs: (item: string) => Promise<DropdownChildAttrs[]>
 	text: string
 	onInput: (text: string) => void
@@ -48,7 +48,7 @@ export class BubbleTextField implements ClassComponent<BubbleTextFieldAttrs> {
 								".flex-no-grow-shrink-auto.overflow-hidden",
 								m(BaseButton, {
 									label: bubbleText,
-									text: bubbleText,
+									text: bubbleText.text,
 									class: "text-bubble button-content content-fg text-ellipsis flash",
 									style: {
 										"max-width": "100%",

--- a/src/common/gui/base/Button.ts
+++ b/src/common/gui/base/Button.ts
@@ -1,5 +1,5 @@
 import m, { Children, ClassComponent, CVnode } from "mithril"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { Translation, TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { getElevatedBackground, theme } from "../theme"
 import type { lazy } from "@tutao/tutanota-utils"
@@ -62,8 +62,8 @@ export function getColors(buttonColors: ButtonColor | null | undefined): {
 }
 
 export interface ButtonAttrs {
-	label: TranslationKey | lazy<string>
-	title?: TranslationKey | lazy<string>
+	label: MaybeTranslation
+	title?: MaybeTranslation
 	click?: ClickHandler
 	type: ButtonType
 	colors?: ButtonColor
@@ -74,13 +74,11 @@ export interface ButtonAttrs {
  */
 export class Button implements ClassComponent<ButtonAttrs> {
 	view({ attrs }: CVnode<ButtonAttrs>): Children {
-		const getKey = lang.getMaybeLazy
-		const title = attrs.title == null ? getKey(attrs.label) : getKey(attrs.title)
 		let classes = this.resolveClasses(attrs.type)
 
 		return m(BaseButton, {
-			label: title,
-			text: getKey(attrs.label),
+			label: attrs.title == null ? attrs.label : attrs.title,
+			text: lang.getTranslationText(attrs.label),
 			class: classes.join(" "),
 			style: {
 				borderColor: getColors(attrs.colors).border,

--- a/src/common/gui/base/Checkbox.ts
+++ b/src/common/gui/base/Checkbox.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { BootIcons, BootIconsSvg } from "./icons/BootIcons"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import type { lazy } from "@tutao/tutanota-utils"
 import { theme } from "../theme.js"
@@ -11,7 +11,7 @@ export type CheckboxAttrs = {
 	checked: boolean
 	onChecked: (value: boolean) => unknown
 	class?: string
-	helpLabel?: TranslationKey | lazy<string>
+	helpLabel?: MaybeTranslation
 	disabled?: boolean
 }
 
@@ -23,7 +23,7 @@ export class Checkbox implements Component<CheckboxAttrs> {
 
 	view(vnode: Vnode<CheckboxAttrs>): Children {
 		const a = vnode.attrs
-		const helpLabelText = a.helpLabel ? lang.getMaybeLazy(a.helpLabel) : ""
+		const helpLabelText = lang.getTranslationText(a.helpLabel ? a.helpLabel : "emptyString_msg")
 		const helpLabel = a.helpLabel ? m(`small.block.content-fg${Checkbox.getBreakClass(helpLabelText)}`, helpLabelText) : []
 		const userClasses = a.class == null ? "" : " " + a.class
 		return m(

--- a/src/common/gui/base/ColumnEmptyMessageBox.ts
+++ b/src/common/gui/base/ColumnEmptyMessageBox.ts
@@ -1,5 +1,5 @@
 import m, { Children, Component, Vnode } from "mithril"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import type { AllIcons } from "./Icon"
 import { Icon } from "./Icon"
@@ -11,7 +11,7 @@ assertMainOrNode()
 
 // If you change this make sure you pass through all the attrs
 export type InfoMessaggeBoxAttrs = {
-	message: TranslationKey | lazy<Children>
+	message: MaybeTranslation
 	icon?: AllIcons
 	color: string
 	bottomContent?: Children
@@ -38,7 +38,7 @@ export class IconMessageBox implements Component<InfoMessaggeBoxAttrs> {
 						color: attrs.color,
 					},
 				},
-				getMessage(attrs),
+				lang.getTranslationText(attrs.message),
 			),
 		])
 	}
@@ -79,8 +79,4 @@ export default class ColumnEmptyMessageBox implements Component<ColumnEmptyMessa
 			),
 		)
 	}
-}
-
-function getMessage({ message }: InfoMessaggeBoxAttrs) {
-	return typeof message === "function" ? message() : lang.get(message)
 }

--- a/src/common/gui/base/DialogHeaderBar.ts
+++ b/src/common/gui/base/DialogHeaderBar.ts
@@ -3,11 +3,12 @@ import type { ButtonAttrs } from "./Button.js"
 import { Button } from "./Button.js"
 import type { lazy, MaybeLazy } from "@tutao/tutanota-utils"
 import { resolveMaybeLazy } from "@tutao/tutanota-utils"
+import { lang, MaybeTranslation } from "../../misc/LanguageViewModel.js"
 
 export type DialogHeaderBarAttrs = {
 	left?: MaybeLazy<Array<ButtonAttrs>>
 	right?: MaybeLazy<Array<ButtonAttrs>>
-	middle?: lazy<string>
+	middle?: MaybeTranslation
 	create?: (dom: HTMLElement) => void
 	remove?: () => void
 	noHeader?: boolean
@@ -44,7 +45,11 @@ export class DialogHeaderBar implements Component<DialogHeaderBarAttrs> {
 					columnClass + ".ml-negative-s",
 					resolveMaybeLazy(a.left).map((a) => m(Button, a)),
 				), // ellipsis is not working if the text is directly in the flex element, so create a child div for it
-				a.middle ? m("#dialog-title.flex-third-middle.overflow-hidden.flex.justify-center.items-center.b", [m(".text-ellipsis", a.middle())]) : null,
+				a.middle
+					? m("#dialog-title.flex-third-middle.overflow-hidden.flex.justify-center.items-center.b", [
+							m(".text-ellipsis", lang.getTranslationText(a.middle)),
+					  ])
+					: null,
 				m(
 					columnClass + ".mr-negative-s.flex.justify-end",
 					resolveMaybeLazy(a.right).map((a) => m(Button, a)),

--- a/src/common/gui/base/DropDownSelector.ts
+++ b/src/common/gui/base/DropDownSelector.ts
@@ -4,7 +4,7 @@ import { createDropdown } from "./Dropdown.js"
 import type { AllIcons } from "./Icon"
 import type { lazy } from "@tutao/tutanota-utils"
 import { lazyStringValue, noOp } from "@tutao/tutanota-utils"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import { lang, TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { BootIcons } from "./icons/BootIcons"
 import { ClickHandler, getOperatingClasses } from "./GuiUtils"
 import { assertMainOrNode } from "../../api/common/Env"
@@ -22,7 +22,7 @@ export type SelectorItem<T> = {
 export type SelectorItemList<T> = ReadonlyArray<SelectorItem<T>>
 
 export interface DropDownSelectorAttrs<T> {
-	label: TranslationKey | lazy<string>
+	label: MaybeTranslation
 	items: SelectorItemList<T>
 	selectedValue: T | null
 	/** Override what is displayed for the selected value in the text field (but not in the dropdown) */
@@ -86,7 +86,7 @@ export class DropDownSelector<T> implements ClassComponent<DropDownSelectorAttrs
 					.filter((item) => item.selectable !== false)
 					.map((item) => {
 						return {
-							label: () => item.name,
+							label: lang.makeTranslation(item.name, item.name),
 							click: () => {
 								a.selectionChangedHandler?.(item.value)
 								m.redraw()
@@ -108,7 +108,7 @@ export class DropDownSelector<T> implements ClassComponent<DropDownSelectorAttrs
 		if (selectedItem) {
 			return selectedItem.name
 		} else {
-			console.log(`Dropdown ${lazyStringValue(a.label)} couldn't find element for value: ${String(JSON.stringify(value))}`)
+			console.log(`Dropdown ${lang.getTranslationText(a.label)} couldn't find element for value: ${String(JSON.stringify(value))}`)
 			return null
 		}
 	}

--- a/src/common/gui/base/Dropdown.ts
+++ b/src/common/gui/base/Dropdown.ts
@@ -5,7 +5,7 @@ import { ease } from "../animation/Easing"
 import { px, size } from "../size"
 import { focusNext, focusPrevious, Shortcut } from "../../misc/KeyManager"
 import type { ButtonAttrs } from "./Button.js"
-import { lang, TranslationText } from "../../misc/LanguageViewModel"
+import { lang, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { Keys, TabIndex } from "../../api/common/TutanotaConstants"
 import { getSafeAreaInsetBottom, getSafeAreaInsetTop } from "../HtmlUtils"
 import type { $Promisable, lazy, lazyAsync } from "@tutao/tutanota-utils"
@@ -29,9 +29,9 @@ export type DropdownInfoAttrs = {
 
 export interface DropdownButtonAttrs {
 	/** accessibility & tooltip description */
-	label: TranslationText
+	label: MaybeTranslation
 	/** visible text inside button */
-	text?: TranslationText
+	text?: MaybeTranslation
 	icon?: AllIcons
 	click?: ClickHandler
 	selected?: boolean
@@ -211,7 +211,7 @@ export class Dropdown implements ModalComponent {
 		}
 		const closeBtn = () => {
 			return m(BaseButton, {
-				label: lang.get("close_alt"),
+				label: "close_alt",
 				text: lang.get("close_alt"),
 				class: "hidden-until-focus content-accent-fg button-content",
 				onclick: () => {
@@ -338,7 +338,7 @@ export class Dropdown implements ModalComponent {
 
 		let visibleElements: Array<ButtonAttrs> = downcast(this.visibleChildren().filter((b) => !isDropDownInfo(b)))
 		let matchingButton =
-			visibleElements.length === 1 ? visibleElements[0] : visibleElements.find((b) => lang.getMaybeLazy(b.label).toLowerCase() === filterString)
+			visibleElements.length === 1 ? visibleElements[0] : visibleElements.find((b) => lang.getTranslationText(b.label).toLowerCase() === filterString)
 
 		if (this.domInput && document.activeElement === this.domInput && matchingButton && matchingButton.click) {
 			matchingButton.click(new MouseEvent("click"), this.domInput)
@@ -365,7 +365,7 @@ export class Dropdown implements ModalComponent {
 			if (isDropDownInfo(b)) {
 				return b.info.includes(this.filterString.toLowerCase())
 			} else if (this.isFilterable) {
-				const filterable = lang.getMaybeLazy(b.text ?? b.label)
+				const filterable = lang.getTranslationText(b.text ?? b.label)
 				return filterable.toLowerCase().includes(this.filterString.toLowerCase())
 			} else {
 				return true

--- a/src/common/gui/base/Expander.ts
+++ b/src/common/gui/base/Expander.ts
@@ -1,5 +1,5 @@
 import m, { Children, Component, Vnode } from "mithril"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { Icon, IconSize } from "./Icon"
 import { Icons } from "./icons/Icons"
@@ -13,7 +13,7 @@ import { isKeyPressed } from "../../misc/KeyManager.js"
 import { Keys } from "../../api/common/TutanotaConstants.js"
 
 export type ExpanderAttrs = {
-	label: TranslationKey | lazy<string>
+	label: MaybeTranslation
 	expanded: boolean
 	onExpandedChange: (value: boolean) => unknown
 	isPropagatingEvents?: boolean
@@ -30,7 +30,7 @@ export type ExpanderPanelAttrs = {
 export class ExpanderButton implements Component<ExpanderAttrs> {
 	view(vnode: Vnode<ExpanderAttrs>): Children {
 		const a = vnode.attrs
-		const label = lang.getMaybeLazy(a.label)
+		const label = lang.getTranslationText(a.label)
 		return m(
 			".limit-width",
 			m(

--- a/src/common/gui/base/GuiUtils.ts
+++ b/src/common/gui/base/GuiUtils.ts
@@ -1,6 +1,6 @@
 import type { Country } from "../../api/common/CountryList"
 import { Countries } from "../../api/common/CountryList"
-import type { InfoLink, TranslationKey } from "../../misc/LanguageViewModel"
+import type { InfoLink, TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { ButtonColor } from "./Button.js"
 import { Icons } from "./icons/Icons"
@@ -45,7 +45,7 @@ export function renderCountryDropdown(params: {
 	selectedCountry: Country | null
 	onSelectionChanged: (country: Country) => void
 	helpLabel?: lazy<string>
-	label?: TranslationKey | lazy<string>
+	label?: MaybeTranslation
 }): Children {
 	return m(DropDownSelector, {
 		label: params.label ?? "invoiceCountry_label",
@@ -92,7 +92,7 @@ type Confirmation = {
  * @param confirmMessage
  * @returns {Confirmation}
  */
-export function getConfirmation(message: TranslationKey | lazy<string>, confirmMessage: TranslationKey = "ok_action"): Confirmation {
+export function getConfirmation(message: MaybeTranslation, confirmMessage: TranslationKey = "ok_action"): Confirmation {
 	const confirmationPromise = Dialog.confirm(message, confirmMessage)
 	const confirmation: Confirmation = {
 		confirmed(action) {

--- a/src/common/gui/base/IconButton.ts
+++ b/src/common/gui/base/IconButton.ts
@@ -1,5 +1,5 @@
 import m, { Children, Component, Vnode } from "mithril"
-import type { TranslationText } from "../../misc/LanguageViewModel"
+import type { MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { AllIcons, Icon, IconSize } from "./Icon"
 import type { ClickHandler } from "./GuiUtils"
@@ -12,7 +12,7 @@ assertMainOrNode()
 
 export interface IconButtonAttrs {
 	icon: AllIcons
-	title: TranslationText
+	title: MaybeTranslation
 	click: ClickHandler
 	colors?: ButtonColor
 	size?: ButtonSize
@@ -23,7 +23,7 @@ export interface IconButtonAttrs {
 export class IconButton implements Component<IconButtonAttrs> {
 	view({ attrs }: Vnode<IconButtonAttrs>): Children {
 		return m(BaseButton, {
-			label: lang.getMaybeLazy(attrs.title),
+			label: attrs.title,
 			icon: m(Icon, {
 				icon: attrs.icon,
 				container: "div",

--- a/src/common/gui/base/IconSegmentControl.ts
+++ b/src/common/gui/base/IconSegmentControl.ts
@@ -1,12 +1,12 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { AllIcons, Icon, IconSize } from "./Icon.js"
-import { lang, TranslationText } from "../../misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../misc/LanguageViewModel.js"
 import { ButtonColor, getColors } from "./Button.js"
 import { px } from "../size.js"
 
 export interface IconSegmentControlItem<T> {
 	icon: AllIcons
-	label: TranslationText
+	label: MaybeTranslation
 	value: T
 }
 
@@ -29,7 +29,7 @@ export class IconSegmentControl<T> implements Component<IconSegmentControlAttrs<
 					role: "tablist",
 				},
 				vnode.attrs.items.map((item) => {
-					const title = lang.getMaybeLazy(item.label)
+					const title = lang.getTranslationText(item.label)
 					return m(
 						"button.icon-segment-control-item.flex.center-horizontally.center-vertically.text-ellipsis.small.state-bg.pt-xs.pb-xs",
 						{

--- a/src/common/gui/base/NavButton.ts
+++ b/src/common/gui/base/NavButton.ts
@@ -7,7 +7,7 @@ import type { lazyIcon } from "./Icon"
 import { Icon } from "./Icon"
 import { theme } from "../theme"
 import { styles } from "../styles"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { Keys } from "../../api/common/TutanotaConstants"
 import { isKeyPressed } from "../../misc/KeyManager"
@@ -18,7 +18,7 @@ import { fileListToArray } from "../../api/common/utils/FileUtils.js"
 
 assertMainOrNode()
 export type NavButtonAttrs = {
-	label: TranslationKey | lazy<string>
+	label: MaybeTranslation
 	icon?: lazyIcon
 	href: string | lazy<string>
 	isSelectedPrefix?: string | boolean
@@ -66,7 +66,7 @@ export class NavButton implements Component<NavButtonAttrs> {
 						},
 				  })
 				: null,
-			!a.hideLabel ? m("span.label.click.text-ellipsis" + (!a.vertical && icon ? ".pl-m" : ""), this.getLabel(a.label)) : null,
+			!a.hideLabel ? m("span.label.click.text-ellipsis" + (!a.vertical && icon ? ".pl-m" : ""), lang.getTranslationText(a.label)) : null,
 		]
 
 		// allow nav button without label for registration button on mobile devices
@@ -75,10 +75,6 @@ export class NavButton implements Component<NavButtonAttrs> {
 		} else {
 			return m(m.route.Link, linkAttrs, children)
 		}
-	}
-
-	getLabel(label: TranslationKey | lazy<string>): string {
-		return lang.getMaybeLazy(label)
 	}
 
 	_getUrl(href: string | lazy<string>): string {
@@ -124,7 +120,7 @@ export class NavButton implements Component<NavButtonAttrs> {
 				"font-size": a.fontSize ? px(a.fontSize) : "",
 				background: (isNavButtonSelected(a) && a.persistentBackground) || this._draggedOver ? stateBgHover : "",
 			},
-			title: this.getLabel(a.label),
+			title: lang.getTranslationText(a.label),
 			target: this._isExternalUrl(a.href) ? "_blank" : undefined,
 			selector: this._getNavButtonClass(a),
 			onclick: (e: MouseEvent) => this.click(e, a, e.target as HTMLElement),
@@ -136,6 +132,7 @@ export class NavButton implements Component<NavButtonAttrs> {
 			onfocus: a.onfocus,
 			onblur: a.onblur,
 			onkeydown: a.onkeydown,
+			"data-testid": lang.getTestId(a.label),
 		}
 
 		if (a.dropHandler) {

--- a/src/common/gui/base/RadioGroup.ts
+++ b/src/common/gui/base/RadioGroup.ts
@@ -1,4 +1,4 @@
-import type { TranslationText } from "../../misc/LanguageViewModel"
+import type { MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import m, { Child, Children, Component, Vnode } from "mithril"
 import { isKeyPressed } from "../../misc/KeyManager.js"
@@ -6,20 +6,20 @@ import { Keys } from "../../api/common/TutanotaConstants.js"
 import { AriaRole } from "../AriaUtils.js"
 
 export interface SingularOrPluralLabel {
-	singular: TranslationText
-	plural: TranslationText
+	singular: MaybeTranslation
+	plural: MaybeTranslation
 }
 
 export type RadioGroupOption<T> = {
-	readonly name: TranslationText
+	readonly name: MaybeTranslation
 	readonly value: T
 }
 
 export type RadioGroupAttrs<T> = {
 	// The unique name of the radio button group. The browser uses it to group the radio buttons together.
-	name: TranslationText
+	name: MaybeTranslation
 	options: ReadonlyArray<RadioGroupOption<T>>
-	ariaLabel: TranslationText
+	ariaLabel: MaybeTranslation
 	classes?: Array<string>
 	selectedOption: T | null
 	onOptionSelected: (arg0: T) => unknown
@@ -34,7 +34,7 @@ export class RadioGroup<T> implements Component<RadioGroupAttrs<T>> {
 		return m(
 			"ul.unstyled-list.flex.col.gap-vpad",
 			{
-				ariaLabel: lang.getMaybeLazy(attrs.ariaLabel),
+				ariaLabel: lang.getTranslationText(attrs.ariaLabel),
 				role: AriaRole.RadioGroup,
 			},
 			attrs.options.map((option) =>
@@ -44,14 +44,14 @@ export class RadioGroup<T> implements Component<RadioGroupAttrs<T>> {
 	}
 
 	private renderOption(
-		groupName: TranslationText,
+		groupName: MaybeTranslation,
 		option: RadioGroupOption<T>,
 		selectedOption: T | null,
 		optionClass: string | undefined,
 		onOptionSelected: (arg0: T) => unknown,
 		injectionMap?: Map<string, Child>,
 	): Children {
-		const name = lang.getMaybeLazy(groupName)
+		const name = lang.getTranslationText(groupName)
 		const valueString = String(option.value)
 		const isSelected = option.value === selectedOption
 
@@ -73,7 +73,7 @@ export class RadioGroup<T> implements Component<RadioGroupAttrs<T>> {
 					/* The `name` attribute defines the group the radio button belongs to. Not the name/label of the radio button itself.
 					 * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#defining_a_radio_group
 					 */
-					name: lang.getMaybeLazy(groupName),
+					name: lang.getTranslationText(groupName),
 					value: valueString,
 					id: optionId,
 					// Handle changes in value from the attributes
@@ -87,7 +87,7 @@ export class RadioGroup<T> implements Component<RadioGroupAttrs<T>> {
 					},
 				}),
 				m(".flex.flex-column.full-width", [
-					m("label.cursor-pointer", { for: optionId }, lang.getMaybeLazy(option.name)),
+					m("label.cursor-pointer", { for: optionId }, lang.getTranslationText(option.name)),
 					this.getInjection(String(option.value), injectionMap),
 				]),
 			],

--- a/src/common/gui/base/RadioSelector.ts
+++ b/src/common/gui/base/RadioSelector.ts
@@ -1,15 +1,15 @@
-import type { TranslationText } from "../../misc/LanguageViewModel"
+import type { MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import m, { Children, Component, Vnode } from "mithril"
 import { theme } from "../theme"
 
 export type RadioSelectorOption<T> = {
-	readonly name: TranslationText
+	readonly name: MaybeTranslation
 	readonly value: T
 }
 export type RadioSelectorAttrs<T> = {
 	// The unique name of the radio button group. The browser uses it to group the radio buttons together.
-	name: TranslationText
+	name: MaybeTranslation
 	options: ReadonlyArray<RadioSelectorOption<T>>
 	class?: string
 	selectedOption: T
@@ -25,13 +25,13 @@ export class RadioSelector<T> implements Component<RadioSelectorAttrs<T>> {
 	}
 
 	private renderOption(
-		groupName: TranslationText,
+		groupName: MaybeTranslation,
 		option: RadioSelectorOption<T>,
 		selectedOption: T,
 		optionClass: string | undefined,
 		onOptionSelected: (arg0: T) => unknown,
 	): Children {
-		const name = lang.getMaybeLazy(groupName)
+		const name = lang.getTranslationText(groupName)
 		const valueString = String(option.value)
 		const isSelected = option.value === selectedOption
 
@@ -60,13 +60,13 @@ export class RadioSelector<T> implements Component<RadioSelectorAttrs<T>> {
 					/* The `name` attribute defines the group the radio button belongs to. Not the name/label of the radio button itself.
 					 * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#defining_a_radio_group
 					 */
-					name: lang.getMaybeLazy(groupName),
+					name: lang.getTranslationText(groupName),
 					value: valueString,
 					id: optionId,
 					// Handle changes in value from the attributes
 					checked: isSelected ? true : null,
 				}),
-				m("label.b.left.pt-xs.pb-xs", { for: optionId }, lang.getMaybeLazy(option.name)),
+				m("label.b.left.pt-xs.pb-xs", { for: optionId }, lang.getTranslationText(option.name)),
 			],
 		)
 	}

--- a/src/common/gui/base/RichTextToolbar.ts
+++ b/src/common/gui/base/RichTextToolbar.ts
@@ -5,7 +5,7 @@ import { Alignment } from "../editor/Editor"
 import { numberRange } from "@tutao/tutanota-utils"
 import { size } from "../size"
 import { createDropdown, DropdownButtonAttrs } from "./Dropdown.js"
-import { lang, TranslationKey } from "../../misc/LanguageViewModel"
+import { lang, TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { animations, height, opacity } from "../animation/Animations"
 import { client } from "../../misc/ClientDetector"
 import { BrowserType } from "../../misc/ClientConstants"
@@ -93,7 +93,7 @@ export class RichTextToolbar implements Component<RichTextToolbarAttrs> {
 
 	private renderStyleToggleButton(style: Style, title: string, icon: Icons, editor: Editor): Children {
 		return this.renderToggleButton(
-			title,
+			lang.makeTranslation(title, title),
 			icon,
 			() => editor.setStyle(!editor.hasStyle(style), style),
 			() => editor.hasStyle(style),
@@ -102,7 +102,7 @@ export class RichTextToolbar implements Component<RichTextToolbarAttrs> {
 
 	private renderListToggleButton(listing: Listing, title: string, icon: Icons, editor: Editor): Children {
 		return this.renderToggleButton(
-			title,
+			lang.makeTranslation(title, title),
 			icon,
 			() =>
 				editor.styles.listing === listing
@@ -114,9 +114,9 @@ export class RichTextToolbar implements Component<RichTextToolbarAttrs> {
 		)
 	}
 
-	private renderToggleButton(title: string, icon: Icons, click: () => void, isSelected: () => boolean): Children {
+	private renderToggleButton(title: MaybeTranslation, icon: Icons, click: () => void, isSelected: () => boolean): Children {
 		return m(ToggleButton, {
-			title: () => title,
+			title: title,
 			onToggled: click,
 			icon: icon,
 			toggled: isSelected(),
@@ -192,7 +192,7 @@ export class RichTextToolbar implements Component<RichTextToolbarAttrs> {
 					lazyButtons: () =>
 						numberRange(8, 144).map((n) => {
 							return {
-								label: () => n.toString(),
+								label: lang.makeTranslation("font_size_" + n, n.toString()),
 								click: () => {
 									editor.squire.setFontSize(n)
 									this.selectedSize = n

--- a/src/common/gui/base/SidebarSectionRow.ts
+++ b/src/common/gui/base/SidebarSectionRow.ts
@@ -1,8 +1,8 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { AllIcons, Icon, IconSize } from "./Icon"
-import { isNavButtonSelected, NavButton } from "./NavButton"
+import { isNavButtonSelected, NavButton, NavButtonAttrs } from "./NavButton"
 import { ClickHandler } from "./GuiUtils"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import type { lazy } from "@tutao/tutanota-utils"
 import { stateBgHover } from "../builtinThemes"
 import { client } from "../../misc/ClientDetector"
@@ -11,7 +11,7 @@ import { theme } from "../theme"
 
 export interface SidebarSectionRowAttrs {
 	icon: AllIcons
-	label: TranslationKey | lazy<string>
+	label: MaybeTranslation
 	path: string
 	onClick: ClickHandler
 	moreButton: IconButtonAttrs
@@ -43,7 +43,7 @@ export class SidebarSectionRow implements Component<SidebarSectionRowAttrs> {
 			if (event.key === "Tab" && event.shiftKey) this.hovered = false
 		}
 
-		const navButtonAttrs = {
+		const navButtonAttrs: NavButtonAttrs = {
 			label: attrs.label,
 			href: () => attrs.path,
 			disableHoverBackground: true,

--- a/src/common/gui/base/SnackBar.ts
+++ b/src/common/gui/base/SnackBar.ts
@@ -4,7 +4,7 @@ import { DefaultAnimationTime } from "../animation/Animations"
 import { displayOverlay } from "./Overlay"
 import type { ButtonAttrs } from "./Button.js"
 import { Button, ButtonType } from "./Button.js"
-import { lang, TranslationText } from "../../misc/LanguageViewModel"
+import { lang, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { styles } from "../styles"
 import { LayerType } from "../../../RootView"
 import type { ClickHandler } from "./GuiUtils"
@@ -15,11 +15,11 @@ assertMainOrNode()
 export const SNACKBAR_SHOW_TIME = 6000
 const MAX_SNACKBAR_WIDTH = 400
 export type SnackBarButtonAttrs = {
-	label: TranslationText
+	label: MaybeTranslation
 	click: ClickHandler
 }
 type SnackBarAttrs = {
-	message: TranslationText
+	message: MaybeTranslation
 	button: ButtonAttrs | null
 }
 type QueueItem = SnackBarAttrs & { onClose: (() => void) | null }
@@ -30,7 +30,7 @@ class SnackBar implements Component<SnackBarAttrs> {
 	view(vnode: Vnode<SnackBarAttrs>) {
 		// use same padding as MinimizedEditor
 		return m(".snackbar-content.flex.flex-space-between.border-radius.plr.pb-xs.pt-xs", [
-			m(".flex.center-vertically.smaller", lang.getMaybeLazy(vnode.attrs.message)),
+			m(".flex.center-vertically.smaller", lang.getTranslationText(vnode.attrs.message)),
 			vnode.attrs.button ? m(".flex-end.center-vertically.pl", m(Button, vnode.attrs.button)) : null,
 		])
 	}
@@ -51,7 +51,7 @@ function makeButtonAttrsForSnackBar(button: SnackBarButtonAttrs): ButtonAttrs {
  * @param onClose called when the snackbar is closed (either by timeout or button click)
  * @param waitingTime number of milliseconds to wait before showing the snackbar
  */
-export async function showSnackBar(args: { message: TranslationText; button: SnackBarButtonAttrs; onClose?: () => void; waitingTime?: number }) {
+export async function showSnackBar(args: { message: MaybeTranslation; button: SnackBarButtonAttrs; onClose?: () => void; waitingTime?: number }) {
 	const { message, button, onClose, waitingTime } = args
 	const triggerSnackbar = () => {
 		const buttonAttrs = makeButtonAttrsForSnackBar(button)

--- a/src/common/gui/base/Table.ts
+++ b/src/common/gui/base/Table.ts
@@ -1,5 +1,5 @@
 import m, { Children, Component, Vnode } from "mithril"
-import { lang, TranslationText } from "../../misc/LanguageViewModel"
+import { lang, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { progressIcon } from "./Icon"
 import { downcast, neverNull } from "@tutao/tutanota-utils"
 import { createDropdown, DropdownButtonAttrs } from "./Dropdown.js"
@@ -21,8 +21,8 @@ export const enum ColumnWidth {
 }
 
 export type TableHeading = {
-	text: TranslationText
-	helpText?: TranslationText
+	text: MaybeTranslation
+	helpText?: MaybeTranslation
 }
 
 /**
@@ -34,7 +34,7 @@ export type TableHeading = {
  * @param lines the lines of the table
  */
 export type TableAttrs = {
-	columnHeading?: Array<TableHeading | TranslationText>
+	columnHeading?: Array<TableHeading | MaybeTranslation>
 	columnWidths: ReadonlyArray<ColumnWidth>
 	columnAlignments?: Array<boolean>
 	verticalColumnHeadings?: boolean
@@ -76,9 +76,9 @@ export class Table implements Component<TableAttrs> {
 									cells: () =>
 										a.columnHeading!.map((header) => {
 											const text = this.isTableHeading(header) ? header.text : header
-											const info = this.isTableHeading(header) && header.helpText ? [lang.getMaybeLazy(header.helpText)] : undefined
+											const info = this.isTableHeading(header) && header.helpText ? [lang.getTranslationText(header.helpText)] : undefined
 											return {
-												main: lang.getMaybeLazy(text),
+												main: lang.getTranslationText(text),
 												info: info,
 											} satisfies CellTextData
 										}),
@@ -100,7 +100,7 @@ export class Table implements Component<TableAttrs> {
 		])
 	}
 
-	private isTableHeading(textIdOrFunction: TableHeading | TranslationText): textIdOrFunction is TableHeading {
+	private isTableHeading(textIdOrFunction: TableHeading | MaybeTranslation): textIdOrFunction is TableHeading {
 		return (textIdOrFunction as TableHeading).text !== undefined
 	}
 

--- a/src/common/gui/base/TextDisplayArea.ts
+++ b/src/common/gui/base/TextDisplayArea.ts
@@ -1,5 +1,5 @@
 import m, { Children, Component, Vnode } from "mithril"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { theme } from "../theme"
 import { inputLineHeight, px, size } from "../size"
@@ -7,7 +7,7 @@ import type { lazy } from "@tutao/tutanota-utils"
 
 export type TextDisplayAreaAttrs = {
 	value: string
-	label: TranslationKey | lazy<string>
+	label: MaybeTranslation
 }
 
 /**
@@ -23,7 +23,7 @@ export class TextDisplayArea implements Component<TextDisplayAreaAttrs> {
 						fontSize: px(size.font_size_small),
 					},
 				},
-				lang.getMaybeLazy(vnode.attrs.label),
+				lang.getTranslationText(vnode.attrs.label),
 			),
 			m(
 				".text-pre.flex-grow",

--- a/src/common/gui/base/TextField.ts
+++ b/src/common/gui/base/TextField.ts
@@ -2,7 +2,7 @@ import m, { Children, ClassComponent, CVnode } from "mithril"
 import { px, size } from "../size"
 import { DefaultAnimationTime } from "../animation/Animations"
 import { theme } from "../theme"
-import type { TranslationKey } from "../../misc/LanguageViewModel"
+import type { MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import type { lazy } from "@tutao/tutanota-utils"
 import { isKeyPressed, keyHandler, useKeyHandler } from "../../misc/KeyManager"
@@ -12,7 +12,7 @@ import { AriaPopupType } from "../AriaUtils.js"
 
 export type TextFieldAttrs = {
 	id?: string
-	label: TranslationKey | lazy<string>
+	label: MaybeTranslation
 	value: string
 	autocompleteAs?: Autocomplete
 	autocapitalize?: Autocapitalize
@@ -134,7 +134,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 							transition: `transform ${labelTransitionSpeed}ms ease-out, font-size ${labelTransitionSpeed}ms  ease-out`,
 						},
 					},
-					lang.getMaybeLazy(a.label),
+					lang.getTranslationText(a.label),
 				),
 				m(".flex.flex-column", [
 					// another wrapper to fix IE 11 min-height bug https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
@@ -246,7 +246,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 						type: a.type,
 						min: a.min,
 						max: a.max,
-						"aria-label": lang.getMaybeLazy(a.label),
+						"aria-label": lang.getTranslationText(a.label),
 						disabled: a.disabled,
 						class: getOperatingClasses(a.disabled) + " text",
 						oncreate: (vnode) => {
@@ -298,6 +298,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 							lineHeight: px(inputLineHeight),
 							fontSize: a.fontSize,
 						},
+						"data-testid": lang.getTestId(a.label),
 					}),
 				]),
 			)
@@ -318,7 +319,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 			)
 		} else {
 			return m("textarea.input-area.text-pre", {
-				"aria-label": lang.getMaybeLazy(a.label),
+				"aria-label": lang.getTranslationText(a.label),
 				disabled: a.disabled,
 				autocapitalize: a.autocapitalize,
 				class: getOperatingClasses(a.disabled) + " text",

--- a/src/common/gui/base/ViewColumn.ts
+++ b/src/common/gui/base/ViewColumn.ts
@@ -1,8 +1,9 @@
 import m, { Component } from "mithril"
 import { AriaLandmarks, landmarkAttrs } from "../AriaUtils"
 import { LayerType } from "../../../RootView"
-import type { lazy } from "@tutao/tutanota-utils"
+import { lazy, MaybeLazy, resolveMaybeLazy } from "@tutao/tutanota-utils"
 import { assertMainOrNode } from "../../api/common/Env"
+import { lang, Translation, TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel.js"
 
 assertMainOrNode()
 
@@ -20,7 +21,7 @@ export class ViewColumn implements Component<Attrs> {
 	readonly columnType: ColumnType
 	readonly minWidth: number
 	readonly maxWidth: number
-	private readonly headerCenter: lazy<string>
+	private readonly headerCenter: MaybeLazy<MaybeTranslation>
 	private readonly ariaLabel: lazy<string>
 	width: number
 	offset: number // offset to the left
@@ -51,11 +52,11 @@ export class ViewColumn implements Component<Attrs> {
 			// note: headerCenter is a candidate for removal, ViewColumn is not responsible for the header. This is only useful as an ARIA description which we can already
 			// provide separately. We should always require aria description instead.
 			headerCenter,
-			ariaLabel = () => this.getTitle(),
+			ariaLabel = () => lang.getTranslationText(this.getTitle()),
 		}: {
 			minWidth: number
 			maxWidth: number
-			headerCenter?: lazy<string>
+			headerCenter?: MaybeLazy<MaybeTranslation>
 			ariaLabel?: lazy<string>
 		},
 	) {
@@ -64,7 +65,7 @@ export class ViewColumn implements Component<Attrs> {
 		this.minWidth = minWidth
 		this.maxWidth = maxWidth
 
-		this.headerCenter = headerCenter || (() => "")
+		this.headerCenter = headerCenter || "emptyString_msg"
 
 		this.ariaLabel = ariaLabel ?? null
 		this.width = minWidth
@@ -77,7 +78,7 @@ export class ViewColumn implements Component<Attrs> {
 
 	view() {
 		const zIndex = !this.isVisible && this.columnType === ColumnType.Foreground ? LayerType.ForegroundMenu + 1 : ""
-		const landmark = this.ariaRole ? landmarkAttrs(this.ariaRole, this.ariaLabel ? this.ariaLabel() : this.getTitle()) : {}
+		const landmark = this.ariaRole ? landmarkAttrs(this.ariaRole, this.ariaLabel ? this.ariaLabel() : lang.getTranslationText(this.getTitle())) : {}
 		return m(
 			".view-column.fill-absolute",
 			{
@@ -102,8 +103,8 @@ export class ViewColumn implements Component<Attrs> {
 		)
 	}
 
-	getTitle(): string {
-		return this.headerCenter()
+	getTitle(): MaybeTranslation {
+		return resolveMaybeLazy(this.headerCenter)
 	}
 
 	getOffsetForeground(foregroundState: boolean): number {

--- a/src/common/gui/base/buttons/ArrowButton.ts
+++ b/src/common/gui/base/buttons/ArrowButton.ts
@@ -10,7 +10,7 @@ import { theme } from "../../theme.js"
 
 export default function renderSwitchMonthArrowIcon(forward: boolean, size: number, onClick: ClickHandler): Children {
 	return m(BaseButton, {
-		label: forward ? lang.get("nextMonth_label") : lang.get("prevMonth_label"),
+		label: forward ? "nextMonth_label" : "prevMonth_label",
 		icon: m(Icon, {
 			icon: forward ? Icons.ArrowForward : BootIcons.Back,
 			container: "div",

--- a/src/common/gui/base/buttons/BannerButton.ts
+++ b/src/common/gui/base/buttons/BannerButton.ts
@@ -1,5 +1,4 @@
-import { lang, TranslationKey } from "../../../misc/LanguageViewModel.js"
-import { lazy } from "@tutao/tutanota-utils"
+import { lang, MaybeTranslation } from "../../../misc/LanguageViewModel.js"
 import m, { Children, Component, Vnode } from "mithril"
 import { px, size } from "../../size.js"
 import { BaseButton } from "./BaseButton.js"
@@ -13,16 +12,15 @@ export type BannerButtonAttrs = {
 	class?: string
 	disabled?: boolean
 	click: ClickHandler
-	text: TranslationKey | lazy<string>
+	text: MaybeTranslation
 	icon?: Children
 }
 
 export class BannerButton implements Component<BannerButtonAttrs> {
 	view({ attrs }: Vnode<BannerButtonAttrs>): Children {
-		const text = lang.getMaybeLazy(attrs.text)
 		return m(BaseButton, {
-			label: text,
-			text,
+			label: attrs.text,
+			text: lang.getTranslationText(attrs.text),
 			class: `border-radius mr-s center ${attrs.class} ${attrs.disabled ? "disabled" : ""}`,
 			style: {
 				border: `2px solid ${attrs.disabled ? theme.content_button : attrs.borderColor}`,

--- a/src/common/gui/base/buttons/BaseButton.ts
+++ b/src/common/gui/base/buttons/BaseButton.ts
@@ -3,11 +3,12 @@ import { ClickHandler } from "../GuiUtils.js"
 import { assertNotNull } from "@tutao/tutanota-utils"
 import { TabIndex } from "../../../api/common/TutanotaConstants.js"
 import { AriaRole } from "../../AriaUtils.js"
+import { lang, Translation, TranslationKey, MaybeTranslation } from "../../../misc/LanguageViewModel.js"
 
 // `staticRightText` to be passed as a child
 export interface BaseButtonAttrs {
 	/** accessibility & tooltip description */
-	label: string
+	label: MaybeTranslation
 	/** visible text inside button */
 	text?: Children
 	icon?: Children
@@ -33,7 +34,7 @@ export class BaseButton implements ClassComponent<BaseButtonAttrs> {
 		return m(
 			"button",
 			{
-				title: attrs.label,
+				title: lang.getTranslationText(attrs.label),
 				disabled,
 				"aria-disabled": disabled,
 				pressed,
@@ -44,6 +45,7 @@ export class BaseButton implements ClassComponent<BaseButtonAttrs> {
 				class: attrs.class,
 				style: attrs.style,
 				role: attrs.role,
+				"data-testid": lang.getTestId(attrs.label),
 			},
 			[attrs.icon ? this.renderIcon(attrs.icon, attrs.iconWrapperSelector) : null, attrs.text ?? null, children],
 		)

--- a/src/common/gui/base/buttons/BubbleButton.ts
+++ b/src/common/gui/base/buttons/BubbleButton.ts
@@ -1,14 +1,14 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { BaseButton, BaseButtonAttrs } from "./BaseButton.js"
-import { lang, TranslationText } from "../../../misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../../misc/LanguageViewModel.js"
 import { AllIcons, Icon } from "../Icon.js"
 import { theme } from "../../theme.js"
 import { styles } from "../../styles.js"
 import { px, size } from "../../size.js"
 
 export interface BubbleButtonAttrs {
-	label: TranslationText
-	text?: TranslationText
+	label: MaybeTranslation
+	text?: MaybeTranslation
 	icon?: AllIcons
 	onclick: BaseButtonAttrs["onclick"]
 }
@@ -32,12 +32,11 @@ export function bubbleButtonPadding(): string {
  */
 export class BubbleButton implements Component<BubbleButtonAttrs> {
 	view({ attrs, children }: Vnode<BubbleButtonAttrs>): Children {
-		const label = lang.getMaybeLazy(attrs.label)
 		return m(
 			BaseButton,
 			{
-				label,
-				text: attrs.text ? m("span.text-ellipsis", lang.getMaybeLazy(attrs.text)) : label,
+				label: attrs.label,
+				text: attrs.text ? m("span.text-ellipsis", lang.getTranslationText(attrs.text)) : lang.getTranslationText(attrs.label),
 				icon:
 					attrs.icon &&
 					m(Icon, {

--- a/src/common/gui/base/buttons/LoginButton.ts
+++ b/src/common/gui/base/buttons/LoginButton.ts
@@ -1,15 +1,14 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { BaseButton, BaseButtonAttrs } from "./BaseButton.js"
-import { lang, TranslationText } from "../../../misc/LanguageViewModel.js"
+import { lang, Translation, TranslationKey, MaybeTranslation } from "../../../misc/LanguageViewModel.js"
 
-export type LoginButtonAttrs = Pick<BaseButtonAttrs, "onclick" | "class"> & { label: TranslationText; disabled?: boolean }
+export type LoginButtonAttrs = Pick<BaseButtonAttrs, "onclick" | "class"> & { label: MaybeTranslation; disabled?: boolean }
 
 export class LoginButton implements Component<LoginButtonAttrs> {
 	view({ attrs }: Vnode<LoginButtonAttrs>): Children {
-		const label = lang.getMaybeLazy(attrs.label)
 		return m(BaseButton, {
-			label,
-			text: label,
+			label: attrs.label,
+			text: lang.getTranslationText(attrs.label),
 
 			// This makes the button appear "disabled" (grey color, no hover) when disabled is set to true
 			class: `button-content border-radius ${attrs.disabled ? "button-bg" : `accent-bg`} full-width center plr-button flash ${attrs.class} `,

--- a/src/common/gui/base/buttons/OutlineButton.ts
+++ b/src/common/gui/base/buttons/OutlineButton.ts
@@ -1,12 +1,12 @@
 import m, { Children, ClassComponent, Vnode } from "mithril"
-import { lang, TranslationKey, TranslationText } from "../../../misc/LanguageViewModel.js"
+import { lang, TranslationKey, MaybeTranslation } from "../../../misc/LanguageViewModel.js"
 import { ClickHandler } from "../GuiUtils.js"
 import { BaseButton, BaseButtonAttrs } from "./BaseButton.js"
 import { theme } from "../../theme.js"
 
 export interface OutlineButtonAttrs {
 	label: TranslationKey
-	text?: TranslationText
+	text?: MaybeTranslation
 	click?: ClickHandler
 	disabled?: boolean
 	expanded?: boolean
@@ -25,8 +25,8 @@ export interface OutlineButtonAttrs {
 export class OutlineButton implements ClassComponent<OutlineButtonAttrs> {
 	view({ attrs }: Vnode<OutlineButtonAttrs>): Children {
 		return m(BaseButton, {
-			label: lang.getMaybeLazy(attrs.label),
-			text: attrs.text ? lang.getMaybeLazy(attrs.text) : lang.getMaybeLazy(attrs.label),
+			label: attrs.label,
+			text: attrs.text ? lang.getTranslationText(attrs.text) : lang.getTranslationText(attrs.label),
 			onclick: attrs.click,
 			disabled: attrs.disabled,
 			style: {

--- a/src/common/gui/base/buttons/RowButton.ts
+++ b/src/common/gui/base/buttons/RowButton.ts
@@ -4,13 +4,13 @@ import { AllIcons, Icon, IconSize } from "../Icon.js"
 import { ClickHandler } from "../GuiUtils.js"
 import { AriaRole } from "../../AriaUtils.js"
 import { theme } from "../../theme.js"
-import { lang, TranslationText } from "../../../misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../../misc/LanguageViewModel.js"
 
 export interface RowButtonAttrs {
 	/** accessibility & tooltip description */
-	label: TranslationText
+	label: MaybeTranslation
 	/** visible text inside button */
-	text?: TranslationText
+	text?: MaybeTranslation
 	icon?: AllIcons | "none"
 	selected?: boolean
 	onclick: ClickHandler
@@ -23,11 +23,11 @@ export interface RowButtonAttrs {
 export class RowButton implements Component<RowButtonAttrs> {
 	view(vnode: Vnode<RowButtonAttrs>) {
 		const attrs = vnode.attrs
-		const label = lang.getMaybeLazy(attrs.label)
-		const text = lang.getMaybeLazy(attrs.text ?? attrs.label)
+		const label = lang.getTranslationText(attrs.label)
+		const text = lang.getTranslationText(attrs.text ?? attrs.label)
 		const color = attrs.selected ? theme.content_button_selected : theme.content_button
 		return m(BaseButton, {
-			label,
+			label: attrs.label,
 			text: m(
 				".plr-button.text-ellipsis",
 				{

--- a/src/common/gui/base/buttons/ToggleButton.ts
+++ b/src/common/gui/base/buttons/ToggleButton.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { AllIcons, Icon, IconSize } from "../Icon.js"
-import { lang, TranslationText } from "../../../misc/LanguageViewModel.js"
+import { lang, Translation, MaybeTranslation } from "../../../misc/LanguageViewModel.js"
 import { ButtonColor, getColors } from "../Button.js"
 import { ButtonSize } from "../ButtonSize.js"
 import { BaseButton } from "./BaseButton.js"
@@ -8,7 +8,7 @@ import { BaseButton } from "./BaseButton.js"
 export interface ToggleButtonAttrs {
 	icon: AllIcons
 	// The title should not change on toggle. See: https://www.w3.org/WAI/ARIA/apg/patterns/button/
-	title: TranslationText
+	title: MaybeTranslation
 	toggled: boolean
 	onToggled: (selected: boolean, event: MouseEvent) => unknown
 	colors?: ButtonColor
@@ -19,7 +19,7 @@ export interface ToggleButtonAttrs {
 export class ToggleButton implements Component<ToggleButtonAttrs> {
 	view({ attrs }: Vnode<ToggleButtonAttrs>): Children {
 		return m(BaseButton, {
-			label: lang.getMaybeLazy(attrs.title),
+			label: attrs.title,
 			icon: m(Icon, {
 				icon: attrs.icon,
 				container: "div",

--- a/src/common/gui/dialogs/SelectCredentialsEncryptionModeDialog.ts
+++ b/src/common/gui/dialogs/SelectCredentialsEncryptionModeDialog.ts
@@ -175,10 +175,9 @@ export class SelectCredentialsEncryptionModeView implements Component<SelectCred
 	}
 
 	private renderSelectButton(onclick: () => unknown) {
-		const label = lang.get("ok_action")
 		return m(BaseButton, {
-			label,
-			text: label,
+			label: "ok_action",
+			text: lang.get("ok_action"),
 			class: "uppercase accent-bg full-width center b content-fg flash",
 			style: {
 				height: "60px",

--- a/src/common/gui/dialogs/ShortcutDialog.ts
+++ b/src/common/gui/dialogs/ShortcutDialog.ts
@@ -1,4 +1,4 @@
-import { lang } from "../../misc/LanguageViewModel"
+import { lang, Translation } from "../../misc/LanguageViewModel"
 import m, { Component, Vnode } from "mithril"
 import { Dialog } from "../base/Dialog"
 import { Keys } from "../../api/common/TutanotaConstants"
@@ -8,16 +8,17 @@ import { ButtonType } from "../base/Button.js"
 import { DialogHeaderBarAttrs } from "../base/DialogHeaderBar"
 import { isAppleDevice } from "../../api/common/Env.js"
 
-function makeShortcutName(shortcut: Shortcut): string {
+function makeShortcutName(shortcut: Shortcut): Translation {
 	const mainModifier = isAppleDevice() ? Keys.META.name : Keys.CTRL.name
 
-	return (
+	return lang.makeTranslation(
+		shortcut.help,
 		(shortcut.meta ? Keys.META.name + " + " : "") +
-		(shortcut.ctrlOrCmd ? mainModifier + " + " : "") +
-		(shortcut.ctrl ? Keys.CTRL.name + " + " : "") +
-		(shortcut.shift ? Keys.SHIFT.name + " + " : "") +
-		(shortcut.alt ? Keys.ALT.name + " + " : "") +
-		shortcut.key.name
+			(shortcut.ctrlOrCmd ? mainModifier + " + " : "") +
+			(shortcut.ctrl ? Keys.CTRL.name + " + " : "") +
+			(shortcut.shift ? Keys.SHIFT.name + " + " : "") +
+			(shortcut.alt ? Keys.ALT.name + " + " : "") +
+			shortcut.key.name,
 	)
 }
 
@@ -46,7 +47,7 @@ class ShortcutDialog implements Component<ShortcutDialogAttrs> {
 		const textFieldAttrs = shortcuts
 			.filter((shortcut) => shortcut.enabled == null || shortcut.enabled())
 			.map((shortcut) => ({
-				label: () => makeShortcutName(shortcut),
+				label: makeShortcutName(shortcut),
 				value: lang.get(shortcut.help),
 				isReadOnly: true,
 			}))

--- a/src/common/gui/editor/HtmlEditor.ts
+++ b/src/common/gui/editor/HtmlEditor.ts
@@ -1,7 +1,7 @@
 import m, { Children, Component } from "mithril"
 import stream from "mithril/stream"
 import { Editor } from "./Editor.js"
-import type { TranslationKey, TranslationText } from "../../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { px } from "../size"
 import { htmlSanitizer } from "../../misc/HtmlSanitizer"
@@ -27,12 +27,12 @@ export class HtmlEditor implements Component {
 	private placeholderDomElement: HTMLElement | null = null
 	private value = stream("")
 	private htmlMonospace = true
-	private modeSwitcherLabel: TranslationText | null = null
+	private modeSwitcherLabel: MaybeTranslation | null = null
 	private toolbarEnabled = false
 	private toolbarAttrs: Omit<RichTextToolbarAttrs, "editor"> = {}
 	private staticLineAmount: number | null = null // Static amount of lines the editor shall allow at all times
 
-	constructor(private label?: TranslationText, private readonly injections?: () => Children) {
+	constructor(private label?: MaybeTranslation, private readonly injections?: () => Children) {
 		this.editor = new Editor(null, (html) => htmlSanitizer.sanitizeFragment(html, { blockExternalContent: false }).fragment, null)
 		this.view = this.view.bind(this)
 		this.initializeEditorListeners()
@@ -64,7 +64,7 @@ export class HtmlEditor implements Component {
 		return m(".html-editor" + (this.mode === HtmlEditorMode.WYSIWYG ? ".text-break" : ""), { class: this.editor.isEnabled() ? "" : "disabled" }, [
 			modeSwitcherLabel != null
 				? m(DropDownSelector, {
-						label: () => lang.getMaybeLazy(modeSwitcherLabel),
+						label: modeSwitcherLabel,
 						items: [
 							{ name: lang.get("richText_label"), value: HtmlEditorMode.WYSIWYG },
 							{ name: lang.get("htmlSourceCode_label"), value: HtmlEditorMode.HTML },
@@ -77,7 +77,7 @@ export class HtmlEditor implements Component {
 						},
 				  })
 				: null,
-			this.label ? m(".small.mt-form", lang.getMaybeLazy(this.label)) : null,
+			this.label ? m(".small.mt-form", lang.getTranslationText(this.label)) : null,
 			m(borderClasses, [
 				getPlaceholder(),
 				this.mode === HtmlEditorMode.WYSIWYG
@@ -157,7 +157,7 @@ export class HtmlEditor implements Component {
 		}
 	}
 
-	setModeSwitcher(label: TranslationText): this {
+	setModeSwitcher(label: MaybeTranslation): this {
 		this.modeSwitcherLabel = label
 		return this
 	}

--- a/src/common/login/CredentialsSelector.ts
+++ b/src/common/login/CredentialsSelector.ts
@@ -2,6 +2,7 @@ import m, { Children, Component, Vnode } from "mithril"
 import { Button, ButtonType } from "../gui/base/Button.js"
 import { LoginButton } from "../gui/base/buttons/LoginButton.js"
 import { CredentialsInfo } from "../native/common/generatedipc/CredentialsInfo.js"
+import { lang } from "../misc/LanguageViewModel.js"
 
 export type CredentialsSelectorAttrs = {
 	credentials: ReadonlyArray<CredentialsInfo>
@@ -18,7 +19,7 @@ export class CredentialsSelector implements Component<CredentialsSelectorAttrs> 
 			const onCredentialsDeleted = a.onCredentialsDeleted
 			buttons.push(
 				m(LoginButton, {
-					label: () => c.login,
+					label: lang.makeTranslation("login_label", c.login),
 					onclick: () => a.onCredentialsSelected(c),
 				}),
 			)

--- a/src/common/login/LoginForm.ts
+++ b/src/common/login/LoginForm.ts
@@ -134,9 +134,11 @@ export class LoginForm implements Component<LoginFormAttrs> {
 									checked: a.savePassword(),
 									onChecked: a.savePassword,
 									helpLabel: canSaveCredentials
-										? () =>
+										? lang.makeTranslation(
+												"onlyPrivateComputer_msg",
 												lang.get("onlyPrivateComputer_msg") +
-												(isOfflineStorageAvailable() ? "\n" + lang.get("dataWillBeStored_msg") : "")
+													(isOfflineStorageAvailable() ? "\n" + lang.get("dataWillBeStored_msg") : ""),
+										  )
 										: "functionNotSupported_msg",
 									disabled: !canSaveCredentials,
 								}),

--- a/src/common/login/LoginView.ts
+++ b/src/common/login/LoginView.ts
@@ -1,7 +1,7 @@
 import m, { Children, Vnode } from "mithril"
 import { client } from "../misc/ClientDetector.js"
 import { assertMainOrNode, isApp, isDesktop } from "../api/common/Env"
-import { lang, TranslationKey } from "../misc/LanguageViewModel.js"
+import { lang, TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { defer, DeferredObject, mapNullable } from "@tutao/tutanota-utils"
 import { BootIcons } from "../gui/base/icons/BootIcons"
 import { showProgressDialog } from "../gui/dialogs/ProgressDialog"
@@ -33,7 +33,7 @@ export interface LoginViewAttrs extends TopLevelAttrs {
 }
 
 /** create a string provider that changes periodically until promise is resolved */
-function makeDynamicLoggingInMessage(promise: Promise<unknown>): () => string {
+function makeDynamicLoggingInMessage(promise: Promise<unknown>): () => TranslationKey {
 	const messageArray: Array<TranslationKey> = [
 		"dynamicLoginDecryptingMails_msg",
 		"dynamicLoginOrganizingCalendarEvents_msg",
@@ -52,7 +52,7 @@ function makeDynamicLoggingInMessage(promise: Promise<unknown>): () => string {
 		m.redraw()
 	}, 4000 /** spinner spins every 2s */)
 	promise.finally(() => clearInterval(messageIntervalId))
-	return () => lang.get(currentMessage)
+	return () => currentMessage
 }
 
 export class LoginView extends BaseTopLevelView implements TopLevelView<LoginViewAttrs> {
@@ -212,7 +212,7 @@ export class LoginView extends BaseTopLevelView implements TopLevelView<LoginVie
 				]
 				const customButtons = (await locator.themeController.getCustomThemes()).map((themeId) => {
 					return {
-						label: () => themeId,
+						label: lang.makeTranslation(themeId, themeId),
 						click: () => locator.themeController.setThemePreference(themeId),
 					}
 				})
@@ -264,7 +264,7 @@ export class LoginView extends BaseTopLevelView implements TopLevelView<LoginVie
 				mailAddress: this.viewModel.mailAddress,
 				password: this.viewModel.password,
 				savePassword: this.viewModel.savePassword,
-				helpText: lang.getMaybeLazy(this.viewModel.helpText),
+				helpText: lang.getTranslationText(this.viewModel.helpText),
 				invalidCredentials: this.viewModel.state === LoginState.InvalidCredentials,
 				showRecoveryOption: this._recoverLoginVisible(),
 				accessExpired: this.viewModel.state === LoginState.AccessExpired,
@@ -290,7 +290,7 @@ export class LoginView extends BaseTopLevelView implements TopLevelView<LoginVie
 					...liveDataAttrs(),
 					class: styles.isSingleColumnLayout() ? "" : "pt-xs",
 				},
-				lang.getMaybeLazy(this.viewModel.helpText),
+				lang.getTranslationText(this.viewModel.helpText),
 			),
 			m(CredentialsSelector, {
 				credentials: this.viewModel.getSavedCredentials(),

--- a/src/common/login/LoginViewModel.ts
+++ b/src/common/login/LoginViewModel.ts
@@ -1,5 +1,5 @@
 import { AccessExpiredError, BadRequestError, NotAuthenticatedError } from "../api/common/error/RestError"
-import type { TranslationText } from "../misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { SecondFactorHandler } from "../misc/2fa/SecondFactorHandler.js"
 import { getLoginErrorMessage, handleExpectedLoginError } from "../misc/LoginUtils.js"
 import type { LoginController } from "../api/main/LoginController"
@@ -72,7 +72,7 @@ export interface ILoginViewModel {
 	readonly displayMode: DisplayMode
 	readonly mailAddress: Stream<string>
 	readonly password: Stream<string>
-	readonly helpText: TranslationText
+	readonly helpText: MaybeTranslation
 	readonly savePassword: Stream<boolean>
 
 	/**
@@ -133,7 +133,7 @@ export class LoginViewModel implements ILoginViewModel {
 	readonly password: Stream<string>
 	displayMode: DisplayMode
 	state: LoginState
-	helpText: TranslationText
+	helpText: MaybeTranslation
 	readonly savePassword: Stream<boolean>
 	private savedInternalCredentials: ReadonlyArray<CredentialsInfo>
 
@@ -360,7 +360,7 @@ export class LoginViewModel implements ILoginViewModel {
 				// The app already shows a dialog with FAQ link so we don't have to explain
 				// much here, just catching it to avoid unexpected error dialog
 				this.state = LoginState.NotAuthenticated
-				this.helpText = () => "Could not access secret storage"
+				this.helpText = lang.makeTranslation("help_text", "Could not access secret storage")
 			} else {
 				await this.onLoginFailed(e)
 			}

--- a/src/common/login/MobileWebauthnView.ts
+++ b/src/common/login/MobileWebauthnView.ts
@@ -41,7 +41,7 @@ export class MobileWebauthnView implements TopLevelView<MobileWebauthnAttrs> {
 				},
 			],
 			right: [],
-			middle: () => lang.get("u2fSecurityKey_label"),
+			middle: "u2fSecurityKey_label",
 		}
 
 		return m(

--- a/src/common/login/NativeWebauthnView.ts
+++ b/src/common/login/NativeWebauthnView.ts
@@ -32,7 +32,7 @@ export class NativeWebauthnView implements TopLevelView {
 				},
 			],
 			right: [],
-			middle: () => lang.get("u2fSecurityKey_label"),
+			middle: "u2fSecurityKey_label",
 		}
 
 		return m(

--- a/src/common/login/recover/RecoverLoginDialog.ts
+++ b/src/common/login/recover/RecoverLoginDialog.ts
@@ -61,7 +61,7 @@ export function show(mailAddress?: string | null, resetAction?: ResetAction): Di
 	editor.setMinHeight(80)
 	editor.showBorders()
 	const recoverDialog = Dialog.showActionDialog({
-		title: lang.get("recover_label"),
+		title: "recover_label",
 		type: DialogType.EditSmall,
 		child: {
 			view: () => {

--- a/src/common/login/recover/TakeOverDeletedAddressDialog.ts
+++ b/src/common/login/recover/TakeOverDeletedAddressDialog.ts
@@ -21,7 +21,7 @@ export function showTakeOverDialog(mailAddress: string, password: string): Dialo
 	editor.setMinHeight(80)
 	editor.showBorders()
 	const takeoverDialog = Dialog.showActionDialog({
-		title: lang.get("help_label"),
+		title: "help_label",
 		type: DialogType.EditSmall,
 		child: {
 			view: () => {

--- a/src/common/mailFunctionality/SendMailModel.ts
+++ b/src/common/mailFunctionality/SendMailModel.ts
@@ -36,7 +36,7 @@ import type { File as TutanotaFile } from "../../common/api/entities/tutanota/Ty
 import { checkAttachmentSize, getDefaultSender, getTemplateLanguages, isUserEmail, RecipientField } from "./SharedMailUtils.js"
 import { cloneInlineImages, InlineImages, revokeInlineImages } from "./inlineImagesUtils.js"
 import { RecipientsModel, ResolvableRecipient, ResolveMode } from "../api/main/RecipientsModel.js"
-import { getAvailableLanguageCode, getSubstitutedLanguageCode, lang, Language, languages, TranslationKey, TranslationText } from "../misc/LanguageViewModel.js"
+import { getAvailableLanguageCode, getSubstitutedLanguageCode, lang, Language, languages, TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { MailFacade } from "../api/worker/facades/lazy/MailFacade.js"
 import { EntityClient } from "../api/common/EntityClient.js"
 import { LoginController } from "../api/main/LoginController.js"
@@ -618,7 +618,7 @@ export class SendMailModel {
 		this.markAsChangedIfNecessary(sizeCheckResult.attachableFiles.length > 0)
 
 		if (sizeCheckResult.tooBigFiles.length > 0) {
-			throw new UserError(() => lang.get("tooBigAttachment_msg") + "\n" + sizeCheckResult.tooBigFiles.join("\n"))
+			throw new UserError(lang.makeTranslation("tooBigAttachment_msg", lang.get("tooBigAttachment_msg") + "\n" + sizeCheckResult.tooBigFiles.join("\n")))
 		}
 	}
 
@@ -717,8 +717,8 @@ export class SendMailModel {
 	 */
 	async send(
 		mailMethod: MailMethod,
-		getConfirmation: (arg0: TranslationText) => Promise<boolean> = (_) => Promise.resolve(true),
-		waitHandler: (arg0: TranslationText, arg1: Promise<any>) => Promise<any> = (_, p) => p,
+		getConfirmation: (arg0: MaybeTranslation) => Promise<boolean> = (_) => Promise.resolve(true),
+		waitHandler: (arg0: MaybeTranslation, arg1: Promise<any>) => Promise<any> = (_, p) => p,
 		tooManyRequestsError: TranslationKey = "tooManyMails_msg",
 	): Promise<boolean> {
 		// To avoid parallel invocations do not do anything async here that would later execute the sending.
@@ -791,7 +791,10 @@ export class SendMailModel {
 					} else {
 						let invalidRecipients = e.message
 						throw new UserError(
-							() => lang.get("tutanotaAddressDoesNotExist_msg") + " " + lang.get("invalidRecipients_msg") + "\n" + invalidRecipients,
+							lang.makeTranslation(
+								"error_msg",
+								lang.get("tutanotaAddressDoesNotExist_msg") + " " + lang.get("invalidRecipients_msg") + "\n" + invalidRecipients,
+							),
 						)
 					}
 				}),

--- a/src/common/mailFunctionality/SharedMailUtils.ts
+++ b/src/common/mailFunctionality/SharedMailUtils.ts
@@ -17,7 +17,7 @@ import {
 } from "../api/common/TutanotaConstants.js"
 import { UserController } from "../api/main/UserController.js"
 import { getEnabledMailAddressesForGroupInfo, getGroupInfoDisplayName } from "../api/common/utils/GroupUtils.js"
-import { lang, Language, TranslationKey } from "../misc/LanguageViewModel.js"
+import { lang, Language, Translation, TranslationKey } from "../misc/LanguageViewModel.js"
 import { MailboxDetail } from "./MailboxModel.js"
 import { LoginController } from "../api/main/LoginController.js"
 import { EntityClient } from "../api/common/EntityClient.js"
@@ -273,8 +273,8 @@ export function insertInlineImageB64ClickHandler(ev: Event, handler: ImageHandle
 		}
 
 		if (tooBig.length > 0) {
-			Dialog.message(() =>
-				lang.get("tooBigInlineImages_msg", {
+			Dialog.message(
+				lang.getTranslation("tooBigInlineImages_msg", {
 					"{size}": MAX_BASE64_IMAGE_SIZE / 1024,
 				}),
 			)

--- a/src/common/misc/2fa/SecondFactorAuthDialog.ts
+++ b/src/common/misc/2fa/SecondFactorAuthDialog.ts
@@ -111,7 +111,7 @@ export class SecondFactorAuthDialog {
 
 		const { mailAddress } = this.authData
 		this.waitingForSecondFactorDialog = Dialog.showActionDialog({
-			title: "",
+			title: "emptyString_msg",
 			allowOkWithReturn: true,
 			child: {
 				view: () => {

--- a/src/common/misc/2fa/SecondFactorHandler.ts
+++ b/src/common/misc/2fa/SecondFactorHandler.ts
@@ -128,7 +128,7 @@ export class SecondFactorHandler {
 		}
 
 		this.otherLoginDialog = Dialog.showActionDialog({
-			title: lang.get("secondFactorConfirmLogin_label"),
+			title: "secondFactorConfirmLogin_label",
 			child: {
 				view: () => m(".text-break.pt", text),
 			},

--- a/src/common/misc/ErrorHandlerImpl.ts
+++ b/src/common/misc/ErrorHandlerImpl.ts
@@ -93,8 +93,10 @@ export async function handleUncaughtErrorImpl(e: Error) {
 		if (logins.getUserController().isGlobalAdmin()) {
 			showMoreStorageNeededOrderDialog("insufficientStorageAdmin_msg")
 		} else {
-			const errorMessage = () => lang.get("insufficientStorageUser_msg") + " " + lang.get("contactAdmin_msg")
-
+			const errorMessage = lang.makeTranslation(
+				"insufficientStorageUser_msg",
+				lang.get("insufficientStorageUser_msg") + " " + lang.get("contactAdmin_msg"),
+			)
 			Dialog.message(errorMessage)
 		}
 	} else if (e instanceof ServiceUnavailableError) {
@@ -206,7 +208,7 @@ export async function reloginForExpiredSession() {
 					e instanceof ConnectionError
 				) {
 					const { getLoginErrorMessage } = await import("../misc/LoginUtils.js")
-					return lang.getMaybeLazy(getLoginErrorMessage(e, false))
+					return lang.getTranslationText(getLoginErrorMessage(e, false))
 				} else {
 					throw e
 				}
@@ -251,19 +253,16 @@ function handleImportError() {
 	showingImportError = true
 	const message =
 		"There was an error while loading part of the app. It might be that you are offline, running an outdated version, or your browser is blocking the request."
-	Dialog.choice(
-		() => message,
-		[
-			{
-				text: "close_alt",
-				value: false,
-			},
-			{
-				text: "reloadPage_action",
-				value: true,
-			},
-		],
-	).then((reload) => {
+	Dialog.choice(lang.makeTranslation("error_msg", message), [
+		{
+			text: "close_alt",
+			value: false,
+		},
+		{
+			text: "reloadPage_action",
+			value: true,
+		},
+	]).then((reload) => {
 		showingImportError = false
 
 		if (reload) {
@@ -278,5 +277,5 @@ if (typeof window !== "undefined") {
 }
 
 export function showUserError(error: UserError): Promise<void> {
-	return Dialog.message(() => error.message)
+	return Dialog.message(lang.makeTranslation("error_msg", error.message))
 }

--- a/src/common/misc/ErrorReporter.ts
+++ b/src/common/misc/ErrorReporter.ts
@@ -81,7 +81,7 @@ async function showErrorOverlay(): Promise<{ decision: "send" | "cancel"; ignore
 			},
 			[
 				{
-					label: () => "Send report",
+					label: lang.makeTranslation("send", "Send report"),
 					click: () => resolve("send"),
 					type: ButtonType.Secondary,
 				},
@@ -112,7 +112,7 @@ function showReportDialog(
 				}),
 				m(Checkbox, {
 					label: () => lang.get("sendLogs_action"),
-					helpLabel: () => lang.get("sendLogsInfo_msg"),
+					helpLabel: "sendLogsInfo_msg",
 					checked: sendLogs,
 					onChecked: (checked) => (sendLogs = checked),
 				}),
@@ -120,7 +120,7 @@ function showReportDialog(
 					".flex.flex-column.space-around.items-center",
 					logs.map((l) =>
 						m(BubbleButton, {
-							label: () => l.name,
+							label: lang.makeTranslation("filename", l.name),
 							onclick: () => showLogDialog(l.name, uint8ArrayToString("utf-8", (l as DataFile).data)),
 						}),
 					),
@@ -150,7 +150,7 @@ function showReportDialog(
 	return new Promise((resolve) => {
 		Dialog.showActionDialog({
 			okActionTextId: "send_action",
-			title: lang.get("sendErrorReport_action"),
+			title: "sendErrorReport_action",
 			type: DialogType.EditMedium,
 			child: dialogContent,
 			okAction: (dialog: Dialog) => {
@@ -180,7 +180,7 @@ async function showLogDialog(heading: string, text: string) {
 					type: ButtonType.Secondary,
 				},
 			],
-			middle: () => heading,
+			middle: lang.makeTranslation("heading", heading),
 		},
 		{
 			view: () => m(".white-space-pre.pt.pb.selectable", text),

--- a/src/common/misc/LoginUtils.ts
+++ b/src/common/misc/LoginUtils.ts
@@ -1,7 +1,7 @@
 import type { LoginController } from "../api/main/LoginController"
 import { Dialog } from "../gui/base/Dialog"
 import { generatedIdToTimestamp } from "../api/common/utils/EntityUtils"
-import type { TranslationText } from "./LanguageViewModel"
+import type { MaybeTranslation } from "./LanguageViewModel"
 import { lang } from "./LanguageViewModel"
 import {
 	AccessBlockedError,
@@ -71,9 +71,7 @@ export function checkApprovalStatus(logins: LoginController, includeInvoiceNotPa
 			} else if (status === ApprovalStatus.INVOICE_NOT_PAID) {
 				if (logins.getUserController().isGlobalAdmin()) {
 					if (includeInvoiceNotPaidForAdmin) {
-						return Dialog.message(() => {
-							return lang.get("invoiceNotPaid_msg")
-						})
+						return Dialog.message("invoiceNotPaid_msg")
 							.then(() => {
 								// TODO: navigate to payment site in settings
 								//m.route.set("/settings")
@@ -84,7 +82,7 @@ export function checkApprovalStatus(logins: LoginController, includeInvoiceNotPa
 						return true
 					}
 				} else {
-					const errorMessage = () => lang.get("invoiceNotPaidUser_msg") + " " + lang.get("contactAdmin_msg")
+					const errorMessage = lang.makeTranslation("invoiceNotPaidUser_msg", lang.get("invoiceNotPaidUser_msg") + " " + lang.get("contactAdmin_msg"))
 
 					return Dialog.message(errorMessage).then(() => false)
 				}
@@ -107,7 +105,7 @@ export function checkApprovalStatus(logins: LoginController, includeInvoiceNotPa
 		})
 }
 
-export function getLoginErrorMessage(error: Error, isExternalLogin: boolean): TranslationText {
+export function getLoginErrorMessage(error: Error, isExternalLogin: boolean): MaybeTranslation {
 	switch (error.constructor) {
 		case BadRequestError:
 		case NotAuthenticatedError:
@@ -127,10 +125,9 @@ export function getLoginErrorMessage(error: Error, isExternalLogin: boolean): Tr
 			return "emptyString_msg"
 
 		case CredentialAuthenticationError:
-			return () =>
-				lang.get("couldNotUnlockCredentials_msg", {
-					"{reason}": error.message,
-				})
+			return lang.getTranslation("couldNotUnlockCredentials_msg", {
+				"{reason}": error.message,
+			})
 
 		case ConnectionError:
 			return "connectionLostLong_msg"
@@ -162,7 +159,7 @@ export function handleExpectedLoginError<E extends Error>(error: E, handler: (er
 	}
 }
 
-export function getLoginErrorStateAndMessage(error: Error): { errorMessage: TranslationText; state: LoginState } {
+export function getLoginErrorStateAndMessage(error: Error): { errorMessage: MaybeTranslation; state: LoginState } {
 	let errorMessage = getLoginErrorMessage(error, false)
 	let state
 	if (error instanceof BadRequestError || error instanceof NotAuthenticatedError) {

--- a/src/common/misc/SubscriptionDialogs.ts
+++ b/src/common/misc/SubscriptionDialogs.ts
@@ -1,6 +1,6 @@
 import { assertNotNull, downcast, isEmpty, neverNull } from "@tutao/tutanota-utils"
 import { Dialog } from "../gui/base/Dialog"
-import type { TranslationKey, TranslationText } from "./LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "./LanguageViewModel"
 import { lang } from "./LanguageViewModel"
 import type { ClickHandler } from "../gui/base/GuiUtils"
 import { locator } from "../api/main/CommonLocator"
@@ -75,7 +75,7 @@ export async function showMoreStorageNeededOrderDialog(messageIdOrMessageFunctio
 /**
  * @returns true if the needed plan has been ordered
  */
-export async function showPlanUpgradeRequiredDialog(acceptedPlans: AvailablePlanType[], reason?: TranslationText): Promise<boolean> {
+export async function showPlanUpgradeRequiredDialog(acceptedPlans: AvailablePlanType[], reason?: MaybeTranslation): Promise<boolean> {
 	if (isEmpty(acceptedPlans)) {
 		throw new ProgrammingError("no plans specified")
 	}
@@ -84,7 +84,7 @@ export async function showPlanUpgradeRequiredDialog(acceptedPlans: AvailablePlan
 		showNotAvailableForFreeDialog(acceptedPlans)
 		return false
 	} else if (!userController.isGlobalAdmin()) {
-		Dialog.message(() => lang.get("contactAdmin_msg"))
+		Dialog.message("contactAdmin_msg")
 		return false
 	} else {
 		if (reason == null) {
@@ -109,7 +109,7 @@ export async function showUpgradeWizardOrSwitchSubscriptionDialog(userController
 	}
 }
 
-async function showSwitchPlanDialog(userController: UserController, acceptedPlans: AvailablePlanType[], reason?: TranslationText): Promise<void> {
+async function showSwitchPlanDialog(userController: UserController, acceptedPlans: AvailablePlanType[], reason?: MaybeTranslation): Promise<void> {
 	let customerInfo = await userController.loadCustomerInfo()
 	const bookings = await locator.entityClient.loadRange(BookingTypeRef, neverNull(customerInfo.bookings).items, GENERATED_MAX_ID, 1, true)
 	const { showSwitchDialog } = await import("../subscription/SwitchSubscriptionDialog")

--- a/src/common/misc/UsageTestModel.ts
+++ b/src/common/misc/UsageTestModel.ts
@@ -32,11 +32,11 @@ import { EntityUpdateData, isUpdateForTypeRef } from "../api/common/utils/Entity
 const PRESELECTED_LIKERT_VALUE = null
 
 type ExperienceSamplingOptions = {
-	title?: lazy<string> | string
-	explanationText?: TranslationKey | lazy<string>
+	title?: TranslationKey
+	explanationText?: TranslationKey
 	perMetric: {
 		[key: string]: {
-			question: TranslationKey | lazy<string>
+			question: TranslationKey
 			answerOptions: Array<string>
 		}
 	}
@@ -68,12 +68,12 @@ export async function showExperienceSamplingDialog(stage: Stage, experienceSampl
 			stage.complete().then(() => dialog.close())
 			return Dialog.message("experienceSamplingThankYou_msg")
 		},
-		title: experienceSamplingOptions.title ?? lang.get("experienceSamplingHeader_label"),
+		title: experienceSamplingOptions.title ?? "experienceSamplingHeader_label",
 		child: () => {
 			const children: Array<Children> = []
 
 			if (experienceSamplingOptions.explanationText) {
-				const explanationTextLines = lang.getMaybeLazy(experienceSamplingOptions.explanationText).split("\n")
+				const explanationTextLines = lang.getTranslationText(experienceSamplingOptions.explanationText).split("\n")
 
 				children.push(
 					m("#dialog-message.text-break.text-prewrap.selectable.scroll", [explanationTextLines.map((line) => m(".text-break.selectable", line))]),
@@ -90,7 +90,7 @@ export async function showExperienceSamplingDialog(stage: Stage, experienceSampl
 					}
 				})
 
-				children.push(m("p.text-prewrap.scroll", lang.getMaybeLazy(metricOptions.question)))
+				children.push(m("p.text-prewrap.scroll", lang.getTranslationText(metricOptions.question)))
 
 				children.push(
 					m(DropDownSelector, {

--- a/src/common/misc/credentials/CredentialFormatMigrator.ts
+++ b/src/common/misc/credentials/CredentialFormatMigrator.ts
@@ -6,6 +6,7 @@ import { base64ToUint8Array, mapNullable } from "@tutao/tutanota-utils"
 import { MobileSystemFacade } from "../../native/common/generatedipc/MobileSystemFacade.js"
 import { CredentialEncryptionMode } from "./CredentialEncryptionMode.js"
 import { AppLockMethod } from "../../native/common/generatedipc/AppLockMethod.js"
+import { lang } from "../LanguageViewModel.js"
 
 function credentialEncryptionModeToAppLockMethod(mode: CredentialEncryptionMode): AppLockMethod {
 	switch (mode) {
@@ -32,7 +33,7 @@ export class CredentialFormatMigrator {
 		} catch (e) {
 			console.error(e)
 			await Dialog.message(
-				() => "Could not migrate credentials",
+				lang.makeTranslation("confirm_msg", "Could not migrate credentials"),
 				`${e.name} ${e.message}
 ${e.stack}`,
 			).then(() => this.migrate())

--- a/src/common/misc/news/NewsDialog.ts
+++ b/src/common/misc/news/NewsDialog.ts
@@ -22,7 +22,7 @@ export function showNewsDialog(newsModel: NewsModel) {
 	}
 	const header: DialogHeaderBarAttrs = {
 		left: [closeButton],
-		middle: () => lang.get("news_label"),
+		middle: "news_label",
 	}
 
 	let loaded = false
@@ -42,7 +42,7 @@ export function showNewsDialog(newsModel: NewsModel) {
 						  })
 						: m(
 								".flex-center.mt-l",
-								m(".flex-v-center", [m(".full-width.flex-center", progressIcon()), m("p", lang.getMaybeLazy("pleaseWait_msg"))]),
+								m(".flex-v-center", [m(".full-width.flex-center", progressIcon()), m("p", lang.getTranslationText("pleaseWait_msg"))]),
 						  ),
 				]),
 			]

--- a/src/common/misc/news/items/PinBiometricsNews.ts
+++ b/src/common/misc/news/items/PinBiometricsNews.ts
@@ -68,7 +68,7 @@ export class PinBiometricsNews implements NewsListItem {
 			label: "secureNow_action",
 			click: async () => {
 				if ((await this.credentialsProvider.getCredentialsInfoByUserId(this.userId)) === null) {
-					await Dialog.message(() => lang.get("needSavedCredentials_msg", { "{storePasswordAction}": lang.get("storePassword_action") }))
+					await Dialog.message(lang.getTranslation("needSavedCredentials_msg", { "{storePasswordAction}": lang.get("storePassword_action") }))
 				} else {
 					await showCredentialsEncryptionModeDialog(this.credentialsProvider)
 

--- a/src/common/misc/news/items/RecoveryCodeNews.ts
+++ b/src/common/misc/news/items/RecoveryCodeNews.ts
@@ -85,7 +85,7 @@ export class RecoveryCodeNews implements NewsListItem {
 						dialog.close()
 						this.newsModel.acknowledgeNews(newsId.newsItemId).then(m.redraw)
 					},
-					title: lang.get("recoveryCode_label"),
+					title: "recoveryCode_label",
 					allowCancel: true,
 					child: () => m("p", lang.get("recoveryCodeConfirmation_msg")),
 				}),

--- a/src/common/misc/passwords/PasswordField.ts
+++ b/src/common/misc/passwords/PasswordField.ts
@@ -7,12 +7,12 @@ import { CompletenessIndicator } from "../../gui/CompletenessIndicator.js"
 import { isSecurePassword, scaleToVisualPasswordStrength } from "./PasswordUtils.js"
 import { Status, StatusField } from "../../gui/base/StatusField.js"
 import type { lazy } from "@tutao/tutanota-utils"
-import type { TranslationKey } from "../LanguageViewModel.js"
+import type { TranslationKey, MaybeTranslation } from "../LanguageViewModel.js"
 
 type StatusSetting = Status | "auto"
 
 export interface PasswordFieldAttrs extends Omit<TextFieldAttrs, "label" | "type"> {
-	label?: TranslationKey | lazy<string>
+	label?: MaybeTranslation
 	passwordStrength?: number
 	status?: StatusSetting
 }

--- a/src/common/misc/passwords/PasswordGeneratorDialog.ts
+++ b/src/common/misc/passwords/PasswordGeneratorDialog.ts
@@ -39,7 +39,7 @@ export async function showPasswordGeneratorDialog(): Promise<string> {
 		updateAction()
 
 		const dialog = Dialog.showActionDialog({
-			title: () => "Passphrase",
+			title: lang.makeTranslation("passphrase_title", "Passphrase"),
 			child: {
 				view: () =>
 					m(PasswordGeneratorDialog, {

--- a/src/common/misc/passwords/PasswordRequestDialog.ts
+++ b/src/common/misc/passwords/PasswordRequestDialog.ts
@@ -3,7 +3,7 @@
  * @param props.action will be executed as an attempt to apply new password. Error message is the return value.
  */
 import { PasswordField, PasswordFieldAttrs } from "./PasswordField.js"
-import { lang, TranslationKey } from "../LanguageViewModel.js"
+import { TranslationKey, MaybeTranslation } from "../LanguageViewModel.js"
 import { Dialog, INPUT } from "../../gui/base/Dialog.js"
 import m from "mithril"
 import { Autocomplete } from "../../gui/base/TextField.js"
@@ -13,7 +13,7 @@ import { Icon } from "../../gui/base/Icon.js"
 import { BootIcons } from "../../gui/base/icons/BootIcons.js"
 
 export function showRequestPasswordDialog(props: {
-	title?: string
+	title?: MaybeTranslation
 	messageText?: string
 	action: (pw: string) => Promise<string>
 	cancel: {
@@ -21,7 +21,7 @@ export function showRequestPasswordDialog(props: {
 		action: () => void
 	} | null
 }): Dialog {
-	const title = props.title != null ? () => props.title! : () => lang.get("password_label")
+	const title = props.title ? props.title : "password_label"
 	let value = ""
 	let state: { type: "progress" } | { type: "idle"; message: string } = { type: "idle", message: "" }
 

--- a/src/common/native/main/SelectAppLockMethodDialog.ts
+++ b/src/common/native/main/SelectAppLockMethodDialog.ts
@@ -153,10 +153,9 @@ export class SelectAppLockMethodView implements Component<SelectAppLockMethodDia
 	}
 
 	private renderSelectButton(onclick: () => unknown) {
-		const label = lang.get("ok_action")
 		return m(BaseButton, {
-			label,
-			text: label,
+			label: "ok_action",
+			text: lang.get("ok_action"),
 			class: "uppercase accent-bg full-width center b content-fg flash",
 			style: {
 				height: "60px",

--- a/src/common/native/main/WebCommonNativeFacade.ts
+++ b/src/common/native/main/WebCommonNativeFacade.ts
@@ -1,5 +1,5 @@
 import { CommonNativeFacade } from "../common/generatedipc/CommonNativeFacade.js"
-import { TranslationKey, TranslationText } from "../../misc/LanguageViewModel.js"
+import { lang, TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel.js"
 import { decodeBase64, lazyAsync, noOp, ofClass } from "@tutao/tutanota-utils"
 import { CancelledError } from "../../api/common/error/CancelledError.js"
 import { UserError } from "../../api/main/UserError.js"
@@ -114,11 +114,11 @@ export class WebCommonNativeFacade implements CommonNativeFacade {
 					const currentPlanType = await locator.logins.getUserController().getPlanType()
 					const isHighestTierPlan = HighestTierPlans.includes(currentPlanType)
 
-					let importAction: { text: TranslationText; value: boolean } = {
+					let importAction: { text: MaybeTranslation; value: boolean } = {
 						text: "import_action",
 						value: true,
 					}
-					let attachFilesAction: { text: TranslationText; value: boolean } = {
+					let attachFilesAction: { text: MaybeTranslation; value: boolean } = {
 						text: "attachFiles_action",
 						value: false,
 					}
@@ -156,7 +156,7 @@ export class WebCommonNativeFacade implements CommonNativeFacade {
 		} catch (e) {
 			if (e instanceof UserError) {
 				// noinspection ES6MissingAwait
-				Dialog.message(() => e.message)
+				Dialog.message(lang.makeTranslation("error_msg", e.message))
 			}
 			throw e
 		}
@@ -200,7 +200,7 @@ export class WebCommonNativeFacade implements CommonNativeFacade {
 			}
 
 			Dialog.showActionDialog({
-				title: () => title,
+				title: lang.makeTranslation(title, title),
 				child: () => m(PasswordForm, { model }),
 				validator: () => model.getErrorMessageId(),
 				okAction: changePasswordOkAction,
@@ -215,7 +215,7 @@ export class WebCommonNativeFacade implements CommonNativeFacade {
 
 		return new Promise((resolve, reject) => {
 			const dialog = showRequestPasswordDialog({
-				title,
+				title: lang.makeTranslation(title, title),
 				action: async (pw) => {
 					resolve(pw)
 					dialog.close()

--- a/src/common/native/main/wizard/setupwizardpages/SetupCongraulationsPage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupCongraulationsPage.ts
@@ -1,6 +1,6 @@
 import m, { Children } from "mithril"
 import { WizardPageAttrs, WizardPageN } from "../../../../gui/base/WizardDialog.js"
-import { lang } from "../../../../misc/LanguageViewModel.js"
+import { lang, type TranslationKey } from "../../../../misc/LanguageViewModel.js"
 import { SetupPageLayout } from "./SetupPageLayout.js"
 
 export class SetupCongratulationsPage implements WizardPageN<null> {
@@ -17,8 +17,8 @@ export class SetupCongratulationsPageAttrs implements WizardPageAttrs<null> {
 	hidePagingButtonForPage = false
 	data: null = null
 
-	headerTitle(): string {
-		return lang.get("welcome_label")
+	headerTitle(): TranslationKey {
+		return "welcome_label"
 	}
 
 	nextAction(showDialogs: boolean): Promise<boolean> {

--- a/src/common/native/main/wizard/setupwizardpages/SetupContactsPage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupContactsPage.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { WizardPageAttrs } from "../../../../gui/base/WizardDialog.js"
-import { lang } from "../../../../misc/LanguageViewModel.js"
+import { lang, type TranslationKey } from "../../../../misc/LanguageViewModel.js"
 import { SetupPageLayout } from "./SetupPageLayout.js"
 import { NativeContactsSyncManager } from "../../../../../mail-app/contacts/model/NativeContactsSyncManager.js"
 import { ContactImporter } from "../../../../../mail-app/contacts/ContactImporter.js"
@@ -54,8 +54,8 @@ export class SetupContactsPageAttrs implements WizardPageAttrs<null> {
 		public readonly allowContactSyncAndImport: boolean,
 	) {}
 
-	headerTitle(): string {
-		return lang.get("contacts_label")
+	headerTitle(): TranslationKey {
+		return "contacts_label"
 	}
 
 	nextAction(showDialogs: boolean): Promise<boolean> {

--- a/src/common/native/main/wizard/setupwizardpages/SetupLockPage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupLockPage.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { WizardPageAttrs } from "../../../../gui/base/WizardDialog.js"
-import { lang } from "../../../../misc/LanguageViewModel.js"
+import { lang, type TranslationKey } from "../../../../misc/LanguageViewModel.js"
 import { SetupPageLayout } from "./SetupPageLayout.js"
 import { SelectAppLockMethodView } from "../../SelectAppLockMethodDialog.js"
 import { AppLockMethod } from "../../../common/generatedipc/AppLockMethod.js"
@@ -42,8 +42,8 @@ export class SetupLockPageAttrs implements WizardPageAttrs<null> {
 		})
 	}
 
-	headerTitle(): string {
-		return lang.get("credentialsEncryptionMode_label")
+	headerTitle(): TranslationKey {
+		return "credentialsEncryptionMode_label"
 	}
 
 	async nextAction(showDialogs: boolean): Promise<boolean> {

--- a/src/common/native/main/wizard/setupwizardpages/SetupNotificationsPage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupNotificationsPage.ts
@@ -2,7 +2,7 @@ import m, { Children, Component, Vnode } from "mithril"
 import { WizardPageAttrs } from "../../../../gui/base/WizardDialog.js"
 import { PermissionType } from "../../../common/generatedipc/PermissionType.js"
 import { isAndroidApp } from "../../../../api/common/Env.js"
-import { lang } from "../../../../misc/LanguageViewModel.js"
+import { lang, type TranslationKey } from "../../../../misc/LanguageViewModel.js"
 import Stream from "mithril/stream"
 import { SetupPageLayout } from "./SetupPageLayout.js"
 import { SystemPermissionHandler } from "../../SystemPermissionHandler.js"
@@ -82,8 +82,8 @@ export class SetupNotificationsPageAttrs implements WizardPageAttrs<Notification
 		return !data.isNotificationPermissionGranted
 	}
 
-	headerTitle(): string {
-		return lang.get("notificationSettings_action")
+	headerTitle(): TranslationKey {
+		return "notificationSettings_action"
 	}
 
 	nextAction(showDialogs: boolean): Promise<boolean> {

--- a/src/common/native/main/wizard/setupwizardpages/SetupThemePage.ts
+++ b/src/common/native/main/wizard/setupwizardpages/SetupThemePage.ts
@@ -1,6 +1,6 @@
 import m, { Children } from "mithril"
 import { WizardPageAttrs, WizardPageN } from "../../../../gui/base/WizardDialog.js"
-import { lang } from "../../../../misc/LanguageViewModel.js"
+import { lang, TranslationKey } from "../../../../misc/LanguageViewModel.js"
 import { RadioSelector, RadioSelectorAttrs, RadioSelectorOption } from "../../../../gui/base/RadioSelector.js"
 import { themeOptions, ThemePreference } from "../../../../gui/theme.js"
 import { SetupPageLayout } from "./SetupPageLayout.js"
@@ -15,7 +15,7 @@ export class SetupThemePage implements WizardPageN<SetupThemePageAttrs> {
 		// Get the whitelabel themes from the theme controller and map them to `RadioSelector` options.
 		locator.themeController.getCustomThemes().then((customThemes) => {
 			this.customThemes = customThemes.map((themeId) => {
-				return { name: () => themeId, value: themeId }
+				return { name: lang.makeTranslation(themeId, themeId), value: themeId }
 			})
 			m.redraw()
 		})
@@ -48,8 +48,8 @@ export class SetupThemePageAttrs implements WizardPageAttrs<null> {
 	hidePagingButtonForPage = false
 	data: null = null
 
-	headerTitle(): string {
-		return lang.get("appearanceSettings_label")
+	headerTitle(): TranslationKey {
+		return "appearanceSettings_label"
 	}
 
 	nextAction(showDialogs: boolean): Promise<boolean> {

--- a/src/common/ratings/InAppRatingDialog.ts
+++ b/src/common/ratings/InAppRatingDialog.ts
@@ -92,7 +92,7 @@ export async function showAppRatingDialog(): Promise<void> {
 								".flex.flex-column.mt",
 								{ style: { gap: "1em" } },
 								m(BaseButton, {
-									label: lang.get("ratingLoveIt_label"),
+									label: "ratingLoveIt_label",
 									text: lang.get("ratingLoveIt_label"),
 									onclick: () => choose(AppRatingValue.Happy),
 									class: `full-width border-radius-small center b flash accent-bg button-content`,
@@ -102,7 +102,7 @@ export async function showAppRatingDialog(): Promise<void> {
 								} satisfies BaseButtonAttrs),
 
 								m(BaseButton, {
-									label: lang.get("ratingNeedsWork_label"),
+									label: "ratingNeedsWork_label",
 									text: lang.get("ratingNeedsWork_label"),
 									onclick: () => choose(AppRatingValue.Unhappy),
 									class: `full-width border-radius-small center b flash`,

--- a/src/common/settings/AboutDialog.ts
+++ b/src/common/settings/AboutDialog.ts
@@ -51,7 +51,7 @@ export class AboutDialog implements Component<AboutDialogAttrs> {
 				? m(
 						"",
 						m(Button, {
-							label: () => "Show welcome dialog",
+							label: lang.makeTranslation("welcome_label", "Show welcome dialog"),
 							type: ButtonType.Primary,
 							click: vnode.attrs.onShowSetupWizard,
 						}),
@@ -64,7 +64,7 @@ export class AboutDialog implements Component<AboutDialogAttrs> {
 		return m(
 			".mt",
 			m(Button, {
-				label: () => lang.get("sendLogs_action"),
+				label: "sendLogs_action",
 				click: () => this._sendDeviceLogs(),
 				type: ButtonType.Primary,
 			}),

--- a/src/common/settings/AccountMaintenanceSettings.ts
+++ b/src/common/settings/AccountMaintenanceSettings.ts
@@ -295,7 +295,7 @@ export class AccountMaintenanceSettings implements Component<AccountMaintenanceS
 		Promise.all(groupInfoLoadingPromises).then(() => {
 			const groupInfoValue = groupInfo()
 			let dialog = Dialog.showActionDialog({
-				title: lang.get("auditLog_title"),
+				title: "auditLog_title",
 				child: {
 					view: () =>
 						m("table.pt", [

--- a/src/common/settings/AddUserDialog.ts
+++ b/src/common/settings/AddUserDialog.ts
@@ -1,5 +1,5 @@
 import m from "mithril"
-import { lang, TranslationText } from "../misc/LanguageViewModel.js"
+import { lang, TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { BookingItemFeatureType, NewPaidPlans } from "../api/common/TutanotaConstants.js"
 import { Dialog } from "../gui/base/Dialog.js"
 import { PasswordForm, PasswordModel } from "./PasswordForm.js"
@@ -21,7 +21,7 @@ export async function show(): Promise<void> {
 	const availableDomains = await getAvailableDomains(locator.logins)
 	const onNewPaidPlan = await locator.logins.getUserController().isNewPaidPlan()
 	let emailAddress: string | null = null
-	let errorMsg: TranslationText | null = "mailAddressNeutral_msg"
+	let errorMsg: MaybeTranslation | null = "mailAddressNeutral_msg"
 	let isVerificationBusy = false
 	let userName = ""
 	const passwordModel = new PasswordModel(locator.usageTestController, locator.logins, {
@@ -44,7 +44,11 @@ export async function show(): Promise<void> {
 					availableDomains,
 					onDomainChanged: (domain) => {
 						if (domain.isPaid && !onNewPaidPlan) {
-							showUpgradeWizard(locator.logins, NewPaidPlans, () => `${lang.get("paidEmailDomainLegacy_msg")}\n${lang.get("changePaidPlan_msg")}`)
+							showUpgradeWizard(
+								locator.logins,
+								NewPaidPlans,
+								lang.makeTranslation("change_to_new_plan", `${lang.get("paidEmailDomainLegacy_msg")}\n${lang.get("changePaidPlan_msg")}`),
+							)
 						} else {
 							selectedDomain = domain
 						}
@@ -71,7 +75,7 @@ export async function show(): Promise<void> {
 		const passwordFormError = passwordModel.getErrorMessageId()
 
 		if (errorMsg) {
-			Dialog.message(errorMsg)
+			Dialog.message(errorMsg as TranslationKey)
 			return
 		} else if (passwordFormError) {
 			Dialog.message(passwordFormError)
@@ -103,11 +107,10 @@ export async function show(): Promise<void> {
 					operation.id,
 				)
 				showProgressDialog(
-					() =>
-						lang.get("createActionStatus_msg", {
-							"{index}": 0,
-							"{count}": 1,
-						}),
+					lang.getTranslation("createActionStatus_msg", {
+						"{index}": 0,
+						"{count}": 1,
+					}),
 					p,
 					operation.progress,
 				)
@@ -119,7 +122,7 @@ export async function show(): Promise<void> {
 	}
 
 	Dialog.showActionDialog({
-		title: lang.get("addUsers_action"),
+		title: "addUsers_action",
 		child: form,
 		okAction: addUserOkAction,
 	})

--- a/src/common/settings/AffiliateKpisViewer.ts
+++ b/src/common/settings/AffiliateKpisViewer.ts
@@ -29,17 +29,17 @@ export class AffiliateKpisViewer implements UpdatableSettingsDetailsViewer {
 						m(Table, {
 							columnHeading: [
 								{ text: "month_label" },
-								{ text: "affiliateSettingsNewFree_label", helpText: () => lang.get("affiliateSettingsNewFree_msg") },
-								{ text: "affiliateSettingsNewPaid_label", helpText: () => lang.get("affiliateSettingsNewPaid_msg") },
+								{ text: "affiliateSettingsNewFree_label", helpText: "affiliateSettingsNewFree_msg" },
+								{ text: "affiliateSettingsNewPaid_label", helpText: "affiliateSettingsNewPaid_msg" },
 								{
 									text: "affiliateSettingsTotalFree_label",
-									helpText: () => lang.get("affiliateSettingsTotalFree_msg"),
+									helpText: "affiliateSettingsTotalFree_msg",
 								},
 								{
 									text: "affiliateSettingsTotalPaid_label",
-									helpText: () => lang.get("affiliateSettingsTotalPaid_msg"),
+									helpText: "affiliateSettingsTotalPaid_msg",
 								},
-								{ text: "affiliateSettingsCommission_label", helpText: () => lang.get("affiliateSettingsCommission_msg") },
+								{ text: "affiliateSettingsCommission_label", helpText: "affiliateSettingsCommission_msg" },
 							],
 							columnWidths: [
 								ColumnWidth.Largest,

--- a/src/common/settings/EditNotificationEmailDialog.ts
+++ b/src/common/settings/EditNotificationEmailDialog.ts
@@ -179,7 +179,7 @@ export function show(existingTemplate: NotificationMailTemplate | null, customer
 
 	Dialog.showActionDialog({
 		type: DialogType.EditLarge,
-		title: lang.get("edit_action"),
+		title: "edit_action",
 		child: () => {
 			return [
 				m(SegmentControl, {
@@ -192,8 +192,8 @@ export function show(existingTemplate: NotificationMailTemplate | null, customer
 		},
 		okAction: (dialog: Dialog) => {
 			if (!editor.getValue().includes("{link}")) {
-				return Dialog.message(() =>
-					lang.get("templateMustContain_msg", {
+				return Dialog.message(
+					lang.getTranslation("templateMustContain_msg", {
 						"{value}": "{link}",
 					}),
 				)
@@ -231,7 +231,7 @@ export function show(existingTemplate: NotificationMailTemplate | null, customer
 			)
 				.catch(
 					ofClass(UserError, (err) => {
-						return Dialog.message(() => err.message)
+						return Dialog.message(lang.makeTranslation("error_message", err.message))
 					}),
 				)
 				.catch(

--- a/src/common/settings/ExpandableTable.ts
+++ b/src/common/settings/ExpandableTable.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import stream from "mithril/stream"
-import type { InfoLink, TranslationKey } from "../misc/LanguageViewModel.js"
+import type { InfoLink, TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import type { TableAttrs } from "../gui/base/Table.js"
 import { Table } from "../gui/base/Table.js"
 import { SettingsExpander } from "./SettingsExpander.js"
@@ -8,9 +8,9 @@ import type { lazy } from "@tutao/tutanota-utils"
 import Stream from "mithril/stream"
 
 type ExpandableTableAttrs = {
-	title: TranslationKey | lazy<string>
+	title: MaybeTranslation
 	table: TableAttrs
-	infoMsg: TranslationKey | lazy<string>
+	infoMsg: MaybeTranslation
 	infoLinkId?: InfoLink
 	// ExpandableTable uses internal state whenever this isn't passed in
 	expanded?: Stream<boolean>

--- a/src/common/settings/IdentifierRow.ts
+++ b/src/common/settings/IdentifierRow.ts
@@ -29,7 +29,7 @@ export class IdentifierRow implements Component<IdentifierRowAttrs> {
 			},
 			childAttrs: () => [
 				{
-					label: () => lang.get(vnode.attrs.disabled ? "activate_action" : "deactivate_action"),
+					label: vnode.attrs.disabled ? "activate_action" : "deactivate_action",
 					click: vnode.attrs.disableClicked,
 				},
 				{

--- a/src/common/settings/ImportUsersViewer.ts
+++ b/src/common/settings/ImportUsersViewer.ts
@@ -23,8 +23,8 @@ export function checkAndImportUserData(userDetailsInputCsv: string, availableDom
 	let userData = csvToUserDetails(userDetailsInputCsv)
 
 	if (!userData) {
-		Dialog.message(() =>
-			lang.get("wrongUserCsvFormat_msg", {
+		Dialog.message(
+			lang.getTranslation("wrongUserCsvFormat_msg", {
 				"{format}": CSV_USER_FORMAT,
 			}),
 		)
@@ -39,7 +39,7 @@ export function checkAndImportUserData(userDetailsInputCsv: string, availableDom
 
 			return true
 		} else {
-			Dialog.message(() => errorMessage)
+			Dialog.message(lang.makeTranslation("error_msg", errorMessage))
 			return false
 		}
 	}
@@ -140,11 +140,10 @@ async function showBookingDialog(userDetailsArray: UserImportDetails[]) {
 	let notAvailableUsers: UserImportDetails[] = []
 	const operation = locator.operationProgressTracker.startNewOperation()
 	await showProgressDialog(
-		() =>
-			lang.get("createActionStatus_msg", {
-				"{index}": nbrOfCreatedUsers,
-				"{count}": userDetailsArray.length,
-			}),
+		lang.getTranslation("createActionStatus_msg", {
+			"{index}": nbrOfCreatedUsers,
+			"{count}": userDetailsArray.length,
+		}),
 		promiseMap(userDetailsArray, (user, userIndex) => {
 			return createUserIfMailAddressAvailable(user, userIndex, userDetailsArray.length, operation.id).then((created) => {
 				if (created) {
@@ -161,11 +160,16 @@ async function showBookingDialog(userDetailsArray: UserImportDetails[]) {
 		.finally(() => operation.done)
 
 	if (notAvailableUsers.length > 0) {
-		await Dialog.message(() => lang.get("addressesAlreadyInUse_msg") + " " + notAvailableUsers.map((u) => u.mailAddress).join(", "))
+		await Dialog.message(
+			lang.makeTranslation(
+				"addressesAlreadyInUse_msg",
+				lang.get("addressesAlreadyInUse_msg") + " " + notAvailableUsers.map((u) => u.mailAddress).join(", "),
+			),
+		)
 	}
 
-	await Dialog.message(() =>
-		lang.get("createdUsersCount_msg", {
+	await Dialog.message(
+		lang.getTranslation("createdUsersCount_msg", {
 			"{1}": nbrOfCreatedUsers,
 		}),
 	)

--- a/src/common/settings/NotificationPermissionsDialog.ts
+++ b/src/common/settings/NotificationPermissionsDialog.ts
@@ -27,7 +27,7 @@ export async function renderNotificationPermissionsDialog(onClose: () => void) {
 				type: ButtonType.Secondary,
 			},
 		],
-		middle: () => lang.get("permissions_label"),
+		middle: "permissions_label",
 		remove: () => onClose(),
 	}
 	const dialog = Dialog.editSmallDialog(headerBarAttrs, () =>

--- a/src/common/settings/SelectMailAddressForm.ts
+++ b/src/common/settings/SelectMailAddressForm.ts
@@ -136,7 +136,7 @@ export class SelectMailAddressForm implements Component<SelectMailAddressFormAtt
 
 	private createDropdownItemAttrs(domainData: EmailDomainData, attrs: SelectMailAddressFormAttrs): DropdownButtonAttrs {
 		return {
-			label: () => domainData.domain,
+			label: lang.makeTranslation("domain", domainData.domain),
 			click: () => {
 				attrs.onDomainChanged(domainData)
 			},

--- a/src/common/settings/SetDomainCertificateDialog.ts
+++ b/src/common/settings/SetDomainCertificateDialog.ts
@@ -71,7 +71,7 @@ export function show(customerInfo: CustomerInfo): void {
 		},
 	}
 	let dialog = Dialog.showActionDialog({
-		title: lang.get("whitelabelDomain_label"),
+		title: "whitelabelDomain_label",
 		child: form,
 		okAction: () => {
 			const domainAllLowercase = domain().trim().toLowerCase()

--- a/src/common/settings/SettingsExpander.ts
+++ b/src/common/settings/SettingsExpander.ts
@@ -1,4 +1,4 @@
-import type { InfoLink, TranslationKey } from "../misc/LanguageViewModel.js"
+import type { InfoLink, TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { lang } from "../misc/LanguageViewModel.js"
 import m, { Children, Component, Vnode } from "mithril"
 import { ExpanderButton, ExpanderPanel } from "../gui/base/Expander.js"
@@ -8,9 +8,9 @@ import Stream from "mithril/stream"
 import { locator } from "../api/main/CommonLocator.js"
 
 export type SettingsExpanderAttrs = {
-	title: TranslationKey | lazy<string>
-	buttonText?: TranslationKey | lazy<string>
-	infoMsg?: TranslationKey | lazy<string>
+	title: MaybeTranslation
+	buttonText?: MaybeTranslation
+	infoMsg?: MaybeTranslation
 	infoLinkId?: InfoLink | undefined
 	onExpand?: Thunk | undefined
 	expanded: Stream<boolean>
@@ -29,7 +29,7 @@ export class SettingsExpander implements Component<SettingsExpanderAttrs> {
 		const { title, buttonText, infoLinkId, infoMsg, expanded } = vnode.attrs
 		return [
 			m(".flex-space-between.items-center.mb-s.mt-l", [
-				m(".h4", lang.getMaybeLazy(title)),
+				m(".h4", lang.getTranslationText(title)),
 				m(ExpanderButton, {
 					label: buttonText || "show_action",
 					expanded: expanded(),
@@ -43,7 +43,7 @@ export class SettingsExpander implements Component<SettingsExpanderAttrs> {
 				},
 				vnode.children,
 			),
-			infoMsg ? m("small", lang.getMaybeLazy(infoMsg)) : null,
+			infoMsg ? m("small", lang.getTranslationText(infoMsg)) : null,
 			infoLinkId ? ifAllowedTutaLinks(locator.logins, infoLinkId, (link) => m("small.text-break", [m(`a[href=${link}][target=_blank]`, link)])) : null,
 		]
 	}

--- a/src/common/settings/SettingsFolder.ts
+++ b/src/common/settings/SettingsFolder.ts
@@ -1,5 +1,5 @@
 import type { lazyIcon } from "../gui/base/Icon.js"
-import type { TranslationKey } from "../misc/LanguageViewModel.js"
+import type { TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { isSelectedPrefix } from "../gui/base/NavButton.js"
 import type { lazy } from "@tutao/tutanota-utils"
 import { assertMainOrNode } from "../api/common/Env.js"
@@ -15,7 +15,7 @@ export class SettingsFolder<T> {
 	private _isVisibleHandler: lazy<boolean>
 
 	constructor(
-		readonly name: TranslationKey | lazy<string>,
+		readonly name: MaybeTranslation,
 		readonly icon: lazyIcon,
 		readonly path: SettingsFolderPath,
 		readonly viewerCreator: lazy<UpdatableSettingsViewer>,

--- a/src/common/settings/UserViewer.ts
+++ b/src/common/settings/UserViewer.ts
@@ -315,7 +315,7 @@ export class UserViewer implements UpdatableSettingsDetailsViewer {
 
 				let selectedGroupInfo = getFirstOrThrow(availableGroupInfos)
 				Dialog.showActionDialog({
-					title: lang.get("addUserToGroup_label"),
+					title: "addUserToGroup_label",
 					child: {
 						view: () =>
 							m(DropDownSelector, {
@@ -445,7 +445,7 @@ export function showUserImportDialog(customDomains: string[]) {
 		},
 	}
 	Dialog.showActionDialog({
-		title: lang.get("importUsers_action"),
+		title: "importUsers_action",
 		child: form,
 		okAction: (csvDialog) => {
 			let closeCsvDialog = checkAndImportUserData(editor.getValue(), customDomains)

--- a/src/common/settings/groups/GroupDetailsView.ts
+++ b/src/common/settings/groups/GroupDetailsView.ts
@@ -166,7 +166,7 @@ export class GroupDetailsView implements UpdatableSettingsDetailsViewer {
 		}
 
 		Dialog.showActionDialog({
-			title: lang.get("addUserToGroup_label"),
+			title: "addUserToGroup_label",
 			child: {
 				view: () =>
 					m(DropDownSelector, {

--- a/src/common/settings/login/ChangePasswordDialogs.ts
+++ b/src/common/settings/login/ChangePasswordDialogs.ts
@@ -29,7 +29,7 @@ export async function showChangeUserPasswordAsAdminDialog(user: User) {
 	}
 
 	Dialog.showActionDialog({
-		title: lang.get("changePassword_label"),
+		title: "changePassword_label",
 		child: () => m(PasswordForm, { model }),
 		validator: () => model.getErrorMessageId(),
 		okAction: changeUserPasswordAsAdminOkAction,
@@ -96,7 +96,7 @@ export async function showChangeOwnPasswordDialog(allowCancel: boolean = true) {
 	}
 
 	Dialog.showActionDialog({
-		title: lang.get("changePassword_label"),
+		title: "changePassword_label",
 		child: () => m(PasswordForm, { model }),
 		validator: () => model.getErrorMessageId(),
 		okAction: changeOwnPasswordOkAction,

--- a/src/common/settings/login/LoginSettingsViewer.ts
+++ b/src/common/settings/login/LoginSettingsViewer.ts
@@ -34,6 +34,7 @@ import { MoreInfoLink } from "../../misc/news/MoreInfoLink.js"
 import { AppLockMethod } from "../../native/common/generatedipc/AppLockMethod.js"
 import { MobileSystemFacade } from "../../native/common/generatedipc/MobileSystemFacade.js"
 import { UpdatableSettingsViewer } from "../Interfaces.js"
+
 assertMainOrNode()
 
 export class LoginSettingsViewer implements UpdatableSettingsViewer {
@@ -102,7 +103,7 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 					  }
 					: null,
 				{
-					label: () => (neverNull(locator.logins.getUserController().user.auth).recoverCode ? lang.get("update_action") : lang.get("setUp_action")),
+					label: neverNull(locator.logins.getUserController().user.auth).recoverCode ? "update_action" : "setUp_action",
 					click: () => RecoverCodeDialog.showRecoverCodeDialogAfterPasswordVerification("create"),
 				},
 			],
@@ -275,7 +276,7 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 
 	private showActiveSessionInfoDialog(session: Session, isThisSession: boolean) {
 		const actionDialogProperties = {
-			title: () => lang.get("details_label"),
+			title: "details_label",
 			child: {
 				view: () => {
 					return [

--- a/src/common/settings/login/RecoverCodeDialog.ts
+++ b/src/common/settings/login/RecoverCodeDialog.ts
@@ -25,7 +25,7 @@ export function showRecoverCodeDialogAfterPasswordVerificationAndInfoDialog(user
 
 	const isRecoverCodeAvailable = user.auth && user.auth.recoverCode != null
 	Dialog.showActionDialog({
-		title: lang.get("recoveryCode_label"),
+		title: "recoveryCode_label",
 		type: DialogType.EditMedium,
 		child: () => m(".pt", lang.get("recoveryCode_msg")),
 		allowOkWithReturn: true,
@@ -60,7 +60,7 @@ export function showRecoverCodeDialogAfterPasswordVerification(action: Action, s
 export function showRecoverCodeDialog(recoverCode: Hex, showMessage: boolean): Promise<void> {
 	return new Promise((resolve) => {
 		Dialog.showActionDialog({
-			title: lang.get("recoveryCode_label"),
+			title: "recoveryCode_label",
 			child: {
 				view: () => {
 					return m(RecoverCodeField, {

--- a/src/common/settings/login/secondfactor/SecondFactorEditDialog.ts
+++ b/src/common/settings/login/secondfactor/SecondFactorEditDialog.ts
@@ -30,7 +30,7 @@ export class SecondFactorEditDialog {
 
 	constructor(private readonly model: SecondFactorEditModel) {
 		this.dialog = Dialog.createActionDialog({
-			title: lang.get("add_action"),
+			title: "add_action",
 			allowOkWithReturn: true,
 			child: {
 				view: () => this.render(),
@@ -50,7 +50,7 @@ export class SecondFactorEditDialog {
 		} catch (e) {
 			if (e instanceof UserError) {
 				// noinspection ES6MissingAwait
-				Dialog.message(() => e.message)
+				Dialog.message(lang.makeTranslation("error_msg", e.message))
 			} else if (e instanceof NotAuthorizedError) {
 				this.dialog.close()
 				Dialog.message("contactFormSubmitError_msg")

--- a/src/common/settings/mailaddress/AddAliasDialog.ts
+++ b/src/common/settings/mailaddress/AddAliasDialog.ts
@@ -47,7 +47,7 @@ export function showAddAliasDialog(model: MailAddressTableModel, isNewPaidPlan: 
 		}
 
 		Dialog.showActionDialog({
-			title: lang.get("addEmailAlias_label"),
+			title: "addEmailAlias_label",
 			child: {
 				view: () => {
 					return [
@@ -67,13 +67,13 @@ export function showAddAliasDialog(model: MailAddressTableModel, isNewPaidPlan: 
 								if (!domain.isPaid || isNewPaidPlan) {
 									formDomain = domain
 								} else {
-									Dialog.confirm(() => `${lang.get("paidEmailDomainLegacy_msg")}\n${lang.get("changePaidPlan_msg")}`).then(
-										async (confirmed) => {
-											if (confirmed) {
-												isNewPaidPlan = await showPlanUpgradeRequiredDialog(NewPaidPlans)
-											}
-										},
-									)
+									Dialog.confirm(
+										lang.makeTranslation("confirm_msg", `${lang.get("paidEmailDomainLegacy_msg")}\n${lang.get("changePaidPlan_msg")}`),
+									).then(async (confirmed) => {
+										if (confirmed) {
+											isNewPaidPlan = await showPlanUpgradeRequiredDialog(NewPaidPlans)
+										}
+									})
 								}
 							},
 						}),
@@ -112,7 +112,7 @@ async function addAlias(model: MailAddressTableModel, alias: string, senderName:
 				errorMsg = lang.get("addAliasUserDisabled_msg")
 			}
 
-			return Dialog.message(() => errorMsg)
+			return Dialog.message(lang.makeTranslation("confirm_msg", errorMsg))
 		} else if (error instanceof UpgradeRequiredError) {
 			showPlanUpgradeRequiredDialog(error.plans, error.message)
 		} else {

--- a/src/common/settings/mailaddress/MailAddressTable.ts
+++ b/src/common/settings/mailaddress/MailAddressTable.ts
@@ -185,8 +185,8 @@ async function switchAliasStatus(alias: AddressInfo, attrs: MailAddressTableAttr
 	if (deactivateOrDeleteAlias) {
 		// alias from custom domains will be deleted. Tutanota aliases will be deactivated
 		const message: TranslationKey = alias.status === AddressStatus.Custom ? "deleteAlias_msg" : "deactivateAlias_msg"
-		const confirmed = await Dialog.confirm(() =>
-			lang.get(message, {
+		const confirmed = await Dialog.confirm(
+			lang.getTranslation(message, {
 				"{1}": alias.address,
 			}),
 		)
@@ -206,7 +206,7 @@ function showSenderNameChangeDialog(model: MailAddressTableModel, alias: { addre
 	Dialog.showTextInputDialog({
 		title: "edit_action",
 		label: "mailName_label",
-		infoMsgId: () => alias.address,
+		infoMsgId: lang.makeTranslation("alias_addr", alias.address),
 		defaultValue: alias.name,
 	}).then((newName) => showProgressDialog("pleaseWait_msg", model.setAliasName(alias.address, newName)))
 }

--- a/src/common/settings/whitelabel/CustomColorEditor.ts
+++ b/src/common/settings/whitelabel/CustomColorEditor.ts
@@ -170,7 +170,7 @@ function renderCustomColorField(model: CustomColorsEditorViewModel, { name, valu
 		},
 		[
 			m(TextField, {
-				label: () => name,
+				label: lang.makeTranslation(name, name),
 				value: value,
 				injectionsRight: () =>
 					renderColorPicker((event) => model.addCustomization(name, downcast<HTMLInputElement>(event.target).value), processColorInputValue(value)),

--- a/src/common/settings/whitelabel/CustomColorEditorPreview.ts
+++ b/src/common/settings/whitelabel/CustomColorEditorPreview.ts
@@ -9,6 +9,7 @@ import { Icons } from "../../gui/base/icons/Icons.js"
 import { ToggleButton } from "../../gui/base/buttons/ToggleButton.js"
 import { isApp, isDesktop } from "../../api/common/Env.js"
 import { LoginButton } from "../../gui/base/buttons/LoginButton.js"
+import { lang } from "../../misc/LanguageViewModel.js"
 
 export const BUTTON_WIDTH = 270
 
@@ -45,24 +46,24 @@ export class CustomColorEditorPreview implements Component {
 				),
 				m(".pt", [
 					m(Button, {
-						label: () => "Secondary",
+						label: lang.makeTranslation("secondary", "Secondary"),
 						click: noOp,
 						type: ButtonType.Secondary,
 					}),
 					m(Button, {
-						label: () => "Primary",
+						label: lang.makeTranslation("primary", "Primary"),
 						click: noOp,
 						type: ButtonType.Primary,
 					}),
 				]),
 				m(".pt", [
 					m(IconButton, {
-						title: () => "Icon button",
+						title: lang.makeTranslation("icon_button", "Icon button"),
 						icon: Icons.Folder,
 						click: noOp,
 					}),
 					m(ToggleButton, {
-						title: () => "Toggle button",
+						title: lang.makeTranslation("toggle_button", "Toggle button"),
 						icon: this.toggleSelected ? Icons.Lock : Icons.Unlock,
 						toggled: this.toggleSelected,
 						onToggled: () => (this.toggleSelected = !this.toggleSelected),

--- a/src/common/settings/whitelabel/EditCustomColorsDialog.ts
+++ b/src/common/settings/whitelabel/EditCustomColorsDialog.ts
@@ -50,7 +50,7 @@ export function show(model: CustomColorsEditorViewModel) {
 				type: ButtonType.Primary,
 			},
 		],
-		middle: () => lang.get("customColors_label"),
+		middle: "customColors_label",
 	}
 	let dialog = Dialog.largeDialog(actionBarAttrs, form)
 		.addShortcut({

--- a/src/common/settings/whitelabel/WhitelabelBrandingDomainSettings.ts
+++ b/src/common/settings/whitelabel/WhitelabelBrandingDomainSettings.ts
@@ -61,7 +61,7 @@ export class WhitelabelBrandingDomainSettings implements Component<WhitelabelBra
 					if (e.data === FAILURE_LOCKED) {
 						return await Dialog.message("operationStillActive_msg")
 					} else if (e.data === FAILURE_CONTACT_FORM_ACTIVE) {
-						return await Dialog.message(() => lang.get("domainStillHasContactForms_msg", { "{domain}": whitelabelDomain }))
+						return await Dialog.message(lang.getTranslation("domainStillHasContactForms_msg", { "{domain}": whitelabelDomain }))
 					}
 				}
 				throw e

--- a/src/common/settings/whitelabel/WhitelabelCustomMetaTagsSettings.ts
+++ b/src/common/settings/whitelabel/WhitelabelCustomMetaTagsSettings.ts
@@ -33,7 +33,7 @@ export class WhitelabelCustomMetaTagsSettings implements Component<WhitelabelCus
 
 	private showEditMetaTagsDialog(metaTags: string, onMetaTagsChanged: (tags: string) => unknown) {
 		let dialog = Dialog.showActionDialog({
-			title: lang.get("customMetaTags_label"),
+			title: "customMetaTags_label",
 			child: {
 				view: () =>
 					m(TextField, {

--- a/src/common/settings/whitelabel/WhitelabelImprintAndPrivacySettings.ts
+++ b/src/common/settings/whitelabel/WhitelabelImprintAndPrivacySettings.ts
@@ -41,7 +41,7 @@ export class WhitelabelImprintAndPrivacySettings implements Component<Whitelabel
 
 	private editPrivacyStatementUrl(privacyStatementUrl: string, onPrivacyStatementUrlChanged: (arg0: string) => unknown) {
 		let dialog = Dialog.showActionDialog({
-			title: lang.get("privacyLink_label"),
+			title: "privacyLink_label",
 			child: {
 				view: () =>
 					m(TextField, {
@@ -81,7 +81,7 @@ export class WhitelabelImprintAndPrivacySettings implements Component<Whitelabel
 
 	private showEditImprintDialog(imprintUrl: string, onImprintUrlChanged: (imprintUrl: string) => unknown) {
 		const dialog = Dialog.showActionDialog({
-			title: lang.get("imprintUrl_label"),
+			title: "imprintUrl_label",
 			child: {
 				view: () =>
 					m(TextField, {

--- a/src/common/sharing/GroupGuiUtils.ts
+++ b/src/common/sharing/GroupGuiUtils.ts
@@ -1,4 +1,4 @@
-import type { TranslationKey, TranslationText } from "../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel"
 import { lang } from "../misc/LanguageViewModel"
 import { GroupType } from "../api/common/TutanotaConstants"
 import { getDefaultGroupName, ShareableGroupType } from "./GroupUtils"
@@ -16,7 +16,7 @@ export type GroupSharingTexts = {
 	readonly shareEmailBody: (sharer: string, groupName: string) => string
 	readonly addMemberMessage: (groupName: string) => string
 	readonly removeMemberMessage: (groupName: string, member: string) => string
-	readonly alreadyGroupMemberMessage: TranslationText
+	readonly alreadyGroupMemberMessage: MaybeTranslation
 	readonly receivedGroupInvitationMessage: string
 	readonly sharedGroupDefaultCustomName: (invitation: ReceivedGroupInvitation) => string
 	readonly yourCustomNameLabel: (groupName: string) => string

--- a/src/common/sharing/model/GroupSharingModel.ts
+++ b/src/common/sharing/model/GroupSharingModel.ts
@@ -150,7 +150,12 @@ export class GroupSharingModel {
 			}
 		}
 		if (externalRecipients.length) {
-			throw new UserError(() => lang.get("featureTutanotaOnly_msg") + " " + lang.get("invalidRecipients_msg") + "\n" + externalRecipients.join("\n"))
+			throw new UserError(
+				lang.makeTranslation(
+					"featureTutanotaOnly_msg",
+					lang.get("featureTutanotaOnly_msg") + " " + lang.get("invalidRecipients_msg") + "\n" + externalRecipients.join("\n"),
+				),
+			)
 		}
 
 		let groupInvitationReturn
@@ -162,7 +167,12 @@ export class GroupSharingModel {
 			)
 		} catch (e) {
 			if (e instanceof RecipientsNotFoundError) {
-				throw new UserError(() => `${lang.get("tutanotaAddressDoesNotExist_msg")} ${lang.get("invalidRecipients_msg")}\n${e.message}`)
+				throw new UserError(
+					lang.makeTranslation(
+						"tutanotaAddressDoesNotExist_msg",
+						`${lang.get("tutanotaAddressDoesNotExist_msg")} ${lang.get("invalidRecipients_msg")}\n${e.message}`,
+					),
+				)
 			} else {
 				throw e
 			}
@@ -171,13 +181,11 @@ export class GroupSharingModel {
 		if (groupInvitationReturn.existingMailAddresses.length > 0 || groupInvitationReturn.invalidMailAddresses.length > 0) {
 			const existingMailAddresses = groupInvitationReturn.existingMailAddresses.map((ma) => ma.address).join("\n")
 			const invalidMailAddresses = groupInvitationReturn.invalidMailAddresses.map((ma) => ma.address).join("\n")
-			throw new UserError(() => {
-				let msg = ""
-				msg += existingMailAddresses.length === 0 ? "" : lang.get("existingMailAddress_msg") + "\n" + existingMailAddresses
-				msg += existingMailAddresses.length === 0 && invalidMailAddresses.length === 0 ? "" : "\n\n"
-				msg += invalidMailAddresses.length === 0 ? "" : lang.get("invalidMailAddress_msg") + "\n" + invalidMailAddresses
-				return msg
-			})
+			let msg = ""
+			msg += existingMailAddresses.length === 0 ? "" : lang.get("existingMailAddress_msg") + "\n" + existingMailAddresses
+			msg += existingMailAddresses.length === 0 && invalidMailAddresses.length === 0 ? "" : "\n\n"
+			msg += invalidMailAddresses.length === 0 ? "" : lang.get("invalidMailAddress_msg") + "\n" + invalidMailAddresses
+			throw new UserError(lang.makeTranslation("group_invitation_err", msg))
 		}
 
 		return groupInvitationReturn.invitedMailAddresses

--- a/src/common/sharing/view/ReceivedGroupInvitationDialog.ts
+++ b/src/common/sharing/view/ReceivedGroupInvitationDialog.ts
@@ -68,12 +68,12 @@ export function showGroupInvitationDialog(invitation: ReceivedGroupInvitation) {
 	}
 
 	dialog = Dialog.showActionDialog({
-		title: () => lang.get("invitation_label"),
+		title: "invitation_label",
 		child: {
 			view: () =>
 				m(".flex.col", [
 					m(".mb", [
-						m(".pt.selectable", isMember ? lang.getMaybeLazy(texts.alreadyGroupMemberMessage) : texts.receivedGroupInvitationMessage),
+						m(".pt.selectable", isMember ? lang.getTranslationText(texts.alreadyGroupMemberMessage) : texts.receivedGroupInvitationMessage),
 						m(TextField, {
 							value: nameStream(),
 							oninput: nameStream,

--- a/src/common/subscription/BuyDialog.ts
+++ b/src/common/subscription/BuyDialog.ts
@@ -68,7 +68,7 @@ function showDialog(okLabel: TranslationKey, view: () => Children) {
 
 		dialog = Dialog.showActionDialog({
 			okActionTextId: okLabel,
-			title: () => lang.get("bookingSummary_label"),
+			title: "bookingSummary_label",
 			child: () => view(),
 			okAction: () => doAction(true),
 			cancelAction: () => doAction(false),

--- a/src/common/subscription/BuyOptionBox.ts
+++ b/src/common/subscription/BuyOptionBox.ts
@@ -1,6 +1,6 @@
 import m, { Child, Children, Component, Vnode, VnodeDOM } from "mithril"
 import { px, size } from "../gui/size"
-import type { TranslationKey } from "../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel"
 import { lang } from "../misc/LanguageViewModel"
 import type { lazy } from "@tutao/tutanota-utils"
 import { Icon } from "../gui/base/Icon"
@@ -27,8 +27,8 @@ export type BuyOptionBoxAttr = {
 	 * Null when we do not want to show the difference between actual price and reference price.
 	 */
 	referencePrice?: string
-	priceHint?: TranslationKey | lazy<string>
-	helpLabel: TranslationKey | lazy<string>
+	priceHint?: MaybeTranslation
+	helpLabel: MaybeTranslation
 	width: number
 	height: number
 	/**
@@ -175,8 +175,8 @@ export class BuyOptionBox implements Component<BuyOptionBoxAttr> {
 						shouldApplyCyberMondayDesign ? this.renderCyberMondayRibbon() : this.renderBonusMonthsRibbon(attrs.bonusMonths),
 						typeof attrs.heading === "string" ? this.renderHeading(attrs.heading) : attrs.heading,
 						this.renderPrice(attrs.price, isYearly ? attrs.referencePrice : undefined),
-						m(".small.text-center", attrs.priceHint ? lang.getMaybeLazy(attrs.priceHint) : lang.get("emptyString_msg")),
-						m(".small.text-center.pb-ml", lang.getMaybeLazy(attrs.helpLabel)),
+						m(".small.text-center", attrs.priceHint ? lang.getTranslationText(attrs.priceHint) : lang.get("emptyString_msg")),
+						m(".small.text-center.pb-ml", lang.getTranslationText(attrs.helpLabel)),
 						this.renderPaymentIntervalControl(attrs.selectedPaymentInterval, shouldApplyCyberMondayDesign),
 						attrs.actionButton
 							? m(

--- a/src/common/subscription/CancellationReasonInput.ts
+++ b/src/common/subscription/CancellationReasonInput.ts
@@ -18,7 +18,7 @@ export class CancellationReasonInput {
 		return [
 			m(".mt.pb-s.b.center", lang.get("cancellationInfo_msg")),
 			m(DropDownSelector, {
-				label: () => lang.get("whyLeave_msg"),
+				label: "whyLeave_msg",
 				items: [
 					{
 						name: lang.get("experienceSamplingAnswer_label"),

--- a/src/common/subscription/Captcha.ts
+++ b/src/common/subscription/Captcha.ts
@@ -138,7 +138,7 @@ function showCaptchaDialog(challenge: Uint8Array, token: string): Promise<string
 					type: ButtonType.Primary,
 				},
 			],
-			middle: () => lang.get("captchaDisplay_label"),
+			middle: "captchaDisplay_label",
 		}
 		const imageData = `data:image/png;base64,${uint8ArrayToBase64(challenge)}`
 
@@ -161,7 +161,7 @@ function showCaptchaDialog(challenge: Uint8Array, token: string): Promise<string
 							style: captchaFilter,
 						}),
 						m(TextField, {
-							label: () => lang.get("captchaInput_label") + " (hh:mm)",
+							label: lang.makeTranslation("captcha_input", lang.get("captchaInput_label") + " (hh:mm)"),
 							helpLabel: () => lang.get("captchaInfo_msg"),
 							value: captchaInput,
 							oninput: (value) => (captchaInput = value),

--- a/src/common/subscription/DeleteAccountDialog.ts
+++ b/src/common/subscription/DeleteAccountDialog.ts
@@ -19,7 +19,7 @@ export function showDeleteAccountDialog(surveyData: SurveyData | null = null) {
 	const userId = getEtId(locator.logins.getUserController().user)
 
 	Dialog.showActionDialog({
-		title: lang.get("adminDeleteAccount_action"),
+		title: "adminDeleteAccount_action",
 		child: {
 			view: () =>
 				m("#delete-account-dialog", [
@@ -62,14 +62,16 @@ async function deleteAccount(takeover: string, password: string, surveyData: Sur
 		await Dialog.message("mailAddressInvalid_msg")
 		return false
 	} else {
-		const messageFn = () =>
+		const message = lang.makeTranslation(
+			"confirm_msg",
 			cleanedTakeover === ""
 				? lang.get("deleteAccountConfirm_msg")
 				: lang.get("deleteAccountWithTakeoverConfirm_msg", {
 						"{1}": cleanedTakeover,
-				  })
+				  }),
+		)
 
-		const ok = await Dialog.confirm(messageFn)
+		const ok = await Dialog.confirm(message)
 		if (!ok) return false
 		// this is necessary to prevent us from applying websocket events to an already deleted/closed offline DB
 		// which is an immediate crash on ios

--- a/src/common/subscription/InvoiceAndPaymentDataPage.ts
+++ b/src/common/subscription/InvoiceAndPaymentDataPage.ts
@@ -1,6 +1,6 @@
 import m, { Children, Vnode, VnodeDOM } from "mithril"
 import { Dialog, DialogType } from "../gui/base/Dialog"
-import { lang } from "../misc/LanguageViewModel"
+import { lang, type TranslationKey } from "../misc/LanguageViewModel"
 import type { UpgradeSubscriptionData } from "./UpgradeSubscriptionWizard"
 import { InvoiceDataInput, InvoiceDataInputLocation } from "./InvoiceDataInput"
 import { PaymentMethodInput } from "./PaymentMethodInput"
@@ -179,7 +179,7 @@ export class InvoiceAndPaymentDataPage implements WizardPageN<UpgradeSubscriptio
 		}
 
 		return m(
-			"#upgrade-account-dialog.pt",
+			".pt",
 			this._availablePaymentMethods
 				? [
 						m(SegmentControl, {
@@ -233,8 +233,8 @@ export class InvoiceAndPaymentDataPageAttrs implements WizardPageAttrs<UpgradeSu
 		return Promise.resolve(true)
 	}
 
-	headerTitle(): string {
-		return lang.get("adminPayment_action")
+	headerTitle(): TranslationKey {
+		return "adminPayment_action"
 	}
 
 	isSkipAvailable(): boolean {
@@ -276,35 +276,69 @@ export async function updatePaymentData(
 		}
 	} else if (statusCode === PaymentDataResultType.COUNTRY_MISMATCH) {
 		const countryName = invoiceData.country ? invoiceData.country.n : ""
-		const confirmMessage = lang.get("confirmCountry_msg", {
+		const confirmMessage = lang.getTranslation("confirmCountry_msg", {
 			"{1}": countryName,
 		})
-		const confirmed = await Dialog.confirm(() => confirmMessage)
+		const confirmed = await Dialog.confirm(confirmMessage)
 		if (confirmed) {
 			return updatePaymentData(paymentInterval, invoiceData, paymentData, invoiceData.country, isSignup, price, accountingInfo) // add confirmed invoice country
 		} else {
 			return false
 		}
 	} else if (statusCode === PaymentDataResultType.INVALID_VATID_NUMBER) {
-		await Dialog.message(() => lang.get("invalidVatIdNumber_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation("invalidVatIdNumber_msg", lang.get("invalidVatIdNumber_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : "")),
+		)
 	} else if (statusCode === PaymentDataResultType.CREDIT_CARD_DECLINED) {
-		await Dialog.message(() => lang.get("creditCardDeclined_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation("creditCardDeclined_msg", lang.get("creditCardDeclined_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : "")),
+		)
 	} else if (statusCode === PaymentDataResultType.CREDIT_CARD_CVV_INVALID) {
 		await Dialog.message("creditCardCVVInvalid_msg")
 	} else if (statusCode === PaymentDataResultType.PAYMENT_PROVIDER_NOT_AVAILABLE) {
-		await Dialog.message(() => lang.get("paymentProviderNotAvailableError_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation(
+				"paymentProviderNotAvailableError_msg",
+				lang.get("paymentProviderNotAvailableError_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+			),
+		)
 	} else if (statusCode === PaymentDataResultType.OTHER_PAYMENT_ACCOUNT_REJECTED) {
-		await Dialog.message(() => lang.get("paymentAccountRejected_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation(
+				"paymentAccountRejected_msg",
+				lang.get("paymentAccountRejected_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+			),
+		)
 	} else if (statusCode === PaymentDataResultType.CREDIT_CARD_DATE_INVALID) {
 		await Dialog.message("creditCardExprationDateInvalid_msg")
 	} else if (statusCode === PaymentDataResultType.CREDIT_CARD_NUMBER_INVALID) {
-		await Dialog.message(() => lang.get("creditCardNumberInvalid_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation(
+				"creditCardNumberInvalid_msg",
+				lang.get("creditCardNumberInvalid_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+			),
+		)
 	} else if (statusCode === PaymentDataResultType.COULD_NOT_VERIFY_VATID) {
-		await Dialog.message(() => lang.get("invalidVatIdValidationFailed_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation(
+				"invalidVatIdValidationFailed_msg",
+				lang.get("invalidVatIdValidationFailed_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+			),
+		)
 	} else if (statusCode === PaymentDataResultType.CREDIT_CARD_VERIFICATION_LIMIT_REACHED) {
-		await Dialog.message(() => lang.get("creditCardVerificationLimitReached_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation(
+				"creditCardVerificationLimitReached_msg",
+				lang.get("creditCardVerificationLimitReached_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+			),
+		)
 	} else {
-		await Dialog.message(() => lang.get("otherPaymentProviderError_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""))
+		await Dialog.message(
+			lang.makeTranslation(
+				"otherPaymentProviderError_msg",
+				lang.get("otherPaymentProviderError_msg") + (isSignup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+			),
+		)
 	}
 
 	return false

--- a/src/common/subscription/InvoiceDataDialog.ts
+++ b/src/common/subscription/InvoiceDataDialog.ts
@@ -40,7 +40,7 @@ export function show(
 	}
 
 	const dialog = Dialog.showActionDialog({
-		title: headingId ? lang.get(headingId) : lang.get("invoiceData_msg"),
+		title: headingId ? headingId : "invoiceData_msg",
 		child: {
 			view: () => m("#changeInvoiceDataDialog", [infoMessageId ? m(".pt", lang.get(infoMessageId)) : null, m(invoiceDataInput)]),
 		},

--- a/src/common/subscription/LeavingUserSurveyCategoryPage.ts
+++ b/src/common/subscription/LeavingUserSurveyCategoryPage.ts
@@ -2,7 +2,7 @@ import { emitWizardEvent, WizardEventType, WizardPageAttrs, WizardPageN } from "
 import { LeavingUserSurveyData } from "./LeavingUserSurveyWizard.js"
 import m, { Vnode, VnodeDOM } from "mithril"
 import { DropDownSelector, type DropDownSelectorAttrs } from "../gui/base/DropDownSelector.js"
-import { lang } from "../misc/LanguageViewModel.js"
+import { lang, type TranslationKey } from "../misc/LanguageViewModel.js"
 import { theme } from "../gui/theme.js"
 import { SetupLeavingUserSurveyPage } from "./SetupLeavingUserSurveyPage.js"
 
@@ -87,8 +87,8 @@ export class LeavingUserSurveyPageAttrs implements WizardPageAttrs<LeavingUserSu
 		this.data = leavingUserSurveyData
 	}
 
-	headerTitle(): string {
-		return lang.get("survey_label")
+	headerTitle(): TranslationKey {
+		return "survey_label"
 	}
 
 	nextAction(showErrorDialog: boolean): Promise<boolean> {

--- a/src/common/subscription/PaymentDataDialog.ts
+++ b/src/common/subscription/PaymentDataDialog.ts
@@ -86,7 +86,7 @@ export async function show(customer: Customer, accountingInfo: AccountingInfo, p
 		}
 
 		const dialog = Dialog.showActionDialog({
-			title: lang.get("adminPayment_action"),
+			title: "adminPayment_action",
 			child: {
 				view: () =>
 					m(
@@ -111,7 +111,7 @@ export async function show(customer: Customer, accountingInfo: AccountingInfo, p
 			okAction: confirmAction,
 			// if they've just gone through the process of linking a paypal account, don't offer a cancel button
 			allowCancel: () => !didLinkPaypal(),
-			okActionTextId: () => (didLinkPaypal() ? "close_alt" : "save_action"),
+			okActionTextId: didLinkPaypal() ? "close_alt" : "save_action",
 			cancelAction: () => resolve(false),
 		})
 	})

--- a/src/common/subscription/PaymentMethodInput.ts
+++ b/src/common/subscription/PaymentMethodInput.ts
@@ -237,7 +237,7 @@ class PaypalInput {
 					},
 				},
 				m(BaseButton, {
-					label: "PayPal",
+					label: lang.makeTranslation("PayPal", "PayPal"),
 					icon: m(".payment-logo.flex", m.trust(PayPalLogo)),
 					class: "border border-radius bg-white button-height plr",
 					onclick: () => {

--- a/src/common/subscription/PaymentViewer.ts
+++ b/src/common/subscription/PaymentViewer.ts
@@ -141,7 +141,7 @@ export class PaymentViewer implements UpdatableSettingsViewer {
 		if (isIOSApp()) {
 			// Paid users trying to change payment method on iOS with an active subscription
 			if (currentPaymentMethod !== PaymentMethodType.AppStore && this.customer?.type === AccountType.PAID) {
-				return Dialog.message(() => lang.get("storePaymentMethodChange_msg", { "{AppStorePaymentChange}": InfoLink.AppStorePaymentChange }))
+				return Dialog.message(lang.getTranslation("storePaymentMethodChange_msg", { "{AppStorePaymentChange}": InfoLink.AppStorePaymentChange }))
 			}
 
 			return locator.mobilePaymentsFacade.showSubscriptionConfigView()
@@ -152,7 +152,7 @@ export class PaymentViewer implements UpdatableSettingsViewer {
 			// they must downgrade to Free first.
 
 			const isResubscribe = await Dialog.choice(
-				() => lang.get("storeDowngradeOrResubscribe_msg", { "{AppStoreDowngrade}": InfoLink.AppStoreDowngrade }),
+				lang.getTranslation("storeDowngradeOrResubscribe_msg", { "{AppStoreDowngrade}": InfoLink.AppStoreDowngrade }),
 				[
 					{
 						text: "changePlan_action",
@@ -511,7 +511,7 @@ function showPayConfirmDialog(price: number): Promise<boolean> {
 					type: ButtonType.Primary,
 				},
 			],
-			middle: () => lang.get("adminPayment_action"),
+			middle: "adminPayment_action",
 		}
 		dialog = new Dialog(DialogType.EditSmall, {
 			view: (): Children => [
@@ -561,8 +561,8 @@ function getPostingTypeText(posting: CustomerAccountPosting): string {
 }
 
 export async function showManageThroughAppStoreDialog(): Promise<void> {
-	const confirmed = await Dialog.confirm(() =>
-		lang.get("storeSubscription_msg", {
+	const confirmed = await Dialog.confirm(
+		lang.getTranslation("storeSubscription_msg", {
 			"{AppStorePayment}": InfoLink.AppStorePayment,
 		}),
 	)

--- a/src/common/subscription/SignOrderProcessingAgreementDialog.ts
+++ b/src/common/subscription/SignOrderProcessingAgreementDialog.ts
@@ -58,7 +58,7 @@ export function showForSigning(customer: Customer, accountingInfo: AccountingInf
 		.setHtmlMonospace(false)
 		.setValue(formatNameAndAddress(accountingInfo.invoiceName, accountingInfo.invoiceAddress))
 	Dialog.showActionDialog({
-		title: lang.get("orderProcessingAgreement_label"),
+		title: "orderProcessingAgreement_label",
 		okAction: signAction,
 		okActionTextId: "sign_action",
 		type: DialogType.EditLarge,
@@ -112,7 +112,7 @@ function cleanupPrintElement() {
 
 export function showForViewing(agreement: OrderProcessingAgreement, signerUserGroupInfo: GroupInfo) {
 	Dialog.showActionDialog({
-		title: lang.get("orderProcessingAgreement_label"),
+		title: "orderProcessingAgreement_label",
 		okAction: !isApp() && "function" === typeof window.print ? () => printElementContent(document.getElementById("agreement-content")) : null,
 		okActionTextId: "print_action",
 		cancelActionTextId: "close_alt",

--- a/src/common/subscription/SignupForm.ts
+++ b/src/common/subscription/SignupForm.ts
@@ -104,11 +104,13 @@ export class SignupForm implements Component<SignupFormAttrs> {
 				if (!domain.isPaid || a.isPaidSubscription()) {
 					this.selectedDomain = domain
 				} else {
-					Dialog.confirm(() => `${lang.get("paidEmailDomainSignup_msg")}\n${lang.get("changePaidPlan_msg")}`).then((confirmed) => {
-						if (confirmed) {
-							vnode.attrs.onChangePlan()
-						}
-					})
+					Dialog.confirm(lang.makeTranslation("confirm_msg", `${lang.get("paidEmailDomainSignup_msg")}\n${lang.get("changePaidPlan_msg")}`)).then(
+						(confirmed) => {
+							if (confirmed) {
+								vnode.attrs.onChangePlan()
+							}
+						},
+					)
 				}
 			},
 			availableDomains: this.availableDomains,

--- a/src/common/subscription/SignupPage.ts
+++ b/src/common/subscription/SignupPage.ts
@@ -5,6 +5,7 @@ import { emitWizardEvent, WizardEventType } from "../gui/base/WizardDialog.js"
 import { SignupForm } from "./SignupForm"
 import { getDisplayNameOfPlanType } from "./FeatureListProvider"
 import { PlanType } from "../api/common/TutanotaConstants.js"
+import { lang, Translation, TranslationKey } from "../misc/LanguageViewModel.js"
 
 export class SignupPage implements WizardPageN<UpgradeSubscriptionData> {
 	private dom!: HTMLElement
@@ -42,13 +43,13 @@ export class SignupPageAttrs implements WizardPageAttrs<UpgradeSubscriptionData>
 		this.data = signupData
 	}
 
-	headerTitle(): string {
+	headerTitle(): Translation {
 		const title = getDisplayNameOfPlanType(this.data.type)
 
 		if (this.data.type === PlanType.Essential || this.data.type === PlanType.Advanced) {
-			return title + " Business"
+			return lang.makeTranslation("signup_business", title + " Business")
 		} else {
-			return title
+			return lang.makeTranslation("signup_title", title)
 		}
 	}
 

--- a/src/common/subscription/SimplifiedCreditCardInput.ts
+++ b/src/common/subscription/SimplifiedCreditCardInput.ts
@@ -66,7 +66,7 @@ export class SimplifiedCreditCardInput implements Component<SimplifiedCreditCard
 				autocompleteAs: Autocomplete.ccExp,
 			}),
 			m(TextField, {
-				label: () => viewModel.getCvvLabel(),
+				label: lang.makeTranslation("cvv", viewModel.getCvvLabel()),
 				value: viewModel.cvv,
 				helpLabel: () => this.renderCvvNumberHelpLabel(viewModel),
 				oninput: (newValue) => (viewModel.cvv = newValue),

--- a/src/common/subscription/SubscriptionSelector.ts
+++ b/src/common/subscription/SubscriptionSelector.ts
@@ -1,5 +1,5 @@
 import m, { Children, Component, Vnode } from "mithril"
-import type { TranslationKey, TranslationText } from "../misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel"
 import { lang } from "../misc/LanguageViewModel"
 import type { BuyOptionBoxAttr, BuyOptionDetailsAttr } from "./BuyOptionBox"
 import { BOX_MARGIN, BuyOptionBox, BuyOptionDetails, getActiveSubscriptionActionButtonReplacement } from "./BuyOptionBox"
@@ -60,7 +60,7 @@ export type SubscriptionSelectorAttr = {
 	priceAndConfigProvider: PriceAndConfigProvider
 	acceptedPlans: AvailablePlanType[]
 	multipleUsersAllowed: boolean
-	msg: TranslationText | null
+	msg: MaybeTranslation | null
 }
 
 export function getActionButtonBySubscription(actionButtons: SubscriptionActionButtons, subscription: AvailablePlanType): lazy<Children> {
@@ -96,7 +96,7 @@ export class SubscriptionSelector implements Component<SubscriptionSelectorAttr>
 	}
 
 	private renderHeadline(
-		msg: TranslationText | null,
+		msg: MaybeTranslation | null,
 		currentPlanType: PlanType | null,
 		priceInfoTextId: TranslationKey | null,
 		isBusiness: boolean,
@@ -107,7 +107,7 @@ export class SubscriptionSelector implements Component<SubscriptionSelectorAttr>
 		}
 
 		if (msg) {
-			return wrapInDiv(lang.getMaybeLazy(msg))
+			return wrapInDiv(lang.getTranslationText(msg))
 		} else if (currentPlanType != null && LegacyPlans.includes(currentPlanType)) {
 			return wrapInDiv(lang.get("currentPlanDiscontinued_msg"))
 		}
@@ -309,7 +309,7 @@ export class SubscriptionSelector implements Component<SubscriptionSelectorAttr>
 					: getActionButtonBySubscription(selectorAttrs.actionButtons, targetSubscription),
 			price: priceStr,
 			referencePrice: referencePriceStr,
-			priceHint: () => `${getPriceHint(subscriptionPrice, interval, multiuser)}${asteriskOrEmptyString}`,
+			priceHint: lang.makeTranslation("price_hint", `${getPriceHint(subscriptionPrice, interval, multiuser)}${asteriskOrEmptyString}`),
 			helpLabel: getHelpLabel(targetSubscription, selectorAttrs.options.businessUse()),
 			width: selectorAttrs.boxWidth,
 			height: selectorAttrs.boxHeight,

--- a/src/common/subscription/SubscriptionViewer.ts
+++ b/src/common/subscription/SubscriptionViewer.ts
@@ -166,10 +166,9 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 				this.showPriceData() ? this.renderIntervals() : null,
 				this.showPriceData() && this._nextPeriodPriceVisible && this._periodEndDate
 					? m(TextField, {
-							label: () =>
-								lang.get("priceFrom_label", {
-									"{date}": formatDate(new Date(neverNull(this._periodEndDate).getTime() + DAY)),
-								}),
+							label: lang.getTranslation("priceFrom_label", {
+								"{date}": formatDate(new Date(neverNull(this._periodEndDate).getTime() + DAY)),
+							}),
 							helpLabel: () => lang.get("nextSubscriptionPrice_msg"),
 							value: this._nextPriceFieldValue(),
 							oninput: this._nextPriceFieldValue,
@@ -296,8 +295,8 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 			const appStoreSubscriptionOwnership = await queryAppStoreSubscriptionOwnership(null)
 
 			if (appStoreSubscriptionOwnership !== MobilePaymentSubscriptionOwnership.NoSubscription) {
-				return Dialog.message(() =>
-					lang.get("storeMultiSubscriptionError_msg", {
+				return Dialog.message(
+					lang.getTranslation("storeMultiSubscriptionError_msg", {
 						"{AppStorePayment}": InfoLink.AppStorePayment,
 					}),
 				)
@@ -335,8 +334,8 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 		// This prevents the user from accidentally changing a subscription that they don't own
 		if (appStoreSubscriptionOwnership === MobilePaymentSubscriptionOwnership.NotOwner) {
 			// There's a subscription with this apple account that doesn't belong to this user
-			return Dialog.message(() =>
-				lang.get("storeMultiSubscriptionError_msg", {
+			return Dialog.message(
+				lang.getTranslation("storeMultiSubscriptionError_msg", {
 					"{AppStorePayment}": InfoLink.AppStorePayment,
 				}),
 			)
@@ -347,12 +346,12 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 		) {
 			// User has an ongoing subscriptions but not on the current Apple Account, so we shouldn't allow them to change their plan with this account
 			// instead of the account owner of the subscriptions
-			return Dialog.message(() => lang.get("storeNoSubscription_msg", { "{AppStorePayment}": InfoLink.AppStorePayment }))
+			return Dialog.message(lang.getTranslation("storeNoSubscription_msg", { "{AppStorePayment}": InfoLink.AppStorePayment }))
 		} else if (appStoreSubscriptionOwnership === MobilePaymentSubscriptionOwnership.NoSubscription) {
 			// User has no ongoing subscription and isn't approved. We should allow them to downgrade their accounts or resubscribe and
 			// restart an Apple Subscription flow
 			const isResubscribe = await Dialog.choice(
-				() => lang.get("storeDowngradeOrResubscribe_msg", { "{AppStoreDowngrade}": InfoLink.AppStoreDowngrade }),
+				lang.getTranslation("storeDowngradeOrResubscribe_msg", { "{AppStoreDowngrade}": InfoLink.AppStoreDowngrade }),
 				[
 					{
 						text: "changePlan_action",
@@ -422,7 +421,7 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 
 	private async handleAppOpen(app: SubscriptionApp) {
 		const appName = app === SubscriptionApp.Calendar ? "Tuta Calendar" : "Tuta Mail"
-		const dialogResult = await Dialog.confirm(() => lang.get("handleSubscriptionOnApp_msg", { "{1}": appName }), "yes_label")
+		const dialogResult = await Dialog.confirm(lang.getTranslation("handleSubscriptionOnApp_msg", { "{1}": appName }), "yes_label")
 		const query = stringToBase64(`settings=subscription`)
 
 		if (!dialogResult) {
@@ -717,12 +716,12 @@ export class SubscriptionViewer implements UpdatableSettingsViewer {
 						isReadOnly: true,
 				  }),
 			m(TextField, {
-				label: () =>
+				label:
 					this._nextPeriodPriceVisible && this._periodEndDate
-						? lang.get("priceTill_label", {
+						? lang.getTranslation("priceTill_label", {
 								"{date}": formatDate(this._periodEndDate),
 						  })
-						: lang.get("price_label"),
+						: "price_label",
 				value: this._currentPriceFieldValue(),
 				oninput: this._currentPriceFieldValue,
 				isReadOnly: true,
@@ -793,13 +792,11 @@ function _getAccountTypeName(type: AccountType, subscription: PlanType): string 
 
 function showChangeSubscriptionIntervalDialog(accountingInfo: AccountingInfo, paymentInterval: PaymentInterval, periodEndDate: Date | null): void {
 	if (accountingInfo && accountingInfo.invoiceCountry && asPaymentInterval(accountingInfo.paymentInterval) !== paymentInterval) {
-		const confirmationMessage = () => {
-			return periodEndDate
-				? lang.get("subscriptionChangePeriod_msg", {
-						"{1}": formatDate(periodEndDate),
-				  })
-				: lang.get("subscriptionChange_msg")
-		}
+		const confirmationMessage = periodEndDate
+			? lang.getTranslation("subscriptionChangePeriod_msg", {
+					"{1}": formatDate(periodEndDate),
+			  })
+			: "subscriptionChange_msg"
 
 		Dialog.confirm(confirmationMessage).then(async (confirmed) => {
 			if (confirmed) {
@@ -839,7 +836,7 @@ function renderGiftCardTable(giftCards: GiftCard[], isPremiumPredicate: () => bo
 							click: () => {
 								let message = stream(giftCard.message)
 								Dialog.showActionDialog({
-									title: lang.get("editMessage_label"),
+									title: "editMessage_label",
 									child: () =>
 										m(
 											".flex-center",

--- a/src/common/subscription/SwitchSubscriptionDialog.ts
+++ b/src/common/subscription/SwitchSubscriptionDialog.ts
@@ -1,6 +1,6 @@
 import m from "mithril"
 import { Dialog } from "../gui/base/Dialog"
-import { lang, TranslationText } from "../misc/LanguageViewModel"
+import { lang, MaybeTranslation } from "../misc/LanguageViewModel"
 import { ButtonType } from "../gui/base/Button.js"
 import { AccountingInfo, Booking, createSurveyData, createSwitchAccountTypePostIn, Customer, CustomerInfo, SurveyData } from "../api/entities/sys/TypeRefs.js"
 import {
@@ -55,7 +55,7 @@ export async function showSwitchDialog(
 	accountingInfo: AccountingInfo,
 	lastBooking: Booking,
 	acceptedPlans: AvailablePlanType[],
-	reason: TranslationText | null,
+	reason: MaybeTranslation | null,
 ): Promise<void> {
 	if (hasRunningAppStoreSubscription(accountingInfo) && !isIOSApp()) {
 		await showManageThroughAppStoreDialog()
@@ -83,7 +83,7 @@ export async function showSwitchDialog(
 			},
 		],
 		right: [],
-		middle: () => lang.get("subscription_label"),
+		middle: "subscription_label",
 	}
 	const currentPlanInfo = model.currentPlanInfo
 	const businessUse = stream(currentPlanInfo.businessUse)
@@ -93,7 +93,8 @@ export async function showSwitchDialog(
 	const dialog: Dialog = Dialog.largeDialog(headerBarAttrs, {
 		view: () =>
 			m(
-				"#upgrade-account-dialog.pt",
+				".pt",
+				{ "data-testid": "upgrade-account-dialog" },
 				m(SubscriptionSelector, {
 					options: {
 						businessUse,
@@ -220,7 +221,7 @@ function createPlanButton(
 			// Show an extra dialog in the case that someone is upgrading from a legacy plan to a new plan because they can't revert.
 			if (
 				LegacyPlans.includes(currentPlanInfo.planType) &&
-				!(await Dialog.confirm(() => lang.get("upgradePlan_msg", { "{plan}": PlanTypeToName[targetSubscription] })))
+				!(await Dialog.confirm(lang.getTranslation("upgradePlan_msg", { "{plan}": PlanTypeToName[targetSubscription] })))
 			) {
 				return
 			}
@@ -302,8 +303,8 @@ function handleSwitchAccountPreconditionFailed(e: PreconditionFailedError): Prom
 				throw e
 		}
 
-		return Dialog.message(() =>
-			lang.get("accountSwitchNotPossible_msg", {
+		return Dialog.message(
+			lang.getTranslation("accountSwitchNotPossible_msg", {
 				"{detailMsg}": detailMsg,
 			}),
 		)

--- a/src/common/subscription/SwitchToBusinessInvoiceDataDialog.ts
+++ b/src/common/subscription/SwitchToBusinessInvoiceDataDialog.ts
@@ -1,6 +1,5 @@
 import m from "mithril"
 import { Dialog } from "../gui/base/Dialog"
-import { lang } from "../misc/LanguageViewModel"
 import { InvoiceDataInput, InvoiceDataInputLocation } from "./InvoiceDataInput"
 import { updatePaymentData } from "./InvoiceAndPaymentDataPage"
 import { BadRequestError } from "../api/common/error/RestError"
@@ -61,7 +60,7 @@ export function showSwitchToBusinessInvoiceDataDialog(customer: Customer, invoic
 	const cancelAction = () => result.resolve(false)
 
 	const dialog = Dialog.showActionDialog({
-		title: lang.get("invoiceData_msg"),
+		title: "invoiceData_msg",
 		child: {
 			view: () =>
 				m("#changeInvoiceDataDialog", [

--- a/src/common/subscription/TermsAndConditions.ts
+++ b/src/common/subscription/TermsAndConditions.ts
@@ -80,7 +80,7 @@ export async function showServiceTerms(section: TermsSection, version: string) {
 	let headerBarAttrs: DialogHeaderBarAttrs = {
 		left: [
 			{
-				label: () => "EN/DE",
+				label: lang.makeTranslation("lang_toggle", "EN/DE"),
 				click: () => {
 					visibleLang = visibleLang === "de" ? "en" : "de"
 					sanitizedTerms = getSection()

--- a/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
+++ b/src/common/subscription/UpgradeConfirmSubscriptionPage.ts
@@ -95,18 +95,22 @@ export class UpgradeConfirmSubscriptionPage implements WizardPageN<UpgradeSubscr
 			.catch(
 				ofClass(PreconditionFailedError, (e) => {
 					Dialog.message(
-						() =>
+						lang.makeTranslation(
+							"precondition_failed",
 							lang.get(getPreconditionFailedPaymentMsg(e.data)) +
-							(data.upgradeType === UpgradeType.Signup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+								(data.upgradeType === UpgradeType.Signup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+						),
 					)
 				}),
 			)
 			.catch(
 				ofClass(BadGatewayError, (e) => {
 					Dialog.message(
-						() =>
+						lang.makeTranslation(
+							"payment_failed",
 							lang.get("paymentProviderNotAvailableError_msg") +
-							(data.upgradeType === UpgradeType.Signup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+								(data.upgradeType === UpgradeType.Signup ? " " + lang.get("accountWasStillCreated_msg") : ""),
+						),
 					)
 				}),
 			)

--- a/src/common/subscription/UpgradeCongratulationsPage.ts
+++ b/src/common/subscription/UpgradeCongratulationsPage.ts
@@ -1,5 +1,5 @@
 import m, { Children, Vnode, VnodeDOM } from "mithril"
-import { lang } from "../misc/LanguageViewModel"
+import { lang, type TranslationKey } from "../misc/LanguageViewModel"
 import type { UpgradeSubscriptionData } from "./UpgradeSubscriptionWizard"
 import type { WizardPageAttrs, WizardPageN } from "../gui/base/WizardDialog.js"
 import { emitWizardEvent, WizardEventType } from "../gui/base/WizardDialog.js"
@@ -81,8 +81,8 @@ export class UpgradeCongratulationsPageAttrs implements WizardPageAttrs<UpgradeS
 		this.data = upgradeData
 	}
 
-	headerTitle(): string {
-		return lang.get("accountCongratulations_msg")
+	headerTitle(): TranslationKey {
+		return "accountCongratulations_msg"
 	}
 
 	nextAction(showDialogs: boolean): Promise<boolean> {

--- a/src/common/subscription/UpgradeSubscriptionPage.ts
+++ b/src/common/subscription/UpgradeSubscriptionPage.ts
@@ -1,6 +1,6 @@
 import m, { Children, Vnode, VnodeDOM } from "mithril"
 import stream from "mithril/stream"
-import { lang } from "../misc/LanguageViewModel"
+import { lang, type TranslationKey } from "../misc/LanguageViewModel"
 import type { SubscriptionParameters, UpgradeSubscriptionData } from "./UpgradeSubscriptionWizard"
 import { SubscriptionActionButtons, SubscriptionSelector } from "./SubscriptionSelector"
 import { Button, ButtonType } from "../gui/base/Button.js"
@@ -80,13 +80,7 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 			},
 			[PlanType.Revolutionary]: this.createUpgradeButton(data, PlanType.Revolutionary),
 			[PlanType.Legend]: () => ({
-				label: () => {
-					if (shouldApplyCyberMonday) {
-						return lang.get("pricing.cyber_monday_select_action")
-					}
-
-					return lang.get("pricing.select_action")
-				},
+				label: shouldApplyCyberMonday ? "pricing.cyber_monday_select_action" : "pricing.select_action",
 				class: shouldApplyCyberMonday ? "accent-bg-cyber-monday" : undefined,
 				onclick: () => this.setNonFreeDataAndGoToNextPage(data, PlanType.Legend),
 			}),
@@ -94,7 +88,7 @@ export class UpgradeSubscriptionPage implements WizardPageN<UpgradeSubscriptionD
 			[PlanType.Advanced]: this.createUpgradeButton(data, PlanType.Advanced),
 			[PlanType.Unlimited]: this.createUpgradeButton(data, PlanType.Unlimited),
 		}
-		return m("#upgrade-account-dialog.pt", [
+		return m(".pt", { "data-testid": "upgrade-account-dialog" }, [
 			m(SubscriptionSelector, {
 				options: data.options,
 				priceInfoTextId: data.priceInfoTextId,
@@ -241,7 +235,7 @@ function confirmFreeSubscription(): Promise<boolean> {
 		dialog = new Dialog(DialogType.Alert, {
 			view: () => [
 				// m(".h2.pb", lang.get("confirmFreeAccount_label")),
-				m("#dialog-message.dialog-contentButtonsBottom.text-break.text-prewrap.selectable", lang.getMaybeLazy("freeAccountInfo_msg")),
+				m("#dialog-message.dialog-contentButtonsBottom.text-break.text-prewrap.selectable", lang.getTranslationText("freeAccountInfo_msg")),
 				m(".dialog-contentButtonsBottom", [
 					m(Checkbox, {
 						label: () => lang.get("confirmNoOtherFreeAccount_msg"),
@@ -296,8 +290,8 @@ export class UpgradeSubscriptionPageAttrs implements WizardPageAttrs<UpgradeSubs
 		this.data = upgradeData
 	}
 
-	headerTitle(): string {
-		return lang.get("subscription_label")
+	headerTitle(): TranslationKey {
+		return "subscription_label"
 	}
 
 	nextAction(showErrorDialog: boolean): Promise<boolean> {

--- a/src/common/subscription/UpgradeSubscriptionWizard.ts
+++ b/src/common/subscription/UpgradeSubscriptionWizard.ts
@@ -15,7 +15,7 @@ import { getByAbbreviation } from "../api/common/CountryList"
 import { UpgradeSubscriptionPage, UpgradeSubscriptionPageAttrs } from "./UpgradeSubscriptionPage"
 import m from "mithril"
 import stream from "mithril/stream"
-import { InfoLink, lang, TranslationKey, TranslationText } from "../misc/LanguageViewModel"
+import { InfoLink, lang, TranslationKey, MaybeTranslation } from "../misc/LanguageViewModel"
 import { createWizardDialog, wizardPageWrapper } from "../gui/base/WizardDialog.js"
 import { InvoiceAndPaymentDataPage, InvoiceAndPaymentDataPageAttrs } from "./InvoiceAndPaymentDataPage"
 import { UpgradeCongratulationsPage, UpgradeCongratulationsPageAttrs } from "./UpgradeCongratulationsPage.js"
@@ -66,10 +66,10 @@ export type UpgradeSubscriptionData = {
 	referralCode: string | null
 	multipleUsersAllowed: boolean
 	acceptedPlans: AvailablePlanType[]
-	msg: TranslationText | null
+	msg: MaybeTranslation | null
 }
 
-export async function showUpgradeWizard(logins: LoginController, acceptedPlans: AvailablePlanType[] = NewPaidPlans, msg?: TranslationText): Promise<void> {
+export async function showUpgradeWizard(logins: LoginController, acceptedPlans: AvailablePlanType[] = NewPaidPlans, msg?: MaybeTranslation): Promise<void> {
 	const [customer, accountingInfo] = await Promise.all([logins.getUserController().loadCustomer(), logins.getUserController().loadAccountingInfo()])
 
 	const priceDataProvider = await PriceAndConfigProvider.getInitializedInstance(null, locator.serviceExecutor, null)
@@ -149,7 +149,7 @@ export async function loadSignupWizard(
 	const domainConfig = locator.domainConfigProvider().getCurrentDomainConfig()
 	const featureListProvider = await FeatureListProvider.getInitializedInstance(domainConfig)
 
-	let message: TranslationText | null
+	let message: MaybeTranslation | null
 	if (isIOSApp()) {
 		const appstoreSubscriptionOwnership = await queryAppStoreSubscriptionOwnership(null)
 		// if we are on iOS app we only show other plans if AppStore payments are enabled and there's no subscription for this Apple ID.
@@ -158,7 +158,7 @@ export async function loadSignupWizard(
 		}
 		message =
 			appstoreSubscriptionOwnership != MobilePaymentSubscriptionOwnership.NoSubscription
-				? () => lang.get("storeMultiSubscriptionError_msg", { "{AppStorePayment}": InfoLink.AppStorePayment })
+				? lang.getTranslation("storeMultiSubscriptionError_msg", { "{AppStorePayment}": InfoLink.AppStorePayment })
 				: null
 	} else {
 		message = null

--- a/src/common/subscription/giftcards/GiftCardUtils.ts
+++ b/src/common/subscription/giftcards/GiftCardUtils.ts
@@ -3,7 +3,7 @@ import { Icons } from "../../gui/base/icons/Icons"
 import type { CustomerInfo, GiftCard } from "../../api/entities/sys/TypeRefs.js"
 import { CustomerInfoTypeRef, CustomerTypeRef, GiftCardTypeRef } from "../../api/entities/sys/TypeRefs.js"
 import { locator } from "../../api/main/CommonLocator"
-import { lang, TranslationText } from "../../misc/LanguageViewModel"
+import { lang, MaybeTranslation } from "../../misc/LanguageViewModel"
 import { UserError } from "../../api/main/UserError"
 import { Dialog } from "../../gui/base/Dialog"
 import { ButtonType } from "../../gui/base/Button.js"
@@ -66,7 +66,7 @@ export async function generateGiftCardLink(giftCard: GiftCard): Promise<string> 
 
 export function showGiftCardToShare(giftCard: GiftCard) {
 	generateGiftCardLink(giftCard).then((link) => {
-		let infoMessage: TranslationText = "emptyString_msg"
+		let infoMessage: MaybeTranslation = "emptyString_msg"
 		const dialog: Dialog = Dialog.largeDialog(
 			{
 				right: [
@@ -76,7 +76,7 @@ export function showGiftCardToShare(giftCard: GiftCard) {
 						click: () => dialog.close(),
 					},
 				],
-				middle: () => lang.get("giftCard_label"),
+				middle: "giftCard_label",
 			},
 			{
 				view: () => [
@@ -141,7 +141,7 @@ export function showGiftCardToShare(giftCard: GiftCard) {
 							  })
 							: null,
 					]),
-					m(".flex-center", m("small.noprint", lang.getMaybeLazy(infoMessage))),
+					m(".flex-center", m("small.noprint", lang.getTranslationText(infoMessage))),
 				],
 			},
 		)

--- a/src/common/subscription/giftcards/PurchaseGiftCardDialog.ts
+++ b/src/common/subscription/giftcards/PurchaseGiftCardDialog.ts
@@ -12,7 +12,7 @@ import type { DialogHeaderBarAttrs } from "../../gui/base/DialogHeaderBar"
 import { showUserError } from "../../misc/ErrorHandlerImpl"
 import { UserError } from "../../api/main/UserError"
 import { Keys, PaymentMethodType, PlanType } from "../../api/common/TutanotaConstants"
-import { lang } from "../../misc/LanguageViewModel"
+import { lang, Translation } from "../../misc/LanguageViewModel"
 import { BadGatewayError, PreconditionFailedError } from "../../api/common/error/RestError"
 import { GiftCardMessageEditorField } from "./GiftCardMessageEditorField"
 import { client } from "../../misc/ClientDetector"
@@ -82,8 +82,8 @@ class PurchaseGiftCardModel {
 
 			switch (message) {
 				case "giftcard.limitreached":
-					throw new UserError(() =>
-						lang.get("tooManyGiftCards_msg", {
+					throw new UserError(
+						lang.getTranslation("tooManyGiftCards_msg", {
 							"{amount}": `${this.purchaseLimit}`,
 							"{period}": `${this.purchasePeriodMonths} months`,
 						}),
@@ -143,7 +143,7 @@ class GiftCardPurchaseView implements Component<GiftCardPurchaseViewAttrs> {
 								},
 							}),
 						price: formatPrice(value, true),
-						helpLabel: () => this.getGiftCardHelpText(model.revolutionaryPrice, value),
+						helpLabel: this.getGiftCardHelpText(model.revolutionaryPrice, value),
 						width: 230,
 						height: 250,
 						selectedPaymentInterval: null,
@@ -174,7 +174,7 @@ class GiftCardPurchaseView implements Component<GiftCardPurchaseViewAttrs> {
 		onPurchaseSuccess(giftCard)
 	}
 
-	private getGiftCardHelpText(upgradePrice: number, giftCardValue: number): string {
+	private getGiftCardHelpText(upgradePrice: number, giftCardValue: number): Translation {
 		let helpTextId: TranslationKeyType
 		if (giftCardValue < upgradePrice) {
 			helpTextId = "giftCardOptionTextC_msg"
@@ -183,7 +183,7 @@ class GiftCardPurchaseView implements Component<GiftCardPurchaseViewAttrs> {
 		} else {
 			helpTextId = "giftCardOptionTextE_msg"
 		}
-		return lang.get(helpTextId, {
+		return lang.getTranslation(helpTextId, {
 			"{remainingCredit}": formatPrice(giftCardValue - upgradePrice, true),
 			"{fullCredit}": formatPrice(giftCardValue, true),
 		})
@@ -221,7 +221,7 @@ export async function showPurchaseGiftCardDialog() {
 				click: () => dialog.close(),
 			},
 		],
-		middle: () => lang.get("buyGiftCard_label"),
+		middle: "buyGiftCard_label",
 	}
 
 	const content = {
@@ -270,8 +270,8 @@ async function loadGiftCardModel(): Promise<PurchaseGiftCardModel> {
 	const numPurchasedGiftCards = count(existingGiftCards, (giftCard) => giftCard.orderDate > sixMonthsAgo)
 
 	if (numPurchasedGiftCards >= parseInt(giftCardInfo.maxPerPeriod)) {
-		throw new UserError(() =>
-			lang.get("tooManyGiftCards_msg", {
+		throw new UserError(
+			lang.getTranslation("tooManyGiftCards_msg", {
 				"{amount}": giftCardInfo.maxPerPeriod,
 				"{period}": `${giftCardInfo.period} months`,
 			}),

--- a/src/common/subscription/giftcards/RedeemGiftCardWizard.ts
+++ b/src/common/subscription/giftcards/RedeemGiftCardWizard.ts
@@ -147,7 +147,7 @@ class RedeemGiftCardModel {
 			)
 			.catch(
 				ofClass(NotAuthorizedError, (e) => {
-					throw new UserError(() => e.message)
+					throw new UserError(lang.makeTranslation("error_msg", e.message))
 				}),
 			)
 	}
@@ -282,7 +282,7 @@ class GiftCardCredentialsPage implements WizardPageN<RedeemGiftCardModel> {
 						if (e instanceof UserError) {
 							showUserError(e)
 						} else {
-							this.loginFormHelpText = lang.getMaybeLazy(getLoginErrorMessage(e, false))
+							this.loginFormHelpText = lang.getTranslationText(getLoginErrorMessage(e, false))
 						}
 					}
 				}
@@ -308,7 +308,7 @@ class GiftCardCredentialsPage implements WizardPageN<RedeemGiftCardModel> {
 					if (e instanceof UserError) {
 						showUserError(e)
 					} else {
-						this.loginFormHelpText = lang.getMaybeLazy(getLoginErrorMessage(e, false))
+						this.loginFormHelpText = lang.getTranslationText(getLoginErrorMessage(e, false))
 						handleExpectedLoginError(e, noOp)
 					}
 				}
@@ -508,21 +508,21 @@ export async function loadRedeemGiftCardWizard(hashFromUrl: string): Promise<Dia
 	const wizardPages = [
 		wizardPageWrapper(GiftCardWelcomePage, {
 			data: model,
-			headerTitle: () => lang.get("giftCard_label"),
+			headerTitle: () => "giftCard_label",
 			nextAction: async () => true,
 			isSkipAvailable: () => false,
 			isEnabled: () => true,
 		}),
 		wizardPageWrapper(GiftCardCredentialsPage, {
 			data: model,
-			headerTitle: () => lang.get(model.credentialsMethod === GetCredentialsMethod.Signup ? "register_label" : "login_label"),
+			headerTitle: () => (model.credentialsMethod === GetCredentialsMethod.Signup ? "register_label" : "login_label"),
 			nextAction: async () => true,
 			isSkipAvailable: () => false,
 			isEnabled: () => true,
 		}),
 		wizardPageWrapper(RedeemGiftCardPage, {
 			data: model,
-			headerTitle: () => lang.get("redeem_label"),
+			headerTitle: () => "redeem_label",
 			nextAction: async () => true,
 			isSkipAvailable: () => false,
 			isEnabled: () => true,

--- a/src/common/support/SupportDialog.ts
+++ b/src/common/support/SupportDialog.ts
@@ -55,7 +55,7 @@ export async function showSupportDialog(logins: LoginController) {
 
 	const header: DialogHeaderBarAttrs = {
 		left: [closeButton],
-		middle: () => lang.get("supportMenu_label"),
+		middle: "supportMenu_label",
 	}
 	const child: Component = {
 		view: () => {
@@ -63,7 +63,7 @@ export async function showSupportDialog(logins: LoginController) {
 				m(".pt"),
 				m(".h1 .text-center", lang.get("howCanWeHelp_title")),
 				m(TextField, {
-					label: () => lang.get("describeProblem_msg"),
+					label: "describeProblem_msg",
 					value: searchValue(),
 					oninput: searchValue,
 				}),

--- a/src/common/termination/TerminationView.ts
+++ b/src/common/termination/TerminationView.ts
@@ -111,7 +111,7 @@ export class TerminationView extends BaseTopLevelView implements TopLevelView<Te
 			onDateChanged: (date) => (this.model.date = date),
 			terminationPeriodOption: this.model.terminationPeriodOption,
 			onTerminationPeriodOptionChanged: (option) => (this.model.terminationPeriodOption = option),
-			helpText: lang.getMaybeLazy(this.model.helpText),
+			helpText: lang.getTranslationText(this.model.helpText),
 		})
 	}
 }

--- a/src/common/termination/TerminationViewModel.ts
+++ b/src/common/termination/TerminationViewModel.ts
@@ -1,6 +1,6 @@
 import { SessionType } from "../api/common/SessionType.js"
 import { LoginState } from "../login/LoginViewModel.js"
-import { InfoLink, lang, TranslationText } from "../misc/LanguageViewModel.js"
+import { InfoLink, lang, MaybeTranslation } from "../misc/LanguageViewModel.js"
 import { LoginController } from "../api/main/LoginController.js"
 import { getLoginErrorStateAndMessage } from "../misc/LoginUtils.js"
 import { SecondFactorHandler } from "../misc/2fa/SecondFactorHandler.js"
@@ -23,7 +23,7 @@ export class TerminationViewModel {
 	date: Date
 	terminationPeriodOption: TerminationPeriodOptions
 	acceptedTerminationRequest: CustomerAccountTerminationRequest | null
-	helpText: TranslationText
+	helpText: MaybeTranslation
 	loginState: LoginState
 
 	constructor(
@@ -72,8 +72,8 @@ export class TerminationViewModel {
 						this.onTerminationRequestFailed("terminationNoActiveSubscription_msg")
 						break
 					case "hasAppStoreSubscription":
-						this.onTerminationRequestFailed(() =>
-							lang.get("deleteAccountWithAppStoreSubscription_msg", { "{AppStorePayment}": InfoLink.AppStorePayment }),
+						this.onTerminationRequestFailed(
+							lang.getTranslation("deleteAccountWithAppStoreSubscription_msg", { "{AppStorePayment}": InfoLink.AppStorePayment }),
 						)
 						break
 					default:
@@ -88,7 +88,7 @@ export class TerminationViewModel {
 		}
 	}
 
-	private onTerminationRequestFailed(errorMessage: TranslationText) {
+	private onTerminationRequestFailed(errorMessage: MaybeTranslation) {
 		this.helpText = errorMessage
 	}
 
@@ -97,7 +97,7 @@ export class TerminationViewModel {
 		this.loginState = LoginState.LoggedIn
 	}
 
-	private onError(helpText: TranslationText, state: LoginState) {
+	private onError(helpText: MaybeTranslation, state: LoginState) {
 		this.helpText = helpText
 		this.loginState = state
 	}

--- a/src/mail-app/contacts/ContactAggregateEditor.ts
+++ b/src/mail-app/contacts/ContactAggregateEditor.ts
@@ -1,5 +1,5 @@
 import { Autocapitalize, TextField, TextFieldType } from "../../common/gui/base/TextField.js"
-import { lang, TranslationKey, TranslationText } from "../../common/misc/LanguageViewModel"
+import { lang, TranslationKey, MaybeTranslation } from "../../common/misc/LanguageViewModel"
 import m, { Children, Component, Vnode, VnodeDOM } from "mithril"
 import { Icons } from "../../common/gui/base/icons/Icons"
 import { animations, height, opacity } from "../../common/gui/animation/Animations"
@@ -17,8 +17,8 @@ export type AggregateEditorAttrs<AggregateType> = {
 	allowCancel?: boolean
 	fieldType: TextFieldType
 	onUpdate: (newValue: string) => unknown
-	label: string
-	helpLabel: TranslationText
+	label: MaybeTranslation
+	helpLabel: MaybeTranslation
 	typeLabels: ReadonlyArray<[AggregateType, TranslationKey]>
 	onTypeSelected: (arg0: AggregateType) => unknown
 	autocapitalizeTextField?: Autocapitalize
@@ -36,20 +36,13 @@ export class ContactAggregateEditor implements Component<AggregateEditorAttrs<an
 
 	view(vnode: Vnode<AggregateEditorAttrs<any>>): Children {
 		const attrs = vnode.attrs
-		const helpLabel = () => {
-			if (typeof attrs.helpLabel === "function") {
-				return attrs.helpLabel()
-			}
-
-			return lang.get(attrs.helpLabel)
-		}
 		return m(".flex.items-center.child-grow", [
 			m(TextField, {
 				value: attrs.value,
-				label: () => attrs.label,
+				label: attrs.label,
 				type: attrs.fieldType,
 				autocapitalize: attrs.autocapitalizeTextField,
-				helpLabel: () => helpLabel(),
+				helpLabel: () => lang.getTranslationText(attrs.helpLabel),
 				injectionsRight: () => this._moreButtonFor(attrs),
 				oninput: (value) => attrs.onUpdate(value),
 			}),

--- a/src/mail-app/contacts/ContactEditor.ts
+++ b/src/mail-app/contacts/ContactEditor.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { Dialog } from "../../common/gui/base/Dialog"
-import type { TranslationKey } from "../../common/misc/LanguageViewModel"
+import type { Translation, TranslationKey } from "../../common/misc/LanguageViewModel"
 import { lang } from "../../common/misc/LanguageViewModel"
 import { isMailAddress } from "../../common/misc/FormatValidator"
 import { formatBirthdayNumeric, formatContactDate } from "../../common/contactsFunctionality/ContactUtils.js"
@@ -381,17 +381,17 @@ export class ContactEditor {
 	}
 
 	private renderCustomDatesEditor(id: Id, allowCancel: boolean, date: CompleteCustomDate): Children {
-		let dateHelpText = () => {
+		let dateHelpText = (): Translation => {
 			let bday = createBirthday({
 				day: "22",
 				month: "9",
 				year: "2000",
 			})
 			return !date.isValid
-				? lang.get("invalidDateFormat_msg", {
+				? lang.getTranslation("invalidDateFormat_msg", {
 						"{1}": formatBirthdayNumeric(bday),
 				  })
-				: ""
+				: lang.getTranslation("emptyString_msg")
 		}
 
 		const typeLabels: Array<[ContactCustomDateType, TranslationKey]> = typedEntries(ContactCustomDateTypeToLabel)
@@ -399,7 +399,7 @@ export class ContactEditor {
 			value: date.date,
 			fieldType: TextFieldType.Text,
 			label: getContactCustomDateTypeToLabel(downcast(date.type), date.customTypeName),
-			helpLabel: () => dateHelpText(),
+			helpLabel: dateHelpText(),
 			cancelAction: () => {
 				findAndRemove(this.customDates, (t) => t[1] === id)
 			},
@@ -601,7 +601,7 @@ export class ContactEditor {
 		return m(ContactAggregateEditor, {
 			value: pronouns.pronouns,
 			fieldType: TextFieldType.Text,
-			label: pronouns.language,
+			label: lang.makeTranslation("lang", pronouns.language),
 			helpLabel: "emptyString_msg",
 			autocapitalizeTextField: Autocapitalize.none,
 			cancelAction: () => {
@@ -871,7 +871,7 @@ export class ContactEditor {
 	private createDialog(): Dialog {
 		const headerBarAttrs: DialogHeaderBarAttrs = {
 			left: [this.createCloseButtonAttrs()],
-			middle: () => this.contact.firstName + " " + this.contact.lastName,
+			middle: lang.makeTranslation("name", this.contact.firstName + " " + this.contact.lastName),
 			right: [
 				{
 					label: "save_action",

--- a/src/mail-app/contacts/ContactImporter.ts
+++ b/src/mail-app/contacts/ContactImporter.ts
@@ -3,7 +3,7 @@ import { assertNotNull, getFirstOrThrow, ofClass, promiseMap } from "@tutao/tuta
 import { locator } from "../../common/api/main/CommonLocator.js"
 import { vCardFileToVCards, vCardListToContacts } from "./VCardImporter.js"
 import { ImportError } from "../../common/api/common/error/ImportError.js"
-import { lang, TranslationText } from "../../common/misc/LanguageViewModel.js"
+import { lang, MaybeTranslation } from "../../common/misc/LanguageViewModel.js"
 import { showProgressDialog } from "../../common/gui/dialogs/ProgressDialog.js"
 import { ContactFacade } from "../../common/api/worker/facades/lazy/ContactFacade.js"
 import {
@@ -75,20 +75,26 @@ export class ContactImporter {
 			.importContactList(contacts, contactListId)
 			.catch(
 				ofClass(ImportError, (e) =>
-					Dialog.message(() =>
-						lang.get("importContactsError_msg", {
-							"{amount}": e.numFailed + "",
-							"{total}": contacts.length + "",
-						}),
+					Dialog.message(
+						lang.makeTranslation(
+							"confirm_msg",
+							lang.get("importContactsError_msg", {
+								"{amount}": e.numFailed + "",
+								"{total}": contacts.length + "",
+							}),
+						),
 					),
 				),
 			)
 			.catch(() => Dialog.message("unknownError_msg"))
 		await showProgressDialog("pleaseWait_msg", importPromise)
-		await Dialog.message(() =>
-			lang.get("importVCardSuccess_msg", {
-				"{1}": contacts.length,
-			}),
+		await Dialog.message(
+			lang.makeTranslation(
+				"confirm_msg",
+				lang.get("importVCardSuccess_msg", {
+					"{1}": contacts.length,
+				}),
+			),
 		)
 	}
 
@@ -246,7 +252,7 @@ export class ContactImporter {
  * @param contacts The contact list to be previewed
  * @param okAction The action to be executed when the user press the import button with at least one contact selected
  */
-export function showContactImportDialog(contacts: Contact[], okAction: (dialog: Dialog, selectedContacts: Contact[]) => unknown, title: TranslationText) {
+export function showContactImportDialog(contacts: Contact[], okAction: (dialog: Dialog, selectedContacts: Contact[]) => unknown, title: MaybeTranslation) {
 	const viewModel: ContactImportDialogViewModel = new ContactImportDialogViewModel()
 	viewModel.selectContacts(contacts)
 	const renderConfig: RenderConfig<Contact, KindaContactRow> = {
@@ -275,7 +281,7 @@ export function showContactImportDialog(contacts: Contact[], okAction: (dialog: 
 						},
 					},
 				],
-				middle: () => lang.getMaybeLazy(title),
+				middle: title,
 				right: [
 					{
 						type: ButtonType.Primary,

--- a/src/mail-app/contacts/ContactListEditor.ts
+++ b/src/mail-app/contacts/ContactListEditor.ts
@@ -11,7 +11,7 @@ import { Icons } from "../../common/gui/base/icons/Icons.js"
 import { MailRecipientsTextField } from "../../common/gui/MailRecipientsTextField.js"
 import { RecipientsSearchModel } from "../../common/misc/RecipientsSearchModel.js"
 import { lazy, noOp } from "@tutao/tutanota-utils"
-import { lang } from "../../common/misc/LanguageViewModel.js"
+import { lang, TranslationKey } from "../../common/misc/LanguageViewModel.js"
 import { isSameId } from "../../common/api/common/utils/EntityUtils.js"
 import { Keys } from "../../common/api/common/TutanotaConstants.js"
 import { isMailAddress } from "../../common/misc/FormatValidator.js"
@@ -19,7 +19,7 @@ import { cleanMailAddress } from "../../common/api/common/utils/CommonCalendarUt
 
 export async function showContactListEditor(
 	contactListGroupRoot: ContactListGroupRoot | null,
-	headerText: string,
+	headerText: TranslationKey,
 	save: (name: string, addresses: Array<string>) => void,
 	addressesOnList?: Array<string>,
 ): Promise<void> {
@@ -59,7 +59,7 @@ export async function showContactListEditor(
 				type: ButtonType.Primary,
 			},
 		],
-		middle: () => headerText,
+		middle: headerText,
 	}
 
 	const dialog = Dialog.editDialog(headerBarAttrs, ContactListEditor, {
@@ -91,7 +91,7 @@ export async function showContactListNameEditor(name: string, save: (name: strin
 	}
 
 	Dialog.showActionDialog({
-		title: lang.get("editContactList_action"),
+		title: "editContactList_action",
 		child: form,
 		allowOkWithReturn: true,
 		okAction: okAction,

--- a/src/mail-app/contacts/model/NativeContactsSyncManager.ts
+++ b/src/mail-app/contacts/model/NativeContactsSyncManager.ts
@@ -249,7 +249,7 @@ export class NativeContactsSyncManager {
 			return
 		}
 
-		const shouldDedupe = await Dialog.confirm(() => lang.get("importContactRemoveDuplicatesConfirm_msg", { "{count}": duplicateContacts.length }))
+		const shouldDedupe = await Dialog.confirm(lang.getTranslation("importContactRemoveDuplicatesConfirm_msg", { "{count}": duplicateContacts.length }))
 		if (shouldDedupe) {
 			await showProgressDialog("progressDeleting_msg", this.mobileContactsFacade.deleteLocalContacts(duplicateContacts))
 		}

--- a/src/mail-app/contacts/view/ContactGuiUtils.ts
+++ b/src/mail-app/contacts/view/ContactGuiUtils.ts
@@ -7,16 +7,10 @@ import {
 	ContactSocialType,
 	ContactWebsiteType,
 } from "../../../common/api/common/TutanotaConstants"
-import type { TranslationKey } from "../../../common/misc/LanguageViewModel"
+import type { MaybeTranslation, Translation, TranslationKey } from "../../../common/misc/LanguageViewModel"
 import { lang } from "../../../common/misc/LanguageViewModel"
 import type { Contact } from "../../../common/api/entities/tutanota/TypeRefs.js"
 import { sortCompareByReverseId } from "../../../common/api/common/utils/EntityUtils"
-import { locator } from "../../../common/api/main/CommonLocator"
-import { PermissionType } from "../../../common/native/common/generatedipc/PermissionType"
-import { NativeContactsSyncManager } from "../model/NativeContactsSyncManager"
-import { Dialog } from "../../../common/gui/base/Dialog"
-import { isIOSApp, isTest } from "../../../common/api/common/Env"
-import { assert } from "@tutao/tutanota-utils"
 
 export const ContactMailAddressTypeToLabel: Record<ContactAddressType, TranslationKey> = {
 	[ContactAddressType.PRIVATE]: "private_label",
@@ -25,11 +19,12 @@ export const ContactMailAddressTypeToLabel: Record<ContactAddressType, Translati
 	[ContactAddressType.CUSTOM]: "custom_label",
 }
 
-export function getContactAddressTypeLabel(type: ContactAddressType, custom: string): string {
+export function getContactAddressTypeLabel(type: ContactAddressType, custom: string): MaybeTranslation {
 	if (type === ContactAddressType.CUSTOM) {
-		return custom
+		return lang.makeTranslation("custom", custom)
 	} else {
-		return lang.get(ContactMailAddressTypeToLabel[type])
+		let key = ContactMailAddressTypeToLabel[type]
+		return key
 	}
 }
 
@@ -42,11 +37,12 @@ export const ContactPhoneNumberTypeToLabel: Record<ContactPhoneNumberType, Trans
 	[ContactPhoneNumberType.CUSTOM]: "custom_label",
 }
 
-export function getContactPhoneNumberTypeLabel(type: ContactPhoneNumberType, custom: string): string {
+export function getContactPhoneNumberTypeLabel(type: ContactPhoneNumberType, custom: string): MaybeTranslation {
 	if (type === ContactPhoneNumberType.CUSTOM) {
-		return custom
+		return lang.makeTranslation("custom", custom)
 	} else {
-		return lang.get(ContactPhoneNumberTypeToLabel[type])
+		let key = ContactPhoneNumberTypeToLabel[type]
+		return key
 	}
 }
 
@@ -59,11 +55,12 @@ export const ContactSocialTypeToLabel: Record<ContactSocialType, TranslationKey>
 	[ContactSocialType.CUSTOM]: "custom_label",
 }
 
-export function getContactSocialTypeLabel(type: ContactSocialType, custom: string): string {
+export function getContactSocialTypeLabel(type: ContactSocialType, custom: string): MaybeTranslation {
 	if (type === ContactSocialType.CUSTOM) {
-		return custom
+		return lang.makeTranslation("custom", custom)
 	} else {
-		return lang.get(ContactSocialTypeToLabel[type])
+		let key = ContactSocialTypeToLabel[type]
+		return key
 	}
 }
 
@@ -82,11 +79,12 @@ export const ContactRelationshipTypeToLabel: Record<ContactRelationshipType, Tra
 	[ContactRelationshipType.CUSTOM]: "custom_label",
 }
 
-export function getContactRelationshipTypeToLabel(type: ContactRelationshipType, custom: string): string {
+export function getContactRelationshipTypeToLabel(type: ContactRelationshipType, custom: string): MaybeTranslation {
 	if (type === ContactRelationshipType.CUSTOM) {
-		return custom
+		return lang.makeTranslation("custom", custom)
 	} else {
-		return lang.get(ContactRelationshipTypeToLabel[type])
+		let key = ContactRelationshipTypeToLabel[type]
+		return key
 	}
 }
 
@@ -99,11 +97,12 @@ export const ContactMessengerHandleTypeToLabel: Record<ContactMessengerHandleTyp
 	[ContactMessengerHandleType.CUSTOM]: "custom_label",
 }
 
-export function getContactMessengerHandleTypeToLabel(type: ContactMessengerHandleType, custom: string): string {
+export function getContactMessengerHandleTypeToLabel(type: ContactMessengerHandleType, custom: string): MaybeTranslation {
 	if (type === ContactMessengerHandleType.CUSTOM) {
-		return custom
+		return lang.makeTranslation("custom", custom)
 	} else {
-		return lang.get(ContactMessengerHandleTypeToLabel[type])
+		let key = ContactMessengerHandleTypeToLabel[type]
+		return key
 	}
 }
 
@@ -113,11 +112,12 @@ export const ContactCustomDateTypeToLabel: Record<ContactCustomDateType, Transla
 	[ContactCustomDateType.CUSTOM]: "custom_label",
 }
 
-export function getContactCustomDateTypeToLabel(type: ContactCustomDateType, custom: string): string {
+export function getContactCustomDateTypeToLabel(type: ContactCustomDateType, custom: string): MaybeTranslation {
 	if (type === ContactCustomDateType.CUSTOM) {
-		return custom
+		return lang.makeTranslation("custom", custom)
 	} else {
-		return lang.get(ContactCustomDateTypeToLabel[type])
+		let key = ContactCustomDateTypeToLabel[type]
+		return key
 	}
 }
 
@@ -128,11 +128,12 @@ export const ContactCustomWebsiteTypeToLabel: Record<ContactWebsiteType, Transla
 	[ContactWebsiteType.CUSTOM]: "custom_label",
 }
 
-export function getContactCustomWebsiteTypeToLabel(type: ContactWebsiteType, custom: string): string {
+export function getContactCustomWebsiteTypeToLabel(type: ContactWebsiteType, custom: string): MaybeTranslation {
 	if (type === ContactWebsiteType.CUSTOM) {
-		return custom
+		return lang.makeTranslation("custom", custom)
 	} else {
-		return lang.get(ContactCustomWebsiteTypeToLabel[type])
+		let key = ContactCustomWebsiteTypeToLabel[type]
+		return key
 	}
 }
 

--- a/src/mail-app/contacts/view/ContactListEntryViewer.ts
+++ b/src/mail-app/contacts/view/ContactListEntryViewer.ts
@@ -6,7 +6,7 @@ import { responsiveCardHMargin } from "../../../common/gui/cards.js"
 import { ContactCardViewer } from "./ContactCardViewer.js"
 import { ContactAddressType } from "../../../common/api/common/TutanotaConstants.js"
 import { PartialRecipient } from "../../../common/api/common/recipients/Recipient.js"
-import { lang } from "../../../common/misc/LanguageViewModel.js"
+import { lang, Translation } from "../../../common/misc/LanguageViewModel.js"
 
 export interface ContactListEntryViewerAttrs {
 	entry: ContactListEntry
@@ -100,10 +100,10 @@ export class ContactListEntryViewer implements Component<ContactListEntryViewerA
 	}
 }
 
-export function getContactListEntriesSelectionMessage(selectedEntities: ContactListEntry[] | undefined): string {
+export function getContactListEntriesSelectionMessage(selectedEntities: ContactListEntry[] | undefined): Translation {
 	if (selectedEntities && selectedEntities.length > 0) {
-		return lang.get("nbrOfEntriesSelected_msg", { "{nbr}": selectedEntities.length })
+		return lang.getTranslation("nbrOfEntriesSelected_msg", { "{nbr}": selectedEntities.length })
 	} else {
-		return lang.get("noSelection_msg")
+		return lang.getTranslation("noSelection_msg")
 	}
 }

--- a/src/mail-app/contacts/view/ContactMergeView.ts
+++ b/src/mail-app/contacts/view/ContactMergeView.ts
@@ -48,7 +48,7 @@ export class ContactMergeView {
 					type: ButtonType.Primary,
 				},
 			],
-			middle: () => lang.get("merge_action"),
+			middle: "merge_action",
 		}
 		this.dialog = Dialog.largeDialog(headerBarAttrs as DialogHeaderBarAttrs, this)
 			.setCloseHandler(cancelAction)
@@ -220,14 +220,14 @@ export class ContactMergeView {
 	} {
 		const mailAddresses = contact.mailAddresses.map((element) => {
 			return m(TextField, {
-				label: () => getContactAddressTypeLabel(element.type as any, element.customTypeName),
+				label: getContactAddressTypeLabel(element.type as any, element.customTypeName),
 				value: element.address,
 				isReadOnly: true,
 			})
 		})
 		const phones = contact.phoneNumbers.map((element) => {
 			return m(TextField, {
-				label: () => getContactPhoneNumberTypeLabel(element.type as any, element.customTypeName),
+				label: getContactPhoneNumberTypeLabel(element.type as any, element.customTypeName),
 				value: element.number,
 				isReadOnly: true,
 			})
@@ -236,12 +236,12 @@ export class ContactMergeView {
 			// Manually implement text area to make it stretch vertically. TextField is unable to do that.
 			return m(TextDisplayArea, {
 				value: element.address,
-				label: () => getContactAddressTypeLabel(downcast<ContactAddressType>(element.type), element.customTypeName),
+				label: getContactAddressTypeLabel(downcast<ContactAddressType>(element.type), element.customTypeName),
 			})
 		})
 		const socials = contact.socialIds.map((element) => {
 			return m(TextField, {
-				label: () => getContactSocialTypeLabel(getContactSocialType(element), element.customTypeName),
+				label: getContactSocialTypeLabel(getContactSocialType(element), element.customTypeName),
 				value: element.socialId,
 				isReadOnly: true,
 			})

--- a/src/mail-app/contacts/view/ContactViewer.ts
+++ b/src/mail-app/contacts/view/ContactViewer.ts
@@ -260,14 +260,14 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 	private renderCustomDatesAndRelationships(contact: Contact): Children {
 		const dates = contact.customDate.map((element) =>
 			m(TextField, {
-				label: () => getContactCustomDateTypeToLabel(getCustomDateType(element), element.customTypeName),
+				label: getContactCustomDateTypeToLabel(getCustomDateType(element), element.customTypeName),
 				value: formatContactDate(element.dateIso),
 				isReadOnly: true,
 			}),
 		)
 		const relationships = contact.relationships.map((element) =>
 			m(TextField, {
-				label: () => getContactRelationshipTypeToLabel(getRelationshipType(element), element.customTypeName),
+				label: getContactRelationshipTypeToLabel(getRelationshipType(element), element.customTypeName),
 				value: element.person,
 				isReadOnly: true,
 			}),
@@ -309,7 +309,7 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 			size: ButtonSize.Compact,
 		})
 		return m(TextField, {
-			label: () => getContactSocialTypeLabel(getContactSocialType(contactSocialId), contactSocialId.customTypeName),
+			label: getContactSocialTypeLabel(getContactSocialType(contactSocialId), contactSocialId.customTypeName),
 			value: contactSocialId.socialId,
 			isReadOnly: true,
 			injectionsRight: () => m(`a[href=${getSocialUrl(contactSocialId)}][target=_blank]`, showButton),
@@ -324,7 +324,7 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 			size: ButtonSize.Compact,
 		})
 		return m(TextField, {
-			label: () => getContactCustomWebsiteTypeToLabel(downcast(website.type), website.customTypeName),
+			label: getContactCustomWebsiteTypeToLabel(downcast(website.type), website.customTypeName),
 			value: website.url,
 			isReadOnly: true,
 			injectionsRight: () => m(`a[href=${getWebsiteUrl(website.url)}][target=_blank]`, showButton),
@@ -339,7 +339,7 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 			size: ButtonSize.Compact,
 		})
 		return m(TextField, {
-			label: () => getContactMessengerHandleTypeToLabel(downcast(messengerHandle.type), messengerHandle.customTypeName),
+			label: getContactMessengerHandleTypeToLabel(downcast(messengerHandle.type), messengerHandle.customTypeName),
 			value: messengerHandle.handle,
 			isReadOnly: true,
 			injectionsRight: () => m(`a[href=${getMessengerHandleUrl(messengerHandle)}][target=_blank]`, showButton),
@@ -354,7 +354,7 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 			size: ButtonSize.Compact,
 		})
 		return m(TextField, {
-			label: () => getContactAddressTypeLabel(address.type as any, address.customTypeName),
+			label: getContactAddressTypeLabel(address.type as any, address.customTypeName),
 			value: address.address,
 			isReadOnly: true,
 			injectionsRight: () => [newMailButton],
@@ -369,7 +369,7 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 			size: ButtonSize.Compact,
 		})
 		return m(TextField, {
-			label: () => getContactPhoneNumberTypeLabel(phone.type as ContactPhoneNumberType, phone.customTypeName),
+			label: getContactPhoneNumberTypeLabel(phone.type as ContactPhoneNumberType, phone.customTypeName),
 			value: phone.number,
 			isReadOnly: true,
 			injectionsRight: () => m(`a[href="tel:${phone.number}"][target=_blank]`, callButton),
@@ -392,7 +392,7 @@ export class ContactViewer implements ClassComponent<ContactViewerAttrs> {
 			size: ButtonSize.Compact,
 		})
 		return m(TextField, {
-			label: () => getContactAddressTypeLabel(downcast<ContactAddressType>(address.type), address.customTypeName),
+			label: getContactAddressTypeLabel(downcast<ContactAddressType>(address.type), address.customTypeName),
 			value: address.address,
 			isReadOnly: true,
 			type: TextFieldType.Area,

--- a/src/mail-app/contacts/view/ImportNativeContactBooksDialog.ts
+++ b/src/mail-app/contacts/view/ImportNativeContactBooksDialog.ts
@@ -18,7 +18,7 @@ export class ImportNativeContactBooksDialog {
 	show(): Promise<ContactBook[] | null> {
 		const deferred = defer<ContactBook[] | null>()
 		const dialog = Dialog.showActionDialog({
-			title: () => lang.get("importContacts_label"),
+			title: "importContacts_label",
 			type: DialogType.EditMedium,
 			allowCancel: true,
 			child: () => {

--- a/src/mail-app/contacts/view/MultiContactViewer.ts
+++ b/src/mail-app/contacts/view/MultiContactViewer.ts
@@ -1,6 +1,6 @@
 import m, { Component, Vnode } from "mithril"
 import ColumnEmptyMessageBox from "../../../common/gui/base/ColumnEmptyMessageBox"
-import { lang } from "../../../common/misc/LanguageViewModel"
+import { lang, Translation } from "../../../common/misc/LanguageViewModel"
 import { BootIcons } from "../../../common/gui/base/icons/BootIcons"
 import { theme } from "../../../common/gui/theme"
 import { assertMainOrNode } from "../../../common/api/common/Env"
@@ -21,7 +21,7 @@ export class MultiContactViewer implements Component<MultiContactViewerAttrs> {
 	view({ attrs }: Vnode<MultiContactViewerAttrs>) {
 		return [
 			m(ColumnEmptyMessageBox, {
-				message: () => getContactSelectionMessage(attrs.selectedEntities.length),
+				message: getContactSelectionMessage(attrs.selectedEntities.length),
 				icon: BootIcons.Contacts,
 				color: theme.content_message_bg,
 				bottomContent:
@@ -38,11 +38,11 @@ export class MultiContactViewer implements Component<MultiContactViewerAttrs> {
 	}
 }
 
-export function getContactSelectionMessage(numberEntities: number): string {
+export function getContactSelectionMessage(numberEntities: number): Translation {
 	if (numberEntities === 0) {
-		return lang.get("noContact_msg")
+		return lang.getTranslation("noContact_msg")
 	} else {
-		return lang.get("nbrOfContactsSelected_msg", {
+		return lang.getTranslation("nbrOfContactsSelected_msg", {
 			"{1}": numberEntities,
 		})
 	}

--- a/src/mail-app/knowledgebase/view/KnowledgeBaseDialog.ts
+++ b/src/mail-app/knowledgebase/view/KnowledgeBaseDialog.ts
@@ -53,7 +53,7 @@ function createEntryViewHeader(entry: KnowledgeBaseEntry, model: KnowledgeBaseMo
 				type: ButtonType.Secondary,
 			},
 		],
-		middle: () => lang.get("knowledgebase_label"),
+		middle: "knowledgebase_label",
 	}
 }
 
@@ -66,7 +66,7 @@ function createListViewHeader(model: KnowledgeBaseModel, isDialogVisible: Stream
 				type: ButtonType.Primary,
 			},
 		],
-		middle: () => lang.get("knowledgebase_label"),
+		middle: "knowledgebase_label",
 		right: [createAddButtonAttrs(model)],
 	}
 }
@@ -90,7 +90,7 @@ function createAddButtonAttrs(model: KnowledgeBaseModel): ButtonAttrs {
 				lazyButtons: () =>
 					templateGroupInstances.map((groupInstances) => {
 						return {
-							label: () => getSharedGroupName(groupInstances.groupInfo, model.userController, true),
+							label: lang.makeTranslation("group_name", getSharedGroupName(groupInstances.groupInfo, model.userController, true)),
 							click: () => {
 								showKnowledgeBaseEditor(null, groupInstances.groupRoot)
 							},

--- a/src/mail-app/knowledgebase/view/KnowledgeBaseDialogContent.ts
+++ b/src/mail-app/knowledgebase/view/KnowledgeBaseDialogContent.ts
@@ -63,7 +63,7 @@ export class KnowledgeBaseDialogContent implements Component<KnowledgebaseDialog
 			  })
 			: [
 					m(TextField, {
-						label: () => lang.get("filter_label"),
+						label: "filter_label",
 						value: this.filterValue,
 						oninput: (value) => {
 							this.filterValue = value

--- a/src/mail-app/mail/editor/MailEditor.ts
+++ b/src/mail-app/mail/editor/MailEditor.ts
@@ -256,7 +256,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 			}
 
 			if (invalidText !== "") {
-				throw new UserError(() => lang.get("invalidRecipients_msg") + invalidText)
+				throw new UserError(lang.makeTranslation("invalidRecipients_msg", lang.get("invalidRecipients_msg") + invalidText))
 			}
 		})
 		const dialog = a.dialog()
@@ -661,7 +661,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 					return m(PasswordField, {
 						oncreate: (vnode) => this.animateHeight(vnode.dom as HTMLElement, true),
 						onbeforeremove: (vnode) => this.animateHeight(vnode.dom as HTMLElement, false),
-						label: () => lang.get("passwordFor_label", { "{1}": recipient.address }),
+						label: lang.getTranslation("passwordFor_label", { "{1}": recipient.address }),
 						value: this.sendMailModel.getPassword(recipient.address),
 						passwordStrength: this.sendMailModel.getPasswordStrength(recipient),
 						status: "auto",
@@ -754,14 +754,14 @@ export class MailEditor implements Component<MailEditorAttrs> {
 		if (canEditBubbleRecipient) {
 			if (recipient.contact && recipient.contact._id) {
 				contextButtons.push({
-					label: () => lang.get("editContact_label"),
+					label: "editContact_label",
 					click: () => {
 						import("../../contacts/ContactEditor").then(({ ContactEditor }) => new ContactEditor(entity, recipient.contact).show())
 					},
 				})
 			} else {
 				contextButtons.push({
-					label: () => lang.get("createContact_action"),
+					label: "createContact_action",
 					click: () => {
 						// contact list
 						contactModel.getContactListId().then((contactListId: Id) => {
@@ -909,7 +909,7 @@ async function createMailEditorDialog(model: SendMailModel, blockExternalContent
 				type: ButtonType.Primary,
 			},
 		],
-		middle: () => conversationTypeString(model.getConversationType()),
+		middle: lang.makeTranslation("conversation_type", conversationTypeString(model.getConversationType())),
 		create: () => {
 			if (isBrowser()) {
 				// Have a simple listener on browser, so their browser will make the user ask if they are sure they want to close when closing the tab/window
@@ -1137,10 +1137,7 @@ export async function newMailtoUrlMailEditor(mailtoUrl: string, confidential: bo
 			dataFiles = sizeCheckResult.attachableFiles
 
 			if (sizeCheckResult.tooBigFiles.length > 0) {
-				await Dialog.message(
-					() => lang.get("tooBigAttachment_msg"),
-					() => sizeCheckResult.tooBigFiles.map((file) => m(".text-break.selectable", file)),
-				)
+				await Dialog.message("tooBigAttachment_msg", () => sizeCheckResult.tooBigFiles.map((file) => m(".text-break.selectable", file)))
 			}
 		} else {
 			throw new CancelledError("user cancelled opening mail editor with attachments")

--- a/src/mail-app/mail/press/PressReleaseEditor.ts
+++ b/src/mail-app/mail/press/PressReleaseEditor.ts
@@ -17,6 +17,7 @@ import { DialogHeaderBarAttrs } from "../../../common/gui/base/DialogHeaderBar"
 import { RichTextToolbar } from "../../../common/gui/base/RichTextToolbar.js"
 import { locator } from "../../../common/api/main/CommonLocator.js"
 import { getDefaultSender } from "../../../common/mailFunctionality/SharedMailUtils.js"
+import { lang } from "../../../common/misc/LanguageViewModel.js"
 
 type PressContact = {
 	email: string
@@ -46,18 +47,18 @@ export function openPressReleaseEditor(mailboxDetails: MailboxDetail): void {
 
 		// We aren't using translation keys here because it's not a user facing feature
 		const choice = await Dialog.choice(
-			() => `Really send the press release out to ${recipients.length} recipients?`,
+			lang.makeTranslation("press_release_confirmation", `Really send the press release out to ${recipients.length} recipients?`),
 			[
 				{
-					text: () => "Cancel",
+					text: "cancel_action",
 					value: "cancel",
 				},
 				{
-					text: () => "Just test",
+					text: lang.makeTranslation("noOp_action", "Just test"),
 					value: "test",
 				},
 				{
-					text: () => "Yes please",
+					text: "yes_label",
 					value: "send",
 				},
 			],
@@ -139,7 +140,7 @@ export function openPressReleaseEditor(mailboxDetails: MailboxDetail): void {
 				)
 			} catch (e) {
 				// Stop sending after first failure in case something bad happened
-				Dialog.message(() => `Error sending to ${recipient.email}: ${e.message}.\nStopping.`)
+				Dialog.message(lang.makeTranslation("error_msg", `Error sending to ${recipient.email}: ${e.message}.\nStopping.`))
 				didFinish = false
 				break
 			}
@@ -165,7 +166,7 @@ export function openPressReleaseEditor(mailboxDetails: MailboxDetail): void {
 				type: ButtonType.Secondary,
 			},
 		],
-		middle: () => "Press Release",
+		middle: lang.makeTranslation("pr", "Press Release"),
 		right: [
 			{
 				label: "send_action",
@@ -184,20 +185,20 @@ function getValidRecipients(recipientsJSON: string): Array<PressContact> {
 	try {
 		parsed = JSON.parse(recipientsJSON)
 	} catch (e) {
-		throw new UserError(() => "Unable to parse recipients JSON:\n" + e.toString())
+		throw new UserError(lang.makeTranslation("parse_json", "Unable to parse recipients JSON:\n" + e.toString()))
 	}
 
 	if (!(parsed instanceof Array)) {
-		throw new UserError(() => "Recipients must be an array")
+		throw new UserError(lang.makeTranslation("rec_arr", "Recipients must be an array"))
 	}
 
 	return parsed.map(({ email, greeting }) => {
 		if (typeof email !== "string" || !isMailAddress(email, false)) {
-			throw new UserError(() => `Not all provided recipients have an "email" field`)
+			throw new UserError(lang.makeTranslation("no_email", `Not all provided recipients have an "email" field`))
 		}
 
 		if (typeof greeting !== "string") {
-			throw new UserError(() => `Not all provided recipients have a "greeting" field`)
+			throw new UserError(lang.makeTranslation("no_greeting", `Not all provided recipients have a "greeting" field`))
 		}
 
 		// Discard any unneeded fields

--- a/src/mail-app/mail/view/EditFolderDialog.ts
+++ b/src/mail-app/mail/view/EditFolderDialog.ts
@@ -87,10 +87,13 @@ export async function showEditFolderDialog(mailBoxDetail: MailboxDetail, editedF
 			} else {
 				// if it is being moved to trash (and not already in trash), ask about trashing
 				if (selectedParentFolder?.folderType === MailSetKind.TRASH && !isSameId(selectedParentFolder._id, editedFolder.parentFolder)) {
-					const confirmed = await Dialog.confirm(() =>
-						lang.get("confirmDeleteCustomFolder_msg", {
-							"{1}": getFolderName(editedFolder),
-						}),
+					const confirmed = await Dialog.confirm(
+						lang.makeTranslation(
+							"confirm",
+							lang.get("confirmDeleteCustomFolder_msg", {
+								"{1}": getFolderName(editedFolder),
+							}),
+						),
 					)
 					if (!confirmed) return
 
@@ -98,10 +101,13 @@ export async function showEditFolderDialog(mailBoxDetail: MailboxDetail, editedF
 					await mailLocator.mailModel.trashFolderAndSubfolders(editedFolder)
 				} else if (selectedParentFolder?.folderType === MailSetKind.SPAM && !isSameId(selectedParentFolder._id, editedFolder.parentFolder)) {
 					// if it is being moved to spam (and not already in spam), ask about reporting containing emails
-					const confirmed = await Dialog.confirm(() =>
-						lang.get("confirmSpamCustomFolder_msg", {
-							"{1}": getFolderName(editedFolder),
-						}),
+					const confirmed = await Dialog.confirm(
+						lang.makeTranslation(
+							"confirm",
+							lang.get("confirmSpamCustomFolder_msg", {
+								"{1}": getFolderName(editedFolder),
+							}),
+						),
 					)
 					if (!confirmed) return
 
@@ -129,7 +135,7 @@ export async function showEditFolderDialog(mailBoxDetail: MailboxDetail, editedF
 	}
 
 	Dialog.showActionDialog({
-		title: editedFolder ? lang.get("editFolder_action") : lang.get("addFolder_action"),
+		title: editedFolder ? "editFolder_action" : "addFolder_action",
 		child: form,
 		validator: () => checkFolderName(mailBoxDetail, folders, folderNameValue, mailGroupId, selectedParentFolder?._id ?? null),
 		allowOkWithReturn: true,

--- a/src/mail-app/mail/view/EditLabelDialog.ts
+++ b/src/mail-app/mail/view/EditLabelDialog.ts
@@ -39,7 +39,7 @@ export async function showEditLabelDialog(mailbox: MailBox | null, mailViewModel
 	}
 
 	Dialog.showActionDialog({
-		title: lang.get(label ? "editLabel_action" : "addLabel_action"),
+		title: label ? "editLabel_action" : "addLabel_action",
 		allowCancel: true,
 		okAction: (dialog: Dialog) => {
 			onOkClicked(dialog)

--- a/src/mail-app/mail/view/ExternalLoginView.ts
+++ b/src/mail-app/mail/view/ExternalLoginView.ts
@@ -1,7 +1,7 @@
 import m, { Children, Vnode } from "mithril"
 import { AccessExpiredError } from "../../../common/api/common/error/RestError.js"
 import { assertNotNull, base64ToUint8Array, base64UrlToBase64, noOp } from "@tutao/tutanota-utils"
-import type { TranslationText } from "../../../common/misc/LanguageViewModel.js"
+import type { MaybeTranslation } from "../../../common/misc/LanguageViewModel.js"
 import { lang } from "../../../common/misc/LanguageViewModel.js"
 import { keyManager, Shortcut } from "../../../common/misc/KeyManager.js"
 import { client } from "../../../common/misc/ClientDetector.js"
@@ -34,8 +34,8 @@ type UrlData = { userId: Id; salt: Uint8Array; kdfType: KdfType }
 export class ExternalLoginViewModel {
 	password: string = ""
 	doSavePassword: boolean = false
-	helpText: TranslationText = "emptyString_msg"
-	errorMessageId: TranslationText | null = null
+	helpText: MaybeTranslation = "emptyString_msg"
+	errorMessageId: MaybeTranslation | null = null
 	autologinInProgress = false
 	showAutoLoginButton = false
 
@@ -221,12 +221,12 @@ export class ExternalLoginView extends BaseTopLevelView implements TopLevelView<
 		if (this.viewModel.autologinInProgress) {
 			return m("p.center", progressIcon())
 		} else if (this.viewModel.errorMessageId) {
-			return m("p.center", m(MessageBox, {}, lang.getMaybeLazy(this.viewModel.errorMessageId)))
+			return m("p.center", m(MessageBox, {}, lang.getTranslationText(this.viewModel.errorMessageId)))
 		} else {
 			return [
 				m(".flex.col.content-bg.border-radius-big.plr-2l.mt", [
 					this.viewModel.showAutoLoginButton ? this.renderAutoLoginButton() : this.renderForm(),
-					m("p.center.statusTextColor.mt-xs.mb-s", m("small", lang.getMaybeLazy(this.viewModel.helpText))),
+					m("p.center.statusTextColor.mt-xs.mb-s", m("small", lang.getTranslationText(this.viewModel.helpText), [])),
 				]),
 				m(".flex-grow"),
 				renderInfoLinks(),
@@ -254,7 +254,7 @@ export class ExternalLoginView extends BaseTopLevelView implements TopLevelView<
 			}),
 			m(Checkbox, {
 				label: () => lang.get("storePassword_action"),
-				helpLabel: () => lang.get("onlyPrivateComputer_msg"),
+				helpLabel: "onlyPrivateComputer_msg",
 				checked: this.viewModel.doSavePassword,
 				onChecked: (checked) => (this.viewModel.doSavePassword = checked),
 			}),

--- a/src/mail-app/mail/view/LabelsPopup.ts
+++ b/src/mail-app/mail/view/LabelsPopup.ts
@@ -95,7 +95,7 @@ export class LabelsPopup implements ModalComponent {
 			),
 			this.isMaxLabelsReached && m(".small.center.pb-s", lang.get("maximumLabelsPerMailReached_msg")),
 			m(BaseButton, {
-				label: lang.get("apply_action"),
+				label: "apply_action",
 				text: lang.get("apply_action"),
 				class: "limit-width noselect bg-transparent button-height text-ellipsis content-accent-fg flex items-center plr-button button-content justify-center border-top state-bg",
 				onclick: () => {
@@ -103,7 +103,7 @@ export class LabelsPopup implements ModalComponent {
 				},
 			} satisfies BaseButtonAttrs),
 			m(BaseButton, {
-				label: lang.get("close_alt"),
+				label: "close_alt",
 				text: lang.get("close_alt"),
 				class: "hidden-until-focus content-accent-fg button-content",
 				onclick: () => {

--- a/src/mail-app/mail/view/MailFolderRow.ts
+++ b/src/mail-app/mail/view/MailFolderRow.ts
@@ -64,7 +64,7 @@ export class MailFolderRow implements Component<MailFolderRowAttrs> {
 				style: {
 					background: isNavButtonSelected(button) ? stateBgHover : "",
 				},
-				title: lang.getMaybeLazy(button.label),
+				title: lang.getTranslationText(button.label),
 				onmouseenter: onHover,
 				onmouseleave: () => {
 					this.hovered = false

--- a/src/mail-app/mail/view/MailFoldersView.ts
+++ b/src/mail-app/mail/view/MailFoldersView.ts
@@ -22,6 +22,7 @@ import { getFolderName, MAX_FOLDER_INDENT_LEVEL } from "../model/MailUtils.js"
 import { getFolderIcon } from "./MailGuiUtils.js"
 import { isSpamOrTrashFolder } from "../model/MailChecks.js"
 import { DropData } from "../../../common/gui/base/GuiUtils"
+import { lang } from "../../../common/misc/LanguageViewModel.js"
 
 export interface MailFolderViewAttrs {
 	mailModel: MailModel
@@ -95,7 +96,7 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 		for (let system of subSystems) {
 			const id = getElementId(system.folder)
 			const button: NavButtonAttrs = {
-				label: () => getFolderName(system.folder),
+				label: lang.makeTranslation("folder_name", getFolderName(system.folder)),
 				href: () => {
 					if (attrs.inEditMode) {
 						return m.route.get()

--- a/src/mail-app/mail/view/MailGuiUtils.ts
+++ b/src/mail-app/mail/view/MailGuiUtils.ts
@@ -18,7 +18,7 @@ import {
 import { getElementId } from "../../../common/api/common/utils/EntityUtils"
 import { reportMailsAutomatically } from "./MailReportDialog"
 import { DataFile } from "../../../common/api/common/DataFile"
-import { lang, TranslationKey } from "../../../common/misc/LanguageViewModel"
+import { lang, Translation, TranslationKey } from "../../../common/misc/LanguageViewModel"
 import { FileController } from "../../../common/file/FileController"
 import { DomRectReadOnlyPolyfilled, Dropdown, DropdownChildAttrs, PosRect } from "../../../common/gui/base/Dropdown.js"
 import { modal } from "../../../common/gui/base/Modal.js"
@@ -373,12 +373,11 @@ export async function showMailFolderDropdown(
 		(f) =>
 			({
 				// We need to pass in the raw folder name to avoid including it in searches
-				label: () =>
-					lang.get("folderDepth_label", {
-						"{folderName}": getFolderName(f.folder),
-						"{depth}": f.level,
-					}),
-				text: () => getIndentedFolderNameForDropdown(f),
+				label: lang.getTranslation("folderDepth_label", {
+					"{folderName}": getFolderName(f.folder),
+					"{depth}": f.level,
+				}),
+				text: lang.makeTranslation("folder_name", getIndentedFolderNameForDropdown(f)),
 				click: () => {
 					onSelected()
 					onClick(f)
@@ -392,15 +391,15 @@ export async function showMailFolderDropdown(
 	modal.displayUnique(dropdown, withBackground)
 }
 
-export function getConversationTitle(conversationViewModel: ConversationViewModel): string {
+export function getConversationTitle(conversationViewModel: ConversationViewModel): Translation {
 	if (!conversationViewModel.isFinished()) {
-		return lang.get("loading_msg")
+		return lang.getTranslation("loading_msg")
 	}
 	const numberOfEmails = conversationViewModel.conversationItems().length
 	if (numberOfEmails === 1) {
-		return lang.get("oneEmail_label")
+		return lang.getTranslation("oneEmail_label")
 	} else {
-		return lang.get("nbrOrEmails_label", { "{number}": numberOfEmails })
+		return lang.getTranslation("nbrOrEmails_label", { "{number}": numberOfEmails })
 	}
 }
 

--- a/src/mail-app/mail/view/MailReportDialog.ts
+++ b/src/mail-app/mail/view/MailReportDialog.ts
@@ -17,7 +17,7 @@ function confirmMailReportDialog(mailModel: MailModel, mailboxDetails: MailboxDe
 				label: () => lang.get("rememberDecision_msg"),
 				checked: shallRememberDecision,
 				onChecked: (v) => (shallRememberDecision = v),
-				helpLabel: () => lang.get("changeMailSettings_msg"),
+				helpLabel: "changeMailSettings_msg",
 			})
 
 		async function updateSpamReportSetting(areMailsReported: boolean) {
@@ -47,7 +47,7 @@ function confirmMailReportDialog(mailModel: MailModel, mailboxDetails: MailboxDe
 		}
 
 		const dialog = Dialog.confirmMultiple(
-			() => lang.get("unencryptedTransmission_msg") + " " + lang.get("allowOperation_msg"),
+			lang.makeTranslation("unencryptedTransmission_msg", lang.get("unencryptedTransmission_msg") + " " + lang.get("allowOperation_msg")),
 			[noButton, yesButton],
 			onclose,
 			child,

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -167,8 +167,8 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 												console.warn("Cannot delete folder, no folder is selected")
 												return
 											}
-											const confirmed = await Dialog.confirm(() =>
-												lang.get("confirmDeleteFinallySystemFolder_msg", { "{1}": getFolderName(folder) }),
+											const confirmed = await Dialog.confirm(
+												lang.getTranslation("confirmDeleteFinallySystemFolder_msg", { "{1}": getFolderName(folder) }),
 											)
 											if (confirmed) {
 												showProgressDialog("progressDeleting_msg", this.mailViewModel.finallyDeleteAllMailsInSelectedFolder(folder))
@@ -206,8 +206,8 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				minWidth: size.second_col_min_width,
 				maxWidth: size.second_col_max_width,
 				headerCenter: () => {
-					const selectedFolder = this.mailViewModel.getFolder()
-					return selectedFolder ? getFolderName(selectedFolder) : ""
+					const folder = this.mailViewModel.getFolder()
+					return folder ? lang.makeTranslation("folder_name", getFolderName(folder)) : "emptyString_msg"
 				},
 			},
 		)
@@ -619,7 +619,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 			{
 				minWidth: size.first_col_min_width,
 				maxWidth: size.first_col_max_width,
-				headerCenter: () => lang.get("folderTitle_label"),
+				headerCenter: "folderTitle_label",
 			},
 		)
 	}
@@ -642,7 +642,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 			return m(
 				SidebarSection,
 				{
-					name: () => getMailboxName(locator.logins, mailboxDetail),
+					name: lang.makeTranslation("mailbox_name", getMailboxName(locator.logins, mailboxDetail)),
 				},
 				[
 					this.createMailboxFolderItems(mailboxDetail, inEditMode, () => {
@@ -849,16 +849,16 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 		const folders = await mailLocator.mailModel.getMailboxFoldersForId(mailboxDetail.mailbox.folders._id)
 
 		if (isSpamOrTrashFolder(folders, folder)) {
-			const confirmed = await Dialog.confirm(() =>
-				lang.get("confirmDeleteFinallyCustomFolder_msg", {
+			const confirmed = await Dialog.confirm(
+				lang.getTranslation("confirmDeleteFinallyCustomFolder_msg", {
 					"{1}": getFolderName(folder),
 				}),
 			)
 			if (!confirmed) return
 			await mailLocator.mailModel.finallyDeleteCustomMailFolder(folder)
 		} else {
-			const confirmed = await Dialog.confirm(() =>
-				lang.get("confirmDeleteCustomFolder_msg", {
+			const confirmed = await Dialog.confirm(
+				lang.getTranslation("confirmDeleteCustomFolder_msg", {
 					"{1}": getFolderName(folder),
 				}),
 			)
@@ -897,8 +897,8 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	}
 
 	private async showLabelDeleteDialog(label: MailFolder) {
-		const confirmed = await Dialog.confirm(() =>
-			lang.get("confirmDeleteLabel_msg", {
+		const confirmed = await Dialog.confirm(
+			lang.getTranslation("confirmDeleteLabel_msg", {
 				"{1}": label.name,
 			}),
 		)
@@ -922,7 +922,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 							return m(SidebarSectionRow, {
 								icon: Icons.Label,
 								iconColor: getLabelColor(label.color),
-								label: () => label.name,
+								label: lang.makeTranslation("folder_name", label.name),
 								path,
 								isSelectedPrefix: inEditMode ? false : path,
 								disabled: inEditMode,

--- a/src/mail-app/mail/view/MailViewer.ts
+++ b/src/mail-app/mail/view/MailViewer.ts
@@ -736,7 +736,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 		} catch (e) {
 			console.log(e)
 			if (e instanceof UserError) {
-				return await Dialog.message(() => e.message)
+				return await Dialog.message(lang.makeTranslation("error_msg", e.message))
 			}
 
 			await Dialog.message("unknownError_msg")

--- a/src/mail-app/mail/view/MailViewerHeader.ts
+++ b/src/mail-app/mail/view/MailViewerHeader.ts
@@ -526,8 +526,10 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 						  this.renderAttachmentContainer(viewModel, attachments, importFile)
 						: // Otherwise, we show the number of attachments and its total size along with a show all button
 						  m(ExpanderButton, {
-								label: () =>
+								label: lang.makeTranslation(
+									"attachmentAmount_label",
 									lang.get("attachmentAmount_label", { "{amount}": attachmentCount + "" }) + ` (${formatStorageSize(totalAttachmentSize)})`,
+								),
 								style: {
 									"padding-top": "inherit",
 									height: "inherit",

--- a/src/mail-app/mail/view/MailViewerToolbar.ts
+++ b/src/mail-app/mail/view/MailViewerToolbar.ts
@@ -168,18 +168,17 @@ export class MailViewerActions implements Component<MailViewerToolbarAttrs> {
 						type: ButtonType.Secondary,
 					},
 				],
-				middle: () => "",
+				middle: "emptyString_msg",
 			}
 
 			return m(IconButton, {
 				title: "export_action",
 				click: () =>
 					showProgressDialog(
-						() =>
-							lang.get("mailExportProgress_msg", {
-								"{current}": Math.round((operation.progress() / 100) * attrs.mails.length).toFixed(0),
-								"{total}": attrs.mails.length,
-							}),
+						lang.getTranslation("mailExportProgress_msg", {
+							"{current}": Math.round((operation.progress() / 100) * attrs.mails.length).toFixed(0),
+							"{total}": attrs.mails.length,
+						}),
 						exportMails(
 							attrs.mails,
 							locator.mailFacade,
@@ -209,14 +208,16 @@ export class MailViewerActions implements Component<MailViewerToolbarAttrs> {
 
 			const expanded = stream<boolean>(false)
 			const dialog = Dialog.createActionDialog({
-				title: lang.get("failedToExport_title"),
+				title: "failedToExport_title",
 				child: () =>
 					m("", [
 						m(".pt-m", lang.get("failedToExport_msg")),
 						m(".flex-start.items-center", [
 							m(ExpanderButton, {
-								label: () =>
+								label: lang.makeTranslation(
+									"hide_show",
 									`${lang.get(expanded() ? "hide_action" : "show_action")} ${lang.get("failedToExport_label", { "{0}": mailList.length })}`,
+								),
 								expanded: expanded(),
 								onExpandedChange: expanded,
 							}),

--- a/src/mail-app/mail/view/MailViewerUtils.ts
+++ b/src/mail-app/mail/view/MailViewerUtils.ts
@@ -50,7 +50,7 @@ export async function showHeaderDialog(headersPromise: Promise<string | null>) {
 					type: ButtonType.Secondary,
 				},
 			],
-			middle: () => lang.get("mailHeaders_title"),
+			middle: "mailHeaders_title",
 		},
 		{
 			view: () =>
@@ -225,7 +225,7 @@ function reportMail(viewModel: MailViewerViewModel) {
 	}
 
 	const dialog = Dialog.showActionDialog({
-		title: lang.get("reportEmail_action"),
+		title: "reportEmail_action",
 		child: () =>
 			m(
 				".flex.col.mt-m",

--- a/src/mail-app/mail/view/MultiItemViewer.ts
+++ b/src/mail-app/mail/view/MultiItemViewer.ts
@@ -1,7 +1,7 @@
 import m, { Component, Vnode } from "mithril"
 import { assertMainOrNode } from "../../../common/api/common/Env"
 import ColumnEmptyMessageBox from "../../../common/gui/base/ColumnEmptyMessageBox"
-import { lang } from "../../../common/misc/LanguageViewModel"
+import { lang, Translation, MaybeTranslation } from "../../../common/misc/LanguageViewModel"
 import { BootIcons } from "../../../common/gui/base/icons/BootIcons"
 import { theme } from "../../../common/gui/theme"
 import type { Mail } from "../../../common/api/entities/tutanota/TypeRefs.js"
@@ -16,7 +16,7 @@ export type MultiItemViewerAttrs<T> = {
 	loadingAll: "can_load" | "loading" | "loaded"
 	loadAll: () => unknown
 	stopLoadAll: () => unknown
-	getSelectionMessage: (entities: ReadonlyArray<T>) => string
+	getSelectionMessage: (entities: ReadonlyArray<T>) => MaybeTranslation
 }
 
 export class MultiItemViewer<T> implements Component<MultiItemViewerAttrs<T>> {
@@ -28,7 +28,7 @@ export class MultiItemViewer<T> implements Component<MultiItemViewerAttrs<T>> {
 				m(
 					".flex-grow.rel.overflow-hidden",
 					m(ColumnEmptyMessageBox, {
-						message: () => attrs.getSelectionMessage(selectedEntities),
+						message: attrs.getSelectionMessage(selectedEntities),
 						icon: BootIcons.Mail,
 						color: theme.content_message_bg,
 						backgroundColor: theme.navigation_bg,
@@ -74,15 +74,15 @@ export class MultiItemViewer<T> implements Component<MultiItemViewerAttrs<T>> {
 	}
 }
 
-export function getMailSelectionMessage(selectedEntities: ReadonlyArray<Mail>): string {
+export function getMailSelectionMessage(selectedEntities: ReadonlyArray<Mail>): Translation {
 	let nbrOfSelectedMails = selectedEntities.length
 
 	if (nbrOfSelectedMails === 0) {
-		return lang.get("noMail_msg")
+		return lang.getTranslation("noMail_msg")
 	} else if (nbrOfSelectedMails === 1) {
-		return lang.get("oneMailSelected_msg")
+		return lang.getTranslation("oneMailSelected_msg")
 	} else {
-		return lang.get("nbrOfMailsSelected_msg", {
+		return lang.getTranslation("nbrOfMailsSelected_msg", {
 			"{1}": nbrOfSelectedMails,
 		})
 	}

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -1114,7 +1114,7 @@ class MailLocator {
 		if (isApp() || isDesktop()) {
 			calendarModel.syncExternalCalendars().catch(async (e) => {
 				showSnackBar({
-					message: () => e.message,
+					message: lang.makeTranslation("exception_msg", e.message),
 					button: {
 						label: "ok_action",
 						click: noOp,

--- a/src/mail-app/search/view/SearchListView.ts
+++ b/src/mail-app/search/view/SearchListView.ts
@@ -54,7 +54,7 @@ export class SearchListView implements Component<SearchListViewAttrs> {
 		return attrs.listModel.isEmptyAndDone()
 			? m(ColumnEmptyMessageBox, {
 					icon,
-					message: () => lang.get("searchNoResults_msg"),
+					message: "searchNoResults_msg",
 					color: theme.list_message_bg,
 			  })
 			: m(List, {

--- a/src/mail-app/search/view/SearchView.ts
+++ b/src/mail-app/search/view/SearchView.ts
@@ -1,7 +1,7 @@
 import m, { Children, Vnode } from "mithril"
 import { ViewSlider } from "../../../common/gui/nav/ViewSlider.js"
 import { ColumnType, ViewColumn } from "../../../common/gui/base/ViewColumn"
-import type { TranslationKey, TranslationText } from "../../../common/misc/LanguageViewModel"
+import type { TranslationKey, MaybeTranslation } from "../../../common/misc/LanguageViewModel"
 import { lang } from "../../../common/misc/LanguageViewModel"
 import { FeatureType, Keys, MailSetKind } from "../../../common/api/common/TutanotaConstants"
 import { assertMainOrNode } from "../../../common/api/common/Env"
@@ -202,7 +202,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 			{
 				minWidth: size.first_col_min_width,
 				maxWidth: size.first_col_max_width,
-				headerCenter: () => lang.get("search_label"),
+				headerCenter: "search_label",
 			},
 		)
 
@@ -229,7 +229,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 			{
 				minWidth: size.second_col_min_width,
 				maxWidth: size.second_col_max_width,
-				headerCenter: () => lang.get("searchResult_label"),
+				headerCenter: "searchResult_label",
 			},
 		)
 		this.resultDetailsColumn = new ViewColumn(
@@ -381,7 +381,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 						...header,
 						backAction: () => this.viewSlider.focusPreviousColumn(),
 						columnType: "other",
-						title: lang.get("search_label"),
+						title: "search_label",
 						actions: null,
 						multicolumnActions: () => actions,
 						primaryAction: () => this.renderHeaderRightView(),
@@ -474,7 +474,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 						...header,
 						backAction: () => this.viewSlider.focusPreviousColumn(),
 						columnType: "other",
-						title: lang.get("search_label"),
+						title: "search_label",
 						actions: null,
 						multicolumnActions: () => [],
 						primaryAction: () => this.renderHeaderRightView(),
@@ -497,7 +497,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 				m(
 					".flex-grow.rel.overflow-hidden",
 					m(ColumnEmptyMessageBox, {
-						message: () => lang.get("noSelection_msg"),
+						message: "noSelection_msg",
 						color: theme.content_message_bg,
 						backgroundColor: theme.navigation_bg,
 					}),
@@ -795,7 +795,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 	}
 
 	private renderDateRangeSelection(): Children {
-		const renderedHelpText: TranslationText | undefined =
+		const renderedHelpText: MaybeTranslation | undefined =
 			this.searchViewModel.warning === "startafterend"
 				? "startAfterEnd_label"
 				: this.searchViewModel.warning === "long"

--- a/src/mail-app/settings/AddInboxRuleDialog.ts
+++ b/src/mail-app/settings/AddInboxRuleDialog.ts
@@ -109,7 +109,7 @@ export async function show(mailBoxDetail: MailboxDetail, ruleOrTemplate: InboxRu
 		}
 
 		Dialog.showActionDialog({
-			title: lang.get("addInboxRule_action"),
+			title: "addInboxRule_action",
 			child: form,
 			validator: () => validateInboxRuleInput(inboxRuleType(), inboxRuleValue(), ruleOrTemplate._id),
 			allowOkWithReturn: true,

--- a/src/mail-app/settings/AddNotificationEmailDialog.ts
+++ b/src/mail-app/settings/AddNotificationEmailDialog.ts
@@ -22,7 +22,7 @@ export class AddNotificationEmailDialog {
 			let mailAddress = ""
 
 			Dialog.showActionDialog({
-				title: lang.get("notificationSettings_action"),
+				title: "notificationSettings_action",
 				child: {
 					view: () => [
 						m(TextField, {

--- a/src/mail-app/settings/AddSpamRuleDialog.ts
+++ b/src/mail-app/settings/AddSpamRuleDialog.ts
@@ -73,7 +73,7 @@ export function showAddSpamRuleDialog(existingSpamRuleOrTemplate: EmailSenderLis
 	}
 
 	const dialog = Dialog.showActionDialog({
-		title: lang.get("addSpamRule_action"),
+		title: "addSpamRule_action",
 		child: form,
 		validator: () => validate(selectedType(), valueFieldValue(), selectedField(), loadedData, existingSpamRuleOrTemplate),
 		allowOkWithReturn: true,

--- a/src/mail-app/settings/CheckDomainDnsStatusDialog.ts
+++ b/src/mail-app/settings/CheckDomainDnsStatusDialog.ts
@@ -13,7 +13,7 @@ assertMainOrNode()
 export function showDnsCheckDialog(domainStatus: DomainDnsStatus) {
 	let dialog = Dialog.showActionDialog({
 		type: DialogType.EditLarger,
-		title: () => lang.get("checkDnsRecords_action"),
+		title: "checkDnsRecords_action",
 		okActionTextId: "checkAgain_action",
 		cancelActionTextId: "close_alt",
 		child: () => renderCheckResult(domainStatus, true),

--- a/src/mail-app/settings/EditOutOfOfficeNotificationDialog.ts
+++ b/src/mail-app/settings/EditOutOfOfficeNotificationDialog.ts
@@ -70,7 +70,7 @@ export function showEditOutOfOfficeNotificationDialog(outOfOfficeNotification: O
 				type: ButtonType.Primary,
 			},
 		],
-		middle: () => lang.get("outOfOfficeNotification_title"),
+		middle: "outOfOfficeNotification_title",
 	}
 	const dialog = Dialog.editDialog(dialogHeaderAttrs, EditOutOfOfficeNotificationDialog, {
 		model: dialogModel,
@@ -112,7 +112,7 @@ class EditOutOfOfficeNotificationDialog implements Component<EditOutOfOfficeNoti
 					label: () => lang.get("outOfOfficeTimeRange_msg"),
 					checked: model.timeRangeEnabled(),
 					onChecked: model.timeRangeEnabled,
-					helpLabel: () => lang.get("outOfOfficeTimeRangeHelp_msg"),
+					helpLabel: "outOfOfficeTimeRangeHelp_msg",
 				}),
 			),
 			model.timeRangeEnabled() ? this.renderTimeRangeSelector(model, startOfTheWeekOffset) : null,

--- a/src/mail-app/settings/EditOutOfOfficeNotificationDialogModel.ts
+++ b/src/mail-app/settings/EditOutOfOfficeNotificationDialogModel.ts
@@ -6,7 +6,7 @@ import { getDayShifted, getStartOfDay, getStartOfNextDay, ofClass } from "@tutao
 import { OutOfOfficeNotificationMessageType } from "../../common/api/common/TutanotaConstants"
 import { InvalidDataError, PreconditionFailedError } from "../../common/api/common/error/RestError"
 import type { EntityClient } from "../../common/api/common/EntityClient"
-import type { LanguageViewModel } from "../../common/misc/LanguageViewModel"
+import { lang, LanguageViewModel } from "../../common/misc/LanguageViewModel"
 import type { UserController } from "../../common/api/main/UserController"
 import { appendEmailSignature } from "../mail/signature/Signature"
 import { UserError } from "../../common/api/main/UserError"
@@ -199,7 +199,7 @@ export class EditOutOfOfficeNotificationDialogModel {
 					if (e.data === FAILURE_UPGRADE_REQUIRED) {
 						throw new UpgradeRequiredError("upgradeRequired_msg", await getAvailablePlansWithAutoResponder())
 					} else {
-						throw new UserError(() => e.toString())
+						throw new UserError(lang.makeTranslation("error_msg", e.toString()))
 					}
 				}),
 			)

--- a/src/mail-app/settings/EditSignatureDialog.ts
+++ b/src/mail-app/settings/EditSignatureDialog.ts
@@ -1,12 +1,12 @@
 import m from "mithril"
 import { Dialog, DialogType } from "../../common/gui/base/Dialog"
-import { lang } from "../../common/misc/LanguageViewModel"
+import { lang, MaybeTranslation } from "../../common/misc/LanguageViewModel"
 import { EmailSignatureType, FeatureType } from "../../common/api/common/TutanotaConstants"
 import { HtmlEditor } from "../../common/gui/editor/HtmlEditor"
 import type { TutanotaProperties } from "../../common/api/entities/tutanota/TypeRefs.js"
 import { PayloadTooLargeError } from "../../common/api/common/error/RestError"
 import { showProgressDialog } from "../../common/gui/dialogs/ProgressDialog"
-import { neverNull, ofClass } from "@tutao/tutanota-utils"
+import { downcast, neverNull, ofClass } from "@tutao/tutanota-utils"
 import { locator } from "../../common/api/main/CommonLocator"
 import { assertMainOrNode } from "../../common/api/common/Env"
 import { DropDownSelector } from "../../common/gui/base/DropDownSelector.js"
@@ -92,7 +92,7 @@ export function show(props: TutanotaProperties) {
 				if (newType === EmailSignatureType.EMAIL_SIGNATURE_TYPE_CUSTOM && newCustomValue.length > RECOMMENDED_SIGNATURE_SIZE_LIMIT) {
 					const signatureSizeKb = Math.floor(newCustomValue.length / 1024)
 					const confirmLargeSignatureAttrs = {
-						title: lang.get("userEmailSignature_label"),
+						title: downcast("userEmailSignature_label"),
 						child: {
 							view: () =>
 								m(
@@ -116,7 +116,7 @@ export function show(props: TutanotaProperties) {
 		}
 
 		Dialog.showActionDialog({
-			title: lang.get("userEmailSignature_label"),
+			title: "userEmailSignature_label",
 			child: form,
 			type: DialogType.EditLarge,
 			okAction: editSignatureOkAction,

--- a/src/mail-app/settings/GlobalSettingsViewer.ts
+++ b/src/mail-app/settings/GlobalSettingsViewer.ts
@@ -413,8 +413,8 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 	}
 
 	private deleteCustomDomain(domainInfo: DomainInfo) {
-		Dialog.confirm(() =>
-			lang.get("confirmCustomDomainDeletion_msg", {
+		Dialog.confirm(
+			lang.getTranslation("confirmCustomDomainDeletion_msg", {
 				"{domain}": domainInfo.domain,
 			}),
 		).then((confirmed) => {
@@ -427,14 +427,14 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 								this.props() != null ? this.props().whitelabelRegistrationDomains.map((domainWrapper) => domainWrapper.value) : []
 
 							if (registrationDomains.indexOf(domainInfo.domain) !== -1) {
-								Dialog.message(() =>
-									lang.get("customDomainDeletePreconditionWhitelabelFailed_msg", {
+								Dialog.message(
+									lang.getTranslation("customDomainDeletePreconditionWhitelabelFailed_msg", {
 										"{domainName}": domainInfo.domain,
 									}),
 								)
 							} else {
-								Dialog.message(() =>
-									lang.get("customDomainDeletePreconditionFailed_msg", {
+								Dialog.message(
+									lang.getTranslation("customDomainDeletePreconditionFailed_msg", {
 										"{domainName}": domainInfo.domain,
 									}),
 								)

--- a/src/mail-app/settings/KnowledgeBaseEditor.ts
+++ b/src/mail-app/settings/KnowledgeBaseEditor.ts
@@ -50,7 +50,7 @@ export function showKnowledgeBaseEditor(entry: KnowledgeBaseEntry | null, templa
 				type: ButtonType.Primary,
 			},
 		],
-		middle: () => lang.get(editorModel.entry._id ? "editEntry_label" : "createEntry_action"),
+		middle: editorModel.entry._id ? "editEntry_label" : "createEntry_action",
 	}
 	const dialog = Dialog.editDialog(headerBarAttrs, KnowledgeBaseEditor, editorModel)
 	dialog.show()
@@ -95,7 +95,7 @@ class KnowledgeBaseEditor implements Component<KnowledgeBaseEditorModel> {
 			if (templates.length > 0) {
 				return templates.map((template) => {
 					return {
-						label: () => template.tag,
+						label: lang.makeTranslation("tag", template.tag),
 						click: () => this.entryContentEditor.editor.insertHTML(createTemplateLink(template)),
 					}
 				})

--- a/src/mail-app/settings/MailSettingsViewer.ts
+++ b/src/mail-app/settings/MailSettingsViewer.ts
@@ -542,10 +542,10 @@ async function showEditStoredDataTimeRangeDialog(settings: OfflineStorageSetting
 
 	const newTimeRangeDeferred = defer<number>()
 	const dialog = Dialog.showActionDialog({
-		title: "",
+		title: "emptyString_msg",
 		child: () =>
 			m(TextField, {
-				label: () => capitalizeFirstLetter(lang.get("days_label")),
+				label: lang.makeTranslation("days_label", capitalizeFirstLetter(lang.get("days_label"))),
 				helpLabel: () => lang.get("storedDataTimeRangeHelpText_msg"),
 				type: TextFieldType.Number,
 				value: `${timeRange}`,

--- a/src/mail-app/settings/RejectedSendersInfoDialog.ts
+++ b/src/mail-app/settings/RejectedSendersInfoDialog.ts
@@ -22,7 +22,7 @@ label: TranslationKey | lazy<string>,
 */
 export function showRejectedSendersInfoDialog(rejectedSender: RejectedSender) {
 	const actionDialogProperties = {
-		title: () => lang.get("details_label"),
+		title: "details_label",
 		child: {
 			view: () => {
 				return [

--- a/src/mail-app/settings/SettingsView.ts
+++ b/src/mail-app/settings/SettingsView.ts
@@ -178,7 +178,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 		})
 
 		this._dummyTemplateFolder = new SettingsFolder<void>(
-			() => getDefaultGroupName(GroupType.Template),
+			lang.makeTranslation("group_name", getDefaultGroupName(GroupType.Template)),
 			() => Icons.ListAlt,
 			{
 				folder: "templates",
@@ -276,7 +276,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 			{
 				minWidth: size.first_col_min_width,
 				maxWidth: size.first_col_max_width,
-				headerCenter: () => lang.get("settings_label"),
+				headerCenter: "settings_label",
 			},
 		)
 		this._settingsColumn = new ViewColumn(
@@ -298,7 +298,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 								...vnode.attrs.header,
 								backAction: () => this.viewSlider.focusPreviousColumn(),
 								columnType: "first",
-								title: lang.getMaybeLazy(this._selectedFolder.name),
+								title: this._selectedFolder.name,
 								actions: [],
 								primaryAction: () => null,
 							}),
@@ -309,7 +309,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 			{
 				minWidth: 400,
 				maxWidth: 600,
-				headerCenter: () => lang.getMaybeLazy(this._selectedFolder.name),
+				headerCenter: this._selectedFolder.name,
 			},
 		)
 		this._settingsDetailsColumn = new ViewColumn(
@@ -323,7 +323,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 								...vnode.attrs.header,
 								backAction: () => this.viewSlider.focusPreviousColumn(),
 								columnType: "other",
-								title: lang.getMaybeLazy(this._selectedFolder.name),
+								title: this._selectedFolder.name,
 								actions: [],
 								primaryAction: () => null,
 							}),
@@ -334,7 +334,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 			{
 				minWidth: 500,
 				maxWidth: 2400,
-				headerCenter: () => lang.get("settings_label"),
+				headerCenter: "settings_label",
 			},
 		)
 		this.viewSlider = new ViewSlider([this._settingsFoldersColumn, this._settingsColumn, this._settingsDetailsColumn])
@@ -554,8 +554,8 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 	}
 
 	private _leaveTemplateGroup(templateInfo: TemplateGroupInstance) {
-		return getConfirmation(() =>
-			lang.get("confirmLeaveSharedGroup_msg", {
+		return getConfirmation(
+			lang.getTranslation("confirmLeaveSharedGroup_msg", {
 				"{groupName}": getSharedGroupName(templateInfo.groupInfo, this.logins.getUserController(), false),
 			}),
 		).confirmed(() => locator.groupManagementFacade.removeUserFromGroup(getEtId(this.logins.getUserController().user), templateInfo.groupInfo.group))
@@ -745,7 +745,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 						this.viewSlider.focusNextColumn()
 						setTimeout(() => {
 							const dialog = Dialog.showActionDialog({
-								title: () => lang.get("about_label"),
+								title: "about_label",
 								child: () =>
 									m(AboutDialog, {
 										onShowSetupWizard: () => {
@@ -783,7 +783,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 			await loadTemplateGroupInstances(templateMemberships, locator.entityClient),
 			(groupInstance) =>
 				new SettingsFolder(
-					() => getSharedGroupName(groupInstance.groupInfo, userController, true),
+					lang.makeTranslation("group_name", getSharedGroupName(groupInstance.groupInfo, userController, true)),
 					() => Icons.ListAlt,
 					{
 						folder: "templates",
@@ -812,7 +812,7 @@ export class SettingsView extends BaseTopLevelView implements TopLevelView<Setti
 				await loadTemplateGroupInstances(templateMemberships, locator.entityClient),
 				(groupInstance) =>
 					new SettingsFolder(
-						() => getSharedGroupName(groupInstance.groupInfo, userController, true),
+						lang.makeTranslation("group_name", getSharedGroupName(groupInstance.groupInfo, userController, true)),
 						() => Icons.Book,
 						{
 							folder: "knowledgebase",
@@ -845,7 +845,7 @@ function showRenameTemplateListDialog(instance: TemplateGroupInstance) {
 	const logins = locator.logins
 	const name = stream(getSharedGroupName(instance.groupInfo, logins.getUserController(), true))
 	Dialog.showActionDialog({
-		title: () => lang.get("renameTemplateList_label"),
+		title: "renameTemplateList_label",
 		allowOkWithReturn: true,
 		child: {
 			view: () =>

--- a/src/mail-app/settings/TemplateEditor.ts
+++ b/src/mail-app/settings/TemplateEditor.ts
@@ -52,7 +52,7 @@ export function showTemplateEditor(template: EmailTemplate | null, templateGroup
 				type: ButtonType.Primary,
 			},
 		],
-		middle: () => lang.get(editorModel.template._id ? "editTemplate_action" : "createTemplate_action"),
+		middle: editorModel.template._id ? "editTemplate_action" : "createTemplate_action",
 	}
 	const dialog = Dialog.editDialog(headerBarAttrs, TemplateEditor, {
 		model: editorModel,
@@ -100,7 +100,7 @@ class TemplateEditor implements Component<TemplateEditorAttrs> {
 			}),
 			m(TextField, {
 				label: "language_label",
-				value: this.model.selectedContent() ? getLanguageName(this.model.selectedContent()) : "",
+				value: this.model.selectedContent() ? lang.getTranslationText(getLanguageName(this.model.selectedContent())) : "",
 				injectionsRight: () =>
 					m(".flex.ml-between-s", [
 						this.model.getAddedLanguages().length > 1 ? [this.renderRemoveLangButton(), this.renderSelectLangButton()] : null,
@@ -139,7 +139,7 @@ class TemplateEditor implements Component<TemplateEditorAttrs> {
 					this.model.updateContent()
 					return this.model.template.contents.map((content) => {
 						return {
-							label: () => getLanguageName(content),
+							label: getLanguageName(content),
 							click: () => {
 								this.model.selectedContent(content)
 
@@ -162,8 +162,8 @@ class TemplateEditor implements Component<TemplateEditorAttrs> {
 	}
 
 	private removeLanguage() {
-		return Dialog.confirm(() =>
-			lang.get("deleteLanguageConfirmation_msg", {
+		return Dialog.confirm(
+			lang.getTranslation("deleteLanguageConfirmation_msg", {
 				"{language}": getLanguageName(this.model.selectedContent()),
 			}),
 		).then((confirmed) => {

--- a/src/mail-app/settings/TemplateEditorModel.ts
+++ b/src/mail-app/settings/TemplateEditorModel.ts
@@ -1,4 +1,4 @@
-import type { Language, LanguageCode } from "../../common/misc/LanguageViewModel"
+import type { Language, LanguageCode, Translation, TranslationKey } from "../../common/misc/LanguageViewModel"
 import { lang, languageByCode, languages } from "../../common/misc/LanguageViewModel"
 import type { EmailTemplateContent } from "../../common/api/entities/tutanota/TypeRefs.js"
 import type { EmailTemplate } from "../../common/api/entities/tutanota/TypeRefs.js"
@@ -121,6 +121,6 @@ export function getLanguageCode(content: EmailTemplateContent): LanguageCode {
 	return downcast(content.languageCode)
 }
 
-export function getLanguageName(content: EmailTemplateContent): string {
-	return lang.get(languageByCode[getLanguageCode(content)].textId)
+export function getLanguageName(content: EmailTemplateContent): TranslationKey {
+	return languageByCode[getLanguageCode(content)].textId
 }

--- a/src/mail-app/settings/emaildomain/AddEmailAddressesPage.ts
+++ b/src/mail-app/settings/emaildomain/AddEmailAddressesPage.ts
@@ -103,8 +103,8 @@ export class AddEmailAddressesPageAttrs implements WizardPageAttrs<AddDomainData
 		this.isMailVerificationBusy = false
 	}
 
-	headerTitle(): string {
-		return lang.get("domainSetup_title")
+	headerTitle(): TranslationKey {
+		return "domainSetup_title"
 	}
 
 	nextAction(showErrorDialog: boolean): Promise<boolean> {

--- a/src/mail-app/settings/emaildomain/EnterDomainPage.ts
+++ b/src/mail-app/settings/emaildomain/EnterDomainPage.ts
@@ -75,8 +75,8 @@ export class EnterDomainPageAttrs implements WizardPageAttrs<AddDomainData> {
 		this.data = domainData
 	}
 
-	headerTitle(): string {
-		return lang.get("domainSetup_title")
+	headerTitle(): TranslationKey {
+		return "domainSetup_title"
 	}
 
 	nextAction(showErrorDialog: boolean = true): Promise<boolean> {

--- a/src/mail-app/settings/emaildomain/VerifyDnsRecordsPage.ts
+++ b/src/mail-app/settings/emaildomain/VerifyDnsRecordsPage.ts
@@ -3,7 +3,7 @@ import m, { Children, Vnode, VnodeDOM } from "mithril"
 import { assertEnumValue, CustomDomainCheckResult, DnsRecordType, DnsRecordValidation } from "../../../common/api/common/TutanotaConstants"
 import { InfoLink, lang, TranslationKey } from "../../../common/misc/LanguageViewModel"
 import type { AddDomainData, ValidatedDnSRecord } from "./AddDomainWizard"
-import { Dialog } from "../../../common/gui/base/Dialog"
+import { ActionDialogProps, Dialog } from "../../../common/gui/base/Dialog"
 import type { WizardPageAttrs } from "../../../common/gui/base/WizardDialog.js"
 import { emitWizardEvent, WizardEventType, WizardPageN } from "../../../common/gui/base/WizardDialog.js"
 import { Button, ButtonType } from "../../../common/gui/base/Button.js"
@@ -62,8 +62,8 @@ export class VerifyDnsRecordsPage implements WizardPageN<AddDomainData> {
 	}
 
 	_finishDialog(data: AddDomainData, dom: HTMLElement | null): Promise<void> {
-		const leaveUnfinishedDialogAttrs = {
-			title: lang.get("quitSetup_title"),
+		const leaveUnfinishedDialogAttrs: ActionDialogProps = {
+			title: "quitSetup_title",
 			child: {
 				view: () => {
 					return [m("p", lang.get("quitDNSSetup_msg"))]
@@ -204,8 +204,8 @@ export class VerifyDnsRecordsPageAttrs implements WizardPageAttrs<AddDomainData>
 		this.data = domainData
 	}
 
-	headerTitle(): string {
-		return lang.get("domainSetup_title")
+	headerTitle(): TranslationKey {
+		return "domainSetup_title"
 	}
 
 	nextAction(showErrorDialog: boolean): Promise<boolean> {

--- a/src/mail-app/settings/emaildomain/VerifyOwnershipPage.ts
+++ b/src/mail-app/settings/emaildomain/VerifyOwnershipPage.ts
@@ -8,7 +8,7 @@ import type { WizardPageAttrs, WizardPageN } from "../../../common/gui/base/Wiza
 import { emitWizardEvent, WizardEventType } from "../../../common/gui/base/WizardDialog.js"
 import { PreconditionFailedError } from "../../../common/api/common/error/RestError.js"
 import { showPlanUpgradeRequiredDialog } from "../../../common/misc/SubscriptionDialogs.js"
-import { isEmpty, ofClass } from "@tutao/tutanota-utils"
+import { downcast, isEmpty, ofClass } from "@tutao/tutanota-utils"
 import { locator } from "../../../common/api/main/CommonLocator"
 import { assertMainOrNode } from "../../../common/api/common/Env"
 import { createDnsRecordTable } from "./DnsRecordTable.js"
@@ -67,8 +67,8 @@ export class VerifyOwnershipPageAttrs implements WizardPageAttrs<AddDomainData> 
 		this.data = domainData
 	}
 
-	headerTitle(): string {
-		return lang.get("domainSetup_title")
+	headerTitle(): TranslationKey {
+		return "domainSetup_title"
 	}
 
 	nextAction(showErrorDialog: boolean = true): Promise<boolean> {
@@ -96,17 +96,19 @@ export class VerifyOwnershipPageAttrs implements WizardPageAttrs<AddDomainData> 
 						[CustomDomainValidationResult.CUSTOM_DOMAIN_VALIDATION_RESULT_DOMAIN_NOT_AVAILABLE]: "customDomainErrorDomainNotAvailable_msg",
 						[CustomDomainValidationResult.CUSTOM_DOMAIN_VALIDATION_RESULT_VALIDATION_FAILED]: "customDomainErrorValidationFailed_msg",
 					}
-					return () =>
+					return lang.makeTranslation(
+						"error_msg",
 						lang.get(errorMessageMap[validationResult]) + //TODO correct to use? customDomainErrorOtherTxtRecords_msg
-						(result.invalidDnsRecords.length > 0
-							? " " + lang.get("customDomainErrorOtherTxtRecords_msg") + "\n" + result.invalidDnsRecords.map((r) => r.value).join("\n")
-							: "")
+							(result.invalidDnsRecords.length > 0
+								? " " + lang.get("customDomainErrorOtherTxtRecords_msg") + "\n" + result.invalidDnsRecords.map((r) => r.value).join("\n")
+								: ""),
+					)
 				}
 			}),
 		)
 			.then((message) => {
 				if (message) {
-					return showErrorDialog ? Dialog.message(message).then(() => false) : false
+					return showErrorDialog ? Dialog.message(downcast(message)).then(() => false) : false
 				}
 
 				return true
@@ -131,7 +133,7 @@ export class VerifyOwnershipPageAttrs implements WizardPageAttrs<AddDomainData> 
 							showPlanUpgradeRequiredDialog(plans, "moreCustomDomainsRequired_msg")
 						}
 					} else {
-						Dialog.message(() => e.toString())
+						Dialog.message(lang.makeTranslation("error_msg", e.toString()))
 					}
 					return false
 				}),

--- a/src/mail-app/settings/groups/AddGroupDialog.ts
+++ b/src/mail-app/settings/groups/AddGroupDialog.ts
@@ -173,7 +173,7 @@ export function show(): void {
 		}
 
 		Dialog.showActionDialog({
-			title: viewModel.groupType == GroupType.Mail ? lang.get("createSharedMailbox_label") : lang.get("addGroup_label"),
+			title: viewModel.groupType == GroupType.Mail ? "createSharedMailbox_label" : "addGroup_label",
 			child: () =>
 				m(AddGroupDialog, {
 					selectedDomain: viewModel.selectedDomain,
@@ -210,7 +210,7 @@ function addTemplateGroup(name: string): Promise<boolean> {
 						const plans = await getAvailablePlansWithTemplates()
 						showPlanUpgradeRequiredDialog(plans)
 					} else {
-						Dialog.message(() => e.message)
+						Dialog.message(lang.makeTranslation("confirm_msg", e.message))
 					}
 
 					return false

--- a/src/mail-app/settings/groups/GroupListView.ts
+++ b/src/mail-app/settings/groups/GroupListView.ts
@@ -133,9 +133,9 @@ export class GroupListView implements UpdatableSettingsViewer {
 		if (await locator.logins.getUserController().isNewPaidPlan()) {
 			AddGroupDialog.show()
 		} else {
-			const msg = lang.get("newPaidPlanRequired_msg") + " " + lang.get("sharedMailboxesMultiUser_msg")
+			const msg = lang.makeTranslation("upgrade_text", lang.get("newPaidPlanRequired_msg") + " " + lang.get("sharedMailboxesMultiUser_msg"))
 			const wizard = await import("../../../common/subscription/UpgradeSubscriptionWizard")
-			await wizard.showUpgradeWizard(locator.logins, NewPaidPlans, () => msg)
+			await wizard.showUpgradeWizard(locator.logins, NewPaidPlans, msg)
 		}
 	}
 

--- a/src/mail-app/templates/TemplateGroupUtils.ts
+++ b/src/mail-app/templates/TemplateGroupUtils.ts
@@ -19,7 +19,7 @@ export async function createInitialTemplateListIfAllowed(): Promise<TemplateGrou
 		if (userController.isGlobalAdmin()) {
 			allowed = await showPlanUpgradeRequiredDialog(await getAvailablePlansWithTemplates())
 		} else {
-			Dialog.message(() => lang.get("contactAdmin_msg"))
+			Dialog.message("contactAdmin_msg")
 		}
 	}
 

--- a/src/mail-app/templates/view/TemplatePopup.ts
+++ b/src/mail-app/templates/view/TemplatePopup.ts
@@ -308,7 +308,7 @@ export class TemplatePopup implements ModalComponent {
 				childAttrs: () =>
 					writeableGroups.map((groupInstances) => {
 						return {
-							label: () => getSharedGroupName(groupInstances.groupInfo, locator.logins.getUserController(), true),
+							label: lang.makeTranslation("group_name", getSharedGroupName(groupInstances.groupInfo, locator.logins.getUserController(), true)),
 							click: () => this.showTemplateEditor(null, groupInstances.groupRoot),
 						}
 					}),
@@ -337,7 +337,7 @@ export class TemplatePopup implements ModalComponent {
 						selectedTemplate.contents.map((content) => {
 							const langCode: LanguageCode = downcast(content.languageCode)
 							return {
-								label: () => lang.get(languageByCode[langCode].textId),
+								label: languageByCode[langCode].textId,
 								click: (e: MouseEvent) => {
 									e.stopPropagation()
 									this._templateModel.setSelectedContentLanguage(langCode)

--- a/src/mail-app/templates/view/TemplateSearchBar.ts
+++ b/src/mail-app/templates/view/TemplateSearchBar.ts
@@ -1,16 +1,15 @@
-import m, { Children, ClassComponent, Component, Vnode } from "mithril"
-import type { TranslationKey } from "../../../common/misc/LanguageViewModel"
+import m, { Children, ClassComponent, Vnode } from "mithril"
+import type { MaybeTranslation } from "../../../common/misc/LanguageViewModel"
 import { lang } from "../../../common/misc/LanguageViewModel"
 import { inputLineHeight, px } from "../../../common/gui/size"
 import { keyboardEventToKeyPress, keyHandler } from "../../../common/misc/KeyManager"
 import { theme } from "../../../common/gui/theme"
-import type { lazy } from "@tutao/tutanota-utils"
-import Stream from "mithril/stream"
 import { assertNotNull } from "@tutao/tutanota-utils"
+import Stream from "mithril/stream"
 
 export type TemplateSearchBarAttrs = {
 	value: Stream<string>
-	placeholder?: TranslationKey | lazy<string>
+	placeholder?: MaybeTranslation
 	oninput?: (value: string, input: HTMLInputElement) => unknown
 	keyHandler?: keyHandler
 }
@@ -33,7 +32,7 @@ export class TemplateSearchBar implements ClassComponent<TemplateSearchBarAttrs>
 
 	_getInputField(a: TemplateSearchBarAttrs): Children {
 		return m("input.input", {
-			placeholder: a.placeholder && lang.getMaybeLazy(a.placeholder),
+			placeholder: a.placeholder && lang.getTranslationText(a.placeholder),
 			oncreate: (vnode) => {
 				this.domInput = vnode.dom as HTMLInputElement
 				this.domInput.value = a.value()

--- a/src/mail-app/templates/view/TemplateShortcutListener.ts
+++ b/src/mail-app/templates/view/TemplateShortcutListener.ts
@@ -61,7 +61,7 @@ class TemplateShortcutListener {
 						// show dropdown to select language
 						let buttons = template.contents.map((content) => {
 							return {
-								label: () => this._lang.get(languageByCode[downcast(content.languageCode)].textId),
+								label: languageByCode[downcast(content.languageCode)].textId,
 								click: () => {
 									this._editor.insertHTML(content.text)
 

--- a/test/tests/login/LoginViewModelTest.ts
+++ b/test/tests/login/LoginViewModelTest.ts
@@ -361,7 +361,7 @@ o.spec("LoginViewModelTest", () => {
 			o(viewModel.state).equals(LoginState.UnknownError)
 			o(viewModel.displayMode).equals(DisplayMode.Credentials)
 			o(viewModel.getSavedCredentials()).deepEquals([unencryptedCredentials.credentialInfo])
-			o(lang.getMaybeLazy(viewModel.helpText)).satisfies(textIncludes("test"))
+			o(lang.getTranslationText(viewModel.helpText)).satisfies(textIncludes("test"))
 		})
 	})
 	o.spec("Login with email and password", function () {


### PR DESCRIPTION
The reason for this refactor is to make it possible to put "data-testid" attributes on HTML tags. Those attributes can be used with UI test frameworks to make automated testing independent of the translation language or text.

The idea is to get rid of the lazy<string> types and instead use a new type called Translation wherever possible. Translation replaces the old TranslationText and contains both translation key and translation text.

The type MaybeTranslation is a legacy type left to make the transition feasible. It can be replaced with either TranslationKey or Translation in the future.