### PR TITLE
Rejects invalid short dates

### DIFF
--- a/src/common/misc/DateParser.ts
+++ b/src/common/misc/DateParser.ts
@@ -137,6 +137,12 @@ export function parseBirthday(text: string, referenceDateRenderer: (refdate: Dat
 
 		let day, month, year
 
+		// We must validate that NO birthdayValues is equal to 0 since we don't support only
+		// year and month. e.g. 07/00
+		if (birthdayValues.length == 2 && (birthdayValues[0] === 0 || birthdayValues[1] === 0)) {
+			return null
+		}
+
 		if (String(birthdayValues[dayPos]).length < 3 && String(birthdayValues[monthPos]).length < 3) {
 			if (birthdayValues[dayPos] < 32) {
 				day = String(birthdayValues[dayPos])


### PR DESCRIPTION
Adds a validation to mark short year/month dates as invalid. The only validation that we were doing was if Date(str) is valid, which is but not valid as intended to be. e.g. 00-07 would be interpreted as 07/1900 by JS Date instead of 07/2000 as expected.

Closes #8051
