### PR TITLE
fix minor issues with rust version 1.78

### DIFF
--- a/packages/node-mimimi/src/importer.rs
+++ b/packages/node-mimimi/src/importer.rs
@@ -478,7 +478,7 @@ impl Importer {
 	/// check the given directory for any failed mail files that have been left behind during iteration
 	pub(crate) fn have_failed_mails(import_directory: &Path) -> std::io::Result<bool> {
 		let failed_sub_dir = import_directory.join(FAILED_MAILS_SUB_DIR);
-		let have_failed_mails = fs::read_dir(&failed_sub_dir)?
+		let have_failed_mails = fs::read_dir(failed_sub_dir)?
 			.collect::<std::io::Result<Vec<DirEntry>>>()?
 			.iter()
 			.map(DirEntry::path)
@@ -543,12 +543,9 @@ impl Importer {
 		let mail_group_key = logged_in_sdk
 			.get_current_sym_group_key(&target_owner_group)
 			.await
-			.map_err(|e| {
-				eprintln!("Can not load mail group key: {e:?}");
-				PreparationError::NoMailGroupKey
-			})?;
+			.map_err(|_| PreparationError::NoMailGroupKey)?;
 
-		// the key is not copy and we want to re-use it after moving it into the map fn
+		// the key is not copy, and we want to re-use it after moving it into the map fn
 		// not using a move closure also doesn't work since we don't want to collect the iterator here.
 		let mail_group_key_clone = mail_group_key.clone();
 		let attachment_upload_data = import_source.into_iter().map(move |importable_mail| {
@@ -780,7 +777,7 @@ impl Importer {
 				let too_big_chunk_path = import_error
 					.path
 					.expect("All too bug chunk error should contain path");
-				FileImport::move_failed_eml_file(&PathBuf::from(too_big_chunk_path)).unwrap();
+				FileImport::move_failed_eml_file(&PathBuf::from(too_big_chunk_path)).ok();
 
 				Ok(())
 			},
@@ -816,7 +813,7 @@ impl Importer {
 
 		let id_tuple_str = fs::read_to_string(&state_file_path)?;
 		let [list_id, element_id] = id_tuple_str
-			.split("/")
+			.split('/')
 			.map(String::from)
 			.collect::<Vec<_>>()
 			.try_into()

--- a/packages/node-mimimi/src/importer/file_reader.rs
+++ b/packages/node-mimimi/src/importer/file_reader.rs
@@ -50,10 +50,10 @@ impl FileImport {
 			.expect("failed eml path will always have filename");
 		let import_directory = failed_eml_path
 			.parent()
-			.ok_or(std::io::ErrorKind::NotADirectory)?;
+			.ok_or(std::io::ErrorKind::NotFound)?;
 		let new_failed_eml_path = import_directory.join(FAILED_MAILS_SUB_DIR).join(filename);
 
-		fs::rename(failed_eml_path, &new_failed_eml_path)
+		fs::rename(failed_eml_path, new_failed_eml_path)
 	}
 
 	/// Convert mbox files to eml and copy all eml files to target_folder.
@@ -77,7 +77,7 @@ impl FileImport {
 
 		fs::create_dir_all(&import_directory_path)
 			.map_err(|_| PreparationError::CanNotCreateImportDir)?;
-		fs::create_dir_all(&failed_sub_directory_path)
+		fs::create_dir_all(failed_sub_directory_path)
 			.map_err(|_| PreparationError::CanNotCreateImportDir)?;
 
 		for source_path in source_paths {

--- a/packages/node-mimimi/src/importer/filename_producer.rs
+++ b/packages/node-mimimi/src/importer/filename_producer.rs
@@ -27,8 +27,8 @@ impl<'a> FileNameProducer<'a> {
 			.file_name()
 			.and_then(OsStr::to_str)
 			.unwrap_or("unnamed")
-			.to_string()
-			+ "-" + self.eml_file_count.to_string().as_str()
+			.to_string() + "-"
+			+ self.eml_file_count.to_string().as_str()
 			+ ".eml";
 
 		self.eml_file_count += 1;
@@ -42,8 +42,8 @@ impl<'a> FileNameProducer<'a> {
 			.file_name()
 			.and_then(OsStr::to_str)
 			.unwrap_or("unnamed")
-			.to_string()
-			+ "-" + self.mbox_file_count.to_string().as_str()
+			.to_string() + "-"
+			+ self.mbox_file_count.to_string().as_str()
 			+ ".mbox";
 
 		self.mbox_file_count += 1;

--- a/packages/node-mimimi/src/importer/importable_mail/extend_mail_parser.rs
+++ b/packages/node-mimimi/src/importer/importable_mail/extend_mail_parser.rs
@@ -158,7 +158,7 @@ impl MakeString for mail_parser::ContentType<'_> {
 
 fn make_mail_address(name: Option<&str>, address: Option<&str>) -> String {
 	let name = name.unwrap_or_default();
-	let mut res = if name.is_empty() || name.starts_with("\"") {
+	let mut res = if name.is_empty() || name.starts_with('\"') {
 		name.to_string()
 	} else {
 		// always wrap name in quotes. tutadb: #417

--- a/packages/node-mimimi/src/importer/importable_mail/plain_text_to_html_converter.rs
+++ b/packages/node-mimimi/src/importer/importable_mail/plain_text_to_html_converter.rs
@@ -64,10 +64,10 @@ pub(super) fn plain_text_to_html(plain_text: &str) -> String {
 }
 
 fn escape_plain_text_line(line: &str) -> String {
-	let escaped_line = line.replace("&", "&amp;");
-	let escaped_line = escaped_line.replace("<", "&lt;");
+	let escaped_line = line.replace('&', "&amp;");
+	let escaped_line = escaped_line.replace('<', "&lt;");
 
-	escaped_line.replace(">", "&gt;")
+	escaped_line.replace('>', "&gt;")
 }
 
 fn get_line_quote_level(line: String) -> i32 {

--- a/tuta-sdk/rust/sdk/src/id/id_tuple.rs
+++ b/tuta-sdk/rust/sdk/src/id/id_tuple.rs
@@ -41,7 +41,7 @@ impl TryFrom<String> for IdTupleGenerated {
 	type Error = ();
 
 	fn try_from(value: String) -> Result<Self, Self::Error> {
-		let mut ids: Vec<_> = value.split("/").collect();
+		let mut ids: Vec<_> = value.split('/').collect();
 		let element_id = ids.pop().ok_or(())?;
 		let list_id = ids.pop().ok_or(())?;
 		Ok(IdTupleGenerated::new(


### PR DESCRIPTION
Our Jenkins CI is still using rust version 1.78 to compile certain artifacts. This commits ensures that the project is compatible with rust version 1.78.