### PR TITLE
Fix contact view invalid layout width

### DIFF
--- a/src/mail-app/contacts/view/ContactView.ts
+++ b/src/mail-app/contacts/view/ContactView.ts
@@ -120,7 +120,7 @@ export class ContactView extends BaseTopLevelView implements TopLevelView<Contac
 			},
 			ColumnType.Foreground,
 			{
-				minWidth: size.first_col_max_width,
+				minWidth: size.first_col_min_width,
 				maxWidth: size.first_col_max_width,
 				headerCenter: "folderTitle_label",
 			},


### PR DESCRIPTION
Between 1140px and 1200px width there's a mix of desktop header and two-column layout. Caused by minWidth using first_col_max_width.

Close #6850