### PR TITLE
fix ImportMailState CREATE event not downloading imported mails

### DIFF
--- a/src/mail-app/mail/view/MailViewModel.ts
+++ b/src/mail-app/mail/view/MailViewModel.ts
@@ -516,7 +516,10 @@ export class MailViewModel {
 						this.stickyMailId = null
 					}
 				}
-			} else if (isUpdateForTypeRef(ImportMailStateTypeRef, update) && update.operation == OperationType.UPDATE) {
+			} else if (
+				isUpdateForTypeRef(ImportMailStateTypeRef, update) &&
+				(update.operation == OperationType.CREATE || update.operation == OperationType.UPDATE)
+			) {
 				importMailStateUpdates.push(update)
 			}
 


### PR DESCRIPTION
After importing mails on the desktop client, those mails are not visible immediately on other devices with offline storage. This is due to the optimization of EntityEvents (CREATE + UPDATE = CREATE). Previously, the mails were only downloaded on ImportMailState UPDATE events in the MailViewModel, which are never processed on the devices not making the import. This led to a corrupted state where the imported mails are never downloaded to the device. This fix ensures that the mails are downloaded and the offline storage is updated properly.