### PR TITLE
fix ImportMailState CREATE event not updating the search indexer

### DIFF
--- a/src/mail-app/workerUtils/index/MailIndexer.ts
+++ b/src/mail-app/workerUtils/index/MailIndexer.ts
@@ -643,9 +643,9 @@ export class MailIndexer {
 	async processImportStateEntityEvents(events: EntityUpdate[], groupId: Id, batchId: Id, indexUpdate: IndexUpdate): Promise<void> {
 		if (!this.mailIndexingEnabled) return Promise.resolve()
 		await promiseMap(events, async (event) => {
-			// we can only process update event,
-			// and we don't have to look for delete
-			if (event.operation === OperationType.UPDATE) {
+			// we can only process create and update events (create is because of EntityEvent optimization
+			// (CREATE + UPDATE = CREATE) which requires us to process CREATE events with imported mails)
+			if (event.operation === OperationType.CREATE || event.operation === OperationType.UPDATE) {
 				let mailIds: IdTuple[] = await this.loadImportedMailIdsInIndexDateRange([event.instanceListId, event.instanceId])
 
 				await this.preloadMails(mailIds)


### PR DESCRIPTION
After importing mails on the desktop client, those mails were not indexed properly due to missing of the CREATE entity event. This is due to the optimization of EntityEvents (CREATE + UPDATE = CREATE). Previously, the mails were only indexed on ImportMailState UPDATE events in the MailIndexer, This led to a corrupted state where the imported mails are never indexed properly and required the deletion of the offline cache. This fix ensures that the mails are indexed properly.