### PR TITLE
Show which calendar the event belongs to at event preview

### DIFF
--- a/src/calendar-app/calendar/gui/eventpopup/CalendarEventPopup.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/CalendarEventPopup.ts
@@ -127,6 +127,7 @@ export class CalendarEventPopup implements ModalComponent {
 						// use the version of the event the popup was opened with, which means the next
 						// click uses an outdated version.
 						participation: this.model.getParticipationSetterAndThen(() => this.close()),
+						calendarEventPreviewModel: this.model,
 					} satisfies EventPreviewViewAttrs),
 				]),
 			],

--- a/src/calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.ts
@@ -229,4 +229,9 @@ export class CalendarEventPreviewViewModel {
 	getSanitizedDescription() {
 		return this.sanitizedDescription
 	}
+
+	getCalendarRenderInfo() {
+		if (!this.calendarEvent._ownerGroup) throw new Error("Event without an owner group")
+		return this.calendarModel.getCalendarRenderInfo(this.calendarEvent._ownerGroup)
+	}
 }

--- a/src/calendar-app/calendar/view/EventDetailsView.ts
+++ b/src/calendar-app/calendar/view/EventDetailsView.ts
@@ -32,6 +32,7 @@ export class EventDetailsView implements Component<EventDetailsViewAttrs> {
 					event: this.model.calendarEvent,
 					sanitizedDescription: this.model.getSanitizedDescription(),
 					participation: this.model.getParticipationSetterAndThen(() => null),
+					calendarEventPreviewModel: this.model,
 				}),
 			),
 			m(".flex.mt-xs", [this.renderSendUpdateButton(), this.renderEditButton(), this.renderDeleteButton()]),


### PR DESCRIPTION
Add calendar info, color, name, and type, at event popup and event details (search and agenda view)
Changes icon alignment to always align to the top, except when the data displayed fits in a single line, in this case it's centered.
Closes #7209 