### PR TITLE
don't delete outdated external calendar events in parallel

### DIFF
--- a/src/calendar-app/calendar/model/CalendarModel.ts
+++ b/src/calendar-app/calendar/model/CalendarModel.ts
@@ -120,7 +120,13 @@ export class CalendarModel {
 	 * We use the counter to remove the pending request from map when all alarms are processed. We want to do that in case the event gets updated and we need
 	 * to wait for the new version of the event.
 	 */
-	private pendingAlarmRequests: Map<string, { pendingAlarmCounter: number; deferred: DeferredObject<void> }> = new Map()
+	private pendingAlarmRequests: Map<
+		string,
+		{
+			pendingAlarmCounter: number
+			deferred: DeferredObject<void>
+		}
+	> = new Map()
 	private readonly userAlarmToAlarmInfo: Map<string, string> = new Map()
 	private readonly fileIdToSkippedCalendarEventUpdates: Map<Id, CalendarEventUpdate> = new Map()
 
@@ -394,7 +400,7 @@ export class CalendarModel {
 				assertEventValidity(event)
 				operationsLog.created.push(event)
 			}
-			this.calendarFacade.saveImportedCalendarEvents(eventsForCreation, 0)
+			await this.calendarFacade.saveImportedCalendarEvents(eventsForCreation, 0)
 			console.log(TAG, `${operationsLog.created.length} events created`)
 
 			// Remove rest
@@ -402,7 +408,7 @@ export class CalendarModel {
 				(existingEvent) => !parsedExternalEvents.some((externalEvent) => externalEvent.event.uid === existingEvent.uid),
 			)
 			for (const event of eventsToRemove) {
-				this.deleteEvent(event).catch((err) => {
+				await this.deleteEvent(event).catch((err) => {
 					if (err instanceof NotFoundError) {
 						return console.log(`Already deleted event`, event)
 					}


### PR DESCRIPTION
we're seeing some external calendars that change UIDs every day, so it's causing a lot of request on login. the fact that it's done by the calendarModel without any concurrency control also leads to users getting IP banned; the client fires all the delete requests in parallel which gives the connection pooling no chance to kick in because by the time the first TLS handshake is done, all requests are in flight already

awaiting each delete request makes the whole process take more time and more likely to be interrupted. we will have to rethink external calendar sync to improve this.

## Test Notes
this is probably annoying to test because of the debounce for calendar sync. it's probably best to set up a shared calendar on some other services and change them manually.
It needs to be tested on desktop, ios and android if possible.

* [ ] subscribe to some external calendars
* [ ] try to re-sync them after changing lots of events, there should be no errors
* [ ] try to delete the external calendar from some client while another is syncing it. there should be no errors.