### PR TITLE
Fix login issues

### DIFF
--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -590,7 +590,11 @@ class CalendarLocator {
 		this.contactFacade = contactFacade
 		this.serviceExecutor = serviceExecutor
 		this.sqlCipherFacade = sqlCipherFacade
-		this.logins = new LoginController(this.loginFacade, async () => this.loginListener)
+		this.logins = new LoginController(
+			this.loginFacade,
+			async () => this.loginListener,
+			() => this.worker.reset(),
+		)
 		// Should be called elsewhere later e.g. in CommonLocator
 		this.logins.init()
 		this.eventController = new EventController(calendarLocator.logins)

--- a/src/common/api/main/UserController.ts
+++ b/src/common/api/main/UserController.ts
@@ -251,7 +251,6 @@ export class UserController {
 			if (this.sessionType !== SessionType.Persistent) {
 				await locator.loginFacade.deleteSession(this.accessToken).catch((e) => console.log("Error ignored on Logout:", e))
 			}
-			await locator.worker.reset()
 		}
 	}
 

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -745,7 +745,11 @@ class MailLocator {
 		this.contactFacade = contactFacade
 		this.serviceExecutor = serviceExecutor
 		this.sqlCipherFacade = sqlCipherFacade
-		this.logins = new LoginController(this.loginFacade, async () => this.loginListener)
+		this.logins = new LoginController(
+			this.loginFacade,
+			async () => this.loginListener,
+			() => this.worker.reset(),
+		)
 		// Should be called elsewhere later e.g. in CommonLocator
 		this.logins.init()
 		this.eventController = new EventController(mailLocator.logins)


### PR DESCRIPTION
In some cases LoginFacade does succeed with the partial login, but some login actions fail on the page side, e.g. loading of `TutanotaProperties`. This leads to an inconsistent state where the worker is in the logged in state while the page context is not.

We solve the issue by catching the errors during page context init and resetting the state on both sides.

In the future we could make the process more robust by loading all the necessary parts in `LoginFacade` or making some parts lazy-loaded.

Fix #5537