### PR TITLE
Change exported mail file name to include mailId

### DIFF
--- a/src/common/desktop/export/DesktopExportFacade.ts
+++ b/src/common/desktop/export/DesktopExportFacade.ts
@@ -22,6 +22,7 @@ import { formatSortableDate } from "@tutao/tutanota-utils"
 import { FileOpenError } from "../../api/common/error/FileOpenError.js"
 import { ExportError, ExportErrorReason } from "../../api/common/error/ExportError"
 import { DesktopExportLock, LockResult } from "./DesktopExportLock"
+import { elementIdPart } from "../../api/common/utils/EntityUtils"
 
 const EXPORT_DIR = "export"
 
@@ -172,7 +173,7 @@ export class DesktopExportFacade implements ExportFacade {
 		if (exportState == null || exportState.type !== "running") {
 			throw new ProgrammingError("Export is not running")
 		}
-		const filename = generateExportFileName(bundle.subject, new Date(bundle.sentOn), "eml")
+		const filename = generateExportFileName(elementIdPart(bundle.mailId), bundle.subject, new Date(bundle.sentOn), "eml")
 		const fullPath = path.join(exportState.exportDirectoryPath, filename)
 		const file = mailToEmlFile(bundle, filename)
 		try {

--- a/src/mail-app/mail/export/Exporter.ts
+++ b/src/mail-app/mail/export/Exporter.ts
@@ -12,6 +12,7 @@ import { CancelledError } from "../../../common/api/common/error/CancelledError.
 import { CryptoFacade } from "../../../common/api/worker/crypto/CryptoFacade.js"
 import { MailBundle, MailExportMode } from "../../../common/mailFunctionality/SharedMailUtils.js"
 import { generateExportFileName, mailToEmlFile } from "./emlUtils.js"
+import { elementIdPart } from "../../../common/api/common/utils/EntityUtils"
 
 export async function generateMailFile(bundle: MailBundle, fileName: string, mode: MailExportMode): Promise<DataFile> {
 	return mode === "eml" ? mailToEmlFile(bundle, fileName) : locator.fileApp.mailToMsg(bundle, fileName)
@@ -90,7 +91,11 @@ export async function exportMails(
 			if (!bundle) continue
 
 			checkAbortSignal()
-			const mailFile = await generateMailFile(bundle, generateExportFileName(bundle.subject, new Date(bundle.receivedOn), mode), mode)
+			const mailFile = await generateMailFile(
+				bundle,
+				generateExportFileName(elementIdPart(bundle.mailId), bundle.subject, new Date(bundle.receivedOn), mode),
+				mode,
+			)
 			dataFiles.push(mailFile)
 			updateProgress()
 		}

--- a/src/mail-app/mail/export/emlUtils.ts
+++ b/src/mail-app/mail/export/emlUtils.ts
@@ -129,8 +129,8 @@ function breakIntoLines(string: string): Array<string> {
 	return string.length > 0 ? assertNotNull(string.match(/.{1,78}/g)) : []
 }
 
-export function generateExportFileName(subject: string, sentOn: Date, mode: MailExportMode): string {
-	let filename = [...formatSortableDateTime(sentOn).split(" "), subject].join("-")
+export function generateExportFileName(id: string, subject: string, sentOn: Date, mode: MailExportMode): string {
+	let filename = [...formatSortableDateTime(sentOn).split(" "), id, subject].join("-")
 	filename = filename.trim()
 
 	if (filename.length === 0) {

--- a/src/mail-app/mail/view/MailListView.ts
+++ b/src/mail-app/mail/view/MailListView.ts
@@ -12,7 +12,7 @@ import { Button, ButtonColor, ButtonType } from "../../../common/gui/base/Button
 import { Dialog } from "../../../common/gui/base/Dialog"
 import { assertNotNull, AsyncResult, downcast, neverNull, promiseMap } from "@tutao/tutanota-utils"
 import { locator } from "../../../common/api/main/CommonLocator"
-import { getLetId, haveSameId } from "../../../common/api/common/utils/EntityUtils"
+import { getElementId, getLetId, haveSameId } from "../../../common/api/common/utils/EntityUtils"
 import { moveMails, promptAndDeleteMails } from "./MailGuiUtils"
 import { MailRow } from "./MailRow"
 import { makeTrackedProgressMonitor } from "../../../common/api/common/utils/ProgressMonitor"
@@ -224,7 +224,7 @@ export class MailListView implements Component<MailListViewAttrs> {
 		const handleNotDownloaded = (mail: Mail) => {
 			notDownloaded.push({
 				mail,
-				fileName: generateExportFileName(mail.subject, mail.receivedDate, exportMode),
+				fileName: generateExportFileName(getElementId(mail), mail.subject, mail.receivedDate, exportMode),
 			})
 		}
 

--- a/test/tests/desktop/export/DesktopExportFacadeTest.ts
+++ b/test/tests/desktop/export/DesktopExportFacadeTest.ts
@@ -12,6 +12,7 @@ import path from "node:path"
 import { DateProvider } from "../../../../src/common/api/common/DateProvider.js"
 import { ExportError } from "../../../../src/common/api/common/error/ExportError"
 import { DesktopExportLock, LockResult } from "../../../../src/common/desktop/export/DesktopExportLock"
+import { elementIdPart } from "../../../../src/common/api/common/utils/EntityUtils.js"
 
 function enoentError() {
 	const err = new Error()
@@ -186,7 +187,7 @@ o.spec("DesktopExportFacade", function () {
 			}
 			when(persistence.getStateForUser(userId)).thenResolve(runningState)
 			await facade.saveMailboxExport(mailBundleStub, userId, mailBagId, mailId)
-			const fileName = generateExportFileName(mailBundleStub.subject, sentOn, "eml")
+			const fileName = generateExportFileName(elementIdPart(mailBundleStub.mailId), mailBundleStub.subject, sentOn, "eml")
 			const fullPath = path.join(runningState.exportDirectoryPath, fileName)
 			const bundleData = mailToEmlFile(mailBundleStub, fileName)
 


### PR DESCRIPTION
Exporting two mails that have the same subject and sent date will result in the second file overwriting the first one. This is because the exported file name has the following structure: {YYYY-MM-DD-HHhMMmSSs}-{subject}.{exportMode}.

Adding the mailId to the file name solves the issue.

Co-authored-by: ivk <ivk@tutao.de>

Close #8402