### PR TITLE
Set suspension behavior to throw for all export related requests

### DIFF
--- a/src/common/api/worker/facades/lazy/MailExportFacade.ts
+++ b/src/common/api/worker/facades/lazy/MailExportFacade.ts
@@ -13,6 +13,7 @@ import { elementIdPart } from "../../../common/utils/EntityUtils"
 import { BlobAccessTokenFacade } from "../BlobAccessTokenFacade"
 import { BlobServerUrl } from "../../../entities/storage/TypeRefs"
 import { Group } from "../../../entities/sys/TypeRefs"
+import { SuspensionBehavior } from "../../rest/RestClient"
 
 assertWorkerOrNode()
 
@@ -87,11 +88,12 @@ export class MailExportFacade {
 		return attachmentData.filter(isNotNull)
 	}
 
-	private options(token: string): { extraHeaders: Dict } {
+	private options(token: string): { extraHeaders: Dict; suspensionBehavior: SuspensionBehavior.Throw } {
 		return {
 			extraHeaders: {
 				[MAIL_EXPORT_TOKEN_HEADER]: token,
 			},
+			suspensionBehavior: SuspensionBehavior.Throw,
 		}
 	}
 }

--- a/test/tests/api/worker/facades/MailExportFacadeTest.ts
+++ b/test/tests/api/worker/facades/MailExportFacadeTest.ts
@@ -10,6 +10,7 @@ import { FileTypeRef, MailDetailsTypeRef, MailTypeRef } from "../../../../../src
 import { ArchiveDataType } from "../../../../../src/common/api/common/TutanotaConstants"
 import { createReferencingInstance } from "../../../../../src/common/api/common/utils/BlobUtils"
 import { BlobAccessTokenFacade } from "../../../../../src/common/api/worker/facades/BlobAccessTokenFacade"
+import { SuspensionBehavior } from "../../../../../src/common/api/worker/rest/RestClient"
 
 o.spec("MailExportFacade", () => {
 	const token = "my token"
@@ -42,6 +43,7 @@ o.spec("MailExportFacade", () => {
 			bulkMailLoader.loadFixedNumberOfMailsWithCache("mailListId", "startId", {
 				baseUrl: "baseUrl",
 				extraHeaders: tokenHeaders,
+				suspensionBehavior: SuspensionBehavior.Throw,
 			}),
 		).thenResolve([mail1, mail2])
 
@@ -55,7 +57,7 @@ o.spec("MailExportFacade", () => {
 			{ mail: mail1, mailDetails: details1 },
 			{ mail: mail2, mailDetails: details2 },
 		]
-		when(bulkMailLoader.loadMailDetails([mail1, mail2], { extraHeaders: tokenHeaders })).thenResolve(expected)
+		when(bulkMailLoader.loadMailDetails([mail1, mail2], { extraHeaders: tokenHeaders, suspensionBehavior: SuspensionBehavior.Throw })).thenResolve(expected)
 
 		const result = await facade.loadMailDetails([mail1, mail2])
 
@@ -68,6 +70,7 @@ o.spec("MailExportFacade", () => {
 			bulkMailLoader.loadAttachments([mail1, mail2], {
 				baseUrl: "baseUrl",
 				extraHeaders: tokenHeaders,
+				suspensionBehavior: SuspensionBehavior.Throw,
 			}),
 		).thenResolve(expected)
 
@@ -96,6 +99,7 @@ o.spec("MailExportFacade", () => {
 				[createReferencingInstance(mailAttachments[0]), createReferencingInstance(mailAttachments[1])],
 				{
 					extraHeaders: tokenHeaders,
+					suspensionBehavior: SuspensionBehavior.Throw,
 				},
 			),
 		).thenResolve(

--- a/test/tests/api/worker/rest/EntityRestClientTest.ts
+++ b/test/tests/api/worker/rest/EntityRestClientTest.ts
@@ -130,7 +130,12 @@ o.spec("EntityRestClient", function () {
 			).thenResolve(JSON.stringify({ instance: "calendar" }))
 
 			const result = await entityRestClient.load(CalendarEventTypeRef, [calendarListId, id1])
-			o(result as any).deepEquals({ instance: "calendar", decrypted: true, migrated: true, migratedForInstance: true })
+			o(result as any).deepEquals({
+				instance: "calendar",
+				decrypted: true,
+				migrated: true,
+				migratedForInstance: true,
+			})
 		})
 
 		o("loading an element ", async function () {
@@ -145,7 +150,12 @@ o.spec("EntityRestClient", function () {
 			).thenResolve(JSON.stringify({ instance: "customer" }))
 
 			const result = await entityRestClient.load(CustomerTypeRef, id1)
-			o(result as any).deepEquals({ instance: "customer", decrypted: true, migrated: true, migratedForInstance: true })
+			o(result as any).deepEquals({
+				instance: "customer",
+				decrypted: true,
+				migrated: true,
+				migratedForInstance: true,
+			})
 		})
 
 		o("query parameters and additional headers + access token and version are always passed to the rest client", async function () {
@@ -160,7 +170,10 @@ o.spec("EntityRestClient", function () {
 				}),
 			).thenResolve(JSON.stringify({ instance: "calendar" }))
 
-			await entityRestClient.load(CalendarEventTypeRef, [calendarListId, id1], { queryParams: { foo: "bar" }, extraHeaders: { baz: "quux" } })
+			await entityRestClient.load(CalendarEventTypeRef, [calendarListId, id1], {
+				queryParams: { foo: "bar" },
+				extraHeaders: { baz: "quux" },
+			})
 		})
 
 		o("when loading encrypted instance and not being logged in it throws an error", async function () {
@@ -190,7 +203,12 @@ o.spec("EntityRestClient", function () {
 			const typeModel = await resolveTypeReference(CalendarEventTypeRef)
 			verify(instanceMapperMock.decryptAndMapToInstance(typeModel, anything(), sessionKey))
 			verify(cryptoFacadeMock.resolveSessionKey(anything(), anything()), { times: 0 })
-			o(result as any).deepEquals({ _ownerEncSessionKey: "some key", decrypted: true, migrated: true, migratedForInstance: true })
+			o(result as any).deepEquals({
+				_ownerEncSessionKey: "some key",
+				decrypted: true,
+				migrated: true,
+				migratedForInstance: true,
+			})
 		})
 	})
 
@@ -206,6 +224,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { start: startId, count: String(count), reverse: String(false) },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 			).thenResolve(JSON.stringify([{ instance: 1 }, { instance: 2 }]))
 
@@ -235,6 +254,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { ids: "0,1,2,3,4" },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 			).thenResolve(JSON.stringify([{ instance: 1 }, { instance: 2 }]))
 
@@ -257,6 +277,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { ids: ids.join(",") },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 				{ times: 1 },
 			).thenResolve(JSON.stringify([{ instance: 1 }, { instance: 2 }]))
@@ -279,6 +300,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { ids: countFrom(0, 100).join(",") },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 				{ times: 1 },
 			).thenResolve(JSON.stringify([{ instance: 1 }]))
@@ -289,6 +311,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { ids: "100" },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 				{ times: 1 },
 			).thenResolve(JSON.stringify([{ instance: 2 }]))
@@ -309,6 +332,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { ids: countFrom(0, 100).join(",") },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 				{ times: 1 },
 			).thenResolve(JSON.stringify([{ instance: 1 }]))
@@ -319,6 +343,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { ids: countFrom(100, 100).join(",") },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 				{ times: 1 },
 			).thenResolve(JSON.stringify([{ instance: 2 }]))
@@ -329,6 +354,7 @@ o.spec("EntityRestClient", function () {
 					queryParams: { ids: countFrom(200, 11).join(",") },
 					responseType: MediaType.Json,
 					baseUrl: undefined,
+					suspensionBehavior: undefined,
 				}),
 				{ times: 1 },
 			).thenResolve(JSON.stringify([{ instance: 3 }]))
@@ -422,19 +448,31 @@ o.spec("EntityRestClient", function () {
 			when(
 				restClient.request(anything(), HttpMethod.GET, {
 					headers: {},
-					queryParams: { ids: "0,1,2,3,4", ...authHeader, blobAccessToken, v: String(tutanotaModelInfo.version) },
+					queryParams: {
+						ids: "0,1,2,3,4",
+						...authHeader,
+						blobAccessToken,
+						v: String(tutanotaModelInfo.version),
+					},
 					responseType: MediaType.Json,
 					noCORS: true,
 					baseUrl: firstServer,
+					suspensionBehavior: undefined,
 				}),
 			).thenReject(new ConnectionError("test connection error for retry"))
 			when(
 				restClient.request(anything(), HttpMethod.GET, {
 					headers: {},
-					queryParams: { ids: "0,1,2,3,4", ...authHeader, blobAccessToken, v: String(tutanotaModelInfo.version) },
+					queryParams: {
+						ids: "0,1,2,3,4",
+						...authHeader,
+						blobAccessToken,
+						v: String(tutanotaModelInfo.version),
+					},
 					responseType: MediaType.Json,
 					noCORS: true,
 					baseUrl: otherServer,
+					suspensionBehavior: undefined,
 				}),
 			).thenResolve(JSON.stringify([{ instance: 1 }, { instance: 2 }]))
 


### PR DESCRIPTION
This is to prevent suspending subsequent requests when export gets a 429 HTTP response.

Close #8408