### PR TITLE
Fix over-scaling mail body on mobile

### DIFF
--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -252,7 +252,7 @@ styles.registerStyle("main", () => {
 		".border-top": {
 			"border-top": `1px solid ${theme.content_border}`,
 		},
-		"#mail-body.break-pre pre": {
+		"#shadow-mail-body.break-pre pre": {
 			"white-space": "pre-wrap",
 			"word-break": "normal",
 			"overflow-wrap": "anywhere",

--- a/src/mail-app/mail/view/MailViewer.ts
+++ b/src/mail-app/mail/view/MailViewer.ts
@@ -390,6 +390,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 			this.shadowDomRoot.firstChild.remove()
 		}
 		const wrapNode = document.createElement("div")
+		wrapNode.id = "shadow-mail-body"
 		wrapNode.className = "drag selectable touch-callout break-word-links" + (client.isMobileDevice() ? " break-pre" : "")
 		wrapNode.setAttribute("data-testid", "mailBody_label")
 		wrapNode.style.lineHeight = String(this.bodyLineHeight ? this.bodyLineHeight.toString() : size.line_height)


### PR DESCRIPTION
- Break preformatted text on mobile.
- Wrap unbreakable long lines of text when scaling exceeds a certain threshold (scaling might still be applied on top, if necessary).

## Before
<img src="https://github.com/user-attachments/assets/5a5b29cf-92b2-4dd0-88dd-5530b44d7f78" width="220">
<img src="https://github.com/user-attachments/assets/d82d7631-6c49-421c-9daf-e28d7b2e2a3e" width="220">
<img src="https://github.com/user-attachments/assets/ba58cfc9-3dba-4927-89c1-4ad39efa392f" width="220">

## After
<img src="https://github.com/user-attachments/assets/23b1f477-3e70-4686-a039-67080ddce9ae" width="220">
<img src="https://github.com/user-attachments/assets/5c4fd394-440b-42cb-90f0-a79cb29aa05b" width="220">
<img src="https://github.com/user-attachments/assets/3e89b6f7-5f1c-454e-80e9-0d20d3f38c11" width="220">