### PR TITLE
Fix Home Button background color align the app background color

### DIFF
--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -1438,7 +1438,7 @@ styles.registerStyle("main", () => {
 			"border-top": `1px solid ${theme.navigation_border}`,
 			height: positionValue(size.bottom_nav_bar),
 			background: theme.header_bg,
-			"margin-bottom": "env(safe-area-inset-bottom)",
+			"padding-bottom": "env(safe-area-inset-bottom)",
 			"z-index": 2,
 		},
 		".notification-overlay-content": {


### PR DESCRIPTION
Fixed home button background color in ios align to app background color
 when the user is in darkmode theme

close #8426 