### PR TITLE
Use createResizeObserver for ResizeObserver creation everywhere

### DIFF
--- a/packages/tutanota-utils/lib/Utils.ts
+++ b/packages/tutanota-utils/lib/Utils.ts
@@ -616,3 +616,21 @@ export function assertValidURL(url: string) {
 		return false
 	}
 }
+
+/**
+ * Excessive resizing of an observed element can result in one or more resize events being deferred to the next render cycle.
+ * When this happens, the browser sends a `ResizeObserver loop completed with undelivered notifications` error.
+ * To avoid this, we handle resize events in a `requestAnimationFrame` making sure to cancel any pending requests
+ */
+export function createResizeObserver(cb: ResizeObserverCallback): ResizeObserver {
+	let afRequestId: number | null = null
+
+	return new ResizeObserver((entries, observer) => {
+		if (afRequestId != null) {
+			cancelAnimationFrame(afRequestId)
+		}
+		afRequestId = requestAnimationFrame(() => {
+			cb(entries, observer)
+		})
+	})
+}

--- a/src/common/gui/base/List.ts
+++ b/src/common/gui/base/List.ts
@@ -12,6 +12,7 @@ import { theme, ThemeId } from "../theme.js"
 import { ProgrammingError } from "../../api/common/error/ProgrammingError.js"
 import { Coordinate2D } from "./SwipeHandler.js"
 import { styles } from "../styles.js"
+import { createResizeObserver } from "@tutao/tutanota-utils/dist/Utils"
 
 export type ListState<T> = Readonly<{
 	items: ReadonlyArray<T>
@@ -134,9 +135,7 @@ export class List<T, VH extends ViewHolder<T>> implements ClassComponent<ListAtt
 					// Some of the tech-savvy users like to disable *all* "experimental features" in their Safari devices and there's also a toggle to disable
 					// ResizeObserver. Since the app works without it anyway we just fall back to not handling the resize events.
 					if (typeof ResizeObserver !== "undefined") {
-						new ResizeObserver(() => {
-							this.updateSize()
-						}).observe(this.containerDom)
+						createResizeObserver(() => this.updateSize()).observe(this.containerDom)
 					} else {
 						requestAnimationFrame(() => this.updateSize())
 					}


### PR DESCRIPTION
createResizeObserver returns a ResizeObserver that handles resize events in a `requestAnimationFrame`.
This is done to prevent `ResizeObserver loop completed with undelivered notifications` errors, which can happen when excessively resizing an observed element, resulting in resize events being deferred to the next render cycle.

Close #8517