### PR TITLE
Fix zoom factor persistence on macOS 

### DIFF
--- a/src/common/desktop/integration/DesktopIntegratorDarwin.ts
+++ b/src/common/desktop/integration/DesktopIntegratorDarwin.ts
@@ -1,4 +1,4 @@
-import type { MenuItemConstructorOptions } from "electron"
+import type { BaseWindow, KeyboardEvent, MenuItemConstructorOptions } from "electron"
 import type { WindowManager } from "../DesktopWindowManager"
 import { lang } from "../../misc/LanguageViewModel"
 import type { DesktopIntegrator } from "./DesktopIntegrator"
@@ -114,10 +114,32 @@ export class DesktopIntegratorDarwin implements DesktopIntegrator {
 						role: "front",
 					},
 					{
-						role: "zoomIn",
+						click: (_, window, event) => this.emitZoomEvent(wm, window, event, "in"),
+						label: lang.get("zoomIn_action"),
+						accelerator: "Command+=",
+						enabled: true,
 					},
 					{
-						role: "zoomOut",
+						click: (_, window, event) => this.emitZoomEvent(wm, window, event, "out"),
+						label: lang.get("zoomOut_action"),
+						accelerator: "Command+-",
+						enabled: true,
+					},
+					{
+						click: (_, window, event) => this.emitZoomEvent(wm, window, event, "in"),
+						label: lang.get("zoomIn_action"),
+						accelerator: "Command+Shift+=",
+						enabled: true,
+						visible: false,
+						acceleratorWorksWhenHidden: true,
+					},
+					{
+						click: (_, window, event) => this.emitZoomEvent(wm, window, event, "out"),
+						label: lang.get("zoomOut_action"),
+						accelerator: "Command+Shift+-",
+						enabled: true,
+						visible: false,
+						acceleratorWorksWhenHidden: true,
 					},
 					{
 						role: "resetZoom",
@@ -139,6 +161,13 @@ export class DesktopIntegratorDarwin implements DesktopIntegrator {
 		this._electron.Menu.setApplicationMenu(menu)
 
 		return Promise.resolve()
+	}
+
+	private emitZoomEvent(wm: WindowManager, baseWindow: BaseWindow | undefined, event: KeyboardEvent, direction: "in" | "out"): void {
+		if (baseWindow == null) {
+			return
+		}
+		wm.get(baseWindow.id)?._browserWindow.webContents.emit("zoom-changed", event, direction)
 	}
 
 	isIntegrated(): Promise<boolean> {


### PR DESCRIPTION
"zoom-changed" event only fires on pinch zoom on macOS and not when zooming using menu items or keyboard shortcuts.

To make sure zoom is handled similar to other platform, zoom menu items are replaced with custom ones that emit "zoom-changed" events when activated.

Close: #5441 