### PR TITLE
Fixes External Calendars synchronization

### DIFF
--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -749,6 +749,11 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			dialog.close()
 		}
 		const createExternalCalendar = async (dialog: Dialog, properties: CalendarProperties, calendarModel: CalendarModel) => {
+			if (this.viewModel.isCreatingExternalCalendar) {
+				return
+			}
+			this.viewModel.isCreatingExternalCalendar = true
+
 			const iCalStr = await handleUrlSubscription(calendarModel, properties.sourceUrl!)
 			if (iCalStr instanceof Error) throw iCalStr
 
@@ -757,6 +762,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 				events = parseCalendarStringData(iCalStr, getTimeZone()).contents
 			} catch (e) {
 				await Dialog.message("invalidICal_error", e.message)
+				this.viewModel.isCreatingExternalCalendar = false
 				return
 			}
 
@@ -764,6 +770,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			const calendarGroupRoot = await locator.entityClient.load(CalendarGroupRootTypeRef, calendarGroup._id)
 			deviceConfig.updateLastSync(calendarGroup._id)
 			await handleCalendarImport(calendarGroupRoot, events, CalendarType.URL)
+			this.viewModel.isCreatingExternalCalendar = false
 			dialog.close()
 		}
 

--- a/src/calendar-app/calendar/view/CalendarViewModel.ts
+++ b/src/calendar-app/calendar/view/CalendarViewModel.ts
@@ -113,6 +113,7 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 	private _isNewPaidPlan: boolean = false
 	private localCalendars: Map<Id, CalendarInfo> = new Map<Id, CalendarInfo>()
 	private _calendarColors: GroupColors = new Map()
+	isCreatingExternalCalendar: boolean = false
 
 	constructor(
 		private readonly logins: LoginController,


### PR DESCRIPTION
Adds a flag when subscribing to external calendars that locks the interface and prevents users from subscribing to the same calendar multiple times.

It also adds a queue to calendar sync and synchronizes it, preventing the same calendar from being synced in parallel.

Fixes #8446
Fixes #8447