### PR TITLE
Fix mail indexer slowness

### DIFF
--- a/src/common/api/common/EntityClient.ts
+++ b/src/common/api/common/EntityClient.ts
@@ -13,10 +13,12 @@ import {
 	elementIdPart,
 	firstBiggerThanSecond,
 	GENERATED_MIN_ID,
+	generatedIdToTimestamp,
 	getElementId,
 	getLetId,
 	listIdPart,
 	RANGE_ITEM_LIMIT,
+	timeRangeToString,
 } from "./utils/EntityUtils"
 import { Type, ValueType } from "./EntityConstants.js"
 import { downcast, groupByAndMap, last, promiseMap, TypeRef } from "@tutao/tutanota-utils"
@@ -69,7 +71,20 @@ export class EntityClient {
 		if (typeModel.type !== Type.ListElement) throw new Error("only ListElement types are permitted")
 		const loadedEntities = await this._target.loadRange<T>(typeRef, listId, start, rangeItemLimit, true)
 		const filteredEntities = loadedEntities.filter((entity) => firstBiggerThanSecond(getElementId(entity), end, typeModel))
-
+		// FIXME remove
+		if (typeRef.type === "Mail") {
+			console.log("loadReverseRangeBetween", listId, start, end, `loaded ${loadedEntities.length}, filtered: ${filteredEntities.length}`)
+		}
+		if (loadedEntities.length !== 0 && filteredEntities.length === 0) {
+			console.log(
+				"loadReverseRangeBetween",
+				"did throw away everything!",
+				listId,
+				timeRangeToString([generatedIdToTimestamp(start), generatedIdToTimestamp(end)]),
+				"first mail id time",
+				new Date(generatedIdToTimestamp(getElementId(loadedEntities[0]))).toDateString(),
+			)
+		}
 		if (filteredEntities.length === rangeItemLimit) {
 			const lastElementId = getElementId(filteredEntities[loadedEntities.length - 1])
 			const { elements: remainingEntities, loadedCompletely } = await this.loadReverseRangeBetween<T>(typeRef, listId, lastElementId, end, rangeItemLimit)

--- a/src/common/api/common/utils/EntityUtils.ts
+++ b/src/common/api/common/utils/EntityUtils.ts
@@ -18,6 +18,7 @@ import {
 } from "@tutao/tutanota-utils"
 import { Cardinality, ValueType } from "../EntityConstants.js"
 import type { ElementEntity, Entity, ModelValue, SomeEntity, TypeModel } from "../EntityTypes"
+import { TimeRange } from "../../../../mail-app/workerUtils/index/BulkMailLoader"
 
 /**
  * the maximum ID for elements stored on the server (number with the length of 10 bytes) => 2^80 - 1
@@ -483,3 +484,8 @@ export const LEGACY_TO_RECIPIENTS_ID = 112
 export const LEGACY_CC_RECIPIENTS_ID = 113
 export const LEGACY_BCC_RECIPIENTS_ID = 114
 export const LEGACY_BODY_ID = 116
+
+// FIXME move this somewhere else
+export function timeRangeToString([rangeStart, rangeEnd]: TimeRange): string {
+	return `[${rangeStart} (${new Date(rangeStart).toDateString()})-${rangeEnd} (${new Date(rangeEnd).toDateString()})]`
+}

--- a/src/mail-app/workerUtils/index/BulkMailLoader.ts
+++ b/src/mail-app/workerUtils/index/BulkMailLoader.ts
@@ -1,7 +1,7 @@
 import { assertNotNull, groupBy, groupByAndMap, neverNull, promiseMap, splitInChunks, TypeRef } from "@tutao/tutanota-utils"
 import { EntityClient } from "../../../common/api/common/EntityClient.js"
 import { ExposedCacheStorage } from "../../../common/api/worker/rest/DefaultEntityRestCache.js"
-import { elementIdPart, isSameId, listIdPart, timestampToGeneratedId } from "../../../common/api/common/utils/EntityUtils.js"
+import { elementIdPart, isSameId, listIdPart, timeRangeToString, timestampToGeneratedId } from "../../../common/api/common/utils/EntityUtils.js"
 import { CacheMode, EntityRestClientLoadOptions, OwnerEncSessionKeyProvider } from "../../../common/api/worker/rest/EntityRestClient.js"
 import { isDraft } from "../../mail/model/MailChecks.js"
 import {
@@ -33,20 +33,19 @@ export class BulkMailLoader {
 		private readonly cachedStorage: ExposedCacheStorage | null,
 	) {}
 
-	loadMailsInRangeWithCache(
+	async loadMailsInRangeWithCache(
 		mailListId: Id,
 		[rangeStart, rangeEnd]: TimeRange,
 	): Promise<{
 		elements: Array<Mail>
 		loadedCompletely: boolean
 	}> {
-		return this.mailEntityClient.loadReverseRangeBetween(
-			MailTypeRef,
-			mailListId,
-			timestampToGeneratedId(rangeStart),
-			timestampToGeneratedId(rangeEnd),
-			MAIL_INDEXER_CHUNK,
-		)
+		const startId = timestampToGeneratedId(rangeStart)
+		const endId = timestampToGeneratedId(rangeEnd)
+		console.log("BulkMailLoader", `loading ${mailListId}`, timeRangeToString([rangeStart, rangeEnd]), `[${startId}-${endId}]`)
+		const result = await this.mailEntityClient.loadReverseRangeBetween(MailTypeRef, mailListId, startId, endId, MAIL_INDEXER_CHUNK)
+		console.log("BulkMailLoader", `downloaded ${mailListId}`, timeRangeToString([rangeStart, rangeEnd]), `[${startId}-${endId}]`, result.elements.length)
+		return result
 	}
 
 	loadFixedNumberOfMailsWithCache(mailLIstId: Id, startId: Id, options: EntityRestClientLoadOptions = {}): Promise<Mail[]> {

--- a/src/mail-app/workerUtils/index/MailIndexer.ts
+++ b/src/mail-app/workerUtils/index/MailIndexer.ts
@@ -1,6 +1,7 @@
 import {
 	FULL_INDEXED_TIMESTAMP,
 	ImportStatus,
+	isFolder,
 	MailSetKind,
 	MailState,
 	NOTHING_INDEXED_TIMESTAMP,
@@ -19,21 +20,26 @@ import {
 	MailDetailsDraftTypeRef,
 	MailFolder,
 	MailFolderTypeRef,
+	MailSetEntry,
 	MailSetEntryTypeRef,
 	MailTypeRef,
 } from "../../../common/api/entities/tutanota/TypeRefs.js"
 import { ConnectionError, NotAuthorizedError, NotFoundError } from "../../../common/api/common/error/RestError.js"
 import { typeModels } from "../../../common/api/entities/tutanota/TypeModels.js"
-import { assertNotNull, first, groupBy, isEmpty, isNotNull, neverNull, noOp, ofClass, promiseMap } from "@tutao/tutanota-utils"
+import { assertNotNull, clamp, first, groupBy, groupByAndMap, isEmpty, isNotNull, lastThrow, neverNull, noOp, ofClass, promiseMap } from "@tutao/tutanota-utils"
 import {
+	constructMailSetEntryId,
 	deconstructMailSetEntryId,
 	elementIdPart,
+	GENERATED_MAX_ID,
+	getElementId,
 	isSameId,
 	LEGACY_BCC_RECIPIENTS_ID,
 	LEGACY_BODY_ID,
 	LEGACY_CC_RECIPIENTS_ID,
 	LEGACY_TO_RECIPIENTS_ID,
 	listIdPart,
+	timeRangeToString,
 } from "../../../common/api/common/utils/EntityUtils.js"
 import {
 	_createNewIndexUpdate,
@@ -59,11 +65,13 @@ import { b64UserIdHash } from "../../../common/api/worker/search/DbFacade.js"
 import { hasError } from "../../../common/api/common/utils/ErrorUtils.js"
 import { getDisplayedSender, getMailBodyText, MailAddressAndName } from "../../../common/api/common/CommonMailUtils.js"
 import { isDraft } from "../../mail/model/MailChecks.js"
-import { BulkMailLoader } from "./BulkMailLoader.js"
+import { BulkMailLoader, MAIL_INDEXER_CHUNK } from "./BulkMailLoader.js"
 import { parseKeyVersion } from "../../../common/api/worker/facades/KeyLoaderFacade.js"
 
 export const INITIAL_MAIL_INDEX_INTERVAL_DAYS = 28
 const MAIL_INDEX_BATCH_INTERVAL = 1000 * 60 * 60 * 24 // one day
+
+const TAG = "MailIndexer"
 
 export class MailIndexer {
 	// {@link currentIndexTimestamp}: the **oldest** timestamp that has been indexed for all mail lists
@@ -391,7 +399,7 @@ export class MailIndexer {
 		}
 	}
 
-	_indexMailLists(
+	async _indexMailLists(
 		mailBoxes: Array<{
 			mbox: MailBox
 			newestTimestamp: number
@@ -415,38 +423,36 @@ export class MailIndexer {
 
 		const indexLoader = this.bulkLoaderFactory()
 
-		return promiseMap(mailBoxes, (mBoxData) => {
-			return this._loadMailListIds(mBoxData.mbox).then((mailListIds) => {
-				return {
-					mailListIds,
-					newestTimestamp: mBoxData.newestTimestamp,
-					ownerGroup: neverNull(mBoxData.mbox._ownerGroup),
-				}
-			})
-		}).then((mailboxData) => this._indexMailListsInTimeBatches(mailboxData, [newestTimestamp, oldestTimestamp], indexUpdate, progress, indexLoader))
+		const mailboxIndexDatas: Array<MboxIndexData> = await promiseMap(mailBoxes, async (mailboxData) => {
+			const mailSetListIds = await this.loadMailFolderListIds(mailboxData.mbox)
+			return {
+				mailSetListDatas: mailSetListIds.map((listId) => {
+					return { loadedCompletely: false, lastLoadedId: null, loadedButUnusedEntries: [], listId }
+				}),
+				newestTimestamp: mailboxData.newestTimestamp,
+				ownerGroup: assertNotNull(mailboxData.mbox._ownerGroup),
+			}
+		})
+		return this.indexMailListsInTimeBatches(mailboxIndexDatas, [newestTimestamp, oldestTimestamp], indexUpdate, progress, indexLoader)
 	}
 
 	_processedEnough(indexUpdate: IndexUpdate): boolean {
 		return indexUpdate.create.encInstanceIdToElementData.size > 500
 	}
 
-	_indexMailListsInTimeBatches(
-		dataPerMailbox: Array<MboxIndexData>,
-		timeRange: TimeRange,
+	private async indexMailListsInTimeBatches(
+		mailboxIndexDatas: Array<MboxIndexData>,
+		[rangeStart, rangeEnd]: TimeRange,
 		indexUpdate: IndexUpdate,
 		progress: ProgressMonitor,
 		indexLoader: BulkMailLoader,
 	): Promise<void> {
-		const [rangeStart, rangeEnd] = timeRange
-		let batchEnd = rangeStart - MAIL_INDEX_BATCH_INTERVAL
-
 		// Make sure that we index up until aligned date and not more, otherwise it stays misaligned for user after changing the time zone once
-		if (batchEnd < rangeEnd) {
-			batchEnd = rangeEnd
-		}
+		const batchEnd = clamp(rangeStart - MAIL_INDEX_BATCH_INTERVAL, rangeEnd, rangeStart)
 
-		const mailboxesToWrite = dataPerMailbox.filter((mboxData) => batchEnd < mboxData.newestTimestamp)
+		const mailboxesToWrite = mailboxIndexDatas.filter((mboxData) => batchEnd < mboxData.newestTimestamp)
 		const batchRange = [rangeStart, batchEnd] as TimeRange
+		console.log(TAG, "_indexMailListsInTimeBatches", timeRangeToString(batchRange))
 
 		// rangeStart is what we have indexed at the previous step. If it's equals to rangeEnd then we're done.
 		// If it's less then we overdid a little bit but we've covered the range and we will write down rangeStart so
@@ -455,34 +461,32 @@ export class MailIndexer {
 			// all ranges have been processed
 			const indexTimestampPerGroup = mailboxesToWrite.map((data) => ({
 				groupId: data.ownerGroup,
-				indexTimestamp: data.mailListIds.length === 0 ? FULL_INDEXED_TIMESTAMP : rangeStart,
+				indexTimestamp: data.mailSetListDatas.length === 0 ? FULL_INDEXED_TIMESTAMP : rangeStart,
 			}))
-			return this._writeIndexUpdate(indexTimestampPerGroup, indexUpdate).then(() => {
-				progress.workDone(rangeStart - batchEnd)
-			})
+			await this._writeIndexUpdate(indexTimestampPerGroup, indexUpdate)
+			progress.workDone(rangeStart - batchEnd)
+			return
 		}
 
-		return this._prepareMailDataForTimeBatch(mailboxesToWrite, batchRange, indexUpdate, indexLoader).then(() => {
-			const nextRange = [batchEnd, rangeEnd] as TimeRange
+		await this._prepareMailDataForTimeBatch(mailboxesToWrite, batchRange, indexUpdate, indexLoader)
+		const nextRange = [batchEnd, rangeEnd] as TimeRange
 
-			if (this._processedEnough(indexUpdate)) {
-				// only write to database if we have collected enough entities
-				const indexTimestampPerGroup = mailboxesToWrite.map((data) => ({
-					groupId: data.ownerGroup,
-					indexTimestamp: data.mailListIds.length === 0 ? FULL_INDEXED_TIMESTAMP : batchEnd,
-				}))
-				return this._writeIndexUpdate(indexTimestampPerGroup, indexUpdate).then(() => {
-					progress.workDone(rangeStart - batchEnd)
+		if (this._processedEnough(indexUpdate)) {
+			// only write to database if we have collected enough entities
+			const indexTimestampPerGroup = mailboxesToWrite.map((data) => ({
+				groupId: data.ownerGroup,
+				indexTimestamp: data.mailSetListDatas.length === 0 ? FULL_INDEXED_TIMESTAMP : batchEnd,
+			}))
+			await this._writeIndexUpdate(indexTimestampPerGroup, indexUpdate)
+			progress.workDone(rangeStart - batchEnd)
 
-					const newIndexUpdate = _createNewIndexUpdate(indexUpdate.typeInfo)
+			const newIndexUpdate = _createNewIndexUpdate(indexUpdate.typeInfo)
 
-					return this._indexMailListsInTimeBatches(dataPerMailbox, nextRange, newIndexUpdate, progress, indexLoader)
-				})
-			} else {
-				progress.workDone(rangeStart - batchEnd)
-				return this._indexMailListsInTimeBatches(dataPerMailbox, nextRange, indexUpdate, progress, indexLoader)
-			}
-		})
+			return this.indexMailListsInTimeBatches(mailboxIndexDatas, nextRange, newIndexUpdate, progress, indexLoader)
+		} else {
+			progress.workDone(rangeStart - batchEnd)
+			return this.indexMailListsInTimeBatches(mailboxIndexDatas, nextRange, indexUpdate, progress, indexLoader)
+		}
 	}
 
 	/**
@@ -496,40 +500,93 @@ export class MailIndexer {
 		indexLoader: BulkMailLoader,
 	): Promise<void> {
 		const startTimeLoad = getPerformanceTimestamp()
-		return promiseMap(
+		await promiseMap(
 			mboxDataList,
-			(mboxData) => {
-				return promiseMap(
-					mboxData.mailListIds.slice(),
-					async (listId) => {
-						// We use caching here because we may load same emails twice
-						const { elements: mails, loadedCompletely } = await indexLoader.loadMailsInRangeWithCache(listId, timeRange)
-						// If we loaded mail list completely, don't try to load from it anymore
-						if (loadedCompletely) {
-							mboxData.mailListIds.splice(mboxData.mailListIds.indexOf(listId), 1)
-						}
+			async (mboxData) => {
+				const allFolderEntries = await promiseMap(
+					mboxData.mailSetListDatas.filter((data) => !data.loadedCompletely),
+					async (mailListData) => {
+						console.log(TAG, `Download mails for list ${mailListData.listId} ${timeRangeToString(timeRange)}`)
+						// Load mail set entries to cover the range until there are enough. Start loading from the last loaded point for each list.
+						// const { elements: mails, loadedCompletely } = await indexLoader.loadMailsInRangeWithCache(listId, timeRange)
 
-						this._core._stats.mailcount += mails.length
+						const entries = await this.loadMailSetEntriesForTimeRange(mailListData, timeRange)
+
+						this._core._stats.mailcount += entries.length
+
+						// FIXME: we remove mails from cache but MailDetails is probably what takes up the most
 						// Remove all processed entities from cache
-						await Promise.all(mails.map((m) => indexLoader.removeFromCache(m._id)))
-						return this._processIndexMails(mails, indexUpdate, indexLoader)
+						// await Promise.all(mails.map((m) => indexLoader.removeFromCache(m._id)))
+
+						return entries
 					},
 					{
 						concurrency: 2,
 					},
 				)
+				// FIXME we could optimize this in case there are only few emails and keep loading more
+				await this._processIndexMails(allFolderEntries.flat(), indexUpdate, indexLoader)
 			},
 			{
 				concurrency: 5,
 			},
-		).then(() => {
-			this._core._stats.preparingTime += getPerformanceTimestamp() - startTimeLoad
-		})
+		)
+		this._core._stats.preparingTime += getPerformanceTimestamp() - startTimeLoad
 	}
 
-	async _processIndexMails(mails: Array<Mail>, indexUpdate: IndexUpdate, indexLoader: BulkMailLoader): Promise<number> {
+	private async loadMailSetEntriesForTimeRange(mailSetListData: MailSetListData, timeRange: TimeRange): Promise<MailSetEntry[]> {
+		const [rangeStart, rangeEnd] = timeRange
+		// Look for an element that's newer than end of the range in the list
+		const newerItemIndex = mailSetListData.loadedButUnusedEntries.findIndex(
+			(entry) => deconstructMailSetEntryId(getElementId(entry)).receiveDate.getTime() > rangeEnd,
+		)
+		// If there is one we can just use everything that's older than the item outside of range. We take out the
+		// part that we are going to use.
+		if (mailSetListData.lastLoadedId != null && newerItemIndex !== -1) {
+			// +-----------------|--------+
+			//                   index
+			// ^----------------^ <- what we can use
+			return mailSetListData.loadedButUnusedEntries.splice(0, newerItemIndex)
+		} else {
+			// Load from the last loaded element and always load MAIL_INDEXER_CHUNK items to avoid doing small requests.
+			// We would rather do few bigger requests than a lot of small ones.
+			// If start id is not there the indexing might have been just started or restarted. Approximate the start id.
+			const startId = mailSetListData.lastLoadedId ?? constructMailSetEntryId(new Date(rangeStart), GENERATED_MAX_ID)
+			// FIXME: probably not entity client
+			const newItems = await this.entityClient.loadRange(MailSetEntryTypeRef, mailSetListData.listId, startId, MAIL_INDEXER_CHUNK, true)
+			if (newItems.length > 0) {
+				mailSetListData.lastLoadedId = getElementId(lastThrow(newItems))
+			}
+
+			// If we exhausted the list return everything that we've got so far
+			if (newItems.length < MAIL_INDEXER_CHUNK) {
+				const items = mailSetListData.loadedButUnusedEntries.splice(0, mailSetListData.loadedButUnusedEntries.length)
+				mailSetListData.loadedCompletely = true
+				return [...items, ...newItems]
+			} else {
+				// add loaded items again and try to provide the range again
+				mailSetListData.loadedButUnusedEntries.push(...newItems)
+				return this.loadMailSetEntriesForTimeRange(mailSetListData, timeRange)
+			}
+		}
+	}
+
+	private async loadMailsFromMultipleLists(mailSetEntries: readonly MailSetEntry[]): Promise<Mail[]> {
+		const mailIdsByFolder = groupByAndMap(
+			mailSetEntries,
+			(entry) => listIdPart(entry.mail),
+			(entry) => elementIdPart(entry.mail),
+		)
+		// FIXME: maybe not this entityClient
+		const mails = await promiseMap(mailIdsByFolder, ([listId, mailIds]) => this.entityClient.loadMultiple(MailTypeRef, listId, mailIds))
+		return mails.flat()
+	}
+
+	async _processIndexMails(mailSetEntries: Array<MailSetEntry>, indexUpdate: IndexUpdate, indexLoader: BulkMailLoader): Promise<number> {
 		if (this._indexingCancelled) throw new CancelledError("cancelled indexing in processing index mails")
+		const mails = await this.loadMailsFromMultipleLists(mailSetEntries)
 		let mailsWithoutErros = mails.filter((m) => !hasError(m))
+		console.log(TAG, `_processIndexMails ${mails.at(0)?._id.at(0)} ${mails.length}`)
 		const mailsWithMailDetails = await indexLoader.loadMailDetails(mailsWithoutErros)
 		const files = await indexLoader.loadAttachments(mailsWithoutErros)
 		const mailsWithMailDetailsAndFiles = mailsWithMailDetails
@@ -546,17 +603,20 @@ export class MailIndexer {
 
 			this._core.encryptSearchIndexEntries(element.mail._id, neverNull(element.mail._ownerGroup), keyToIndexEntries, indexUpdate)
 		}
+		console.log(TAG, `_processIndexMails done ${mails.at(0)?._id.at(0)} ${mails.length}`)
 		return mailsWithMailDetailsAndFiles.length
 	}
 
-	_writeIndexUpdate(
+	async _writeIndexUpdate(
 		dataPerGroup: Array<{
 			groupId: Id
 			indexTimestamp: number
 		}>,
 		indexUpdate: IndexUpdate,
 	): Promise<void> {
-		return this._core.writeIndexUpdate(dataPerGroup, indexUpdate)
+		console.log(TAG, "_writeIndexUpdate")
+		await this._core.writeIndexUpdate(dataPerGroup, indexUpdate)
+		console.log(TAG, "_writeIndexUpdate done")
 	}
 
 	updateCurrentIndexTimestamp(user: User): Promise<void> {
@@ -585,10 +645,11 @@ export class MailIndexer {
 	}
 
 	/**
-	 * Provides all mail list ids of the given mailbox
+	 * Provides all mail set list ids of the given mailbox
 	 */
-	async _loadMailListIds(mailbox: MailBox): Promise<Id[]> {
-		return [mailbox.currentMailBag!, ...mailbox.archivedMailBags].map((mailbag) => mailbag.mails)
+	private async loadMailFolderListIds(mailbox: MailBox): Promise<Id[]> {
+		const mailSets = await this.entityClient.loadAll(MailFolderTypeRef, assertNotNull(mailbox.folders).folders)
+		return mailSets.filter(isFolder).map((set) => set.entries)
 	}
 
 	_getSpamFolder(mailGroup: GroupMembership): Promise<MailFolder> {
@@ -739,8 +800,16 @@ export function _getCurrentIndexTimestamp(groupIndexTimestamps: number[]): numbe
 }
 
 type TimeRange = [number, number]
+
+interface MailSetListData {
+	listId: Id
+	lastLoadedId: Id | null
+	loadedButUnusedEntries: MailSetEntry[]
+	loadedCompletely: boolean
+}
+
 type MboxIndexData = {
-	mailListIds: Array<Id>
+	mailSetListDatas: Array<MailSetListData>
 	newestTimestamp: number
 	ownerGroup: Id
 }

--- a/src/mail-app/workerUtils/offline/MailOfflineCleaner.ts
+++ b/src/mail-app/workerUtils/offline/MailOfflineCleaner.ts
@@ -27,6 +27,11 @@ import { isDraft, isSpamOrTrashFolder } from "../../mail/model/MailChecks.js"
 
 export class MailOfflineCleaner implements OfflineStorageCleaner {
 	async cleanOfflineDb(offlineStorage: OfflineStorage, timeRangeDays: number | null, userId: Id, now: number): Promise<void> {
+		// FIXME MailOfflineCleaner is currently wrecking the offline cache, especially if we indexed mail set entries
+		//  lists already
+		if (1 + 1 === 2) {
+			return
+		}
 		const user = await offlineStorage.get(UserTypeRef, null, userId)
 
 		// Free users always have default time range regardless of what is stored


### PR DESCRIPTION
Load set set entries, always in full chunks. This gets rid of loading of mails over and over again.

## TODO
 - Figure out caching/entityClient. We just prototyped with the default caching entity client but for the webapp we probably want to use ephemeral one to not run out of RAM. This is normally abstracted away through `BulkMailLoader`. We should probably load mail set entries through it.
 - Fix tests
 - Postpone full loading of data until we have enough mail set entries. This will make sure we don't requests `MailDetails` and `File` entries in small chunks.