### PR TITLE
[desktop] De-init node-mimimi logger on quit instead of on before-quit

### DIFF
--- a/src/common/desktop/mailimport/DesktopMailImportFacade.ts
+++ b/src/common/desktop/mailimport/DesktopMailImportFacade.ts
@@ -90,7 +90,7 @@ export class DesktopMailImportFacade implements NativeMailImportFacade {
 
 	constructor(private readonly electron: ElectronExports, private readonly notifier: DesktopNotifier, private readonly lang: LanguageViewModel) {
 		ImporterApi.initLog()
-		electron.app.on("before-quit", () => ImporterApi.deinitLog())
+		electron.app.on("quit", () => ImporterApi.deinitLog())
 		this.configDirectory = electron.app.getPath("userData")
 	}
 


### PR DESCRIPTION
before-quit might be emitted multiple times such as on an update. This causes the logger to panic due to being de-inited twice.

Close #8619