### PR TITLE
Attachments not removed from viewer in drafts

### DIFF
--- a/src/mail-app/mail/view/MailViewerViewModel.ts
+++ b/src/mail-app/mail/view/MailViewerViewModel.ts
@@ -686,6 +686,8 @@ export class MailViewerViewModel {
 	private async loadAttachments(mail: Mail, inlineCids: string[]): Promise<void> {
 		if (mail.attachments.length === 0) {
 			this.loadingAttachments = false
+			//Setting attachments to empty when we remove the last attachment from the list
+			this.attachments = []
 			m.redraw()
 		} else {
 			this.loadingAttachments = true


### PR DESCRIPTION
When we remove that last attachment from draft and close the editor it is only updating on the mail list not on the viewer. This case happens when there is only one attachment in draft and we try to remove that. Resolved this by setting the attachments array as empty when the loadedAttachments size for mail is empty.

close: #5411
