### PR TITLE
Fix delete action for conversation to only delete mails in trash/spam

### DIFF
--- a/src/common/api/worker/facades/lazy/MailFacade.ts
+++ b/src/common/api/worker/facades/lazy/MailFacade.ts
@@ -425,7 +425,7 @@ export class MailFacade {
 		await this.serviceExecutor.post(ReportMailService, postData)
 	}
 
-	async deleteMails(mails: readonly IdTuple[]): Promise<void> {
+	async deleteMails(mails: readonly IdTuple[], filterMailSet: IdTuple | null): Promise<void> {
 		if (isEmpty(mails)) {
 			return
 		}
@@ -437,7 +437,7 @@ export class MailFacade {
 			for (const mailChunk of mailChunks) {
 				const deleteMailData = createDeleteMailData({
 					mails: mailChunk,
-					folder: null,
+					folder: filterMailSet,
 				})
 				await this.serviceExecutor.delete(MailService, deleteMailData)
 			}

--- a/src/mail-app/mail/model/MailModel.ts
+++ b/src/mail-app/mail/model/MailModel.ts
@@ -332,10 +332,12 @@ export class MailModel {
 	}
 
 	/**
-	 * Finally deletes all given mails. Caller must ensure that mails are only from one folder and the folder must allow final delete operation.
+	 * Finally deletes all given mails. Caller must ensure that all mails are in folders that allows final delete operation.
+	 * @param mailIds mails to delete
+	 * @param filterMailSet when set, only mails in the filterMailSet would be deleted
 	 */
-	async finallyDeleteMails(mailIds: readonly IdTuple[]): Promise<void> {
-		await this.mailFacade.deleteMails(mailIds)
+	async finallyDeleteMails(mailIds: readonly IdTuple[], filterMailSet: IdTuple | null): Promise<void> {
+		await this.mailFacade.deleteMails(mailIds, filterMailSet)
 	}
 
 	/**

--- a/src/mail-app/mail/view/MailGuiUtils.ts
+++ b/src/mail-app/mail/view/MailGuiUtils.ts
@@ -48,16 +48,15 @@ import { getIds } from "../../../common/api/common/utils/EntityUtils"
  */
 export type LazyMailIdResolver = () => $Promisable<readonly IdTuple[]>
 
-export enum DeleteConfirmationResult {
-	Cancel,
-	TrashOnly,
-	FinallyDelete,
-}
-
 /**
  * @return whether emails were deleted
  */
-export async function promptAndDeleteMails(mailModel: MailModel, mailIds: readonly IdTuple[], onConfirm: () => void): Promise<boolean> {
+export async function promptAndDeleteMails(
+	mailModel: MailModel,
+	mailIds: readonly IdTuple[],
+	filterMailSet: IdTuple | null,
+	onConfirm: () => void,
+): Promise<boolean> {
 	const shouldDeletePermanently = await Dialog.confirm("finallyDeleteSelectedEmails_msg", "ok_action")
 	if (!shouldDeletePermanently) {
 		return false
@@ -66,7 +65,7 @@ export async function promptAndDeleteMails(mailModel: MailModel, mailIds: readon
 	onConfirm()
 
 	try {
-		await mailModel.finallyDeleteMails(mailIds)
+		await mailModel.finallyDeleteMails(mailIds, filterMailSet)
 		return true
 	} catch (e) {
 		return handleMoveError(e)

--- a/src/mail-app/mail/view/MailListView.ts
+++ b/src/mail-app/mail/view/MailListView.ts
@@ -411,9 +411,12 @@ export class MailListView implements Component<MailListViewAttrs> {
 
 	private async onSwipeLeft(listElement: Mail): Promise<ListSwipeDecision> {
 		const actionableMails = await this.mailViewModel.getActionableMails([listElement])
+		const currentFolder = this.mailViewModel.getFolder()
 
 		if (this.mailViewModel.currentFolderDeletesPermanently()) {
-			const wereDeleted = await promptAndDeleteMails(mailLocator.mailModel, actionableMails, () => this.mailViewModel.listModel?.selectNone())
+			const wereDeleted = await promptAndDeleteMails(mailLocator.mailModel, actionableMails, assertNotNull(currentFolder)._id, () =>
+				this.mailViewModel.listModel?.selectNone(),
+			)
 			return wereDeleted ? ListSwipeDecision.Commit : ListSwipeDecision.Cancel
 		} else {
 			const wereTrashed = await trashMails(mailLocator.mailModel, actionableMails)

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -6,7 +6,7 @@ import { Dialog } from "../../../common/gui/base/Dialog"
 import { FeatureType, getMailFolderType, Keys, MailSetKind, SystemFolderType } from "../../../common/api/common/TutanotaConstants"
 import { AppHeaderAttrs, Header } from "../../../common/gui/Header.js"
 import { Mail, MailBox, MailFolder } from "../../../common/api/entities/tutanota/TypeRefs.js"
-import { first, getFirstOrThrow, isEmpty, noOp, ofClass } from "@tutao/tutanota-utils"
+import { assertNotNull, first, getFirstOrThrow, isEmpty, noOp, ofClass } from "@tutao/tutanota-utils"
 import { MailListView } from "./MailListView"
 import { assertMainOrNode, isApp } from "../../../common/api/common/Env"
 import type { Shortcut } from "../../../common/misc/KeyManager"
@@ -1025,7 +1025,8 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 
 	private async deleteSelectedMails() {
 		const actionableMails = await this.mailViewModel.getSelectedActionableMails()
-		await promptAndDeleteMails(mailLocator.mailModel, actionableMails, noOp)
+		const currentFolder = assertNotNull(this.mailViewModel.getFolder())
+		await promptAndDeleteMails(mailLocator.mailModel, actionableMails, currentFolder._id, noOp)
 	}
 
 	private async showFolderAddEditDialog(mailGroupId: Id, folder: MailFolder | null, parentFolder: MailFolder | null) {

--- a/src/mail-app/mail/view/MailViewerHeader.ts
+++ b/src/mail-app/mail/view/MailViewerHeader.ts
@@ -737,7 +737,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 				const deleteOrTrashAction: DropdownButtonAttrs = viewModel.isDeletableMail()
 					? {
 							label: "delete_action",
-							click: () => promptAndDeleteMails(viewModel.mailModel, [viewModel.mail._id], noOp),
+							click: () => promptAndDeleteMails(viewModel.mailModel, [viewModel.mail._id], null, noOp),
 							icon: Icons.DeleteForever,
 					  }
 					: {

--- a/src/mail-app/search/view/SearchView.ts
+++ b/src/mail-app/search/view/SearchView.ts
@@ -1189,7 +1189,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 			if (deletable) {
 				return {
 					deleteAction: () => {
-						promptAndDeleteMails(mailLocator.mailModel, getIds(selected), () => this.searchViewModel.listModel.selectNone())
+						promptAndDeleteMails(mailLocator.mailModel, getIds(selected), null, () => this.searchViewModel.listModel.selectNone())
 					},
 					trashAction: null,
 				}


### PR DESCRIPTION
When permanently deleting a conversation that has some of its mails in folders that aren't in trash/spam, only mails that are in the current folder which must be trash/spam are deleted.
This is done by passing the folder id to the DeleteMailService along with all the conversation mailIds.

Close #8658