### PR TITLE
Fix entering multiselect in mail search

### DIFF
--- a/src/mail-app/search/view/SearchView.ts
+++ b/src/mail-app/search/view/SearchView.ts
@@ -582,12 +582,12 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 	}
 
 	private getEditDraftAction(): (() => void) | null {
-		const mails = this.searchViewModel.getSelectedMails()
-		if (mails.length !== 1) {
+		// conversationViewModel is not there if we are in multiselect or if nothing is selected
+		const conversationViewModel = this.searchViewModel.conversationViewModel
+		if (conversationViewModel == null) {
 			return null
 		}
 
-		const conversationViewModel = assertNotNull(this.searchViewModel.conversationViewModel)
 		if (!isDraft(conversationViewModel.primaryMail)) {
 			return null
 		}


### PR DESCRIPTION
The issue happened because we forcefully unwrapped conversationViewModel when only one mail is selected. This is wrong, when one email is selected via multiselect there won't be a conversationViewModel. ViewModel already has this logic so we shouldn't duplicate it in the view.