### PR TITLE
[mail-app] fix the translation for the key "dynamicLoginSwitchingOnPrivacy_msg" in pt-br

### DIFF
--- a/src/mail-app/translations/pt_br.ts
+++ b/src/mail-app/translations/pt_br.ts
@@ -486,7 +486,7 @@ export default {
 		"dynamicLoginPreparingRocketLaunch_msg": "Preparando o lançamento do foguete ...",
 		"dynamicLoginRestockingTutaFridge_msg": "Reesbatecendo o frigorífico Tuta ...",
 		"dynamicLoginSortingContacts_msg": "Ordenando os contatos...",
-		"dynamicLoginSwitchingOnPrivacy_msg": "Ativiando a privacidade...",
+		"dynamicLoginSwitchingOnPrivacy_msg": "Ativando a privacidade...",
 		"dynamicLoginUpdatingOfflineDatabase_msg": "Atualizando para base de dados offline",
 		"Edit contact form": "Editar formulário de contato",
 		"editContactForm_label": "Editar formulário de contato",


### PR DESCRIPTION
The **dynamicLoginSwitchingOnPrivacy_msg** key in translate file for pt-br contains the phrase _“**Ativiando** a privacidade...”_, but the word _“ativiando”_ doesn't exist. The correct word would be _“ativando”_ (equivalent to “enabling” or “activating” in english language). So the correct sentence is: “Ativando a privacidade...”

This Pull Request makes this little rectification.

_Cheers from Brazil 💚💛_