### PR TITLE
[ios] Fix downloading mails for notifications

### DIFF
--- a/app-ios/TutanotaSharedFramework/Notifications/SdkRestClient.swift
+++ b/app-ios/TutanotaSharedFramework/Notifications/SdkRestClient.swift
@@ -12,6 +12,7 @@ public class SdkRestClient: RestClient {
 			case .delete: "delete"
 			case .put: "put"
 			}
+		for (key, value) in options.headers { request.setValue(value, forHTTPHeaderField: key) }
 		request.httpBody = options.body
 		let (data, urlResponse) = try await self.urlSession.data(for: request)
 		let httpUrlResponse = urlResponse as! HTTPURLResponse  // We should only ever receive HTTP URLs


### PR DESCRIPTION
After URLSession refactoring we did not pass the headers that SDK passed to the RestClient to the actual HTTP request.

Additionally, change NotificationService so that the errors do not cause timeout and are logged.