### PR TITLE
Fix duplicate upgrade dialogue to paid plan when in search view

### DIFF
--- a/src/calendar-app/calendar/gui/pickers/DatePicker.ts
+++ b/src/calendar-app/calendar/gui/pickers/DatePicker.ts
@@ -237,13 +237,17 @@ export class DatePicker implements Component<DatePickerAttrs> {
 					}
 
 					this.documentInteractionListener = listener
-					document.addEventListener("click", listener, true)
-					document.addEventListener("focus", listener, true)
+					// We only listen for events on the main view and exclude the modal and overlay layers.
+					// This is done to avoid weird behaviours caused by focus shifting to and from modals
+					const mainViewDom = document.querySelector(".main-view") as HTMLElement
+					mainViewDom.addEventListener("click", listener, true)
+					mainViewDom.addEventListener("focus", listener, true)
 				},
 				onremove: () => {
 					if (this.documentInteractionListener) {
-						document.removeEventListener("click", this.documentInteractionListener, true)
-						document.removeEventListener("focus", this.documentInteractionListener, true)
+						const mainViewDom = document.querySelector(".main-view") as HTMLElement
+						mainViewDom.removeEventListener("click", this.documentInteractionListener, true)
+						mainViewDom.removeEventListener("focus", this.documentInteractionListener, true)
 					}
 				},
 			},


### PR DESCRIPTION
When hitting Return key after extending search range while on free plan, the upgrade dialogue is shown twice.
This happens because input is handled in both the input field's `onkeydown` and in another event listener on the document that is meant to handle input when focus is shifted outside the DatePicker (like when clicking away for example). This is a problem because when the first dialogue appears it grabs focus and since it's outside the DatePicker, it triggers an additional handling of input.

To fix this, we add the event listeners to the main-view instead of the entire document, excluding the modal and overlay layers.

Close #8755
Co-authored-by: hrb-hub <181954414+hrb-hub@users.noreply.github.com>