### PR TITLE
Fix VisualDatePicker showing on mobile when tapping label

### DIFF
--- a/src/calendar-app/calendar/gui/pickers/DatePicker.ts
+++ b/src/calendar-app/calendar/gui/pickers/DatePicker.ts
@@ -285,7 +285,7 @@ export class DatePicker implements Component<DatePickerAttrs> {
 	}
 
 	private renderMobileDateInput({ date, onDateSelected, disabled }: DatePickerAttrs): Children {
-		return m("input.fill-absolute", {
+		return m("input.fill-absolute.z1", {
 			disabled: disabled,
 			type: "date",
 			style: {


### PR DESCRIPTION
The label had a higher z-index than that of the mobile date input which is supposed to cover the input field on mobile.
Giving the mobile date input a z-index of 1 fixes the issue.

Close #8765