### PR TITLE
Put new userGroupKey in the KeyCache after successful rotation

### DIFF
--- a/src/common/api/worker/facades/KeyRotationFacade.ts
+++ b/src/common/api/worker/facades/KeyRotationFacade.ts
@@ -342,6 +342,7 @@ export class KeyRotationFacade {
 		const adminKeyRotationData = await this.prepareKeyRotationForSingleAdmin(keyRotation, user, currentUserGroupKey, currentAdminGroupKey, passphraseKey)
 
 		await this.serviceExecutor.post(AdminGroupKeyRotationService, adminKeyRotationData.keyRotationData)
+		this.userFacade.setNewUserGroupKey(adminKeyRotationData.newUserGroupKeys.symGroupKey)
 		this.groupIdsThatPerformedKeyRotations.add(user.userGroup.group)
 	}
 
@@ -999,6 +1000,7 @@ export class KeyRotationFacade {
 				userGroupKeyData,
 			}),
 		)
+		this.userFacade.setNewUserGroupKey(newUserGroupKeys.symGroupKey)
 		this.groupIdsThatPerformedKeyRotations.add(userGroupId)
 	}
 
@@ -1340,6 +1342,7 @@ export class KeyRotationFacade {
 
 		// call service
 		await this.serviceExecutor.post(AdminGroupKeyRotationService, keyRotationData)
+		this.userFacade.setNewUserGroupKey(symUserGroupKey)
 		this.groupIdsThatPerformedKeyRotations.add(user.userGroup.group)
 	}
 

--- a/src/common/api/worker/facades/UserFacade.ts
+++ b/src/common/api/worker/facades/UserFacade.ts
@@ -264,7 +264,16 @@ export class UserFacade implements AuthDataProvider {
 			object: newUserGroupKeyBytes,
 			version: parseKeyVersion(userGroupKeyDistribution.userGroupKeyVersion),
 		}
-		console.log(`updating userGroupKey. new version: ${userGroupKeyDistribution.userGroupKeyVersion}`)
-		this.keyCache.setCurrentUserGroupKey(newUserGroupKey)
+		this.setNewUserGroupKey(newUserGroupKey)
+	}
+
+	/**
+	 * Update the KeyCache with the newest user group key.
+	 * NOTE: should only be used with a freshly generated key. For keys received from the server, use `updateUserGroupKey`
+	 * @param userGroupKey
+	 */
+	public setNewUserGroupKey(userGroupKey: VersionedKey) {
+		console.log(`updating userGroupKey. new version: ${userGroupKey.version}`)
+		this.keyCache.setCurrentUserGroupKey(userGroupKey)
 	}
 }

--- a/test/tests/api/worker/facades/KeyRotationFacadeTest.ts
+++ b/test/tests/api/worker/facades/KeyRotationFacadeTest.ts
@@ -1024,6 +1024,7 @@ o.spec("KeyRotationFacadeTest", function () {
 				)
 				verify(serviceExecutorMock.put(AdminGroupKeyRotationService, anything()), { times: 0 })
 
+				verify(userFacade.setNewUserGroupKey(NEW_USER_GROUP_KEY))
 				o(keyRotationFacade.pendingKeyRotations.adminOrUserGroupKeyRotation).equals(null)
 				o(keyRotationFacade.pendingKeyRotations.pwKey).equals(null)
 
@@ -1339,6 +1340,7 @@ o.spec("KeyRotationFacadeTest", function () {
 							}),
 						),
 					)
+					verify(userFacade.setNewUserGroupKey(NEW_USER_GROUP_KEY))
 
 					const groupIds = await keyRotationFacade.getGroupIdsThatPerformedKeyRotations()
 					o(groupIds).deepEquals([userGroupId])
@@ -1542,6 +1544,7 @@ o.spec("KeyRotationFacadeTest", function () {
 						}),
 					),
 				)
+				verify(userFacade.setNewUserGroupKey(NEW_USER_GROUP_KEY))
 
 				// noinspection JSVoidFunctionReturnValueUsed
 				verify(


### PR DESCRIPTION
Waitng for the event update to update the cache would cause a race condition where we encrypt with the old key after rotating, which is not allowed.

tutadb#2068