### PR TITLE
Implement keyboard shortcut for zoomin and zoomout

### DIFF
--- a/src/common/api/common/TutanotaConstants.ts
+++ b/src/common/api/common/TutanotaConstants.ts
@@ -817,6 +817,14 @@ export const Keys = Object.freeze({
 		code: "delete",
 		name: "DEL",
 	},
+	"=": {
+		code: "=",
+		name: "=",
+	},
+	"-": {
+		code: "-",
+		name: "-",
+	},
 	"0": {
 		code: "0",
 		name: "0",

--- a/src/common/desktop/ApplicationWindow.ts
+++ b/src/common/desktop/ApplicationWindow.ts
@@ -162,6 +162,40 @@ export class ApplicationWindow {
 							},
 							help: "openNewWindow_action",
 						},
+						{
+							key: Keys["="],
+							ctrl: true,
+							exec: () => {
+								this._browserWindow.webContents.emit("zoom-changed", null, "in")
+							},
+							help: "zoomIn_action",
+						},
+						{
+							key: Keys["="],
+							ctrl: true,
+							shift: true,
+							exec: () => {
+								this._browserWindow.webContents.emit("zoom-changed", null, "in")
+							},
+							help: "zoomIn_action",
+						},
+						{
+							key: Keys["-"],
+							ctrl: true,
+							exec: () => {
+								this._browserWindow.webContents.emit("zoom-changed", null, "out")
+							},
+							help: "zoomOut_action",
+						},
+						{
+							key: Keys["-"],
+							ctrl: true,
+							shift: true,
+							exec: () => {
+								this._browserWindow.webContents.emit("zoom-changed", null, "out")
+							},
+							help: "zoomOut_action",
+						},
 				  ],
 		)
 		log.debug(TAG, "webAssetsPath: ", this.absoluteAssetsPath)

--- a/test/tests/desktop/ApplicationWindowTest.ts
+++ b/test/tests/desktop/ApplicationWindowTest.ts
@@ -259,7 +259,10 @@ o.spec("ApplicationWindow Test", function () {
 			minimized: boolean
 			focused: boolean
 		}
-		type BrowserWindowMock = Class<Electron.BrowserWindow> & { mockedInstances: BrowserWindowInstanceMock[]; lastId: number }
+		type BrowserWindowMock = Class<Electron.BrowserWindow> & {
+			mockedInstances: BrowserWindowInstanceMock[]
+			lastId: number
+		}
 		type ElectronMock = typeof import("electron") & { BrowserWindow: BrowserWindowMock }
 
 		const electronMock = n.mock<ElectronMock>("electron", electron).set()
@@ -410,6 +413,10 @@ o.spec("ApplicationWindow Test", function () {
 			"Alt+Left",
 			"Control+H",
 			"Control+N",
+			"Control+=",
+			"Control+Shift+=",
+			"Control+-",
+			"Control+Shift+-",
 		])
 	})
 	o.test("shortcut creation, windows", function () {
@@ -428,6 +435,10 @@ o.spec("ApplicationWindow Test", function () {
 			"Alt+Left",
 			"Control+H",
 			"Control+N",
+			"Control+=",
+			"Control+Shift+=",
+			"Control+-",
+			"Control+Shift+-",
 		])
 	})
 	o.test("shortcut creation, mac", function () {


### PR DESCRIPTION
Added keyboard shortcuts (Ctrl + + and ctrl + -) for zooming in and out on Linux and Windows. This was already working on Mac.

Close: #8749