### PR TITLE
Make HMAC verification constant time

### DIFF
--- a/packages/tutanota-crypto/lib/encryption/Hmac.ts
+++ b/packages/tutanota-crypto/lib/encryption/Hmac.ts
@@ -1,8 +1,8 @@
 import { AesKey } from "./Aes.js"
 import sjcl from "../internal/sjcl.js"
 import { bitArrayToUint8Array, uint8ArrayToBitArray } from "../misc/Utils.js"
-import { arrayEquals } from "@tutao/tutanota-utils"
 import { CryptoError } from "../misc/CryptoError.js"
+import { constantTimeUint8ArrayEquals } from "../misc/ConstantTime.js"
 
 export type MacTag = Uint8Array & { __brand: "macTag" }
 
@@ -20,7 +20,7 @@ export function hmacSha256(key: AesKey, data: Uint8Array): MacTag {
  */
 export function verifyHmacSha256(key: AesKey, data: Uint8Array, tag: MacTag) {
 	const computedTag = hmacSha256(key, data)
-	if (!arrayEquals(computedTag, tag)) {
+	if (!constantTimeUint8ArrayEquals(computedTag, tag)) {
 		throw new CryptoError("invalid mac")
 	}
 }

--- a/packages/tutanota-crypto/lib/index.ts
+++ b/packages/tutanota-crypto/lib/index.ts
@@ -101,3 +101,4 @@ export {
 export { murmurHash } from "./hashes/MurmurHash.js"
 export { hkdf } from "./hashes/HKDF.js"
 export { hmacSha256, verifyHmacSha256, MacTag } from "./encryption/Hmac.js"
+export { constantTimeByteEquals, constantTimeUint8ArrayEquals, constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness } from "./misc/ConstantTime.js"

--- a/packages/tutanota-crypto/lib/misc/ConstantTime.ts
+++ b/packages/tutanota-crypto/lib/misc/ConstantTime.ts
@@ -1,0 +1,56 @@
+import sjcl from "../internal/sjcl.js"
+import { uint8ArrayToBitArray } from "./Utils.js"
+
+function assertByte(n: number): number {
+	if (n < 0 || n > 255) throw new Error("number is not in the byte range")
+	else return n
+}
+
+/**
+ * Compares two bytes in constant time.
+ * @param leftByte A number in the range 0-255, i.e., a byte
+ * @param rightByte A number in the range 0-255, i.e., a byte
+ */
+export function constantTimeByteEquals(leftByte: number, rightByte: number): boolean {
+	const left = assertByte(leftByte)
+	const right = assertByte(rightByte)
+
+	// see https://stackoverflow.com/questions/17603487/how-does-constanttimebyteeq-work
+
+	let res = ~(left ^ right)
+	res = res & 255 // zero out everything left of our byte
+	// >>> ensures the left-most bits will be filled with zeroes, as opposed to whatever value
+	// was at the left, like *some* bit shifters do (looking at you, >>)
+	res &= res >>> 4
+	res &= res >>> 2
+	res &= res >>> 1
+
+	return res === 1
+}
+
+/**
+ * Compares two Uint8Arrays in constant time.
+ * The only short-circuit is on the length, because this is intended to be used on fixed length arrays.
+ * @param left
+ * @param right
+ */
+export function constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness(left: Uint8Array, right: Uint8Array): boolean {
+	if (left.length !== right.length) {
+		return false
+	}
+	let acc = true
+	for (let i = 0; i < left.length; i++) {
+		// evaluate byte comparison first so as not to short-circuit the whole thing
+		acc = constantTimeByteEquals(left[i], right[i]) && acc
+	}
+	return acc
+}
+
+/**
+ * Compares two Uint8Arrays in ~~constant time~~ a predictable amount of time via SJCL.
+ * @param left
+ * @param right
+ */
+export function constantTimeUint8ArrayEquals(left: Uint8Array, right: Uint8Array): boolean {
+	return sjcl.bitArray.equal(uint8ArrayToBitArray(left), uint8ArrayToBitArray(right))
+}

--- a/packages/tutanota-crypto/test/ConstantTimeTest.ts
+++ b/packages/tutanota-crypto/test/ConstantTimeTest.ts
@@ -1,0 +1,59 @@
+import o from "@tutao/otest"
+import { constantTimeByteEquals, constantTimeUint8ArrayEquals, constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness } from "../lib/index.js"
+import { assertThrows } from "@tutao/tutanota-test-utils"
+
+o.spec("ConstantTimeTest", function () {
+	o.spec("constantTimeByteEquals", function () {
+		o("gives the correct result", function () {
+			o(constantTimeByteEquals(0, 0)).equals(true)
+			o(constantTimeByteEquals(255, 255)).equals(true)
+			o(constantTimeByteEquals(0, 255)).equals(false)
+			o(constantTimeByteEquals(255, 0)).equals(false)
+
+			o(constantTimeByteEquals(1, 1)).equals(true)
+			o(constantTimeByteEquals(123, 123)).equals(true)
+			o(constantTimeByteEquals(1, 123)).equals(false)
+			o(constantTimeByteEquals(123, 1)).equals(false)
+		})
+
+		o("ensures inputs are bytes", async function () {
+			await assertThrows(Error, async () => constantTimeByteEquals(0, 256))
+			await assertThrows(Error, async () => constantTimeByteEquals(0, -1))
+		})
+	})
+	o.spec("constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness", function () {
+		o("false for arrays of different lengths", function () {
+			o(constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness(new Uint8Array(1), new Uint8Array(2))).equals(false)
+		})
+
+		o("false for arrays of the same length but differing content", function () {
+			o(constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness(new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6]))).equals(false)
+		})
+
+		o("true for arrays of the same length and same content", function () {
+			o(constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).equals(true)
+		})
+
+		o("true for two empty arrays", function () {
+			o(constantTimeUint8ArrayEqualsWithFancyByteLevelConstantTimeness(new Uint8Array(), new Uint8Array())).equals(true)
+		})
+	})
+
+	o.spec("constantTimeUint8ArrayEquals", function () {
+		o("false for arrays of different lengths", function () {
+			o(constantTimeUint8ArrayEquals(new Uint8Array(1), new Uint8Array(2))).equals(false)
+		})
+
+		o("false for arrays of the same length but differing content", function () {
+			o(constantTimeUint8ArrayEquals(new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6]))).equals(false)
+		})
+
+		o("true for arrays of the same length and same content", function () {
+			o(constantTimeUint8ArrayEquals(new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3]))).equals(true)
+		})
+
+		o("true for two empty arrays", function () {
+			o(constantTimeUint8ArrayEquals(new Uint8Array(), new Uint8Array())).equals(true)
+		})
+	})
+})

--- a/packages/tutanota-crypto/test/Suite.ts
+++ b/packages/tutanota-crypto/test/Suite.ts
@@ -13,6 +13,7 @@ import "./TotpVerifierTest.js"
 import "./EccTest.js"
 import "./KyberTest.js"
 import "./HmacTest.js"
+import "./ConstantTimeTest.js"
 import { bootstrapTests } from "./bootstrap.js"
 
 await bootstrapTests()


### PR DESCRIPTION
Using SJCL.

We also provide an alternative implementation, with constant time byte level comparison, but it is not yet clear if the additional measures are necessary.