### PR TITLE
[mimimi] fix invalid dates breaking the importer

### DIFF
--- a/packages/node-mimimi/src/importer.rs
+++ b/packages/node-mimimi/src/importer.rs
@@ -782,6 +782,21 @@ pub mod tests {
 		assert_eq!(remote_state.successfulMails, 1);
 	}
 
+	#[cfg_attr(
+		not(feature = "test-with-local-http-server"),
+		ignore = "require local http server."
+	)]
+	#[tokio::test]
+	async fn can_import_single_eml_file_with_invalid_date() {
+		let importer = init_file_importer(vec!["brokendate.eml"]).await;
+		importer.start_stateful_import().await.unwrap();
+
+		let remote_state = importer.essentials.load_remote_state().await.unwrap();
+		assert_eq!(remote_state.status, ImportStatus::Finished as i64);
+		assert_eq!(remote_state.failedMails, 0);
+		assert_eq!(remote_state.successfulMails, 1);
+	}
+
 	#[test]
 	fn max_request_size_in_test_is_different() {
 		assert_eq!(1024 * 5, MAX_REQUEST_SIZE);

--- a/packages/node-mimimi/src/importer/importable_mail.rs
+++ b/packages/node-mimimi/src/importer/importable_mail.rs
@@ -655,10 +655,7 @@ impl ImportableMail {
 	pub fn from_parsed_message(parsed_message: &mail_parser::Message) -> Self {
 		let subject = parsed_message.subject().unwrap_or_default().to_string();
 
-		let date = parsed_message
-			.date()
-			.as_ref()
-			.map(|date_time| DateTime::from_millis(date_time.to_timestamp() as u64 * 1000));
+		let date = get_importable_date_time(parsed_message);
 
 		let name_as_address_if_empty_address = |mut address: MailContact| -> MailContact {
 			if address.mail_address.is_empty() && !address.name.is_empty() {
@@ -770,6 +767,22 @@ impl ImportableMail {
 			is_phishing: false,
 		}
 	}
+}
+
+/**
+* convert the "Date:" header value from the parsed message to something we can import.
+* if the value isn't valid (parser returned -1 or the value doesn't fit in an u64
+* when converted to milliseconds), we'll use midnight, 1st of January 1970 as a default.
+*/
+fn get_importable_date_time(message: &mail_parser::Message) -> Option<DateTime> {
+	message
+		.date()
+		.map(mail_parser::DateTime::to_timestamp)
+		.map(|timestamp| timestamp.max(0))
+		.into_iter()
+		.filter_map(|millis| (millis as u64).checked_mul(1000))
+		.map(DateTime::from_millis)
+		.next()
 }
 
 #[cfg(test)]

--- a/packages/node-mimimi/tests/resources/testmail/brokendate.eml
+++ b/packages/node-mimimi/tests/resources/testmail/brokendate.eml
@@ -1,0 +1,9 @@
+Content-Type: text/plain; charset=iso-8859-1; format=flowed
+Content-Transfer-Encoding: 8bit
+To: sorry@noemail.eu
+From: noreply@noemail.eu
+Date: Fri, Dec 14 2001 16:05:48 -0800
+MIME-Version: 1.0
+Subject: Broken date 
+
+This mail contains a date header that doesn't conform to the standard.


### PR DESCRIPTION
The message parser returns -1 if it can't parse the Date: header. Converting this with `n as u64` leads to an underflow and subsequently to a panic because of the multiplication necessary to convert to milliseconds.

We'll now use safe methods to default to 1970-01-01T00:00:00.000 if the date is unusable.

fix #8766