### PR TITLE
Default mail app on iOS

### DIFF
--- a/app-ios/calendar-project.yml
+++ b/app-ios/calendar-project.yml
@@ -88,9 +88,7 @@ targets:
     type: "bundle.unit-test"
     sources:
       - path: "tutanotaTests"
-        excludes: [ "CompatibilityTest.m" ]
-      - path: "tutanotaTests"
-        includes: [ "CompatibilityTest.m" ]
+        excludes: [ "MailToTest.swift" ]
     settings:
       ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: "YES"
       CODE_SIGN_STYLE: "Automatic"

--- a/app-ios/mail-project.yml
+++ b/app-ios/mail-project.yml
@@ -92,10 +92,6 @@ targets:
     type: "bundle.unit-test"
     sources:
       - path: "tutanotaTests"
-        excludes: ["CompatibilityTest.m"]
-      - path: "tutanotaTests"
-        includes: ["CompatibilityTest.m"]
-        compilerFlags: "-Itutanota/include"
     settings:
       ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: "YES"
       CODE_SIGN_STYLE: "Automatic"

--- a/app-ios/tutanota/Info.plist
+++ b/app-ios/tutanota/Info.plist
@@ -32,11 +32,35 @@
 				<string>tutanota</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>de.tutao.tutanota.tutamailto</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>tutamailto</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Mailto</string>
+			<key>CFBundleURLName</key>
+			<string>de.tutao.tutanota.mailto</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mailto</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>277.250409.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>tutacalendar</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -67,10 +91,6 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
-	</array>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>tutacalendar</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/app-ios/tutanota/Sources/AppDelegate.swift
+++ b/app-ios/tutanota/Sources/AppDelegate.swift
@@ -4,6 +4,8 @@ import UIKit
 import tutasdk
 
 public let TUTA_MAIL_INTEROP_SCHEME = "tutamail"
+public let TUTA_MAIL_MAILTO_SCHEME = "tutamailto"
+public let MAILTO_SCHEME = "mailto"
 
 @UIApplicationMain class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 	var window: UIWindow?
@@ -116,6 +118,7 @@ public let TUTA_MAIL_INTEROP_SCHEME = "tutamail"
 
 				TUTSLog("Tried to open Mail App from an unknown source!")
 			}
+		case TUTA_MAIL_MAILTO_SCHEME, MAILTO_SCHEME: Task { try? await self.viewController.handleMailto(url) }
 		case nil: TUTSLog("missing scheme!")
 		default: TUTSLog("unknown scheme? \(url.scheme!)")
 		}

--- a/app-ios/tutanota/Sources/Utils/Mailto.swift
+++ b/app-ios/tutanota/Sources/Utils/Mailto.swift
@@ -1,0 +1,18 @@
+struct MailtoData: Equatable {
+	let subject: String?
+	let toRecipients: [String]
+	let ccRecipients: [String]
+	let bccRecipients: [String]
+	let body: String?
+}
+
+extension MailtoData {
+	init?(url: URL) {
+		guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+		self.subject = components.queryItems?.first { $0.name == "subject" }?.value
+		self.toRecipients = components.path.split(separator: ",").map { String($0) }
+		self.ccRecipients = components.queryItems?.first { $0.name == "cc" }?.value?.split(separator: ",").map { String($0) } ?? []
+		self.bccRecipients = components.queryItems?.first { $0.name == "bcc" }?.value?.split(separator: ",").map { String($0) } ?? []
+		self.body = components.queryItems?.first { $0.name == "body" }?.value
+	}
+}

--- a/app-ios/tutanota/Sources/ViewController.swift
+++ b/app-ios/tutanota/Sources/ViewController.swift
@@ -258,6 +258,11 @@ class ViewController: UIViewController, WKNavigationDelegate, UIScrollViewDelega
 		}
 	}
 
+	func handleMailto(_ url: URL) async throws {
+		let mailTo = MailtoData(url: url)
+		try await self.bridge.commonNativeFacade.createMailEditor([], mailTo?.body ?? "", mailTo?.toRecipients ?? [], mailTo?.subject ?? "", url.absoluteString)
+	}
+
 	func handleInterop(_ url: URL) async throws {
 		guard let info = await getInteropInfo(url: url) else {
 			TUTSLog("unable to get sharingInfo from url: \(url)")

--- a/app-ios/tutanotaTests/MailToTest.swift
+++ b/app-ios/tutanotaTests/MailToTest.swift
@@ -1,0 +1,44 @@
+import Testing
+
+@testable import tutanota
+
+struct MailToTest {
+	@Test func withEmptyUrl() {
+		let url = URL(string: "mailto:")!
+		let result = MailtoData(url: url)
+		#expect(result == MailtoData(subject: nil, toRecipients: [], ccRecipients: [], bccRecipients: [], body: nil))
+	}
+	@Test func onlyToRecipients() {
+		let url = URL(string: "mailto:someone@example.com")!
+		let result = MailtoData(url: url)
+		#expect(result == MailtoData(subject: nil, toRecipients: ["someone@example.com"], ccRecipients: [], bccRecipients: [], body: nil))
+	}
+	@Test func withMultipleToRecipients() {
+		let url = URL(string: "mailto:someone@example.com,someoneelse@example.com")!
+		let result = MailtoData(url: url)
+		#expect(
+			result
+				== MailtoData(subject: nil, toRecipients: ["someone@example.com", "someoneelse@example.com"], ccRecipients: [], bccRecipients: [], body: nil)
+		)
+	}
+	@Test func withToRecipientsAndBody() {
+		let url = URL(string: "mailto:someone@example.com?body=This%20is%20the%20body")!
+		let result = MailtoData(url: url)
+		#expect(result == MailtoData(subject: nil, toRecipients: ["someone@example.com"], ccRecipients: [], bccRecipients: [], body: "This is the body"))
+	}
+	@Test func withToRecipientsSubjectAndBody() {
+		let url = URL(string: "mailto:someone@example.com?subject=This%20is%20the%20subject&body=This%20is%20the%20body")!
+		let result = MailtoData(url: url)
+		#expect(
+			result
+				== MailtoData(
+					subject: "This is the subject",
+					toRecipients: ["someone@example.com"],
+					ccRecipients: [],
+					bccRecipients: [],
+					body: "This is the body"
+				)
+		)
+	}
+
+}


### PR DESCRIPTION
"mailto" URL scheme is missing in info.plist which is required to set Tuta asdefault app on iOS.
Fixed by adding "mailto" URL scheme in CFBundleURLSchemes member of the CFBundleURLTypes.