### PR TITLE
feat: add support for relative links in editor link creation

### DIFF
--- a/src/common/gui/editor/Editor.ts
+++ b/src/common/gui/editor/Editor.ts
@@ -31,12 +31,13 @@ export class Editor implements ImageHandler, Component {
 	private readOnly = false
 	private createsLists = true
 	private userHasPasted = false
+	private areRelativeLinksAllowed = false
 	private styleActions = Object.freeze({
 		b: [() => this.squire.bold(), () => this.squire.removeBold(), () => this.styles.b],
 		i: [() => this.squire.italic(), () => this.squire.removeItalic(), () => this.styles.i],
 		u: [() => this.squire.underline(), () => this.squire.removeUnderline(), () => this.styles.u],
 		c: [() => this.squire.setFontFace("monospace"), () => this.squire.setFontFace(null), () => this.styles.c],
-		a: [() => this.makeLink(), () => this.squire.removeLink(), () => this.styles.a],
+		a: [() => this.makeLink(this.areRelativeLinksAllowed), () => this.squire.removeLink(), () => this.styles.a],
 	} as const)
 
 	styles: Styles = {
@@ -126,6 +127,10 @@ export class Editor implements ImageHandler, Component {
 
 	setShowOutline(show: boolean) {
 		this.showOutline = show
+	}
+
+	setAreRelativeLinksAllowed(areRelativeLinksAllowed: boolean) {
+		this.areRelativeLinksAllowed = areRelativeLinksAllowed
 	}
 
 	/**
@@ -266,7 +271,12 @@ export class Editor implements ImageHandler, Component {
 		this.styles.i = this.squire.hasFormat("i")
 	}
 
-	makeLink() {
+	/**
+	 * Prompts the user to input a URL and creates a link at the current cursor position in the editor.
+	 *
+	 * @param [areRelativeLinksAllowed=false] - Whether relative links are allowed.
+	 */
+	makeLink(areRelativeLinksAllowed: boolean = false) {
 		Dialog.showTextInputDialog({
 			title: "makeLink_action",
 			label: "url_label",
@@ -274,7 +284,13 @@ export class Editor implements ImageHandler, Component {
 		}).then((url) => {
 			if (isMailAddress(url, false)) {
 				url = "mailto:" + url
-			} else if (!url.startsWith("http://") && !url.startsWith("https://") && !url.startsWith("mailto:") && !url.startsWith("{")) {
+			} else if (
+				!areRelativeLinksAllowed &&
+				!url.startsWith("http://") &&
+				!url.startsWith("https://") &&
+				!url.startsWith("mailto:") &&
+				!url.startsWith("{")
+			) {
 				url = "https://" + url
 			}
 

--- a/src/common/gui/editor/HtmlEditor.ts
+++ b/src/common/gui/editor/HtmlEditor.ts
@@ -1,7 +1,7 @@
 import m, { Children, Component } from "mithril"
 import stream from "mithril/stream"
 import { Editor } from "./Editor.js"
-import type { TranslationKey, MaybeTranslation } from "../../misc/LanguageViewModel"
+import type { MaybeTranslation, TranslationKey } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { px } from "../size"
 import { htmlSanitizer } from "../../misc/HtmlSanitizer"
@@ -27,13 +27,22 @@ export class HtmlEditor implements Component {
 	private placeholderDomElement: HTMLElement | null = null
 	private value = stream("")
 	private htmlMonospace = true
+	private areRelativeLinksAllowed = false
 	private modeSwitcherLabel: MaybeTranslation | null = null
 	private toolbarEnabled = false
 	private toolbarAttrs: Omit<RichTextToolbarAttrs, "editor"> = {}
 	private staticLineAmount: number | null = null // Static amount of lines the editor shall allow at all times
 
 	constructor(private label?: MaybeTranslation, private readonly injections?: () => Children) {
-		this.editor = new Editor(null, (html) => htmlSanitizer.sanitizeFragment(html, { blockExternalContent: false }).fragment, null)
+		this.editor = new Editor(
+			null,
+			(html) =>
+				htmlSanitizer.sanitizeFragment(html, {
+					blockExternalContent: false,
+					allowRelativeLinks: this.areRelativeLinksAllowed,
+				}).fragment,
+			null,
+		)
 		this.view = this.view.bind(this)
 		this.initializeEditorListeners()
 	}
@@ -167,6 +176,12 @@ export class HtmlEditor implements Component {
 		return this
 	}
 
+	setAreRelativeLinksAllowed(allowed: boolean): HtmlEditor {
+		this.areRelativeLinksAllowed = allowed
+		this.editor.setAreRelativeLinksAllowed(allowed)
+		return this
+	}
+
 	setMinHeight(height: number): HtmlEditor {
 		this.minHeight = height
 		this.editor.setMinHeight(height)
@@ -198,7 +213,10 @@ export class HtmlEditor implements Component {
 			}
 		} else {
 			if (this.domTextArea) {
-				return htmlSanitizer.sanitizeHTML(this.domTextArea.value, { blockExternalContent: false }).html
+				return htmlSanitizer.sanitizeHTML(this.domTextArea.value, {
+					blockExternalContent: false,
+					allowRelativeLinks: this.areRelativeLinksAllowed,
+				}).html
 			} else {
 				return this.value()
 			}


### PR DESCRIPTION
Hey,

We would like to allow relative links in the internal newsletters we send out. After some research, I found that there is already a way to do this in our HTML editor, there is just no public API to enable it as far as I know.

The default configuration for sanitizing the HTML is defined here:

https://github.com/tutao/tutanota/blob/9b83722d504c47b5691dc8b1454116f104cf2130/src/common/misc/HtmlSanitizer.ts#L32-L36

So I added a field `areRelativeLinksAllowed` within the Editor and HtmlEditor classes with a public setter method.

Passing `allowRelativeLinks: true` already fixed the sanitation, but did not cover the case when you actually click the "Insert hyperlink" button in the HTML editor toolbar. This automatically converts relative links to https links. So if you'd type `/settings/invoice`, it would become `https:///settings/invoice`. I prevented that behaviour in case of relative links actually being allowed in the `makeLink` method in the Editor.ts.

Do you think that's okay to do?