### PR TITLE
Only show 'search mailbox' in settingsView for browser

### DIFF
--- a/src/mail-app/settings/MailSettingsViewer.ts
+++ b/src/mail-app/settings/MailSettingsViewer.ts
@@ -1,5 +1,5 @@
 import m, { Children } from "mithril"
-import { assertMainOrNode, isApp } from "../../common/api/common/Env"
+import { assertMainOrNode, isApp, isBrowser } from "../../common/api/common/Env"
 import { lang, type MaybeTranslation } from "../../common/misc/LanguageViewModel"
 import type { MailboxGroupRoot, MailboxProperties, OutOfOfficeNotification, TutanotaProperties } from "../../common/api/entities/tutanota/TypeRefs.js"
 import {
@@ -368,7 +368,7 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 					m(".h4.mt-l", lang.get("general_label")),
 					m(DropDownSelector, conversationViewDropdownAttrs),
 					m(DropDownSelector, mailListDisplayMode),
-					m(DropDownSelector, enableMailIndexingAttrs),
+					isBrowser() ? m(DropDownSelector, enableMailIndexingAttrs) : null,
 					m(DropDownSelector, behaviorAfterMoveEmailAction),
 					m(".h4.mt-l", lang.get("emailSending_label")),
 					m(DropDownSelector, defaultSenderAttrs),


### PR DESCRIPTION
Since there is not a separate db for searching when offline storage is available, having the "Search mailbox" option does not make sense, since search is always enabled.
The option remains for web version.

Close: #8834

## Test notes
- [ ] "Search mailbox" setting is hidden from `settings/email` view on desktop and mobile and search is always enabled
- [ ] "Search mailbox" setting is visible on web and it works as expected
