### PR TITLE
Fix mail actions act on entire conversation with list grouping disabled

### DIFF
--- a/libs/purify.js
+++ b/libs/purify.js
@@ -1,4 +1,4 @@
-/*! @license DOMPurify 3.2.4 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.4/LICENSE */
+/*! @license DOMPurify 3.2.5 | (c) Cure53 and other contributors | Released under the Apache license 2.0 and Mozilla Public License 2.0 | github.com/cure53/DOMPurify/blob/3.2.5/LICENSE */
 
 (function (global, factory) {
   typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
@@ -64,6 +64,9 @@
    */
   function unapply(func) {
     return function (thisArg) {
+      if (thisArg instanceof RegExp) {
+        thisArg.lastIndex = 0;
+      }
       for (var _len = arguments.length, args = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
         args[_key - 1] = arguments[_key];
       }
@@ -302,7 +305,7 @@
   function createDOMPurify() {
     let window = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : getGlobal();
     const DOMPurify = root => createDOMPurify(root);
-    DOMPurify.version = '3.2.4';
+    DOMPurify.version = '3.2.5';
     DOMPurify.removed = [];
     if (!window || !window.document || window.document.nodeType !== NODE_TYPE.document || !window.Element) {
       // Not running in a browser, provide a factory function
@@ -907,7 +910,7 @@
         allowedTags: ALLOWED_TAGS
       });
       /* Detect mXSS attempts abusing namespace confusion */
-      if (currentNode.hasChildNodes() && !_isNode(currentNode.firstElementChild) && regExpTest(/<[/\w]/g, currentNode.innerHTML) && regExpTest(/<[/\w]/g, currentNode.textContent)) {
+      if (currentNode.hasChildNodes() && !_isNode(currentNode.firstElementChild) && regExpTest(/<[/\w!]/g, currentNode.innerHTML) && regExpTest(/<[/\w!]/g, currentNode.textContent)) {
         _forceRemove(currentNode);
         return true;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"@types/winreg": "1.2.36",
 				"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#53d4abb647a52eb0d3dc0d46acb192bc5e2c0f40",
 				"cborg": "4.2.2",
-				"dompurify": "3.2.4",
+				"dompurify": "3.2.5",
 				"electron": "34.0.1",
 				"electron-updater": "6.3.4",
 				"jsqr": "1.4.0",
@@ -6155,9 +6155,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
-			"integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.5.tgz",
+			"integrity": "sha512-mLPd29uoRe9HpvwP2TxClGQBzGXeEC/we/q+bFlmPPmj2p2Ugl3r6ATu/UU1v77DXNcehiBg9zsr1dREyA/dJQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@types/winreg": "1.2.36",
 		"better-sqlite3": "git+https://github.com/tutao/better-sqlite3-sqlcipher#53d4abb647a52eb0d3dc0d46acb192bc5e2c0f40",
 		"cborg": "4.2.2",
-		"dompurify": "3.2.4",
+		"dompurify": "3.2.5",
 		"electron": "34.0.1",
 		"electron-updater": "6.3.4",
 		"jsqr": "1.4.0",

--- a/src/mail-app/mail/view/MailListView.ts
+++ b/src/mail-app/mail/view/MailListView.ts
@@ -410,7 +410,7 @@ export class MailListView implements Component<MailListViewAttrs> {
 	}
 
 	private async onSwipeLeft(listElement: Mail): Promise<ListSwipeDecision> {
-		const actionableMails = await this.mailViewModel.getActionableMails([listElement])
+		const actionableMails = await this.mailViewModel.getResolvedMails([listElement])
 		const currentFolder = this.mailViewModel.getFolder()
 
 		if (this.mailViewModel.currentFolderDeletesPermanently()) {
@@ -442,7 +442,7 @@ export class MailListView implements Component<MailListViewAttrs> {
 					? MailSetKind.INBOX
 					: MailSetKind.ARCHIVE
 
-				const actionableMails = await this.mailViewModel.getActionableMails([listElement])
+				const actionableMails = await this.mailViewModel.getResolvedMails([listElement])
 				const wereMoved = await moveMailsToSystemFolder({
 					mailboxModel: locator.mailboxModel,
 					mailModel: mailLocator.mailModel,


### PR DESCRIPTION
Introduced in c65f0f22
When viewing a conversation with conversation thread enabled but with mail list grouping disabled, mail actions apply to the entire conversation without exclusions (sent mails are supposed to be excluded from move operations when acting on conversations). This occurs because the entire conversation was used as actionable mails regardless of whether list grouping was enabled or not.

Sent mails not being excluded from move operations was due to `excludeMailSet` (passed to the server to exclude mails in a specific folder from the being moved) being `null` when mail list grouping is disabled.

To fix this, we use `getStickyMails` which would return the primary mail or the conversation mails being viewed depending on whether mail grouping is enabled or not.

Close #8886