### PR TITLE
[sdk] Set IPHONEOS_DEPLOYMENT_TARGET for make_ios.sh

### DIFF
--- a/tuta-sdk/rust/make_ios.sh
+++ b/tuta-sdk/rust/make_ios.sh
@@ -9,7 +9,9 @@ TARGETS=(
 # XCode tries to be helpful and overwrites the PATH. Reset that.
 PATH="$(bash -l -c 'echo $PATH')"
 
-
+# Export the iOS target version as an environment variable
+# (needed for linking if make_ios.sh is run manually)
+export IPHONEOS_DEPLOYMENT_TARGET="17.2"
 
 for target in "${TARGETS[@]}"; do
   OUT_DIR="out/${target}"


### PR DESCRIPTION
If we don't do this, then we may randomly run into linking errors due to missing symbols (e.g. ___chkstk_darwin), as it will try to link with 10.0, instead.