### PR TITLE
Fix wrong perma delete confirmation text when deleting from Spam

### DIFF
--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -633,7 +633,6 @@ export type TranslationKeyType =
 	| "filterWithAttachments_label"
 	| "filter_label"
 	| "finallyDeleteEmails_msg"
-	| "finallyDeleteSelectedEmails_msg"
 	| "finish_action"
 	| "firstMergeContact_label"
 	| "firstMonthForFreeDetail_msg"

--- a/src/mail-app/mail/view/MailGuiUtils.ts
+++ b/src/mail-app/mail/view/MailGuiUtils.ts
@@ -57,7 +57,7 @@ export async function promptAndDeleteMails(
 	filterMailSet: IdTuple | null,
 	onConfirm: () => void,
 ): Promise<boolean> {
-	const shouldDeletePermanently = await Dialog.confirm("finallyDeleteSelectedEmails_msg", "ok_action")
+	const shouldDeletePermanently = await Dialog.confirm("finallyDeleteEmails_msg", "ok_action")
 	if (!shouldDeletePermanently) {
 		return false
 	}


### PR DESCRIPTION
Use a generic permanent deletion confirmation text since permanent deletion is also possible from the Spam folder.

![image](https://github.com/user-attachments/assets/7176af79-a07f-4b7e-81ec-7c6a218e6bb4)

Close #8936