### PR TITLE
[Android] Fixes the Widget Cache

### DIFF
--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/Agenda.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/Agenda.kt
@@ -73,9 +73,9 @@ import de.tutao.calendar.widget.error.WidgetError
 import de.tutao.calendar.widget.error.WidgetErrorHandler
 import de.tutao.calendar.widget.error.WidgetErrorType
 import de.tutao.calendar.widget.model.WidgetUIViewModel
-import de.tutao.tutasdk.IdTupleCustom
 import de.tutao.tutasdk.Sdk
 import de.tutao.tutashared.AndroidNativeCryptoFacade
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.SdkRestClient
 import de.tutao.tutashared.base64ToBase64Url
 import de.tutao.tutashared.credentials.CredentialsEncryptionFactory
@@ -159,7 +159,7 @@ class Agenda : GlanceAppWidget() {
 		}
 
 		val widgetUIViewModel =
-			WidgetUIViewModel(context.widgetDataRepository, appWidgetId, nativeCredentialsFacade, sdk)
+			WidgetUIViewModel(context.widgetDataRepository, appWidgetId, nativeCredentialsFacade, crypto, sdk)
 		val userId = widgetUIViewModel.getLoggedInUser(context)
 
 		return Pair(widgetUIViewModel, userId)
@@ -182,7 +182,7 @@ class Agenda : GlanceAppWidget() {
 		return actionStartActivity(openCalendarEventEditor)
 	}
 
-	private fun openCalendarAgenda(context: Context, userId: String? = "", eventId: IdTupleCustom? = null): Action {
+	private fun openCalendarAgenda(context: Context, userId: String? = "", eventId: IdTuple? = null): Action {
 		val openCalendarAgenda = Intent(context, MainActivity::class.java)
 		openCalendarAgenda.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 		openCalendarAgenda.action = MainActivity.OPEN_CALENDAR_ACTION
@@ -545,7 +545,7 @@ class Agenda : GlanceAppWidget() {
 			eventData.add(
 				UIEvent(
 					"previewCalendar",
-					IdTupleCustom("", ""),
+					IdTuple("", ""),
 					"2196f3",
 					"Hello Widget $i",
 					"08:00",
@@ -559,7 +559,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents.add(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Summery",
 				"Start Time",
@@ -572,7 +572,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents.add(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Summery",
 				"Start Time",
@@ -606,7 +606,7 @@ class Agenda : GlanceAppWidget() {
 			eventData.add(
 				UIEvent(
 					"previewCalendar",
-					IdTupleCustom("", ""),
+					IdTuple("", ""),
 					"2196f3",
 					"Hello Widget $i",
 					"08:00",

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/WidgetReceiver.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/WidgetReceiver.kt
@@ -16,9 +16,13 @@ import java.util.concurrent.TimeUnit
 
 const val WIDGET_SETTINGS_PREFIX = "calendar_widget_settings"
 const val WIDGET_LAST_SYNC_PREFIX = "calendar_widget_last_sync"
+const val WIDGET_CACHE_DATE_PREFIX = "calendar_widget_cache_date"
 const val WIDGET_SETTINGS_DATASTORE_FILE = "tuta_calendar_widget_settings"
+const val WIDGET_EVENTS_CACHE = "calendar_widget_cache"
+const val WIDGET_CACHE_DATASTORE_FILE = "tuta_calendar_widget_cache"
 
 val Context.widgetDataStore: DataStore<Preferences> by preferencesDataStore(WIDGET_SETTINGS_DATASTORE_FILE)
+val Context.widgetCacheDataStore: DataStore<Preferences> by preferencesDataStore(WIDGET_CACHE_DATASTORE_FILE)
 val Context.widgetDataRepository: WidgetDataRepository
 	get() = WidgetDataRepository.getInstance()
 

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CacheDateDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CacheDateDao.kt
@@ -1,0 +1,8 @@
+package de.tutao.calendar.widget.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CacheDateDao(
+	val createdAt: Long,
+)

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventDao.kt
@@ -1,0 +1,12 @@
+package de.tutao.calendar.widget.data
+
+import de.tutao.tutashared.IdTuple
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CalendarEventDao(
+	val id: IdTuple?,
+	val startTime: ULong,
+	val endTime: ULong,
+	val summary: String
+)

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventListDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventListDao.kt
@@ -1,0 +1,6 @@
+package de.tutao.calendar.widget.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CalendarEventListDao(val shortEvents: List<CalendarEventDao>, val longEvents: List<CalendarEventDao>)

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/LastSyncDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/LastSyncDao.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LastSyncDao(
-	val lastSync: Long,
+	val lastSync: Long, // Used to trigger widget's recomposition
 	val trigger: WidgetUpdateTrigger,
 	val force: Boolean
 )

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/UIEvent.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/UIEvent.kt
@@ -1,11 +1,11 @@
 package de.tutao.calendar.widget.data
 
 import de.tutao.tutasdk.GeneratedId
-import de.tutao.tutasdk.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 
 data class UIEvent(
 	val calendarId: GeneratedId,
-	val eventId: IdTupleCustom?,
+	val eventId: IdTuple?,
 	val calendarColor: String,
 	val summary: String,
 	val startTime: String,

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetDataRepository.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetDataRepository.kt
@@ -1,13 +1,26 @@
 package de.tutao.calendar.widget.data
 
-import de.tutao.tutasdk.CalendarEventsList
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import de.tutao.calendar.widget.WIDGET_CACHE_DATE_PREFIX
+import de.tutao.calendar.widget.WIDGET_EVENTS_CACHE
+import de.tutao.calendar.widget.widgetCacheDataStore
+import de.tutao.tutasdk.CalendarEvent
 import de.tutao.tutasdk.GeneratedId
 import de.tutao.tutasdk.LoggedInSdk
-import de.tutao.tutashared.ipc.NativeCredentialsFacade
+import de.tutao.tutashared.AndroidNativeCryptoFacade
+import de.tutao.tutashared.IdTuple
+import de.tutao.tutashared.base64ToBytes
+import de.tutao.tutashared.ipc.UnencryptedCredentials
+import de.tutao.tutashared.toBase64
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
 import java.util.Calendar
+import java.util.Date
 import java.util.TimeZone
 
-class WidgetDataRepository : WidgetRepository() {
+class WidgetDataRepository() : WidgetRepository() {
 	companion object {
 		@Volatile
 		private var instance: WidgetDataRepository? = null
@@ -24,37 +37,137 @@ class WidgetDataRepository : WidgetRepository() {
 		}
 	}
 
+	private suspend fun updateCacheCreationDate(context: Context, widgetId: Int, now: Date) {
+		val nowTimestamp = now.time
+
+		val cacheDateIdentifier = "${WIDGET_CACHE_DATE_PREFIX}_$widgetId"
+		val preferencesKey = stringPreferencesKey(cacheDateIdentifier)
+
+		val createdAtDao = CacheDateDao(nowTimestamp)
+		context.widgetCacheDataStore.edit { preferences ->
+			preferences[preferencesKey] = json.encodeToString(createdAtDao)
+		}
+	}
+
+	override suspend fun storeCache(
+		context: Context,
+		widgetId: Int,
+		eventsMap: Map<GeneratedId, CalendarEventListDao>,
+		cryptoFacade: AndroidNativeCryptoFacade,
+		credentials: UnencryptedCredentials
+	) {
+		val key = credentials.databaseKey ?: return
+
+		val encryptedEventListMap: MutableMap<GeneratedId, String> = mutableMapOf()
+		for ((calendar, eventList) in eventsMap) {
+			val jsonEncodedEventList = json.encodeToString(eventList)
+
+			val encryptedData = cryptoFacade.aesEncryptData(key.data, jsonEncodedEventList.toByteArray())
+			val base64String = encryptedData.toBase64()
+			encryptedEventListMap[calendar] = base64String
+		}
+
+		val databaseWidgetIdentifier = "${WIDGET_EVENTS_CACHE}_$widgetId"
+		val preferencesKey = stringPreferencesKey(databaseWidgetIdentifier)
+		val encryptedEventListMapJson = json.encodeToString(encryptedEventListMap)
+
+		context.widgetCacheDataStore.edit { preferences ->
+			preferences[preferencesKey] = encryptedEventListMapJson
+		}
+
+		updateCacheCreationDate(context, widgetId, Date())
+	}
+
+	override suspend fun loadCache(
+		context: Context,
+		widgetId: Int,
+		calendars: List<GeneratedId>,
+		cryptoFacade: AndroidNativeCryptoFacade,
+		credentials: UnencryptedCredentials
+	): Map<GeneratedId, CalendarEventListDao> {
+		val key = credentials.databaseKey ?: return mapOf()
+
+		val databaseWidgetIdentifier = "${WIDGET_EVENTS_CACHE}_$widgetId"
+		val preferencesKey = stringPreferencesKey(databaseWidgetIdentifier)
+
+		val preferences = context.widgetCacheDataStore.data.first()
+		val encodedEventsJson = preferences[preferencesKey] ?: return mapOf()
+
+		val encodedEvents = json.decodeFromString<Map<GeneratedId, String>>(encodedEventsJson)
+		val eventsMap: MutableMap<GeneratedId, CalendarEventListDao> = mutableMapOf()
+
+		for ((calendar, encryptedEvents) in encodedEvents) {
+			val decodedEvents = encryptedEvents.base64ToBytes()
+			val decryptedEvents = cryptoFacade.aesDecryptData(key.data, decodedEvents)
+			val eventsJson = String(decryptedEvents)
+
+			eventsMap[calendar] = json.decodeFromString(eventsJson)
+		}
+
+		return eventsMap
+	}
+
 	override suspend fun loadEvents(
+		context: Context,
+		widgetId: Int,
 		userId: GeneratedId,
 		calendars: List<GeneratedId>,
-		credentialsFacade: NativeCredentialsFacade,
-		loggedInSdk: LoggedInSdk
-	): Map<GeneratedId, CalendarEventsList> {
+		credentials: UnencryptedCredentials,
+		loggedInSdk: LoggedInSdk,
+		cryptoFacade: AndroidNativeCryptoFacade
+	): Map<GeneratedId, CalendarEventListDao> {
 		val calendarFacade = loggedInSdk.calendarFacade()
 		val systemCalendar = Calendar.getInstance(TimeZone.getDefault())
 
-		var calendarEventsList: Map<GeneratedId, CalendarEventsList> = HashMap()
+		var calendarEventListMap: Map<GeneratedId, CalendarEventListDao> = HashMap()
 
 		calendars.forEach { calendarId ->
 			val events = calendarFacade.getCalendarEvents(calendarId, (systemCalendar.timeInMillis).toULong())
-
-			cachedEvents[calendarId] = events
-			calendarEventsList = calendarEventsList.plus(calendarId to events)
+			calendarEventListMap = calendarEventListMap.plus(
+				calendarId to CalendarEventListDao(
+					events.shortEvents.toDao(),
+					events.longEvents.toDao()
+				)
+			)
 		}
 
-		return calendarEventsList
+		storeCache(context, widgetId, calendarEventListMap, cryptoFacade, credentials)
+
+		return calendarEventListMap
 	}
 
-	override suspend fun loadEvents(calendars: List<GeneratedId>): Map<GeneratedId, CalendarEventsList> {
+	override suspend fun loadEvents(
+		context: Context,
+		widgetId: Int,
+		calendars: List<GeneratedId>,
+		credentials: UnencryptedCredentials,
+		cryptoFacade: AndroidNativeCryptoFacade
+	): Map<GeneratedId, CalendarEventListDao> {
 		val now = Calendar.getInstance(TimeZone.getDefault()).timeInMillis.toULong()
+		val cachedEvents: MutableMap<GeneratedId, CalendarEventListDao> =
+			loadCache(context, widgetId, calendars, cryptoFacade, credentials).toMutableMap()
 		val cache = cachedEvents.filterKeys { calendars.contains(it) }
 
 		for ((id, events) in cache.entries) {
-			cachedEvents[id] = CalendarEventsList(
+			cachedEvents[id] = CalendarEventListDao(
 				shortEvents = events.shortEvents.filter { it.startTime >= now || it.endTime >= now },
 				longEvents = events.longEvents.filter { it.startTime >= now || it.endTime >= now },
 			)
 		}
+
 		return cachedEvents.filterKeys { calendars.contains(it) }
+	}
+
+	private fun List<CalendarEvent>.toDao(): List<CalendarEventDao> {
+		return this.map {
+			val id = it.id ?: throw RuntimeException("Trying to convert an event without id to CalendarEventDao")
+
+			CalendarEventDao(
+				IdTuple(id.listId, id.elementId),
+				it.startTime,
+				it.endTime,
+				it.summary
+			)
+		}
 	}
 }

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetWorkerRepository.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetWorkerRepository.kt
@@ -25,14 +25,15 @@ class WidgetWorkerRepository : WidgetRepository() {
 
 		// We can't access the DataStore while writing to it, so we collect the changes before and then apply
 		for (id in widgetIds) {
-			val storedLastSync = this.loadLastSync(context, id)
+			val cacheCreation = this.loadCacheCreationDate(context, id)
 
-			val storedLastSyncAsLocalDateTime = LocalDateTime.ofInstant(
-				Instant.ofEpochMilli(storedLastSync?.lastSync ?: 0),
+			val storedCacheDateAsLocalDateTime = LocalDateTime.ofInstant(
+				Instant.ofEpochMilli(cacheCreation?.createdAt ?: 0),
 				Calendar.getInstance().timeZone.toZoneId()
 			)
 
-			val force = storedLastSyncAsLocalDateTime.dayOfYear != nowAsLocalDateTime.dayOfYear
+			val force =
+				storedCacheDateAsLocalDateTime.dayOfYear != nowAsLocalDateTime.dayOfYear
 			val lastSyncIdentifier = "${WIDGET_LAST_SYNC_PREFIX}_$id"
 			val preferencesKey = stringPreferencesKey(lastSyncIdentifier)
 

--- a/tuta-sdk/rust/sdk/Cargo.toml
+++ b/tuta-sdk/rust/sdk/Cargo.toml
@@ -19,7 +19,7 @@ num_enum = "0.7.3"
 minicbor = { version = "0.25", features = ["std", "alloc"] }
 const-hex = { version = "1.12.0", features = ["serde"] }
 lz4_flex = { version = "0.11.3", default-features = false, features = ["safe-encode", "safe-decode", "std"] }
-time = { version = "0.3.37", features = ["serde", "macros"] }
+time = { version = "0.3.37", features = ["serde", "macros", "local-offset"] }
 
 aes = { version = "0.8.4", features = ["zeroize"] }
 cbc = { version = "0.1.2", features = ["std", "zeroize"] }

--- a/tuta-sdk/rust/sdk/src/date/calendar_facade.rs
+++ b/tuta-sdk/rust/sdk/src/date/calendar_facade.rs
@@ -1,7 +1,7 @@
 use num_enum::TryFromPrimitive;
 use std::collections::HashMap;
 use std::sync::Arc;
-use time::{OffsetDateTime, Time};
+use time::{OffsetDateTime, Time, UtcOffset};
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::crypto_entity_client::CryptoEntityClient;
@@ -137,9 +137,16 @@ impl CalendarFacade {
 		};
 
 		let date_in_seconds = (date.as_millis() / 1000) as i64;
+		let Ok(offset) = UtcOffset::current_local_offset() else {
+			return Err(ApiCallError::InternalSdkError {
+				error_message: "Failed to determine device time offset".to_string(),
+			});
+		};
 
 		let parsed_date = match OffsetDateTime::from_unix_timestamp(date_in_seconds) {
-			Ok(date) => date.date().midnight().assume_utc(),
+			Ok(date) => date
+				.to_offset(offset)
+				.replace_time(Time::from_hms(0, 0, 0).unwrap()),
 			Err(e) => return Err(ApiCallError::internal_with_err(e, "Invalid date")),
 		};
 
@@ -149,6 +156,7 @@ impl CalendarFacade {
 
 		let timestamp_start = (parsed_date.unix_timestamp() * 1000) as u64; // x1000 to get the timestamp in milliseconds
 		let timestamp_end = (OffsetDateTime::new_utc(next_day, Time::from_hms(0, 0, 0).unwrap())
+			.replace_offset(offset)
 			.unix_timestamp()
 			* 1000) as u64; // x1000 to get the timestamp in milliseconds
 


### PR DESCRIPTION
This commit chances how the cache is stored on the device. Instead of only living in memory, it encrypts a minimal version of the events and keep them in the Preferences DataStore so it can survive to phone restarts and other events that might purge widget's memory.