### PR TITLE
[Android] Mail notification does not disappear after cancelling

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/MailNotificationActionReceiver.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/MailNotificationActionReceiver.kt
@@ -1,5 +1,6 @@
 package de.tutao.tutanota.push
 
+import android.app.Notification
 import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -75,8 +76,10 @@ class MailNotificationActionReceiver : BroadcastReceiver() {
 
 	private fun dismissNotification(notificationManager: NotificationManager, notificationIdToDismiss: Int) {
 		notificationManager.cancel(notificationIdToDismiss)
-		val activeNotifications = notificationManager.activeNotifications
+		// Filter manually because cancel might not be quick enough
+		val activeNotifications = notificationManager.activeNotifications.filter { it.id != notificationIdToDismiss }
 		for ((_, notifications) in activeNotifications.groupBy { it.groupKey }) {
+
 			if (notifications.size == 1) {
 				// there's only one notification left: summary
 				notificationManager.cancel(notifications[0].id)


### PR DESCRIPTION
Mail notification does not disappear after clicking "Delete" or "Mark Read"

Fixed by filtering manually notification in "dismiss notification"  because cancel might not be quick enough.

Close #8905


Co-authored-by: ivk <ivk@tutao.de>