### PR TITLE
[SDK] Fixes timezone during event generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1559,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1598,44 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher 1.0.1",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1949,6 +2012,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2097,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log 0.4.27",
+ "serde",
+ "thiserror 1.0.69",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2116,6 +2197,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -2256,6 +2343,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -2279,6 +2367,24 @@ checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "time-tz"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733bc522e97980eb421cbf381160ff225bd14262a48a739110f6653c6258d625"
+dependencies = [
+ "cfg-if",
+ "nom",
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+ "serde",
+ "serde-xml-rs",
+ "thiserror 1.0.69",
+ "time",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2431,6 +2537,7 @@ dependencies = [
  "simple_logger",
  "thiserror 2.0.12",
  "time",
+ "time-tz",
  "tokio",
  "tuta-sdk",
  "uniffi",
@@ -2587,7 +2694,7 @@ source = "git+https://github.com/mozilla/uniffi-rs.git?rev=13a1c559cb3708eeca40d
 dependencies = [
  "anyhow",
  "bytes",
- "siphasher",
+ "siphasher 0.3.11",
  "uniffi_checksum_derive",
 ]
 
@@ -2655,6 +2762,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log 0.4.27",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2842,6 +3007,12 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "zerocopy"

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/Agenda.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/Agenda.kt
@@ -73,9 +73,9 @@ import de.tutao.calendar.widget.error.WidgetError
 import de.tutao.calendar.widget.error.WidgetErrorHandler
 import de.tutao.calendar.widget.error.WidgetErrorType
 import de.tutao.calendar.widget.model.WidgetUIViewModel
-import de.tutao.tutasdk.IdTupleCustom
 import de.tutao.tutasdk.Sdk
 import de.tutao.tutashared.AndroidNativeCryptoFacade
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.SdkRestClient
 import de.tutao.tutashared.base64ToBase64Url
 import de.tutao.tutashared.credentials.CredentialsEncryptionFactory
@@ -159,7 +159,7 @@ class Agenda : GlanceAppWidget() {
 		}
 
 		val widgetUIViewModel =
-			WidgetUIViewModel(context.widgetDataRepository, appWidgetId, nativeCredentialsFacade, sdk)
+			WidgetUIViewModel(context.widgetDataRepository, appWidgetId, nativeCredentialsFacade, crypto, sdk)
 		val userId = widgetUIViewModel.getLoggedInUser(context)
 
 		return Pair(widgetUIViewModel, userId)
@@ -182,7 +182,7 @@ class Agenda : GlanceAppWidget() {
 		return actionStartActivity(openCalendarEventEditor)
 	}
 
-	private fun openCalendarAgenda(context: Context, userId: String? = "", eventId: IdTupleCustom? = null): Action {
+	private fun openCalendarAgenda(context: Context, userId: String? = "", eventId: IdTuple? = null): Action {
 		val openCalendarAgenda = Intent(context, MainActivity::class.java)
 		openCalendarAgenda.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 		openCalendarAgenda.action = MainActivity.OPEN_CALENDAR_ACTION
@@ -545,7 +545,7 @@ class Agenda : GlanceAppWidget() {
 			eventData.add(
 				UIEvent(
 					"previewCalendar",
-					IdTupleCustom("", ""),
+					IdTuple("", ""),
 					"2196f3",
 					"Hello Widget $i",
 					"08:00",
@@ -559,7 +559,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents.add(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Summery",
 				"Start Time",
@@ -572,7 +572,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents.add(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Summery",
 				"Start Time",
@@ -606,7 +606,7 @@ class Agenda : GlanceAppWidget() {
 			eventData.add(
 				UIEvent(
 					"previewCalendar",
-					IdTupleCustom("", ""),
+					IdTuple("", ""),
 					"2196f3",
 					"Hello Widget $i",
 					"08:00",

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/WidgetReceiver.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/WidgetReceiver.kt
@@ -16,9 +16,13 @@ import java.util.concurrent.TimeUnit
 
 const val WIDGET_SETTINGS_PREFIX = "calendar_widget_settings"
 const val WIDGET_LAST_SYNC_PREFIX = "calendar_widget_last_sync"
+const val WIDGET_CACHE_DATE_PREFIX = "calendar_widget_cache_date"
 const val WIDGET_SETTINGS_DATASTORE_FILE = "tuta_calendar_widget_settings"
+const val WIDGET_EVENTS_CACHE = "calendar_widget_cache"
+const val WIDGET_CACHE_DATASTORE_FILE = "tuta_calendar_widget_cache"
 
 val Context.widgetDataStore: DataStore<Preferences> by preferencesDataStore(WIDGET_SETTINGS_DATASTORE_FILE)
+val Context.widgetCacheDataStore: DataStore<Preferences> by preferencesDataStore(WIDGET_CACHE_DATASTORE_FILE)
 val Context.widgetDataRepository: WidgetDataRepository
 	get() = WidgetDataRepository.getInstance()
 

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CacheDateDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CacheDateDao.kt
@@ -1,0 +1,8 @@
+package de.tutao.calendar.widget.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CacheDateDao(
+	val createdAt: Long,
+)

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventDao.kt
@@ -1,0 +1,12 @@
+package de.tutao.calendar.widget.data
+
+import de.tutao.tutashared.IdTuple
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CalendarEventDao(
+	val id: IdTuple?,
+	val startTime: ULong,
+	val endTime: ULong,
+	val summary: String
+)

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventListDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventListDao.kt
@@ -1,0 +1,6 @@
+package de.tutao.calendar.widget.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CalendarEventListDao(val shortEvents: List<CalendarEventDao>, val longEvents: List<CalendarEventDao>)

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/LastSyncDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/LastSyncDao.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LastSyncDao(
-	val lastSync: Long,
+	val lastSync: Long, // Used to trigger widget's recomposition
 	val trigger: WidgetUpdateTrigger,
 	val force: Boolean
 )

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/UIEvent.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/UIEvent.kt
@@ -1,11 +1,11 @@
 package de.tutao.calendar.widget.data
 
 import de.tutao.tutasdk.GeneratedId
-import de.tutao.tutasdk.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 
 data class UIEvent(
 	val calendarId: GeneratedId,
-	val eventId: IdTupleCustom?,
+	val eventId: IdTuple?,
 	val calendarColor: String,
 	val summary: String,
 	val startTime: String,

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetDataRepository.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetDataRepository.kt
@@ -1,13 +1,26 @@
 package de.tutao.calendar.widget.data
 
-import de.tutao.tutasdk.CalendarEventsList
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import de.tutao.calendar.widget.WIDGET_CACHE_DATE_PREFIX
+import de.tutao.calendar.widget.WIDGET_EVENTS_CACHE
+import de.tutao.calendar.widget.widgetCacheDataStore
+import de.tutao.tutasdk.CalendarEvent
 import de.tutao.tutasdk.GeneratedId
 import de.tutao.tutasdk.LoggedInSdk
-import de.tutao.tutashared.ipc.NativeCredentialsFacade
+import de.tutao.tutashared.AndroidNativeCryptoFacade
+import de.tutao.tutashared.IdTuple
+import de.tutao.tutashared.base64ToBytes
+import de.tutao.tutashared.ipc.UnencryptedCredentials
+import de.tutao.tutashared.toBase64
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
 import java.util.Calendar
+import java.util.Date
 import java.util.TimeZone
 
-class WidgetDataRepository : WidgetRepository() {
+class WidgetDataRepository() : WidgetRepository() {
 	companion object {
 		@Volatile
 		private var instance: WidgetDataRepository? = null
@@ -24,37 +37,137 @@ class WidgetDataRepository : WidgetRepository() {
 		}
 	}
 
+	private suspend fun updateCacheCreationDate(context: Context, widgetId: Int, now: Date) {
+		val nowTimestamp = now.time
+
+		val cacheDateIdentifier = "${WIDGET_CACHE_DATE_PREFIX}_$widgetId"
+		val preferencesKey = stringPreferencesKey(cacheDateIdentifier)
+
+		val createdAtDao = CacheDateDao(nowTimestamp)
+		context.widgetCacheDataStore.edit { preferences ->
+			preferences[preferencesKey] = json.encodeToString(createdAtDao)
+		}
+	}
+
+	override suspend fun storeCache(
+		context: Context,
+		widgetId: Int,
+		eventsMap: Map<GeneratedId, CalendarEventListDao>,
+		cryptoFacade: AndroidNativeCryptoFacade,
+		credentials: UnencryptedCredentials
+	) {
+		val key = credentials.databaseKey ?: return
+
+		val encryptedEventListMap: MutableMap<GeneratedId, String> = mutableMapOf()
+		for ((calendar, eventList) in eventsMap) {
+			val jsonEncodedEventList = json.encodeToString(eventList)
+
+			val encryptedData = cryptoFacade.aesEncryptData(key.data, jsonEncodedEventList.toByteArray())
+			val base64String = encryptedData.toBase64()
+			encryptedEventListMap[calendar] = base64String
+		}
+
+		val databaseWidgetIdentifier = "${WIDGET_EVENTS_CACHE}_$widgetId"
+		val preferencesKey = stringPreferencesKey(databaseWidgetIdentifier)
+		val encryptedEventListMapJson = json.encodeToString(encryptedEventListMap)
+
+		context.widgetCacheDataStore.edit { preferences ->
+			preferences[preferencesKey] = encryptedEventListMapJson
+		}
+
+		updateCacheCreationDate(context, widgetId, Date())
+	}
+
+	override suspend fun loadCache(
+		context: Context,
+		widgetId: Int,
+		calendars: List<GeneratedId>,
+		cryptoFacade: AndroidNativeCryptoFacade,
+		credentials: UnencryptedCredentials
+	): Map<GeneratedId, CalendarEventListDao> {
+		val key = credentials.databaseKey ?: return mapOf()
+
+		val databaseWidgetIdentifier = "${WIDGET_EVENTS_CACHE}_$widgetId"
+		val preferencesKey = stringPreferencesKey(databaseWidgetIdentifier)
+
+		val preferences = context.widgetCacheDataStore.data.first()
+		val encodedEventsJson = preferences[preferencesKey] ?: return mapOf()
+
+		val encodedEvents = json.decodeFromString<Map<GeneratedId, String>>(encodedEventsJson)
+		val eventsMap: MutableMap<GeneratedId, CalendarEventListDao> = mutableMapOf()
+
+		for ((calendar, encryptedEvents) in encodedEvents) {
+			val decodedEvents = encryptedEvents.base64ToBytes()
+			val decryptedEvents = cryptoFacade.aesDecryptData(key.data, decodedEvents)
+			val eventsJson = String(decryptedEvents)
+
+			eventsMap[calendar] = json.decodeFromString(eventsJson)
+		}
+
+		return eventsMap
+	}
+
 	override suspend fun loadEvents(
+		context: Context,
+		widgetId: Int,
 		userId: GeneratedId,
 		calendars: List<GeneratedId>,
-		credentialsFacade: NativeCredentialsFacade,
-		loggedInSdk: LoggedInSdk
-	): Map<GeneratedId, CalendarEventsList> {
+		credentials: UnencryptedCredentials,
+		loggedInSdk: LoggedInSdk,
+		cryptoFacade: AndroidNativeCryptoFacade
+	): Map<GeneratedId, CalendarEventListDao> {
 		val calendarFacade = loggedInSdk.calendarFacade()
 		val systemCalendar = Calendar.getInstance(TimeZone.getDefault())
 
-		var calendarEventsList: Map<GeneratedId, CalendarEventsList> = HashMap()
+		var calendarEventListMap: Map<GeneratedId, CalendarEventListDao> = HashMap()
 
 		calendars.forEach { calendarId ->
 			val events = calendarFacade.getCalendarEvents(calendarId, (systemCalendar.timeInMillis).toULong())
-
-			cachedEvents[calendarId] = events
-			calendarEventsList = calendarEventsList.plus(calendarId to events)
+			calendarEventListMap = calendarEventListMap.plus(
+				calendarId to CalendarEventListDao(
+					events.shortEvents.toDao(),
+					events.longEvents.toDao()
+				)
+			)
 		}
 
-		return calendarEventsList
+		storeCache(context, widgetId, calendarEventListMap, cryptoFacade, credentials)
+
+		return calendarEventListMap
 	}
 
-	override suspend fun loadEvents(calendars: List<GeneratedId>): Map<GeneratedId, CalendarEventsList> {
+	override suspend fun loadEvents(
+		context: Context,
+		widgetId: Int,
+		calendars: List<GeneratedId>,
+		credentials: UnencryptedCredentials,
+		cryptoFacade: AndroidNativeCryptoFacade
+	): Map<GeneratedId, CalendarEventListDao> {
 		val now = Calendar.getInstance(TimeZone.getDefault()).timeInMillis.toULong()
+		val cachedEvents: MutableMap<GeneratedId, CalendarEventListDao> =
+			loadCache(context, widgetId, calendars, cryptoFacade, credentials).toMutableMap()
 		val cache = cachedEvents.filterKeys { calendars.contains(it) }
 
 		for ((id, events) in cache.entries) {
-			cachedEvents[id] = CalendarEventsList(
+			cachedEvents[id] = CalendarEventListDao(
 				shortEvents = events.shortEvents.filter { it.startTime >= now || it.endTime >= now },
 				longEvents = events.longEvents.filter { it.startTime >= now || it.endTime >= now },
 			)
 		}
+
 		return cachedEvents.filterKeys { calendars.contains(it) }
+	}
+
+	private fun List<CalendarEvent>.toDao(): List<CalendarEventDao> {
+		return this.map {
+			val id = it.id ?: throw RuntimeException("Trying to convert an event without id to CalendarEventDao")
+
+			CalendarEventDao(
+				IdTuple(id.listId, id.elementId),
+				it.startTime,
+				it.endTime,
+				it.summary
+			)
+		}
 	}
 }

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetWorkerRepository.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetWorkerRepository.kt
@@ -25,14 +25,15 @@ class WidgetWorkerRepository : WidgetRepository() {
 
 		// We can't access the DataStore while writing to it, so we collect the changes before and then apply
 		for (id in widgetIds) {
-			val storedLastSync = this.loadLastSync(context, id)
+			val cacheCreation = this.loadCacheCreationDate(context, id)
 
-			val storedLastSyncAsLocalDateTime = LocalDateTime.ofInstant(
-				Instant.ofEpochMilli(storedLastSync?.lastSync ?: 0),
+			val storedCacheDateAsLocalDateTime = LocalDateTime.ofInstant(
+				Instant.ofEpochMilli(cacheCreation?.createdAt ?: 0),
 				Calendar.getInstance().timeZone.toZoneId()
 			)
 
-			val force = storedLastSyncAsLocalDateTime.dayOfYear != nowAsLocalDateTime.dayOfYear
+			val force =
+				storedCacheDateAsLocalDateTime.dayOfYear != nowAsLocalDateTime.dayOfYear
 			val lastSyncIdentifier = "${WIDGET_LAST_SYNC_PREFIX}_$id"
 			val preferencesKey = stringPreferencesKey(lastSyncIdentifier)
 

--- a/tuta-sdk/rust/sdk/Cargo.toml
+++ b/tuta-sdk/rust/sdk/Cargo.toml
@@ -20,6 +20,7 @@ minicbor = { version = "0.25", features = ["std", "alloc"] }
 const-hex = { version = "1.12.0", features = ["serde"] }
 lz4_flex = { version = "0.11.3", default-features = false, features = ["safe-encode", "safe-decode", "std"] }
 time = { version = "0.3.37", features = ["serde", "macros", "local-offset"] }
+time-tz = { version = "2.0.0", features = ["db", "posix-tz"] }
 
 aes = { version = "0.8.4", features = ["zeroize"] }
 cbc = { version = "0.1.2", features = ["std", "zeroize"] }

--- a/tuta-sdk/rust/sdk/Cargo.toml
+++ b/tuta-sdk/rust/sdk/Cargo.toml
@@ -19,7 +19,7 @@ num_enum = "0.7.3"
 minicbor = { version = "0.25", features = ["std", "alloc"] }
 const-hex = { version = "1.12.0", features = ["serde"] }
 lz4_flex = { version = "0.11.3", default-features = false, features = ["safe-encode", "safe-decode", "std"] }
-time = { version = "0.3.37", features = ["serde", "macros"] }
+time = { version = "0.3.37", features = ["serde", "macros", "local-offset"] }
 
 aes = { version = "0.8.4", features = ["zeroize"] }
 cbc = { version = "0.1.2", features = ["std", "zeroize"] }

--- a/tuta-sdk/rust/sdk/src/date/calendar_facade.rs
+++ b/tuta-sdk/rust/sdk/src/date/calendar_facade.rs
@@ -1,7 +1,7 @@
 use num_enum::TryFromPrimitive;
 use std::collections::HashMap;
 use std::sync::Arc;
-use time::{OffsetDateTime, Time};
+use time::{OffsetDateTime, Time, UtcOffset};
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::crypto_entity_client::CryptoEntityClient;
@@ -137,9 +137,16 @@ impl CalendarFacade {
 		};
 
 		let date_in_seconds = (date.as_millis() / 1000) as i64;
+		let Ok(offset) = UtcOffset::current_local_offset() else {
+			return Err(ApiCallError::InternalSdkError {
+				error_message: "Failed to determine device time offset".to_string(),
+			});
+		};
 
 		let parsed_date = match OffsetDateTime::from_unix_timestamp(date_in_seconds) {
-			Ok(date) => date.date().midnight().assume_utc(),
+			Ok(date) => date
+				.to_offset(offset)
+				.replace_time(Time::from_hms(0, 0, 0).unwrap()),
 			Err(e) => return Err(ApiCallError::internal_with_err(e, "Invalid date")),
 		};
 
@@ -149,6 +156,7 @@ impl CalendarFacade {
 
 		let timestamp_start = (parsed_date.unix_timestamp() * 1000) as u64; // x1000 to get the timestamp in milliseconds
 		let timestamp_end = (OffsetDateTime::new_utc(next_day, Time::from_hms(0, 0, 0).unwrap())
+			.replace_offset(offset)
 			.unix_timestamp()
 			* 1000) as u64; // x1000 to get the timestamp in milliseconds
 

--- a/tuta-sdk/rust/sdk/src/date/calendar_facade.rs
+++ b/tuta-sdk/rust/sdk/src/date/calendar_facade.rs
@@ -262,6 +262,7 @@ impl CalendarFacade {
 						.collect(),
 					None,
 					Some(DateTime::from_millis(timestamp_end)),
+					repeat_rule.timeZone.clone(),
 				) {
 					Ok(ev) => ev,
 					Err(e) => {


### PR DESCRIPTION
When generating event instances, the SDK was not aware of timezone changes. This PR adds a calculation to fix the timezone when there are DST changes during an event series.

Co-authored-by: André Dias <and@tutao.de>