### PR TITLE
Add keyboard shortcut to create new folder

### DIFF
--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -575,6 +575,20 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				help: "moveToInbox_action",
 			},
 			{
+				key: Keys.N,
+				shift: true,
+				ctrlOrCmd: true,
+				exec: () => {
+					// Since the user can have multiple mailboxes, get the current folder to find which mailbox the user selected
+					const currentFolder = this.mailViewModel.getFolder()
+					if (currentFolder != null) {
+						this.showFolderAddEditDialog(assertNotNull(currentFolder._ownerGroup), null, null)
+					}
+					return true
+				},
+				help: "addFolder_action",
+			},
+			{
 				key: Keys.V,
 				exec: () => {
 					this.moveMailsFromFolder(getMoveMailBounds())


### PR DESCRIPTION
Add a shortcut (ctrl-shift-N) to allow the user to create a new folder without having to click on anything to open the dialog.

Since a user may have access to more than one mail group, we can disambiguate this by checking what folder they are looking at (if any) and use this folder's owner group.

close #8922