### PR TITLE
Add console.debug to replaceNativeLogger

### DIFF
--- a/src/common/api/common/Logger.ts
+++ b/src/common/api/common/Logger.ts
@@ -106,6 +106,10 @@ export function replaceNativeLogger(global: any, loggerInstance: Logger, force: 
 			info(...args: any[]) {
 				globalConsole.info(...args)
 			},
+
+			debug(...args: any[]) {
+				globalConsole.debug(...args)
+			},
 		}
 	}
 }


### PR DESCRIPTION
While we never use console.debug ourselves, a lot of browser extensions unconditionally expect this to be present and (understandably) do not check to see if it's there or not before calling it.

Closes #8809