### PR TITLE
Inject type model resolvers

### DIFF
--- a/src/calendar-app/calendar/search/view/CalendarSearchViewModel.ts
+++ b/src/calendar-app/calendar/search/view/CalendarSearchViewModel.ts
@@ -2,7 +2,6 @@ import { CalendarSearchResultListEntry } from "./CalendarSearchListView.js"
 import { SearchRestriction, SearchResult } from "../../../../common/api/worker/search/SearchTypes.js"
 import { EntityEventsListener, EventController } from "../../../../common/api/main/EventController.js"
 import { CalendarEvent, CalendarEventTypeRef, ContactTypeRef, MailTypeRef } from "../../../../common/api/entities/tutanota/TypeRefs.js"
-import { SomeEntity } from "../../../../common/api/common/EntityTypes.js"
 import { CLIENT_ONLY_CALENDARS, OperationType } from "../../../../common/api/common/TutanotaConstants.js"
 import { assertIsEntity2, elementIdPart, GENERATED_MAX_ID, getElementId, isSameId, ListElement } from "../../../../common/api/common/utils/EntityUtils.js"
 import { ListLoadingState, ListState } from "../../../../common/gui/base/List.js"
@@ -47,8 +46,7 @@ import { locator } from "../../../../common/api/main/CommonLocator.js"
 import { CalendarEventsRepository } from "../../../../common/calendar/date/CalendarEventsRepository"
 import { getClientOnlyCalendars } from "../../gui/CalendarGuiUtils"
 import { ListElementListModel } from "../../../../common/misc/ListElementListModel"
-import { AppName } from "@tutao/tutanota-utils/dist/TypeRef"
-import { resolveTypeRefFromAppAndTypeNameLegacy } from "../../../../common/api/common/EntityFunctions"
+import { TypeModelResolver } from "../../../../common/api/common/EntityFunctions"
 
 const SEARCH_PAGE_SIZE = 100
 
@@ -499,9 +497,7 @@ export class CalendarSearchViewModel {
 		const { instanceListId, instanceId, operation } = update
 		const id = [neverNull(instanceListId), instanceId] as const
 
-		const typeRef = update.typeId
-			? new TypeRef<SomeEntity>(update.application as AppName, update.typeId)
-			: resolveTypeRefFromAppAndTypeNameLegacy(update.application as AppName, update.type)
+		const typeRef = update.typeRef
 
 		if (!this.isInSearchResult(typeRef, id) && isPossibleABirthdayContactUpdate) {
 			return

--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -113,6 +113,7 @@ import { MailImporter } from "../mail-app/mail/import/MailImporter.js"
 import { SyncTracker } from "../common/api/main/SyncTracker.js"
 import { KeyVerificationFacade } from "../common/api/worker/facades/lazy/KeyVerificationFacade"
 import { getEventWithDefaultTimes, setNextHalfHour } from "../common/api/common/utils/CommonCalendarUtils.js"
+import { ClientModelInfo, ClientTypeModelResolver } from "../common/api/common/EntityFunctions"
 
 assertMainOrNode()
 
@@ -172,6 +173,10 @@ class CalendarLocator {
 	private nativeInterfaces: NativeInterfaces | null = null
 	private entropyFacade!: EntropyFacade
 	private sqlCipherFacade!: SqlCipherFacade
+
+	readonly typeModelResolver: lazy<ClientTypeModelResolver> = lazyMemoized(() => {
+		return ClientModelInfo.getInstance()
+	})
 
 	readonly recipientsModel: lazyAsync<RecipientsModel> = lazyMemoized(async () => {
 		const { RecipientsModel } = await import("../common/api/main/RecipientsModel.js")
@@ -607,7 +612,7 @@ class CalendarLocator {
 		this.progressTracker = new ProgressTracker()
 		this.syncTracker = new SyncTracker()
 		this.search = new CalendarSearchModel(() => this.calendarEventsRepository())
-		this.entityClient = new EntityClient(restInterface)
+		this.entityClient = new EntityClient(restInterface, this.typeModelResolver())
 		this.cryptoFacade = cryptoFacade
 		this.cacheStorage = cacheStorage
 		this.entropyFacade = entropyFacade
@@ -638,6 +643,7 @@ class CalendarLocator {
 			this.logins,
 			this.eventController,
 			() => this.usageTestController,
+			this.typeModelResolver(),
 		)
 		this.usageTestController = new UsageTestController(this.usageTestModel)
 

--- a/src/common/api/worker/crypto/CryptoFacade.ts
+++ b/src/common/api/worker/crypto/CryptoFacade.ts
@@ -25,7 +25,7 @@ import {
 	PublicKeyIdentifierType,
 	SYSTEM_GROUP_MAIL_ADDRESS,
 } from "../../common/TutanotaConstants"
-import { HttpMethod, resolveClientTypeReference, resolveServerTypeReference } from "../../common/EntityFunctions"
+import { HttpMethod, TypeModelResolver } from "../../common/EntityFunctions"
 import type { BucketPermission, GroupMembership, InstanceSessionKey, Permission } from "../../entities/sys/TypeRefs.js"
 import {
 	BucketPermissionTypeRef,
@@ -37,8 +37,6 @@ import {
 	PushIdentifierTypeRef,
 } from "../../entities/sys/TypeRefs.js"
 import {
-	Contact,
-	ContactTypeRef,
 	createEncryptTutanotaPropertiesData,
 	createInternalRecipientKeyData,
 	createSymEncInternalRecipientKeyData,
@@ -50,9 +48,8 @@ import {
 	SymEncInternalRecipientKeyData,
 	TutanotaPropertiesTypeRef,
 } from "../../entities/tutanota/TypeRefs.js"
-import { LockedError, NotFoundError, PayloadTooLargeError, TooManyRequestsError } from "../../common/error/RestError"
+import { NotFoundError, PayloadTooLargeError, TooManyRequestsError } from "../../common/error/RestError"
 import { SessionKeyNotFoundError } from "../../common/error/SessionKeyNotFoundError"
-import { birthdayToIsoDate, oldBirthdayToBirthday } from "../../common/utils/BirthdayUtils"
 import type { ClientModelEncryptedParsedInstance, ClientTypeModel, Entity, ServerModelEncryptedParsedInstance, SomeEntity } from "../../common/EntityTypes"
 import { assertWorkerOrNode } from "../../common/Env"
 import type { EntityClient } from "../../common/EntityClient"
@@ -87,9 +84,9 @@ import type { KeyVerificationFacade } from "../facades/lazy/KeyVerificationFacad
 import { PublicKeyProvider } from "../facades/PublicKeyProvider.js"
 import { KeyVersion, Nullable } from "@tutao/tutanota-utils/dist/Utils.js"
 import { KeyRotationFacade } from "../facades/KeyRotationFacade.js"
-import { typeRefToRestPath } from "../rest/EntityRestClient"
 import { InstancePipeline } from "./InstancePipeline"
 import { EntityAdapter } from "./EntityAdapter"
+import { typeModelToRestPath } from "../rest/EntityRestClient"
 
 assertWorkerOrNode()
 
@@ -112,6 +109,7 @@ export class CryptoFacade {
 		private readonly lazyKeyVerificationFacade: lazyAsync<KeyVerificationFacade>,
 		private readonly publicKeyProvider: PublicKeyProvider,
 		private readonly keyRotationFacade: lazy<KeyRotationFacade>,
+		private readonly typeModelResolver: TypeModelResolver,
 	) {}
 
 	/** Resolve a session key an {@param instance} using an already known {@param ownerKey}. */
@@ -133,7 +131,7 @@ export class CryptoFacade {
 	 * @param instance The unencrypted (client-side) instance or encrypted (server-side) object literal
 	 */
 	async resolveSessionKey(instance: Entity): Promise<Nullable<AesKey>> {
-		const clientTypeModel = await resolveClientTypeReference(instance._type)
+		const clientTypeModel = await this.typeModelResolver.resolveClientTypeReference(instance._type)
 		if (!clientTypeModel.encrypted) {
 			return null
 		}
@@ -192,7 +190,7 @@ export class CryptoFacade {
 	 * @throws {Error} if `instance.bucketKey == null`
 	 */
 	async resolveWithBucketKey(instance: Entity): Promise<ResolvedSessionKeys> {
-		const typeModel = await resolveClientTypeReference(instance._type)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(instance._type)
 		const bucketKey = assertNotNull(instance.bucketKey)
 
 		let decryptedBucketKey: AesKey
@@ -473,7 +471,7 @@ export class CryptoFacade {
 		if (decryptedInstance.isAdapter) {
 			const entityAdapter = downcast<EntityAdapter>(instance)
 			const parsedInstance = await this.instancePipeline.cryptoMapper.decryptParsedInstance(
-				await resolveServerTypeReference(instance._type),
+				await this.typeModelResolver.resolveServerTypeReference(instance._type),
 				entityAdapter.encryptedParsedInstance as ServerModelEncryptedParsedInstance,
 				resolvedSessionKeyForInstance,
 			)
@@ -779,7 +777,8 @@ export class CryptoFacade {
 		this.setOwnerEncSessionKey(instance, newOwnerEncSessionKey)
 
 		const id = instance._id
-		const path = (await typeRefToRestPath(instance._type)) + "/" + (id instanceof Array ? id.join("/") : id)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(instance._type)
+		const path = typeModelToRestPath(typeModel) + "/" + (id instanceof Array ? id.join("/") : id)
 		const headers = this.userFacade.createAuthHeaders()
 		headers.v = String(instance.typeModel.version)
 

--- a/src/common/api/worker/crypto/OwnerEncSessionKeysUpdateQueue.ts
+++ b/src/common/api/worker/crypto/OwnerEncSessionKeysUpdateQueue.ts
@@ -6,7 +6,7 @@ import { IServiceExecutor } from "../../common/ServiceRequest"
 import { UpdateSessionKeysService } from "../../entities/sys/Services"
 import { UserFacade } from "../facades/UserFacade"
 import { TypeModel } from "../../common/EntityTypes.js"
-import { resolveClientTypeReference } from "../../common/EntityFunctions.js"
+import { TypeModelResolver } from "../../common/EntityFunctions"
 
 assertWorkerOrNode()
 
@@ -27,6 +27,7 @@ export class OwnerEncSessionKeysUpdateQueue {
 	constructor(
 		private readonly userFacade: UserFacade,
 		private readonly serviceExecutor: IServiceExecutor,
+		private readonly typeModelResolver: TypeModelResolver,
 		// allow passing the timeout for testability
 		debounceTimeoutMs: number = UPDATE_SESSION_KEYS_SERVICE_DEBOUNCE_MS,
 	) {
@@ -41,7 +42,7 @@ export class OwnerEncSessionKeysUpdateQueue {
 	 */
 	async updateInstanceSessionKeys(instanceSessionKeys: Array<InstanceSessionKey>, typeModel: TypeModel) {
 		if (this.userFacade.isLeader()) {
-			const groupKeyUpdateTypeModel = await resolveClientTypeReference(GroupKeyUpdateTypeRef)
+			const groupKeyUpdateTypeModel = await this.typeModelResolver.resolveClientTypeReference(GroupKeyUpdateTypeRef)
 			if (groupKeyUpdateTypeModel.id !== typeModel.id) {
 				this.updateInstanceSessionKeyQueue.push(...instanceSessionKeys)
 				this.invokeUpdateSessionKeyService()

--- a/src/common/api/worker/facades/lazy/BlobFacade.ts
+++ b/src/common/api/worker/facades/lazy/BlobFacade.ts
@@ -17,7 +17,7 @@ import {
 } from "@tutao/tutanota-utils"
 import { ArchiveDataType, MAX_BLOB_SIZE_BYTES } from "../../../common/TutanotaConstants.js"
 
-import { HttpMethod, MediaType, resolveClientTypeReference } from "../../../common/EntityFunctions.js"
+import { HttpMethod, MediaType } from "../../../common/EntityFunctions.js"
 import { assertWorkerOrNode, isApp, isDesktop } from "../../../common/Env.js"
 import type { SuspensionHandler } from "../../SuspensionHandler.js"
 import { BlobService } from "../../../entities/storage/Services.js"
@@ -352,7 +352,6 @@ export class BlobFacade {
 
 	// Visible for testing
 	public async parseBlobPostOutResponse(jsonData: string): Promise<BlobReferenceTokenWrapper> {
-		const responseTypeModel = await resolveClientTypeReference(BlobPostOutTypeRef)
 		const instance = AttributeModel.removeNetworkDebuggingInfoIfNeeded<ServerModelUntypedInstance>(JSON.parse(jsonData))
 		const { blobReferenceToken } = await this.instancePipeline.decryptAndMap(BlobPostOutTypeRef, instance, null)
 		// is null in case of post multiple to the BlobService, currently only supported in the rust-sdk

--- a/src/common/api/worker/facades/lazy/CalendarFacade.ts
+++ b/src/common/api/worker/facades/lazy/CalendarFacade.ts
@@ -70,7 +70,6 @@ import { isOfflineError } from "../../../common/utils/ErrorUtils.js"
 import type { EventWrapper } from "../../../../calendar/import/ImportExportUtils.js"
 import { InstancePipeline } from "../../crypto/InstancePipeline"
 import { AttributeModel } from "../../../common/AttributeModel"
-import { resolveClientTypeReference } from "../../../common/EntityFunctions"
 import { ClientModelUntypedInstance } from "../../../common/EntityTypes"
 
 assertWorkerOrNode()
@@ -94,9 +93,6 @@ export type CalendarEventUidIndexEntry = {
 }
 
 export class CalendarFacade {
-	// visible for testing
-	readonly cachingEntityClient: EntityClient
-
 	constructor(
 		private readonly userFacade: UserFacade,
 		private readonly groupManagementFacade: GroupManagementFacade,
@@ -109,9 +105,9 @@ export class CalendarFacade {
 		private readonly cryptoFacade: CryptoFacade,
 		private readonly infoMessageHandler: InfoMessageHandler,
 		private readonly instancePipeline: InstancePipeline,
-	) {
-		this.cachingEntityClient = new EntityClient(this.entityRestCache)
-	}
+		// visible for testing
+		public readonly cachingEntityClient: EntityClient,
+	) {}
 
 	async saveImportedCalendarEvents(eventWrappers: Array<EventWrapper>, operationId: OperationId): Promise<void> {
 		// it is safe to assume that all event uids are set at this time

--- a/src/common/api/worker/facades/lazy/ConfigurationDatabase.ts
+++ b/src/common/api/worker/facades/lazy/ConfigurationDatabase.ts
@@ -19,7 +19,7 @@ import { DbError } from "../../../common/error/DbError.js"
 import { checkKeyVersionConstraints, KeyLoaderFacade } from "../KeyLoaderFacade.js"
 import type { QueuedBatch } from "../../EventQueue.js"
 import { encryptKeyWithVersionedKey, VersionedKey } from "../../crypto/CryptoWrapper.js"
-import { isUpdateForTypeRef } from "../../../common/utils/EntityUpdateUtils"
+import { EntityUpdateData, isUpdateForTypeRef } from "../../../common/utils/EntityUpdateUtils"
 
 const VERSION: number = 2
 const DB_KEY_PREFIX: string = "ConfigStorage"
@@ -128,8 +128,7 @@ export class ConfigurationDatabase {
 		}
 	}
 
-	async onEntityEventsReceived(batch: QueuedBatch): Promise<any> {
-		const { events, groupId, batchId } = batch
+	async onEntityEventsReceived(events: readonly EntityUpdateData[], _batchId: Id, _groupId: Id): Promise<any> {
 		for (const event of events) {
 			if (!(event.operation === OperationType.UPDATE && isUpdateForTypeRef(UserTypeRef, event))) {
 				continue

--- a/src/common/api/worker/facades/lazy/MailFacade.ts
+++ b/src/common/api/worker/facades/lazy/MailFacade.ts
@@ -154,7 +154,7 @@ import { KeyLoaderFacade, parseKeyVersion } from "../KeyLoaderFacade.js"
 import { encryptBytes, encryptKeyWithVersionedKey, encryptString, VersionedKey } from "../../crypto/CryptoWrapper.js"
 import { PublicKeyProvider } from "../PublicKeyProvider.js"
 import { KeyVerificationMismatchError } from "../../../common/error/KeyVerificationMismatchError"
-import { isUpdateForTypeRef } from "../../../common/utils/EntityUpdateUtils"
+import { EntityUpdateData, isUpdateForTypeRef } from "../../../common/utils/EntityUpdateUtils"
 
 assertWorkerOrNode()
 type Attachments = ReadonlyArray<TutanotaFile | DataFile | FileReference>
@@ -893,7 +893,7 @@ export class MailFacade {
 			.catch(ofClass(NotFoundError, () => null))
 	}
 
-	entityEventsReceived(data: EntityUpdate[]): Promise<void> {
+	entityEventsReceived(data: readonly EntityUpdateData[]): Promise<void> {
 		return promiseMap(data, (update) => {
 			if (
 				this.deferredDraftUpdate != null &&

--- a/src/common/api/worker/offline/OfflineStorage.ts
+++ b/src/common/api/worker/offline/OfflineStorage.ts
@@ -17,7 +17,6 @@ import {
 	TypeRef,
 } from "@tutao/tutanota-utils"
 import { isDesktop, isOfflineStorageAvailable, isTest } from "../../common/Env.js"
-import { resolveClientTypeReference, resolveServerTypeReference } from "../../common/EntityFunctions.js"
 import { DateProvider } from "../../common/DateProvider.js"
 import { TokenOrNestedTokens } from "cborg/interface"
 import { CalendarEventTypeRef, MailTypeRef } from "../../entities/tutanota/TypeRefs.js"
@@ -32,6 +31,7 @@ import { OutOfSyncError } from "../../common/error/OutOfSyncError.js"
 import { sql, SqlFragment } from "./Sql.js"
 import { ModelMapper } from "../crypto/ModelMapper"
 import { AttributeModel } from "../../common/AttributeModel"
+import { TypeModelResolver } from "../../common/EntityFunctions"
 
 /**
  * this is the value of SQLITE_MAX_VARIABLE_NUMBER in sqlite3.c
@@ -108,6 +108,7 @@ export class OfflineStorage implements CacheStorage {
 		private readonly migrator: OfflineStorageMigrator,
 		private readonly cleaner: OfflineStorageCleaner,
 		private readonly modelMapper: ModelMapper,
+		private readonly typeModelResolver: TypeModelResolver,
 	) {
 		assert(isOfflineStorageAvailable() || isTest(), "Offline storage is not available.")
 	}
@@ -187,7 +188,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async deleteIfExists(typeRef: TypeRef<SomeEntity>, listId: Id | null, elementId: Id): Promise<void> {
 		const type = getTypeString(typeRef)
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const encodedElementId = ensureBase64Ext(typeModel, elementId)
 		let formattedQuery
 		switch (typeModel.type) {
@@ -219,7 +220,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async deleteAllOfType(typeRef: TypeRef<SomeEntity>): Promise<void> {
 		const type = getTypeString(typeRef)
-		let typeModel = await resolveClientTypeReference(typeRef)
+		let typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		let formattedQuery
 		switch (typeModel.type) {
 			case TypeId.Element:
@@ -263,7 +264,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async getParsed(typeRef: TypeRef<unknown>, listId: Id | null, id: Id): Promise<ServerModelParsedInstance | null> {
 		const type = getTypeString(typeRef)
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const encodedElementId = ensureBase64Ext(typeModel, id)
 		let formattedQuery
 		switch (typeModel.type) {
@@ -296,7 +297,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async provideMultipleParsed<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, elementIds: Id[]): Promise<Array<ServerModelParsedInstance>> {
 		if (elementIds.length === 0) return []
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const encodedElementIds = elementIds.map((elementId) => ensureBase64Ext(typeModel, elementId))
 
 		const type = getTypeString(typeRef)
@@ -314,7 +315,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async getIdsInRange<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<Id>> {
 		const type = getTypeString(typeRef)
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const range = await this.getRange(typeRef, listId)
 		if (range == null) {
 			throw new Error(`no range exists for ${type} and list ${listId}`)
@@ -336,7 +337,7 @@ export class OfflineStorage implements CacheStorage {
 	async getRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Range | null> {
 		let range = await this.getRange(typeRef, listId)
 		if (range == null) return range
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		return {
 			lower: customIdToBase64Url(typeModel, range.lower),
 			upper: customIdToBase64Url(typeModel, range.upper),
@@ -344,7 +345,7 @@ export class OfflineStorage implements CacheStorage {
 	}
 
 	async isElementIdInCacheRange<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, elementId: Id): Promise<boolean> {
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const encodedElementId = ensureBase64Ext(typeModel, elementId)
 
 		const range = await this.getRange(typeRef, listId)
@@ -358,7 +359,7 @@ export class OfflineStorage implements CacheStorage {
 		count: number,
 		reverse: boolean,
 	): Promise<ServerModelParsedInstance[]> {
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const encodedStartId = ensureBase64Ext(typeModel, start)
 		const type = getTypeString(typeRef)
 		let formattedQuery
@@ -389,7 +390,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async put(typeRef: TypeRef<unknown>, instance: ServerModelParsedInstance): Promise<void> {
 		const serializedInstance = await this.serialize(instance)
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 
 		const { listId, elementId } = expandId(AttributeModel.getAttribute<IdTuple | Id>(instance, "_id", typeModel))
 		const ownerGroup = AttributeModel.getAttribute<Id>(instance, "_ownerGroup", typeModel)
@@ -433,7 +434,7 @@ export class OfflineStorage implements CacheStorage {
 	}
 
 	async setLowerRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lowerId: Id): Promise<void> {
-		lowerId = ensureBase64Ext(await resolveClientTypeReference(typeRef), lowerId)
+		lowerId = ensureBase64Ext(await this.typeModelResolver.resolveClientTypeReference(typeRef), lowerId)
 		const type = getTypeString(typeRef)
 		const { query, params } = sql`UPDATE ranges
 									  SET lower = ${lowerId}
@@ -443,7 +444,7 @@ export class OfflineStorage implements CacheStorage {
 	}
 
 	async setUpperRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, upperId: Id): Promise<void> {
-		upperId = ensureBase64Ext(await resolveClientTypeReference(typeRef), upperId)
+		upperId = ensureBase64Ext(await this.typeModelResolver.resolveClientTypeReference(typeRef), upperId)
 		const type = getTypeString(typeRef)
 		const { query, params } = sql`UPDATE ranges
 									  SET upper = ${upperId}
@@ -453,7 +454,7 @@ export class OfflineStorage implements CacheStorage {
 	}
 
 	async setNewRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lower: Id, upper: Id): Promise<void> {
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		lower = ensureBase64Ext(typeModel, lower)
 		upper = ensureBase64Ext(typeModel, upper)
 
@@ -541,7 +542,7 @@ export class OfflineStorage implements CacheStorage {
 			this.customCacheHandler = new CustomCacheHandlerMap(
 				{
 					ref: CalendarEventTypeRef,
-					handler: new CustomCalendarEventCacheHandler(entityRestClient),
+					handler: new CustomCalendarEventCacheHandler(entityRestClient, this.typeModelResolver),
 				},
 				{ ref: MailTypeRef, handler: new CustomMailEventCacheHandler() },
 			)
@@ -678,7 +679,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async deleteIn(typeRef: TypeRef<unknown>, listId: Id | null, elementIds: Id[]): Promise<void> {
 		if (elementIds.length === 0) return
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const encodedElementIds = elementIds.map((elementIds) => ensureBase64Ext(typeModel, elementIds))
 		switch (typeModel.type) {
 			case TypeId.Element:
@@ -733,7 +734,7 @@ export class OfflineStorage implements CacheStorage {
 	}
 
 	async updateRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, rawCutoffId: Id): Promise<void> {
-		const typeModel = await resolveClientTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const isCustomId = isCustomIdType(typeModel)
 		const encodedCutoffId = ensureBase64Ext(typeModel, rawCutoffId)
 

--- a/src/common/api/worker/rest/AdminClientDummyEntityRestCache.ts
+++ b/src/common/api/worker/rest/AdminClientDummyEntityRestCache.ts
@@ -1,14 +1,13 @@
-import { QueuedBatch } from "../EventQueue.js"
-import { EntityUpdate } from "../../entities/sys/TypeRefs.js"
 import { ListElementEntity, SomeEntity } from "../../common/EntityTypes"
 import { ProgrammingError } from "../../common/error/ProgrammingError"
 import { TypeRef } from "@tutao/tutanota-utils"
 import { EntityRestCache } from "./DefaultEntityRestCache.js"
 import { EntityRestClientLoadOptions } from "./EntityRestClient.js"
+import { EntityUpdateData } from "../../common/utils/EntityUpdateUtils"
 
 export class AdminClientDummyEntityRestCache implements EntityRestCache {
-	async entityEventsReceived(batch: QueuedBatch): Promise<Array<EntityUpdate>> {
-		return batch.events
+	async entityEventsReceived(events: readonly EntityUpdateData[], batchId: Id, groupId: Id): Promise<readonly EntityUpdateData[]> {
+		return events
 	}
 
 	async erase<T extends SomeEntity>(instance: T): Promise<void> {

--- a/src/common/api/worker/rest/CacheStorageProxy.ts
+++ b/src/common/api/worker/rest/CacheStorageProxy.ts
@@ -47,8 +47,8 @@ export class LateInitializedCacheStorageImpl implements CacheStorageLateInitiali
 	private _inner: SomeStorage | null = null
 
 	constructor(
-		private readonly modelMapper: ModelMapper,
 		private readonly sendError: (error: Error) => Promise<void>,
+		private readonly ephemeralStorageProvider: () => Promise<EphemeralCacheStorage>,
 		private readonly offlineStorageProvider: () => Promise<null | OfflineStorage>,
 	) {}
 
@@ -118,7 +118,7 @@ export class LateInitializedCacheStorageImpl implements CacheStorageLateInitiali
 			}
 		}
 		// both "else" case and fallback for unavailable storage and error cases
-		const storage = new EphemeralCacheStorage(this.modelMapper)
+		const storage = await this.ephemeralStorageProvider()
 		storage.init(args)
 		return {
 			storage,

--- a/src/common/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/common/api/worker/rest/EphemeralCacheStorage.ts
@@ -4,13 +4,13 @@ import { firstBiggerThanSecond } from "../../common/utils/EntityUtils.js"
 import { CacheStorage, expandId, LastUpdateTime } from "./DefaultEntityRestCache.js"
 import { assertNotNull, clone, getFromMap, getTypeString, remove, TypeRef } from "@tutao/tutanota-utils"
 import { CustomCacheHandlerMap } from "./CustomCacheHandler.js"
-import { resolveClientTypeReference, resolveServerTypeReference } from "../../common/EntityFunctions.js"
 import { Type as TypeId } from "../../common/EntityConstants.js"
 import { ProgrammingError } from "../../common/error/ProgrammingError.js"
 import { customIdToBase64Url, ensureBase64Ext } from "../offline/OfflineStorage.js"
 import { AttributeModel } from "../../common/AttributeModel"
 import { ModelMapper } from "../crypto/ModelMapper"
 import { parseTypeString } from "@tutao/tutanota-utils/dist/TypeRef"
+import { ServerTypeModelResolver } from "../../common/EntityFunctions"
 
 /** Cache for a single list. */
 type ListCache = {
@@ -47,7 +47,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	private userId: Id | null = null
 	private lastBatchIdPerGroup = new Map<Id, Id>()
 
-	constructor(private readonly modelMapper: ModelMapper) {}
+	constructor(private readonly modelMapper: ModelMapper, private readonly typeModelResolver: ServerTypeModelResolver) {}
 
 	init({ userId }: EphemeralStorageInitArgs) {
 		this.userId = userId
@@ -68,7 +68,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	async getParsed(typeRef: TypeRef<unknown>, listId: Id | null, id: Id): Promise<ServerModelParsedInstance | null> {
 		// We downcast because we can't prove that map has correct entity on the type level
 		const type = getTypeString(typeRef)
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		id = ensureBase64Ext(typeModel, id)
 		switch (typeModel.type) {
 			case TypeId.Element:
@@ -89,7 +89,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 		count: number,
 		reverse: boolean,
 	): Promise<ServerModelParsedInstance[]> {
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		startElementId = ensureBase64Ext(typeModel, startElementId)
 
 		const listCache = this.lists.get(getTypeString(typeRef))?.get(listId)
@@ -136,7 +136,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	async provideMultipleParsed(typeRef: TypeRef<unknown>, listId: string, elementIds: string[]): Promise<ServerModelParsedInstance[]> {
 		const listCache = this.lists.get(getTypeString(typeRef))?.get(listId)
 
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		elementIds = elementIds.map((el) => ensureBase64Ext(typeModel, el))
 
 		if (listCache == null) {
@@ -173,7 +173,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 
 	async deleteIfExists<T>(typeRef: TypeRef<T>, listId: Id | null, elementId: Id): Promise<void> {
 		const type = getTypeString(typeRef)
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		elementId = ensureBase64Ext(typeModel, elementId)
 		switch (typeModel.type) {
 			case TypeId.Element:
@@ -200,7 +200,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	}
 
 	async isElementIdInCacheRange(typeRef: TypeRef<unknown>, listId: Id, elementId: Id): Promise<boolean> {
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		elementId = ensureBase64Ext(typeModel, elementId)
 
 		const cache = this.lists.get(getTypeString(typeRef))?.get(listId)
@@ -209,7 +209,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 
 	async put(typeRef: TypeRef<unknown>, instance: ServerModelParsedInstance): Promise<void> {
 		const instanceClone = clone(instance)
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		const instanceId = AttributeModel.getAttribute<IdTuple | Id>(instanceClone, "_id", typeModel)
 		let { listId, elementId } = expandId(instanceId)
 		elementId = ensureBase64Ext(typeModel, elementId)
@@ -264,7 +264,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 			// if the element already exists in the cache, overwrite it
 			// add new element to existing list if necessary
 			cache.elements.set(elementId, entity)
-			const typeModel = await resolveServerTypeReference(typeRef)
+			const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 			if (await this.isElementIdInCacheRange(typeRef, listId, customIdToBase64Url(typeModel, elementId))) {
 				this.insertIntoRange(cache.allRange, elementId)
 			}
@@ -309,7 +309,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 			return null
 		}
 
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		return {
 			lower: customIdToBase64Url(typeModel, listCache.lowerRangeId),
 			upper: customIdToBase64Url(typeModel, listCache.upperRangeId),
@@ -317,7 +317,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	}
 
 	async setUpperRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, upperId: Id): Promise<void> {
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		upperId = ensureBase64Ext(typeModel, upperId)
 		const listCache = this.lists.get(getTypeString(typeRef))?.get(listId)
 		if (listCache == null) {
@@ -327,7 +327,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	}
 
 	async setLowerRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lowerId: Id): Promise<void> {
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		lowerId = ensureBase64Ext(typeModel, lowerId)
 		const listCache = this.lists.get(getTypeString(typeRef))?.get(listId)
 		if (listCache == null) {
@@ -344,7 +344,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	 * @param upper
 	 */
 	async setNewRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lower: Id, upper: Id): Promise<void> {
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		lower = ensureBase64Ext(typeModel, lower)
 		upper = ensureBase64Ext(typeModel, upper)
 
@@ -365,7 +365,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	}
 
 	async getIdsInRange<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id): Promise<Array<Id>> {
-		const typeModel = await resolveServerTypeReference(typeRef)
+		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		return (
 			this.lists
 				.get(getTypeString(typeRef))
@@ -412,7 +412,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	async deleteAllOwnedBy(owner: Id): Promise<void> {
 		for (const [typeString, typeMap] of this.entities.entries()) {
 			const typeRef = parseTypeString(typeString)
-			const typeModel = await resolveServerTypeReference(typeRef)
+			const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 			for (const [id, entity] of typeMap.entries()) {
 				const ownerGroup = AttributeModel.getAttribute<Id>(entity, "_ownerGroup", typeModel)
 				if (ownerGroup === owner) {
@@ -422,12 +422,12 @@ export class EphemeralCacheStorage implements CacheStorage {
 		}
 		for (const [typeString, cacheForType] of this.lists.entries()) {
 			const typeRef = parseTypeString(typeString)
-			const typeModel = await resolveServerTypeReference(typeRef)
+			const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 			this.deleteAllOwnedByFromCache(typeModel, cacheForType, owner)
 		}
 		for (const [typeString, cacheForType] of this.blobEntities.entries()) {
 			const typeRef = parseTypeString(typeString)
-			const typeModel = await resolveServerTypeReference(typeRef)
+			const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 			this.deleteAllOwnedByFromCache(typeModel, cacheForType, owner)
 		}
 		this.lastBatchIdPerGroup.delete(owner)

--- a/src/common/desktop/sse/DesktopAlarmStorage.ts
+++ b/src/common/desktop/sse/DesktopAlarmStorage.ts
@@ -13,6 +13,7 @@ import { hasError } from "../../api/common/utils/ErrorUtils"
 import { CryptoError } from "@tutao/tutanota-crypto/error.js"
 import { EncryptedAlarmNotification } from "../../native/common/EncryptedAlarmNotification"
 import { AttributeModel } from "../../api/common/AttributeModel"
+import { ClientTypeModelResolver, TypeModelResolver } from "../../api/common/EntityFunctions"
 
 /**
  * manages session keys used for decrypting alarm notifications, encrypting & persisting them to disk
@@ -26,6 +27,7 @@ export class DesktopAlarmStorage {
 		private readonly cryptoFacade: DesktopNativeCryptoFacade,
 		private readonly keyStoreFacade: DesktopKeyStoreFacade,
 		private readonly alarmStorageInstancePipeline: InstancePipeline,
+		private readonly typeModelResolver: ClientTypeModelResolver,
 	) {
 		this.unencryptedSessionKeys = {}
 	}
@@ -191,7 +193,7 @@ export class DesktopAlarmStorage {
 	}
 
 	public async decryptAlarmNotification(an: ClientModelUntypedInstance): Promise<AlarmNotification> {
-		const encryptedAlarmNotification = await EncryptedAlarmNotification.from(an as unknown as ServerModelUntypedInstance)
+		const encryptedAlarmNotification = await EncryptedAlarmNotification.from(an as unknown as ServerModelUntypedInstance, this.typeModelResolver)
 		for (const currentNotificationSessionKey of encryptedAlarmNotification.getNotificationSessionKeys()) {
 			const pushIdentifierSessionKey = await this.getPushIdentifierSessionKey(currentNotificationSessionKey.pushIdentifier)
 

--- a/src/common/desktop/sse/TutaNotificationHandler.ts
+++ b/src/common/desktop/sse/TutaNotificationHandler.ts
@@ -15,11 +15,11 @@ import { DesktopAlarmStorage } from "./DesktopAlarmStorage.js"
 import { SseInfo } from "./SseInfo.js"
 import { SseStorage } from "./SseStorage.js"
 import { FetchImpl } from "../net/NetAgent"
-import { resolveClientTypeReference } from "../../api/common/EntityFunctions"
 import { StrippedEntity } from "../../api/common/utils/EntityUtils"
-import { ClientModelUntypedInstance, EncryptedParsedInstance, ServerModelUntypedInstance, TypeModel } from "../../api/common/EntityTypes"
+import { EncryptedParsedInstance, ServerModelUntypedInstance, TypeModel } from "../../api/common/EntityTypes"
 import { AttributeModel } from "../../api/common/AttributeModel"
 import { InstancePipeline } from "../../api/worker/crypto/InstancePipeline"
+import { ClientTypeModelResolver, TypeModelResolver } from "../../api/common/EntityFunctions"
 
 const TAG = "[notifications]"
 
@@ -41,6 +41,7 @@ export class TutaNotificationHandler {
 		private readonly fetch: FetchImpl,
 		private readonly appVersion: string,
 		private readonly nativeInstancePipeline: InstancePipeline,
+		private readonly typeModelResolver: ClientTypeModelResolver,
 	) {}
 
 	async onMailNotification(sseInfo: SseInfo, notificationInfo: StrippedEntity<NotificationInfo>) {
@@ -115,8 +116,8 @@ export class TutaNotificationHandler {
 
 			const parsedResponse = await response.json()
 
-			const mailModel = await resolveClientTypeReference(MailTypeRef)
-			const mailAddressModel = await resolveClientTypeReference(MailAddressTypeRef)
+			const mailModel = await this.typeModelResolver.resolveClientTypeReference(MailTypeRef)
+			const mailAddressModel = await this.typeModelResolver.resolveClientTypeReference(MailAddressTypeRef)
 			const mailEncryptedParsedInstance: EncryptedParsedInstance = await this.nativeInstancePipeline.typeMapper.applyJsTypes(
 				mailModel,
 				parsedResponse as ServerModelUntypedInstance,

--- a/src/common/misc/UsageTestModel.ts
+++ b/src/common/misc/UsageTestModel.ts
@@ -15,7 +15,6 @@ import { SuspensionBehavior } from "../api/worker/rest/RestClient"
 import { DateProvider } from "../api/common/DateProvider.js"
 import { IServiceExecutor } from "../api/common/ServiceRequest"
 import { UsageTestAssignmentService, UsageTestParticipationService } from "../api/entities/usage/Services.js"
-import { resolveClientTypeReference } from "../api/common/EntityFunctions"
 import { lang, TranslationKey } from "./LanguageViewModel"
 import stream from "mithril/stream"
 import { Dialog, DialogType } from "../gui/base/Dialog"
@@ -28,6 +27,7 @@ import { EntityClient } from "../api/common/EntityClient.js"
 import { EventController } from "../api/main/EventController.js"
 import { createUserSettingsGroupRoot, UserSettingsGroupRootTypeRef } from "../api/entities/tutanota/TypeRefs.js"
 import { EntityUpdateData, isUpdateForTypeRef } from "../api/common/utils/EntityUpdateUtils.js"
+import { ClientTypeModelResolver, TypeModelResolver } from "../api/common/EntityFunctions"
 
 const PRESELECTED_LIKERT_VALUE = null
 
@@ -170,6 +170,7 @@ export class UsageTestModel implements PingAdapter {
 		private readonly loginController: LoginController,
 		private readonly eventController: EventController,
 		private readonly usageTestController: () => UsageTestController,
+		private readonly typeModelResolver: ClientTypeModelResolver,
 	) {
 		eventController.addEntityListener((updates: ReadonlyArray<EntityUpdateData>) => {
 			return this.entityEventsReceived(updates)
@@ -304,7 +305,7 @@ export class UsageTestModel implements PingAdapter {
 	}
 
 	private async modelVersion(): Promise<number> {
-		const model = await resolveClientTypeReference(UsageTestAssignmentTypeRef)
+		const model = await this.typeModelResolver.resolveClientTypeReference(UsageTestAssignmentTypeRef)
 		return model.version
 	}
 

--- a/src/common/native/common/EncryptedAlarmNotification.ts
+++ b/src/common/native/common/EncryptedAlarmNotification.ts
@@ -1,5 +1,4 @@
 import { ServerModelUntypedInstance, TypeModel, UntypedInstance } from "../../api/common/EntityTypes"
-import { resolveClientTypeReference } from "../../api/common/EntityFunctions"
 import {
 	AlarmInfoTypeRef,
 	AlarmNotificationTypeRef,
@@ -10,6 +9,7 @@ import {
 import { AttributeModel } from "../../api/common/AttributeModel"
 import { isSameId } from "../../api/common/utils/EntityUtils"
 import { assertNotNull, Base64, base64ToUint8Array } from "@tutao/tutanota-utils"
+import { ClientTypeModelResolver, TypeModelResolver } from "../../api/common/EntityFunctions"
 
 export class EncryptedAlarmNotification {
 	private constructor(
@@ -19,10 +19,10 @@ export class EncryptedAlarmNotification {
 		private alarmInfoTypeModel: TypeModel,
 	) {}
 
-	public static async from(untypedInstance: ServerModelUntypedInstance): Promise<EncryptedAlarmNotification> {
-		const alarmNotificationTypeModel = await resolveClientTypeReference(AlarmNotificationTypeRef)
-		const notificationSessionKeyTypeModel = await resolveClientTypeReference(NotificationSessionKeyTypeRef)
-		const alarmInfoTypeModel = await resolveClientTypeReference(AlarmInfoTypeRef)
+	public static async from(untypedInstance: ServerModelUntypedInstance, typeModelResolver: ClientTypeModelResolver): Promise<EncryptedAlarmNotification> {
+		const alarmNotificationTypeModel = await typeModelResolver.resolveClientTypeReference(AlarmNotificationTypeRef)
+		const notificationSessionKeyTypeModel = await typeModelResolver.resolveClientTypeReference(NotificationSessionKeyTypeRef)
+		const alarmInfoTypeModel = await typeModelResolver.resolveClientTypeReference(AlarmInfoTypeRef)
 
 		const sanitizedUntypedInstance = await AttributeModel.removeNetworkDebuggingInfoIfNeeded<ServerModelUntypedInstance>(untypedInstance)
 		return new EncryptedAlarmNotification(sanitizedUntypedInstance, alarmNotificationTypeModel, notificationSessionKeyTypeModel, alarmInfoTypeModel)

--- a/src/common/native/common/EncryptedMissedNotification.ts
+++ b/src/common/native/common/EncryptedMissedNotification.ts
@@ -1,5 +1,4 @@
 import { ServerModelUntypedInstance, TypeModel } from "../../api/common/EntityTypes"
-import { resolveClientTypeReference } from "../../api/common/EntityFunctions"
 import {
 	AlarmNotificationTypeRef,
 	createNotificationSessionKey,
@@ -10,6 +9,7 @@ import {
 import { AttributeModel } from "../../api/common/AttributeModel"
 import { Base64, base64ToUint8Array } from "@tutao/tutanota-utils"
 import { Nullable } from "@tutao/tutanota-utils/dist/Utils"
+import { ClientTypeModelResolver } from "../../api/common/EntityFunctions"
 
 export class EncryptedMissedNotification {
 	private constructor(
@@ -19,10 +19,10 @@ export class EncryptedMissedNotification {
 		private readonly notificationSessionKeyTypeModel: TypeModel,
 	) {}
 
-	public static async from(untypedInstance: ServerModelUntypedInstance): Promise<EncryptedMissedNotification> {
-		const missedNotificationTypeModel = await resolveClientTypeReference(MissedNotificationTypeRef)
-		const alarmNotificationTypeModel = await resolveClientTypeReference(AlarmNotificationTypeRef)
-		const notificationSessionKeyTypeModel = await resolveClientTypeReference(NotificationSessionKeyTypeRef)
+	public static async from(untypedInstance: ServerModelUntypedInstance, typeModelResolver: ClientTypeModelResolver): Promise<EncryptedMissedNotification> {
+		const missedNotificationTypeModel = await typeModelResolver.resolveClientTypeReference(MissedNotificationTypeRef)
+		const alarmNotificationTypeModel = await typeModelResolver.resolveClientTypeReference(AlarmNotificationTypeRef)
+		const notificationSessionKeyTypeModel = await typeModelResolver.resolveClientTypeReference(NotificationSessionKeyTypeRef)
 
 		const sanitizedUntypedInstance = await AttributeModel.removeNetworkDebuggingInfoIfNeeded<ServerModelUntypedInstance>(untypedInstance)
 

--- a/src/mail-app/mail/view/MailViewModel.ts
+++ b/src/mail-app/mail/view/MailViewModel.ts
@@ -673,9 +673,7 @@ export class MailViewModel {
 						instanceId: elementIdPart(importedMailSetEntry._id),
 						instanceListId: importedFolder.entries,
 						operation: OperationType.CREATE,
-						typeId: MailSetEntryTypeRef.typeId,
-						type: "MailSetEntry",
-						application: MailSetEntryTypeRef.app,
+						typeRef: MailSetEntryTypeRef,
 					})
 				})
 			}

--- a/src/mail-app/search/view/SearchViewModel.ts
+++ b/src/mail-app/search/view/SearchViewModel.ts
@@ -82,7 +82,6 @@ import { YEAR_IN_MILLIS } from "@tutao/tutanota-utils/dist/DateUtils.js"
 import { ListFilter } from "../../../common/misc/ListModel"
 import { client } from "../../../common/misc/ClientDetector"
 import { AppName } from "@tutao/tutanota-utils/dist/TypeRef"
-import { resolveTypeRefFromAppAndTypeNameLegacy } from "../../../common/api/common/EntityFunctions"
 
 const SEARCH_PAGE_SIZE = 100
 
@@ -774,9 +773,7 @@ export class SearchViewModel {
 
 		const { instanceListId, instanceId, operation } = update
 		const id = [neverNull(instanceListId), instanceId] as const
-		const typeRef = update.typeId
-			? new TypeRef<SomeEntity>(update.application as AppName, update.typeId)
-			: resolveTypeRefFromAppAndTypeNameLegacy(update.application as AppName, update.type)
+		const typeRef = update.typeRef
 
 		if (!this.isInSearchResult(typeRef, id) && !isPossibleABirthdayContactUpdate) {
 			return

--- a/src/mail-app/workerUtils/index/ContactIndexer.ts
+++ b/src/mail-app/workerUtils/index/ContactIndexer.ts
@@ -12,6 +12,7 @@ import type { EntityUpdate } from "../../../common/api/entities/sys/TypeRefs.js"
 import { EntityClient } from "../../../common/api/common/EntityClient.js"
 import { GroupDataOS, MetaDataOS } from "../../../common/api/worker/search/IndexTables.js"
 import { AttributeModel } from "../../../common/api/common/AttributeModel"
+import { EntityUpdateData } from "../../../common/api/common/utils/EntityUpdateUtils"
 
 export class ContactIndexer {
 	_core: IndexerCore
@@ -83,7 +84,7 @@ export class ContactIndexer {
 		return tokenize(contact.firstName + " " + contact.lastName + " " + contact.mailAddresses.map((ma) => ma.address).join(" "))
 	}
 
-	processNewContact(event: EntityUpdate): Promise<
+	processNewContact(event: EntityUpdateData): Promise<
 		| {
 				contact: Contact
 				keyToIndexEntries: Map<string, SearchIndexEntry[]>
@@ -156,7 +157,7 @@ export class ContactIndexer {
 		}
 	}
 
-	processEntityEvents(events: EntityUpdate[], groupId: Id, batchId: Id, indexUpdate: IndexUpdate): Promise<void> {
+	processEntityEvents(events: EntityUpdateData[], groupId: Id, batchId: Id, indexUpdate: IndexUpdate): Promise<void> {
 		return promiseMap(events, async (event) => {
 			if (event.operation === OperationType.CREATE) {
 				await this.processNewContact(event).then((result) => {

--- a/src/mail-app/workerUtils/index/IndexerCore.ts
+++ b/src/mail-app/workerUtils/index/IndexerCore.ts
@@ -72,7 +72,7 @@ import {
 } from "../../../common/api/worker/search/IndexTables.js"
 import { AppName } from "@tutao/tutanota-utils/dist/TypeRef"
 import { SomeEntity } from "../../../common/api/common/EntityTypes"
-import { resolveTypeRefFromAppAndTypeNameLegacy } from "../../../common/api/common/EntityFunctions"
+import { EntityUpdateData } from "../../../common/api/common/utils/EntityUpdateUtils"
 
 const SEARCH_INDEX_ROW_LENGTH = 1000
 
@@ -198,12 +198,10 @@ export class IndexerCore {
 	/**
 	 * Process delete event before applying to the index.
 	 */
-	async _processDeleted(event: EntityUpdate, indexUpdate: IndexUpdate): Promise<void> {
+	async _processDeleted(event: EntityUpdateData, indexUpdate: IndexUpdate): Promise<void> {
 		const encInstanceIdPlain = encryptIndexKeyUint8Array(this.db.key, event.instanceId, this.db.iv)
 		const encInstanceIdB64 = uint8ArrayToBase64(encInstanceIdPlain)
-		const typeRef = event.typeId
-			? new TypeRef<SomeEntity>(event.application as AppName, parseInt(event.typeId))
-			: resolveTypeRefFromAppAndTypeNameLegacy(event.application as AppName, event.type)
+		const typeRef = event.typeRef
 
 		const { appId, typeId } = typeRefToTypeInfo(typeRef)
 		const transaction = await this.db.dbFacade.createTransaction(true, [ElementDataOS])

--- a/test/tests/TestUtils.ts
+++ b/test/tests/TestUtils.ts
@@ -3,7 +3,7 @@ import type { Db } from "../../src/common/api/worker/search/SearchTypes.js"
 import { IndexerCore } from "../../src/mail-app/workerUtils/index/IndexerCore.js"
 import { EventQueue } from "../../src/common/api/worker/EventQueue.js"
 import { DbFacade, DbTransaction } from "../../src/common/api/worker/search/DbFacade.js"
-import { AppNameEnum, assertNotNull, deepEqual, defer, Thunk, TypeRef } from "@tutao/tutanota-utils"
+import { AppNameEnum, assertNotNull, clone, deepEqual, defer, Thunk, TypeRef } from "@tutao/tutanota-utils"
 import type { DesktopKeyStoreFacade } from "../../src/common/desktop/DesktopKeyStoreFacade.js"
 import { mock } from "@tutao/tutanota-test-utils"
 import { aes256RandomKey, fixedIv, uint8ArrayToKey } from "@tutao/tutanota-crypto"
@@ -11,9 +11,11 @@ import { ScheduledPeriodicId, ScheduledTimeoutId, Scheduler } from "../../src/co
 import { matchers, object, when } from "testdouble"
 import { Entity, ModelValue, TypeModel } from "../../src/common/api/common/EntityTypes.js"
 import { create } from "../../src/common/api/common/utils/EntityUtils.js"
-import { ClientModelInfo, ServerModelInfo } from "../../src/common/api/common/EntityFunctions.js"
+import { ClientModelInfo, ServerModelInfo, TypeModelResolver } from "../../src/common/api/common/EntityFunctions.js"
 import { type fetch as undiciFetch, type Response } from "undici"
 import { Cardinality, ValueType } from "../../src/common/api/common/EntityConstants.js"
+import { InstancePipeline } from "../../src/common/api/worker/crypto/InstancePipeline"
+import { ModelMapper } from "../../src/common/api/worker/crypto/ModelMapper"
 
 export const browserDataStub: BrowserData = {
 	needsMicrotaskHack: false,
@@ -143,7 +145,7 @@ export const domainConfigStub: DomainConfig = {
 
 // non-async copy of the function
 function resolveTypeReference(typeRef: TypeRef<any>): TypeModel {
-	const modelMap = new ClientModelInfo().typeModels[typeRef.app]
+	const modelMap = ClientModelInfo.getNewInstanceForTestsOnly().typeModels[typeRef.app]
 	const typeModel = modelMap[typeRef.typeId]
 
 	if (typeModel == null) {
@@ -272,11 +274,47 @@ export function clientModelAsServerModel(serverModel: ServerModelInfo, clientMod
 			[app]: {
 				name: app,
 				version: clientModel.modelInfos[app].version,
-				types: clientModel.typeModels[app],
+				types: clone(clientModel.typeModels[app]),
 			},
 		})
 		return obj
 	}, {})
 
 	serverModel.init("some_dummy_hash", models)
+}
+
+export function clientInitializedTypeModelResolver(): TypeModelResolver {
+	const clientModelInfo = ClientModelInfo.getNewInstanceForTestsOnly()
+	const serverModelInfo = ServerModelInfo.getUninitializedInstanceForTestsOnly(clientModelInfo)
+	const typeModelResolver = new TypeModelResolver(clientModelInfo, serverModelInfo)
+	clientModelAsServerModel(serverModelInfo, clientModelInfo)
+	return typeModelResolver
+}
+
+export function instancePipelineFromTypeModelResolver(typeModelResolver: TypeModelResolver): InstancePipeline {
+	return new InstancePipeline(
+		typeModelResolver.resolveClientTypeReference.bind(typeModelResolver),
+		typeModelResolver.resolveServerTypeReference.bind(typeModelResolver),
+	)
+}
+
+export function modelMapperFromTypeModelResolver(typeModelResolver: TypeModelResolver): ModelMapper {
+	return new ModelMapper(
+		typeModelResolver.resolveClientTypeReference.bind(typeModelResolver),
+		typeModelResolver.resolveServerTypeReference.bind(typeModelResolver),
+	)
+}
+
+export async function withOverriddenEnv<F extends (...args: any[]) => any>(override: Partial<typeof env>, action: () => ReturnType<F>) {
+	const previousEnv: typeof env = clone(env)
+	for (const [key, value] of Object.entries(override)) {
+		env[key] = value
+	}
+	try {
+		return await action()
+	} finally {
+		for (const key of Object.keys(override)) {
+			env[key] = previousEnv[key]
+		}
+	}
 }

--- a/test/tests/api/common/EntityFunctionsTest.ts
+++ b/test/tests/api/common/EntityFunctionsTest.ts
@@ -1,5 +1,5 @@
 import o from "@tutao/otest"
-import { ClientModelInfo, resolveTypeRefFromAppAndTypeNameLegacy, ServerModelInfo, ServerModels } from "../../../../src/common/api/common/EntityFunctions"
+import { ClientModelInfo, ServerModelInfo, ServerModels } from "../../../../src/common/api/common/EntityFunctions"
 import { AppName } from "@tutao/tutanota-utils/lib/TypeRef"
 import { stringToUtf8Uint8Array } from "@tutao/tutanota-utils"
 import { Cardinality, Type, ValueType } from "../../../../src/common/api/common/EntityConstants"
@@ -13,14 +13,12 @@ import { TypeModel } from "../../../../src/common/api/common/EntityTypes"
 o.spec("EntityFunctionsTest", function () {
 	let serverModelInfo: ServerModelInfo
 	let clientModelInfo: ClientModelInfo
-	let emptyTypeModel: ServerModels
 	let applicationTypesFacade: ApplicationTypesFacade
 
 	o.beforeEach(async () => {
-		clientModelInfo = new ClientModelInfo()
-		serverModelInfo = new ServerModelInfo(clientModelInfo)
+		clientModelInfo = ClientModelInfo.getNewInstanceForTestsOnly()
+		serverModelInfo = ServerModelInfo.getUninitializedInstanceForTestsOnly(clientModelInfo)
 		clientModelAsServerModel(serverModelInfo, clientModelInfo)
-		emptyTypeModel = {} as ServerModels
 		applicationTypesFacade = await ApplicationTypesFacade.getInitialized(object(), object(), serverModelInfo)
 	})
 
@@ -85,9 +83,9 @@ o.spec("EntityFunctionsTest", function () {
 		o("fail to parse if encrypted value is changed to unencrypted", async () => {
 			const serverModel = Object.assign({}, serverModelInfo.typeModels, partialServerModel)
 			const serverModelString = JSON.stringify({ base: serverModel })
-			clientModelInfo = new ClientModelInfo()
+			clientModelInfo = ClientModelInfo.getNewInstanceForTestsOnly()
 			clientModelInfo.typeModels = Object.assign({}, clientModelInfo.typeModels, { base: clientModel })
-			serverModelInfo = new ServerModelInfo(clientModelInfo)
+			serverModelInfo = ServerModelInfo.getUninitializedInstanceForTestsOnly(clientModelInfo)
 
 			const applicationTypesHashTruncatedBase64 = applicationTypesFacade.computeApplicationTypesHash(stringToUtf8Uint8Array(serverModelString))
 			const e = await assertThrows(ProgrammingError, async () => serverModelInfo.init(applicationTypesHashTruncatedBase64, serverModel))
@@ -97,7 +95,7 @@ o.spec("EntityFunctionsTest", function () {
 		o("ignore non-existent typeValue on client", async () => {
 			const serverModel = Object.assign({}, serverModelInfo.typeModels, partialServerModel)
 			const serverModelString = JSON.stringify({ base: serverModel })
-			clientModelInfo = new ClientModelInfo()
+			clientModelInfo = ClientModelInfo.getNewInstanceForTestsOnly()
 			clientModelInfo.typeModels = Object.assign({}, clientModelInfo.typeModels, {
 				base: {
 					"0": {
@@ -124,7 +122,7 @@ o.spec("EntityFunctionsTest", function () {
 					},
 				},
 			})
-			serverModelInfo = new ServerModelInfo(clientModelInfo)
+			serverModelInfo = ServerModelInfo.getUninitializedInstanceForTestsOnly(clientModelInfo)
 			const applicationTypesHashTruncatedBase64 = applicationTypesFacade.computeApplicationTypesHash(stringToUtf8Uint8Array(serverModelString))
 			serverModelInfo.init(applicationTypesHashTruncatedBase64, serverModel)
 		})
@@ -134,7 +132,7 @@ o.spec("EntityFunctionsTest", function () {
 		const app = "tutanota" as AppName
 		const mailTypeId = 97
 		const mailTypeName = clientModelInfo.typeModels.tutanota[mailTypeId].name
-		const mailTypeRef = resolveTypeRefFromAppAndTypeNameLegacy(app, mailTypeName)
+		const mailTypeRef = ClientModelInfo.getNewInstanceForTestsOnly().resolveTypeRefFromAppAndTypeNameLegacy(app, mailTypeName)
 		o(mailTypeId).equals(mailTypeRef.typeId)
 	})
 })

--- a/test/tests/api/worker/crypto/EntityAdapterTest.ts
+++ b/test/tests/api/worker/crypto/EntityAdapterTest.ts
@@ -1,18 +1,24 @@
 import o from "@tutao/otest"
-import { resolveClientTypeReference, resolveServerTypeReference } from "../../../../../src/common/api/common/EntityFunctions"
 import { ImportMailGetInTypeRef, MailAddressTypeRef, MailTypeRef } from "../../../../../src/common/api/entities/tutanota/TypeRefs"
-import { createTestEntity } from "../../../TestUtils"
+import { clientInitializedTypeModelResolver, createTestEntity, instancePipelineFromTypeModelResolver } from "../../../TestUtils"
 import { stringToUtf8Uint8Array } from "@tutao/tutanota-utils"
 import { BucketKey, BucketKeyTypeRef, GroupInfoTypeRef } from "../../../../../src/common/api/entities/sys/TypeRefs"
 import { EntityAdapter } from "../../../../../src/common/api/worker/crypto/EntityAdapter"
 import { InstancePipeline } from "../../../../../src/common/api/worker/crypto/InstancePipeline"
 import { assertThrows } from "@tutao/tutanota-test-utils"
+import { TypeModelResolver } from "../../../../../src/common/api/common/EntityFunctions"
 
 o.spec("EntityAdapter", () => {
-	const instancePipeline = new InstancePipeline(resolveClientTypeReference, resolveServerTypeReference)
+	let typeModelResolver: TypeModelResolver
+	let instancePipeline: InstancePipeline
+
+	o.beforeEach(() => {
+		typeModelResolver = clientInitializedTypeModelResolver()
+		instancePipeline = instancePipelineFromTypeModelResolver(typeModelResolver)
+	})
 
 	o.test("can create local mapped/decrypted instance - GroupInfo", async () => {
-		const groupModel = await resolveClientTypeReference(GroupInfoTypeRef)
+		const groupModel = await typeModelResolver.resolveClientTypeReference(GroupInfoTypeRef)
 
 		const groupInfo = createTestEntity(GroupInfoTypeRef, {
 			_ownerGroup: "ownerGroupId",
@@ -34,7 +40,7 @@ o.spec("EntityAdapter", () => {
 	})
 
 	o.test("can create local mapped/decrypted instance - Mail", async () => {
-		const mailModel = await resolveClientTypeReference(MailTypeRef)
+		const mailModel = await typeModelResolver.resolveClientTypeReference(MailTypeRef)
 
 		const mail = createTestEntity(MailTypeRef, {
 			_ownerGroup: "ownerGroupId",
@@ -61,7 +67,7 @@ o.spec("EntityAdapter", () => {
 	})
 
 	o.test("can create local mapped/decrypted data transfer instance", async () => {
-		const importMailGetInModel = await resolveClientTypeReference(ImportMailGetInTypeRef)
+		const importMailGetInModel = await typeModelResolver.resolveClientTypeReference(ImportMailGetInTypeRef)
 
 		const importMailGetIn = createTestEntity(ImportMailGetInTypeRef, {
 			ownerGroup: "ownerGroupId", // ownerGroupId is currently not used as MailGroup is hardcoded in CryptoFacade#resolveSessionKey
@@ -78,7 +84,7 @@ o.spec("EntityAdapter", () => {
 	})
 
 	o.test("set _ownerEncSessionKey", async () => {
-		const mailModel = await resolveClientTypeReference(MailTypeRef)
+		const mailModel = await typeModelResolver.resolveClientTypeReference(MailTypeRef)
 
 		const mail = createTestEntity(MailTypeRef, {
 			_permissions: "permissionListId",
@@ -102,7 +108,7 @@ o.spec("EntityAdapter", () => {
 	})
 
 	o.test("set _ownerGroup", async () => {
-		const mailModel = await resolveClientTypeReference(MailTypeRef)
+		const mailModel = await typeModelResolver.resolveClientTypeReference(MailTypeRef)
 
 		const mail = createTestEntity(MailTypeRef, {
 			_permissions: "permissionListId",

--- a/test/tests/api/worker/facades/BlobAccessTokenFacadeTest.ts
+++ b/test/tests/api/worker/facades/BlobAccessTokenFacadeTest.ts
@@ -16,7 +16,7 @@ import {
 	BlobWriteDataTypeRef,
 	InstanceIdTypeRef,
 } from "../../../../../src/common/api/entities/storage/TypeRefs.js"
-import { createTestEntity } from "../../../TestUtils.js"
+import { clientInitializedTypeModelResolver, createTestEntity } from "../../../TestUtils.js"
 import { FileTypeRef, MailBoxTypeRef } from "../../../../../src/common/api/entities/tutanota/TypeRefs.js"
 import { BlobTypeRef } from "../../../../../src/common/api/entities/sys/TypeRefs.js"
 import { BlobReferencingInstance } from "../../../../../src/common/api/common/utils/BlobUtils.js"
@@ -45,11 +45,7 @@ o.spec("BlobAccessTokenFacade", function () {
 		}
 		serviceMock = object<ServiceExecutor>()
 		authDataProvider = object<AuthDataProvider>()
-		blobAccessTokenFacade = new BlobAccessTokenFacade(serviceMock, authDataProvider, dateProvider)
-	})
-
-	o.afterEach(function () {
-		env.mode = Mode.Browser
+		blobAccessTokenFacade = new BlobAccessTokenFacade(serviceMock, authDataProvider, dateProvider, clientInitializedTypeModelResolver())
 	})
 
 	o.spec("evict Tokens", function () {

--- a/test/tests/api/worker/facades/CalendarFacadeTest.ts
+++ b/test/tests/api/worker/facades/CalendarFacadeTest.ts
@@ -31,12 +31,12 @@ import { UserFacade } from "../../../../../src/common/api/worker/facades/UserFac
 import { InfoMessageHandler } from "../../../../../src/common/gui/InfoMessageHandler.js"
 import { ConnectionError } from "../../../../../src/common/api/common/error/RestError.js"
 import { EntityClient } from "../../../../../src/common/api/common/EntityClient.js"
-import { createTestEntity } from "../../../TestUtils.js"
+import { clientInitializedTypeModelResolver, createTestEntity, instancePipelineFromTypeModelResolver } from "../../../TestUtils.js"
 import { EntityRestClient } from "../../../../../src/common/api/worker/rest/EntityRestClient"
 import { InstancePipeline } from "../../../../../src/common/api/worker/crypto/InstancePipeline"
-import { resolveClientTypeReference, resolveServerTypeReference } from "../../../../../src/common/api/common/EntityFunctions"
 import { uint8ArrayToBitArray } from "@tutao/tutanota-crypto"
 import { OperationType } from "../../../../../src/common/api/common/TutanotaConstants"
+import { TypeModelResolver } from "../../../../../src/common/api/common/EntityFunctions"
 
 o.spec("CalendarFacadeTest", function () {
 	let userAlarmInfoListId: Id
@@ -57,6 +57,7 @@ o.spec("CalendarFacadeTest", function () {
 	let serviceExecutor: IServiceExecutor
 	let cryptoFacade: CryptoFacade
 	let infoMessageHandler: InfoMessageHandler
+	let typeModelResolver: TypeModelResolver
 	let instancePipeline: InstancePipeline
 
 	function sortEventsWithAlarmInfos(eventsWithAlarmInfos: Array<EventWithUserAlarmInfos>) {
@@ -125,18 +126,20 @@ o.spec("CalendarFacadeTest", function () {
 		serviceExecutor = object()
 		cryptoFacade = object()
 		infoMessageHandler = object()
-		instancePipeline = new InstancePipeline(resolveClientTypeReference, resolveServerTypeReference)
+		typeModelResolver = clientInitializedTypeModelResolver()
+		instancePipeline = instancePipelineFromTypeModelResolver(typeModelResolver)
 		calendarFacade = new CalendarFacade(
 			userFacade,
 			groupManagementFacade,
 			entityRestCache,
-			new EntityClient(entityRestCache),
+			new EntityClient(entityRestCache, typeModelResolver),
 			nativeMock,
 			workerMock,
 			serviceExecutor,
 			cryptoFacade,
 			infoMessageHandler,
 			instancePipeline,
+			new EntityClient(entityRestCache, typeModelResolver),
 		)
 	})
 

--- a/test/tests/api/worker/facades/KeyVerificationFacadeTest.ts
+++ b/test/tests/api/worker/facades/KeyVerificationFacadeTest.ts
@@ -16,6 +16,7 @@ import { KeyPairType, PQPublicKeys, PublicKey } from "@tutao/tutanota-crypto"
 import { PublicKeyIdentifier, PublicKeyProvider } from "../../../../../src/common/api/worker/facades/PublicKeyProvider"
 import { CustomerFacade } from "../../../../../src/common/api/worker/facades/lazy/CustomerFacade"
 import { Mode } from "../../../../../src/common/api/common/Env"
+import { withOverriddenEnv } from "../../../TestUtils"
 
 const { anything } = matchers
 
@@ -75,9 +76,6 @@ o.spec("KeyVerificationFacadeTest", function () {
 	let backupEnv: any
 
 	o.beforeEach(function () {
-		// Better safe than sorry.
-		backupEnv = globalThis.env
-
 		customerFacade = object()
 		sqlCipherFacade = object()
 		publicKeyProvider = object()
@@ -88,10 +86,6 @@ o.spec("KeyVerificationFacadeTest", function () {
 		keyVerification = new KeyVerificationFacade(lazyCustomerFacade, sqlCipherFacade, publicKeyProvider)
 
 		when(publicKeyProvider.convertFromPublicKeyGetOut(PUBLIC_KEY_GET_OUT)).thenReturn(PUBLIC_KEY)
-	})
-
-	o.afterEach(function () {
-		globalThis.env = backupEnv
 	})
 
 	o.spec("confirm trusted identity database works as intended", function () {
@@ -353,26 +347,23 @@ o.spec("KeyVerificationFacadeTest", function () {
 	})
 
 	o("feature should be supported when on desktop and enabled", async function () {
-		globalThis.env.mode = Mode.Desktop
 		when(customerFacade.isEnabled(FeatureType.KeyVerification)).thenResolve(true)
 
-		const isSupported = await keyVerification.isSupported()
+		const isSupported = await withOverriddenEnv({ mode: Mode.Desktop }, () => keyVerification.isSupported())
 		o(isSupported).equals(true)
 	})
 
 	o("feature should NOT be supported when on desktop and disabled", async function () {
-		globalThis.env.mode = Mode.Desktop
 		when(customerFacade.isEnabled(FeatureType.KeyVerification)).thenResolve(false)
 
-		const isSupported = await keyVerification.isSupported()
+		const isSupported = await withOverriddenEnv({ mode: Mode.Desktop }, () => keyVerification.isSupported())
 		o(isSupported).equals(false)
 	})
 
 	o("feature should NOT be supported when on browser and enabled", async function () {
-		globalThis.env.mode = Mode.Browser
 		when(customerFacade.isEnabled(FeatureType.KeyVerification)).thenResolve(true)
 
-		const isSupported = await keyVerification.isSupported()
+		const isSupported = await withOverriddenEnv({ mode: Mode.Browser }, () => keyVerification.isSupported())
 		o(isSupported).equals(false)
 	})
 

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -36,14 +36,14 @@ import { defer, DeferredObject, uint8ArrayToBase64 } from "@tutao/tutanota-utils
 import { AccountType, Const, DEFAULT_KDF_TYPE, KdfType } from "../../../../../src/common/api/common/TutanotaConstants"
 import { AccessExpiredError, ConnectionError, NotAuthenticatedError } from "../../../../../src/common/api/common/error/RestError"
 import { SessionType } from "../../../../../src/common/api/common/SessionType"
-import { HttpMethod, resolveClientTypeReference, resolveServerTypeReference } from "../../../../../src/common/api/common/EntityFunctions"
+import { HttpMethod, TypeModelResolver } from "../../../../../src/common/api/common/EntityFunctions"
 import { ConnectMode, EventBusClient } from "../../../../../src/common/api/worker/EventBusClient"
 import { TutanotaPropertiesTypeRef } from "../../../../../src/common/api/entities/tutanota/TypeRefs"
 import { BlobAccessTokenFacade } from "../../../../../src/common/api/worker/facades/BlobAccessTokenFacade.js"
 import { EntropyFacade } from "../../../../../src/common/api/worker/facades/EntropyFacade.js"
 import { DatabaseKeyFactory } from "../../../../../src/common/misc/credentials/DatabaseKeyFactory.js"
 import { Argon2idFacade } from "../../../../../src/common/api/worker/facades/Argon2idFacade.js"
-import { createTestEntity } from "../../../TestUtils.js"
+import { clientInitializedTypeModelResolver, createTestEntity, instancePipelineFromTypeModelResolver } from "../../../TestUtils.js"
 import { KeyRotationFacade } from "../../../../../src/common/api/worker/facades/KeyRotationFacade.js"
 import { CredentialType } from "../../../../../src/common/misc/credentials/CredentialType.js"
 import { encryptString } from "../../../../../src/common/api/worker/crypto/CryptoWrapper.js"
@@ -120,6 +120,7 @@ o.spec("LoginFacadeTest", function () {
 	let databaseKeyFactoryMock: DatabaseKeyFactory
 	let argon2idFacade: Argon2idFacade
 	let cacheManagmentFacadeMock: CacheManagementFacade
+	let typeModelResolver: TypeModelResolver
 
 	const timeRangeDays = 42
 	const login = "born.slippy@tuta.io"
@@ -135,7 +136,8 @@ o.spec("LoginFacadeTest", function () {
 		when(entityClientMock.loadRoot(TutanotaPropertiesTypeRef, anything())).thenResolve(createTestEntity(TutanotaPropertiesTypeRef))
 
 		loginListener = object<LoginListener>()
-		instancePipeline = new InstancePipeline(resolveClientTypeReference, resolveServerTypeReference)
+		typeModelResolver = clientInitializedTypeModelResolver()
+		instancePipeline = instancePipelineFromTypeModelResolver(typeModelResolver)
 		cryptoFacadeMock = object<CryptoFacade>()
 		usingOfflineStorage = false
 		cacheStorageInitializerMock = object()
@@ -181,6 +183,7 @@ o.spec("LoginFacadeTest", function () {
 			entityClientMock,
 			async (error: Error) => {},
 			async () => cacheManagmentFacadeMock,
+			typeModelResolver,
 		)
 
 		eventBusClientMock = instance(EventBusClient)

--- a/test/tests/api/worker/rest/EphemeralCacheStorageTest.ts
+++ b/test/tests/api/worker/rest/EphemeralCacheStorageTest.ts
@@ -1,25 +1,24 @@
 import o from "@tutao/otest"
 import { EphemeralCacheStorage } from "../../../../../src/common/api/worker/rest/EphemeralCacheStorage.js"
 import { BodyTypeRef, MailDetailsBlobTypeRef, MailDetailsTypeRef, RecipientsTypeRef } from "../../../../../src/common/api/entities/tutanota/TypeRefs.js"
-import { clientModelAsServerModel, createTestEntity } from "../../../TestUtils.js"
+import { clientInitializedTypeModelResolver, createTestEntity, modelMapperFromTypeModelResolver } from "../../../TestUtils.js"
 import { ModelMapper } from "../../../../../src/common/api/worker/crypto/ModelMapper"
-import {
-	globalClientModelInfo,
-	globalServerModelInfo,
-	resolveClientTypeReference,
-	resolveServerTypeReference,
-} from "../../../../../src/common/api/common/EntityFunctions"
 import { ServerModelParsedInstance } from "../../../../../src/common/api/common/EntityTypes"
+import { TypeModelResolver } from "../../../../../src/common/api/common/EntityFunctions"
 
 o.spec("EphemeralCacheStorageTest", function () {
 	const userId = "userId"
 	const archiveId = "archiveId"
 	const blobElementId = "blobElementId1"
-	const modelMapper = new ModelMapper(resolveClientTypeReference, resolveServerTypeReference)
+	let typeModelResolver: TypeModelResolver
+	let modelMapper: ModelMapper
+	let storage: EphemeralCacheStorage
 
-	clientModelAsServerModel(globalServerModelInfo, globalClientModelInfo)
-
-	const storage = new EphemeralCacheStorage(modelMapper)
+	o.beforeEach(() => {
+		typeModelResolver = clientInitializedTypeModelResolver()
+		modelMapper = modelMapperFromTypeModelResolver(typeModelResolver)
+		storage = new EphemeralCacheStorage(modelMapper, typeModelResolver)
+	})
 
 	o.spec("BlobElementType", function () {
 		o("cache roundtrip: put, get, delete", async function () {

--- a/test/tests/api/worker/search/EventQueueTest.ts
+++ b/test/tests/api/worker/search/EventQueueTest.ts
@@ -1,23 +1,25 @@
 import o from "@tutao/otest"
 import { batchMod, EntityModificationType, EventQueue, QueuedBatch } from "../../../../../src/common/api/worker/EventQueue.js"
-import { EntityUpdate, EntityUpdateTypeRef, GroupTypeRef } from "../../../../../src/common/api/entities/sys/TypeRefs.js"
+import { GroupTypeRef } from "../../../../../src/common/api/entities/sys/TypeRefs.js"
 import { OperationType } from "../../../../../src/common/api/common/TutanotaConstants.js"
 import { defer, delay } from "@tutao/tutanota-utils"
 import { ConnectionError } from "../../../../../src/common/api/common/error/RestError.js"
 import { ContactTypeRef, MailboxGroupRootTypeRef, MailTypeRef } from "../../../../../src/common/api/entities/tutanota/TypeRefs.js"
 import { spy } from "@tutao/tutanota-test-utils"
-import { createTestEntity } from "../../../TestUtils.js"
+import { EntityUpdateData } from "../../../../../src/common/api/common/utils/EntityUpdateUtils"
 
 o.spec("EventQueueTest", function () {
 	let queue: EventQueue
 	let processElement: any
 	let lastProcess: { resolve: () => void; reject: (Error) => void; promise: Promise<void> }
 
-	const newUpdate = (type: OperationType, instanceId: string) => {
-		const update = createTestEntity(EntityUpdateTypeRef)
-		update.operation = type
-		update.instanceId = instanceId
-		return update
+	const newUpdate = (type: OperationType, instanceId: string): EntityUpdateData => {
+		return {
+			operation: type,
+			instanceId,
+			instanceListId: "",
+			typeRef: MailTypeRef,
+		} as Partial<EntityUpdateData> as EntityUpdateData
 	}
 
 	o.beforeEach(function () {
@@ -107,15 +109,15 @@ o.spec("EventQueueTest", function () {
 		})
 
 		o("create + delete == delete", async function () {
-			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1", "u1")
-			const deleteEvent = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId, "u2")
+			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1")
+			const deleteEvent = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId)
 
 			queue.add("batch-id-1", "group-id", [createEvent])
 			queue.add("batch-id-2", "group-id", [deleteEvent])
 			queue.resume()
 			await lastProcess.promise
 
-			const expectedDelete = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId, "u2")
+			const expectedDelete = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId)
 
 			o(processElement.invocations).deepEquals([
 				[{ events: [], batchId: "batch-id-1", groupId: "group-id" }],
@@ -124,15 +126,15 @@ o.spec("EventQueueTest", function () {
 		})
 
 		o("create + update == create", async function () {
-			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1", "u1")
-			const updateEvent = createUpdate(OperationType.UPDATE, createEvent.instanceListId, createEvent.instanceId, "u2")
+			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1")
+			const updateEvent = createUpdate(OperationType.UPDATE, createEvent.instanceListId, createEvent.instanceId)
 
 			queue.add("batch-id-1", "group-id", [createEvent])
 			queue.add("batch-id-2", "group-id", [updateEvent])
 			queue.resume()
 			await lastProcess.promise
 
-			const expectedCreate = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId, "u1")
+			const expectedCreate = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId)
 
 			o(processElement.invocations).deepEquals([
 				[{ events: [expectedCreate], batchId: "batch-id-1", groupId: "group-id" }],
@@ -141,16 +143,16 @@ o.spec("EventQueueTest", function () {
 		})
 
 		o("create + create == create + create", async function () {
-			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1", "u1")
-			const createEvent2 = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId, "u2")
+			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1")
+			const createEvent2 = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId)
 
 			queue.add("batch-id-1", "group-id", [createEvent])
 			queue.add("batch-id-2", "group-id", [createEvent2])
 			queue.resume()
 			await lastProcess.promise
 
-			const expectedCreate = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId, "u1")
-			const expectedCreate2 = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId, "u2")
+			const expectedCreate = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId)
+			const expectedCreate2 = createUpdate(OperationType.CREATE, createEvent.instanceListId, createEvent.instanceId)
 
 			o(processElement.invocations).deepEquals([
 				[{ events: [expectedCreate], batchId: "batch-id-1", groupId: "group-id" }],
@@ -159,9 +161,9 @@ o.spec("EventQueueTest", function () {
 		})
 
 		o("create + update + delete == delete", async function () {
-			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1", "u1")
-			const updateEvent = createUpdate(OperationType.UPDATE, "new-mail-list", "1", "u2")
-			const deleteEvent = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId, "u")
+			const createEvent = createUpdate(OperationType.CREATE, "new-mail-list", "1")
+			const updateEvent = createUpdate(OperationType.UPDATE, "new-mail-list", "1")
+			const deleteEvent = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId)
 
 			queue.add("batch-id-1", "group-id", [createEvent])
 			queue.add("batch-id-2", "group-id", [updateEvent])
@@ -169,7 +171,7 @@ o.spec("EventQueueTest", function () {
 			queue.resume()
 			await lastProcess.promise
 
-			const expectedDelete = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId, "u")
+			const expectedDelete = createUpdate(OperationType.DELETE, createEvent.instanceListId, createEvent.instanceId)
 
 			o(processElement.invocations).deepEquals([
 				[{ events: [], batchId: "batch-id-1", groupId: "group-id" }],
@@ -180,8 +182,8 @@ o.spec("EventQueueTest", function () {
 
 		o("delete + create == delete + create", async function () {
 			// DELETE can happen after CREATE in case of custom id. We keep it as-is
-			const deleteEvent = createUpdate(OperationType.DELETE, "mail-list", "1", "u0")
-			const createEvent = createUpdate(OperationType.CREATE, "mail-list", "1", "u1")
+			const deleteEvent = createUpdate(OperationType.DELETE, "mail-list", "1")
+			const createEvent = createUpdate(OperationType.CREATE, "mail-list", "1")
 
 			queue.add("batch-id-0", "group-id", [deleteEvent])
 			queue.add("batch-id-1", "group-id", [createEvent])
@@ -196,12 +198,12 @@ o.spec("EventQueueTest", function () {
 
 		o("delete + create + delete + create == delete + create", async function () {
 			// This tests that create still works a
-			const deleteEvent1 = createUpdate(OperationType.DELETE, "list", "1", "u1")
-			const nonEmptyEventInBetween = createUpdate(OperationType.CREATE, "list2", "2", "u1.1")
-			const createEvent1 = createUpdate(OperationType.CREATE, "list", "1", "u2")
+			const deleteEvent1 = createUpdate(OperationType.DELETE, "list", "1")
+			const nonEmptyEventInBetween = createUpdate(OperationType.CREATE, "list2", "2")
+			const createEvent1 = createUpdate(OperationType.CREATE, "list", "1")
 
-			const deleteEvent2 = createUpdate(OperationType.DELETE, "list", "1", "u3")
-			const createEvent2 = createUpdate(OperationType.CREATE, "list", "1", "u4")
+			const deleteEvent2 = createUpdate(OperationType.DELETE, "list", "1")
+			const createEvent2 = createUpdate(OperationType.CREATE, "list", "1")
 
 			queue.add("batch-id-1", "group-id", [deleteEvent1])
 			queue.add("batch-id-1.1", "group-id", [nonEmptyEventInBetween])
@@ -211,9 +213,9 @@ o.spec("EventQueueTest", function () {
 			queue.resume()
 			await lastProcess.promise
 
-			const expectedDelete = createUpdate(OperationType.DELETE, createEvent1.instanceListId, createEvent1.instanceId, "u1")
-			const expectedCreate = createUpdate(OperationType.CREATE, createEvent1.instanceListId, createEvent1.instanceId, "u4")
-			const expectedDelete2 = createUpdate(OperationType.DELETE, createEvent1.instanceListId, createEvent1.instanceId, "u3")
+			const expectedDelete = createUpdate(OperationType.DELETE, createEvent1.instanceListId, createEvent1.instanceId)
+			const expectedCreate = createUpdate(OperationType.CREATE, createEvent1.instanceListId, createEvent1.instanceId)
+			const expectedDelete2 = createUpdate(OperationType.DELETE, createEvent1.instanceListId, createEvent1.instanceId)
 
 			o(processElement.invocations).deepEquals([
 				[{ events: [expectedDelete], batchId: "batch-id-1", groupId: "group-id" }],
@@ -226,16 +228,16 @@ o.spec("EventQueueTest", function () {
 
 		o("delete (list 1) + create (list 2) == delete (list 1) + create (list 2)", async function () {
 			// entity updates with for the same element id but different list IDs do not influence each other
-			const deleteEvent1 = createUpdate(OperationType.DELETE, "list1", "1", "u1")
-			const createEvent1 = createUpdate(OperationType.CREATE, "list2", "1", "u2")
+			const deleteEvent1 = createUpdate(OperationType.DELETE, "list1", "1")
+			const createEvent1 = createUpdate(OperationType.CREATE, "list2", "1")
 
 			queue.add("batch-id-1", "group-id", [deleteEvent1])
 			queue.add("batch-id-2", "group-id", [createEvent1])
 			queue.resume()
 			await lastProcess.promise
 
-			const expectedDelete = createUpdate(OperationType.DELETE, deleteEvent1.instanceListId, deleteEvent1.instanceId, "u1")
-			const expectedCreate = createUpdate(OperationType.CREATE, createEvent1.instanceListId, createEvent1.instanceId, "u2")
+			const expectedDelete = createUpdate(OperationType.DELETE, deleteEvent1.instanceListId, deleteEvent1.instanceId)
+			const expectedCreate = createUpdate(OperationType.CREATE, createEvent1.instanceListId, createEvent1.instanceId)
 
 			o(processElement.invocations).deepEquals([
 				[{ events: [expectedDelete], batchId: "batch-id-1", groupId: "group-id" }],
@@ -245,9 +247,9 @@ o.spec("EventQueueTest", function () {
 
 		o("create (list 1) + update (list 1) + delete (list 2) == create (list 1) + delete (list 2)", async function () {
 			// entity updates with for the same element id but different list IDs do not influence each other
-			const createEvent1 = createUpdate(OperationType.CREATE, "list1", "1", "u1")
-			const updateEvent1 = createUpdate(OperationType.UPDATE, "list1", "1", "u2")
-			const deleteEvent1 = createUpdate(OperationType.DELETE, "list2", "1", "u3")
+			const createEvent1 = createUpdate(OperationType.CREATE, "list1", "1")
+			const updateEvent1 = createUpdate(OperationType.UPDATE, "list1", "1")
+			const deleteEvent1 = createUpdate(OperationType.DELETE, "list2", "1")
 
 			queue.add("batch-id-1", "group-id", [createEvent1])
 			queue.add("batch-id-2", "group-id", [updateEvent1])
@@ -255,8 +257,8 @@ o.spec("EventQueueTest", function () {
 			queue.resume()
 			await lastProcess.promise
 
-			const expectedCreate = createUpdate(OperationType.CREATE, createEvent1.instanceListId, createEvent1.instanceId, "u1")
-			const expectedDelete = createUpdate(OperationType.DELETE, deleteEvent1.instanceListId, deleteEvent1.instanceId, "u3")
+			const expectedCreate = createUpdate(OperationType.CREATE, createEvent1.instanceListId, createEvent1.instanceId)
+			const expectedDelete = createUpdate(OperationType.DELETE, deleteEvent1.instanceListId, deleteEvent1.instanceId)
 
 			o(processElement.invocations).deepEquals([
 				[{ events: [expectedCreate], batchId: "batch-id-1", groupId: "group-id" }],
@@ -265,8 +267,8 @@ o.spec("EventQueueTest", function () {
 		})
 
 		o("same batch in two different groups", async function () {
-			const createEvent1 = createUpdate(OperationType.CREATE, "old-mail-list", "1", "u0")
-			const createEvent2 = createUpdate(OperationType.CREATE, "old-mail-list", "1", "u0")
+			const createEvent1 = createUpdate(OperationType.CREATE, "old-mail-list", "1")
+			const createEvent2 = createUpdate(OperationType.CREATE, "old-mail-list", "1")
 
 			queue.add("batch-id-1", "group-id-1", [createEvent1])
 			queue.add("batch-id-1", "group-id-2", [createEvent2])
@@ -282,10 +284,10 @@ o.spec("EventQueueTest", function () {
 		o(
 			"[delete (list 1) + create (list 2)] + delete (list 2) + create (list 2) = [delete (list 1) + create (list 2)] + delete (list 2) + create (list 2)",
 			async function () {
-				const deleteEvent1 = createUpdate(OperationType.DELETE, "l1", "1", "u0")
-				const createEvent1 = createUpdate(OperationType.CREATE, "l2", "1", "u1")
-				const deleteEvent2 = createUpdate(OperationType.DELETE, "l2", "1", "u2")
-				const createEvent2 = createUpdate(OperationType.CREATE, "l2", "1", "u3")
+				const deleteEvent1 = createUpdate(OperationType.DELETE, "l1", "1")
+				const createEvent1 = createUpdate(OperationType.CREATE, "l2", "1")
+				const deleteEvent2 = createUpdate(OperationType.DELETE, "l2", "1")
+				const createEvent2 = createUpdate(OperationType.CREATE, "l2", "1")
 
 				queue.add("batch-id-1", "group-id-1", [deleteEvent1, createEvent1])
 				queue.add("batch-id-2", "group-id-1", [deleteEvent2])
@@ -305,26 +307,21 @@ o.spec("EventQueueTest", function () {
 			const batchId = "batch-id-1"
 			const groupId = "group-id-1"
 			const instanceId = "instance-id-1"
-			const eventId = "event-id-1"
-			const updateEvent1 = createUpdate(OperationType.UPDATE, "", instanceId, eventId)
-			const updateEvent2 = createUpdate(OperationType.UPDATE, "", instanceId, eventId)
-			updateEvent1.typeId = GroupTypeRef.typeId.toString()
-			updateEvent2.typeId = MailboxGroupRootTypeRef.typeId.toString()
+			const updateEvent1 = createUpdate(OperationType.UPDATE, "", instanceId)
+			const updateEvent2 = createUpdate(OperationType.UPDATE, "", instanceId)
+			updateEvent1.typeRef = GroupTypeRef
+			updateEvent2.typeRef = MailboxGroupRootTypeRef
 			queue.add(batchId, groupId, [updateEvent1])
 			queue.add(batchId, groupId, [updateEvent2])
 		})
 
-		function createUpdate(type: OperationType, listId: Id, instanceId: Id, eventId?: Id): EntityUpdate {
-			let update = createTestEntity(EntityUpdateTypeRef)
-			update.operation = type
-			update.instanceListId = listId
-			update.instanceId = instanceId
-			update.typeId = MailTypeRef.typeId.toString()
-			update.application = MailTypeRef.app
-			if (eventId) {
-				update._id = eventId
+		function createUpdate(type: OperationType, listId: Id, instanceId: Id): EntityUpdateData {
+			return {
+				typeRef: MailTypeRef,
+				operation: type,
+				instanceId,
+				instanceListId: listId,
 			}
-			return update
 		}
 	})
 
@@ -337,21 +334,19 @@ o.spec("EventQueueTest", function () {
 				batchMod(
 					batchId,
 					[
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: MailTypeRef.typeId.toString(),
-							operation: OperationType.CREATE,
+						{
+							typeRef: MailTypeRef,
 							instanceId,
 							instanceListId,
-						}),
+							operation: OperationType.CREATE,
+						},
 					],
-					createTestEntity(EntityUpdateTypeRef, {
-						application: "tutanota",
-						typeId: MailTypeRef.typeId.toString(),
-						operation: OperationType.CREATE,
+					{
+						typeRef: MailTypeRef,
 						instanceId,
 						instanceListId,
-					}),
+						operation: OperationType.CREATE,
+					},
 				),
 			).equals(EntityModificationType.CREATE)
 		})
@@ -361,28 +356,25 @@ o.spec("EventQueueTest", function () {
 				batchMod(
 					batchId,
 					[
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: MailTypeRef.typeId.toString(),
-							operation: OperationType.DELETE,
+						{
+							typeRef: MailTypeRef,
 							instanceId: "instanceId2",
 							instanceListId,
-						}),
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: MailTypeRef.typeId.toString(),
-							operation: OperationType.CREATE,
+							operation: OperationType.DELETE,
+						},
+						{
+							typeRef: MailTypeRef,
 							instanceId,
 							instanceListId,
-						}),
+							operation: OperationType.CREATE,
+						},
 					],
-					createTestEntity(EntityUpdateTypeRef, {
-						application: "tutanota",
-						typeId: MailTypeRef.typeId.toString(),
-						operation: OperationType.CREATE,
+					{
+						typeRef: MailTypeRef,
 						instanceId,
 						instanceListId,
-					}),
+						operation: OperationType.CREATE,
+					},
 				),
 			).equals(EntityModificationType.CREATE)
 		})
@@ -392,28 +384,25 @@ o.spec("EventQueueTest", function () {
 				batchMod(
 					batchId,
 					[
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: MailTypeRef.typeId.toString(),
-							operation: OperationType.DELETE,
+						{
+							typeRef: MailTypeRef,
 							instanceId,
 							instanceListId: "instanceListId2",
-						}),
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: MailTypeRef.typeId.toString(),
-							operation: OperationType.CREATE,
+							operation: OperationType.DELETE,
+						},
+						{
+							typeRef: MailTypeRef,
 							instanceId,
 							instanceListId,
-						}),
+							operation: OperationType.CREATE,
+						},
 					],
-					createTestEntity(EntityUpdateTypeRef, {
-						application: "tutanota",
-						typeId: MailTypeRef.typeId.toString(),
-						operation: OperationType.CREATE,
+					{
+						typeRef: MailTypeRef,
 						instanceId,
 						instanceListId,
-					}),
+						operation: OperationType.CREATE,
+					},
 				),
 			).equals(EntityModificationType.CREATE)
 		})
@@ -423,28 +412,25 @@ o.spec("EventQueueTest", function () {
 				batchMod(
 					batchId,
 					[
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: ContactTypeRef.typeId.toString(),
+						{
+							typeRef: ContactTypeRef,
+							instanceId,
+							instanceListId,
 							operation: OperationType.DELETE,
+						},
+						{
+							typeRef: MailTypeRef,
 							instanceId,
 							instanceListId,
-						}),
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: MailTypeRef.typeId.toString(),
 							operation: OperationType.CREATE,
-							instanceId,
-							instanceListId,
-						}),
+						},
 					],
-					createTestEntity(EntityUpdateTypeRef, {
-						application: "tutanota",
-						typeId: MailTypeRef.typeId.toString(),
-						operation: OperationType.CREATE,
+					{
+						typeRef: MailTypeRef,
 						instanceId,
 						instanceListId,
-					}),
+						operation: OperationType.CREATE,
+					},
 				),
 			).equals(EntityModificationType.CREATE)
 		})
@@ -454,21 +440,19 @@ o.spec("EventQueueTest", function () {
 				batchMod(
 					batchId,
 					[
-						createTestEntity(EntityUpdateTypeRef, {
-							application: "tutanota",
-							typeId: MailTypeRef.typeId.toString(),
-							operation: OperationType.CREATE,
+						{
+							typeRef: MailTypeRef,
 							instanceId,
 							instanceListId,
-						}),
+							operation: OperationType.CREATE,
+						},
 					],
-					createTestEntity(EntityUpdateTypeRef, {
-						application: "tutanota",
-						typeId: MailTypeRef.typeId.toString(),
-						operation: OperationType.DELETE,
+					{
+						typeRef: MailTypeRef,
 						instanceId,
 						instanceListId,
-					}),
+						operation: OperationType.DELETE,
+					},
 				),
 			).equals(EntityModificationType.CREATE)
 		})

--- a/test/tests/api/worker/search/IndexUtilsTest.ts
+++ b/test/tests/api/worker/search/IndexUtilsTest.ts
@@ -15,13 +15,13 @@ import {
 } from "../../../../../src/common/api/worker/search/IndexUtils.js"
 import { base64ToUint8Array, byteLength, concat, utf8Uint8ArrayToString } from "@tutao/tutanota-utils"
 import type { SearchIndexEntry, SearchIndexMetaDataRow } from "../../../../../src/common/api/worker/search/SearchTypes.js"
-import { EntityUpdateTypeRef, GroupMembershipTypeRef, UserTypeRef } from "../../../../../src/common/api/entities/sys/TypeRefs.js"
+import { GroupMembershipTypeRef, UserTypeRef } from "../../../../../src/common/api/entities/sys/TypeRefs.js"
 import { ContactTypeRef, MailTypeRef } from "../../../../../src/common/api/entities/tutanota/TypeRefs.js"
 import { GroupType, OperationType } from "../../../../../src/common/api/common/TutanotaConstants.js"
 import { aes256RandomKey, fixedIv, unauthenticatedAesDecrypt } from "@tutao/tutanota-crypto"
-import { resolveClientTypeReference } from "../../../../../src/common/api/common/EntityFunctions.js"
 import { createTestEntity } from "../../../TestUtils.js"
-import { containsEventOfType, entityUpdateToUpdateData, EntityUpdateData } from "../../../../../src/common/api/common/utils/EntityUpdateUtils.js"
+import { containsEventOfType, EntityUpdateData } from "../../../../../src/common/api/common/utils/EntityUpdateUtils.js"
+import { ClientModelInfo } from "../../../../../src/common/api/common/EntityFunctions"
 
 o.spec("Index Utils", () => {
 	o("encryptIndexKey", function () {
@@ -118,7 +118,7 @@ o.spec("Index Utils", () => {
 		// o(typeRefToTypeInfo(UserTypeRef).appId).equals(0)
 		// o(typeRefToTypeInfo(UserTypeRef).typeId).equals(UserTypeModel.id)
 		o(typeRefToTypeInfo(ContactTypeRef).appId).equals(1)
-		const ContactTypeModel = await resolveClientTypeReference(ContactTypeRef)
+		const ContactTypeModel = await ClientModelInfo.getNewInstanceForTestsOnly().resolveClientTypeReference(ContactTypeRef)
 		o(typeRefToTypeInfo(ContactTypeRef).typeId).equals(ContactTypeModel.id)
 	})
 	o("userIsGlobalAdmin", function () {
@@ -179,10 +179,11 @@ o.spec("Index Utils", () => {
 	})
 	o("containsEventOfType", function () {
 		function createUpdate(type: OperationType, id: Id): EntityUpdateData {
-			let update = createTestEntity(EntityUpdateTypeRef)
-			update.operation = type
-			update.instanceId = id
-			return entityUpdateToUpdateData(update)
+			return {
+				operation: type,
+				instanceId: id,
+				instanceListId: "",
+			} as Partial<EntityUpdateData> as EntityUpdateData
 		}
 
 		o(containsEventOfType([], OperationType.CREATE, "1")).equals(false)

--- a/test/tests/api/worker/search/MailIndexerTest.ts
+++ b/test/tests/api/worker/search/MailIndexerTest.ts
@@ -59,7 +59,6 @@ import { EntityRestClientMock } from "../rest/EntityRestClientMock.js"
 import type { DateProvider } from "../../../../../src/common/api/worker/DateProvider.js"
 import { LocalTimeDateProvider } from "../../../../../src/common/api/worker/DateProvider.js"
 import { aes256RandomKey, fixedIv } from "@tutao/tutanota-crypto"
-import { resolveClientTypeReference } from "../../../../../src/common/api/common/EntityFunctions.js"
 import { matchers, object, verify, when } from "testdouble"
 import { InfoMessageHandler } from "../../../../../src/common/gui/InfoMessageHandler.js"
 import { ElementDataOS, GroupDataOS, Metadata as MetaData, MetaDataOS } from "../../../../../src/common/api/worker/search/IndexTables.js"
@@ -70,6 +69,8 @@ import { BulkMailLoader, MAIL_INDEXER_CHUNK, MailWithMailDetails } from "../../.
 import { DbFacade } from "../../../../../src/common/api/worker/search/DbFacade"
 import { ProgressMonitor } from "../../../../../src/common/api/common/utils/ProgressMonitor"
 import { AttributeModel } from "../../../../../src/common/api/common/AttributeModel"
+import { ClientModelInfo, ClientTypeModelResolver } from "../../../../../src/common/api/common/EntityFunctions"
+import { EntityUpdateData } from "../../../../../src/common/api/common/utils/EntityUpdateUtils"
 
 class FixedDateProvider implements DateProvider {
 	now: number
@@ -98,11 +99,15 @@ o.spec("MailIndexer test", () => {
 	let bulkMailLoader: BulkMailLoader
 	let dateProvider: DateProvider
 	let mailFacade: MailFacade
+	let clientTypeModelResolver: ClientTypeModelResolver
 	o.beforeEach(function () {
 		entityMock = new EntityRestClientMock()
-		entityClient = new EntityClient(entityMock)
+		clientTypeModelResolver = ClientModelInfo.getNewInstanceForTestsOnly()
+		entityClient = new EntityClient(entityMock, clientTypeModelResolver)
 		mailFacade = object()
-		bulkMailLoader = new BulkMailLoader(entityClient, new EntityClient(entityMock), mailFacade)
+		bulkMailLoader = new BulkMailLoader(entityClient, new EntityClient(entityMock, clientTypeModelResolver), mailFacade)
+		dateProvider = new LocalTimeDateProvider()
+		bulkMailLoader = new BulkMailLoader(entityClient, new EntityClient(entityMock, clientTypeModelResolver), mailFacade)
 		dateProvider = new LocalTimeDateProvider()
 	})
 	o("createMailIndexEntries without entries", function () {
@@ -202,7 +207,7 @@ o.spec("MailIndexer test", () => {
 				value: h.value(),
 			}
 		})
-		const MailModel = await resolveClientTypeReference(MailTypeRef)
+		const MailModel = await clientTypeModelResolver.resolveClientTypeReference(MailTypeRef)
 		o(JSON.stringify(attributes)).equals(
 			JSON.stringify([
 				{
@@ -297,10 +302,10 @@ o.spec("MailIndexer test", () => {
 		await o(() => indexer.processNewMail([event.instanceListId, event.instanceId])).asyncThrows(Error)
 	})
 	o("processMovedMail", async function () {
-		let event: EntityUpdate = {
+		let event: EntityUpdateData = {
 			instanceListId: "new-list-id",
 			instanceId: "eid",
-		} as any
+		} as Partial<EntityUpdateData> as EntityUpdateData
 		let elementData: ElementDataDbRow = ["old-list-id", new Uint8Array(0), "owner-group-id"]
 		let db: Db = {
 			key: aes256RandomKey(),
@@ -980,17 +985,13 @@ o.spec("MailIndexer test", () => {
 	})
 })
 
-function createUpdate(type: OperationType, listId: Id, instanceId: Id, eventId?: Id) {
-	let update = createTestEntity(EntityUpdateTypeRef)
-	update.operation = type
-	update.instanceListId = listId
-	update.instanceId = instanceId
-
-	if (eventId) {
-		update._id = eventId
+function createUpdate(type: OperationType, listId: Id, instanceId: Id): EntityUpdateData {
+	return {
+		typeRef: MailTypeRef,
+		operation: type,
+		instanceListId: listId,
+		instanceId: instanceId,
 	}
-
-	return update
 }
 
 async function indexMailboxTest(startTimestamp: number, endIndexTimstamp: number, fullyIndexed: boolean, indexMailList: boolean) {
@@ -1030,7 +1031,7 @@ async function indexMailboxTest(startTimestamp: number, endIndexTimstamp: number
 		iv: fixedIv,
 	} as any
 	const infoMessageHandler = object<InfoMessageHandler>()
-	const entityClient = new EntityClient(entityMock)
+	const entityClient = new EntityClient(entityMock, ClientModelInfo.getNewInstanceForTestsOnly())
 	const mailFacade: MailFacade = object()
 	const bulkMailLoader = new BulkMailLoader(entityClient, entityClient, mailFacade)
 	const indexer = mock(
@@ -1113,7 +1114,7 @@ function _prepareProcessEntityTests(indexingEnabled: boolean, mailState: MailSta
 	const entityMock = new EntityRestClientMock()
 	entityMock.addBlobInstances(mailDetailsBlob)
 	entityMock.addListInstances(mail)
-	const entityClient = new EntityClient(entityMock)
+	const entityClient = new EntityClient(entityMock, ClientModelInfo.getNewInstanceForTestsOnly())
 	const bulkMailLoader = new BulkMailLoader(entityClient, entityClient, mailFacade)
 	return mock(new MailIndexer(core, db, null as any, () => bulkMailLoader, entityClient, new LocalTimeDateProvider(), mailFacade), (mocked) => {
 		mocked.processNewMail = spy(mocked.processNewMail.bind(mocked))

--- a/test/tests/api/worker/search/SearchFacadeTest.ts
+++ b/test/tests/api/worker/search/SearchFacadeTest.ts
@@ -29,6 +29,7 @@ import { aes256RandomKey, fixedIv } from "@tutao/tutanota-crypto"
 import { ElementDataOS, SearchIndexMetaDataOS, SearchIndexOS } from "../../../../../src/common/api/worker/search/IndexTables.js"
 import { object, when } from "testdouble"
 import { EntityClient } from "../../../../../src/common/api/common/EntityClient.js"
+import { ClientModelInfo } from "../../../../../src/common/api/common/EntityFunctions"
 
 type SearchIndexEntryWithType = SearchIndexEntry & {
 	typeInfo: TypeInfo
@@ -69,6 +70,7 @@ o.spec("SearchFacade test", () => {
 			[],
 			browserData,
 			entityClient,
+			ClientModelInfo.getNewInstanceForTestsOnly(),
 		)
 	}
 

--- a/test/tests/api/worker/search/SuggestionFacadeTest.ts
+++ b/test/tests/api/worker/search/SuggestionFacadeTest.ts
@@ -8,21 +8,26 @@ import { downcast } from "@tutao/tutanota-utils"
 import { aes256RandomKey, fixedIv } from "@tutao/tutanota-crypto"
 import { SearchTermSuggestionsOS } from "../../../../../src/common/api/worker/search/IndexTables.js"
 import { spy } from "@tutao/tutanota-test-utils"
-import { resolveClientTypeReference } from "../../../../../src/common/api/common/EntityFunctions"
+import { ClientModelInfo, ClientTypeModelResolver } from "../../../../../src/common/api/common/EntityFunctions"
+import { TypeModel } from "../../../../../src/common/api/common/EntityTypes"
+import { Db } from "../../../../../src/common/api/worker/search/SearchTypes"
+import { DbFacade } from "../../../../../src/common/api/worker/search/DbFacade"
 
 o.spec("SuggestionFacade test", () => {
-	let db
-	let facade
-	let contactTypeModel
+	let db: Db
+	let facade: SuggestionFacade<any>
+	let contactTypeModel: TypeModel
+	let clientModelResolver: ClientTypeModelResolver
 	o.beforeEach(async function () {
 		db = {
 			key: aes256RandomKey(),
 			iv: fixedIv,
-			dbFacade: {},
+			dbFacade: {} as unknown as DbFacade,
 			initialized: Promise.resolve(),
 		}
-		facade = new SuggestionFacade(ContactTypeRef, db)
-		contactTypeModel = await resolveClientTypeReference(ContactTypeRef)
+		clientModelResolver = ClientModelInfo.getNewInstanceForTestsOnly()
+		facade = new SuggestionFacade(ContactTypeRef, db, clientModelResolver)
+		contactTypeModel = await clientModelResolver.resolveClientTypeReference(ContactTypeRef)
 	})
 	o("add and get suggestion", () => {
 		o(facade.getSuggestions("a").join("")).equals("")

--- a/test/tests/calendar/CalendarModelTest.ts
+++ b/test/tests/calendar/CalendarModelTest.ts
@@ -38,6 +38,7 @@ import { incrementByRepeatPeriod } from "../../../src/common/calendar/date/Calen
 import { ExternalCalendarFacade } from "../../../src/common/native/common/generatedipc/ExternalCalendarFacade.js"
 import { DeviceConfig } from "../../../src/common/misc/DeviceConfig.js"
 import { SyncTracker } from "../../../src/common/api/main/SyncTracker.js"
+import { ClientModelInfo } from "../../../src/common/api/common/EntityFunctions"
 
 o.spec("CalendarModel", function () {
 	o.spec("incrementByRepeatPeriod", function () {
@@ -673,12 +674,10 @@ o.spec("CalendarModel", function () {
 
 			// calendar update create event
 			await eventControllerMock.sendEvent({
-				application: CalendarEventUpdateTypeRef.app,
-				typeId: CalendarEventUpdateTypeRef.typeId,
+				typeRef: CalendarEventUpdateTypeRef,
 				instanceListId: listIdPart(eventUpdate._id),
 				instanceId: elementIdPart(eventUpdate._id),
 				operation: OperationType.CREATE,
-				type: "CalendarEventUpdate",
 			})
 
 			o(model.getFileIdToSkippedCalendarEventUpdates().get(getElementId(calendarFile))!).deepEquals(eventUpdate)
@@ -690,12 +689,10 @@ o.spec("CalendarModel", function () {
 			// set owner enc session key to ensure that we can process the calendar event file
 			calendarFile._ownerEncSessionKey = hexToUint8Array("01")
 			await eventControllerMock.sendEvent({
-				application: FileTypeRef.app,
-				typeId: FileTypeRef.typeId,
+				typeRef: FileTypeRef,
 				instanceListId: listIdPart(calendarFile._id),
 				instanceId: elementIdPart(calendarFile._id),
 				operation: OperationType.UPDATE,
-				type: "File",
 			})
 
 			o(model.getFileIdToSkippedCalendarEventUpdates().size).deepEquals(0)
@@ -806,7 +803,7 @@ function init({
 	restClientMock,
 	loginController = makeLoginController(),
 	progressTracker = makeProgressTracker(),
-	entityClient = new EntityClient(restClientMock),
+	entityClient = new EntityClient(restClientMock, ClientModelInfo.getNewInstanceForTestsOnly()),
 	mailModel = makeMailModel(),
 	alarmScheduler = makeAlarmScheduler(),
 	calendarFacade = makeCalendarFacade(

--- a/test/tests/calendar/CalendarViewModelTest.ts
+++ b/test/tests/calendar/CalendarViewModelTest.ts
@@ -30,6 +30,7 @@ import { addDaysForEventInstance, getMonthRange } from "../../../src/common/cale
 import { CalendarEventModel, CalendarOperation, EventSaveResult } from "../../../src/calendar-app/calendar/gui/eventeditor-model/CalendarEventModel.js"
 import { ContactModel } from "../../../src/common/contactsFunctionality/ContactModel.js"
 import { CalendarEventTypeRef } from "../../../src/common/api/entities/tutanota/TypeRefs.js"
+import { ClientModelInfo } from "../../../src/common/api/common/EntityFunctions"
 
 let saveAndSendMock
 let rescheduleEventMock
@@ -87,7 +88,7 @@ o.spec("CalendarViewModel", function () {
 			contactPreviewModelFactory,
 			calendarModel,
 			eventsRepository,
-			new EntityClient(entityClientMock),
+			new EntityClient(entityClientMock, ClientModelInfo.getNewInstanceForTestsOnly()),
 			eventController,
 			progressTracker,
 			deviceConfig,
@@ -413,12 +414,10 @@ o.spec("CalendarViewModel", function () {
 			o(viewModel.temporaryEvents.some((e) => e.uid === eventToDrag.uid)).equals(true)("Has transient event")
 			o(entityListeners.length).equals(1)("Listener was added")
 			const entityUpdate: EntityUpdateData = {
-				application: "tutanota",
-				typeId: CalendarEventTypeRef.typeId,
+				typeRef: CalendarEventTypeRef,
 				instanceListId: getListId(eventToDrag),
 				instanceId: getElementId(eventToDrag),
 				operation: OperationType.CREATE,
-				type: "CalendarEvent",
 			}
 			const updatedEventFromServer = makeEvent(getElementId(eventToDrag), newData, new Date(2021, 0, 5, 14, 30), assertNotNull(eventToDrag.uid))
 			entityClientMock.addListInstances(updatedEventFromServer)

--- a/test/tests/desktop/sse/DesktopAlarmStorageTest.ts
+++ b/test/tests/desktop/sse/DesktopAlarmStorageTest.ts
@@ -4,11 +4,11 @@ import { DesktopAlarmStorage } from "../../../../src/common/desktop/sse/DesktopA
 import { DesktopConfig } from "../../../../src/common/desktop/config/DesktopConfig.js"
 import { DesktopNativeCryptoFacade } from "../../../../src/common/desktop/DesktopNativeCryptoFacade.js"
 import type { DesktopKeyStoreFacade } from "../../../../src/common/desktop/DesktopKeyStoreFacade.js"
-import { createTestEntity, makeKeyStoreFacade } from "../../TestUtils.js"
+import { clientInitializedTypeModelResolver, createTestEntity, instancePipelineFromTypeModelResolver, makeKeyStoreFacade } from "../../TestUtils.js"
 import { DesktopConfigKey } from "../../../../src/common/desktop/config/ConfigKeys.js"
 import { assertNotNull, uint8ArrayToBase64 } from "@tutao/tutanota-utils"
 import { InstancePipeline } from "../../../../src/common/api/worker/crypto/InstancePipeline"
-import { resolveClientTypeReference, resolveServerTypeReference } from "../../../../src/common/api/common/EntityFunctions"
+import { TypeModelResolver } from "../../../../src/common/api/common/EntityFunctions"
 import { aes256RandomKey, bitArrayToUint8Array, encryptKey, uint8ArrayToBitArray } from "@tutao/tutanota-crypto"
 import {
 	AlarmInfoTypeRef,
@@ -21,6 +21,9 @@ import { hasError } from "../../../../src/common/api/common/utils/ErrorUtils.js"
 o.spec("DesktopAlarmStorageTest", function () {
 	let cryptoMock: DesktopNativeCryptoFacade
 	let confMock: DesktopConfig
+	let typeModelResolver: TypeModelResolver
+	let instancePipeline: InstancePipeline
+	let desktopStorage: DesktopAlarmStorage
 
 	const key1 = new Uint8Array([1])
 	const key2 = new Uint8Array([2])
@@ -28,7 +31,6 @@ o.spec("DesktopAlarmStorageTest", function () {
 	const key4 = new Uint8Array([4])
 	const decryptedKey = new Uint8Array([0, 1])
 	const encryptedKey = new Uint8Array([1, 0])
-	const instancePipeline = new InstancePipeline(resolveClientTypeReference, resolveServerTypeReference)
 
 	o.beforeEach(function () {
 		cryptoMock = instance(DesktopNativeCryptoFacade)
@@ -42,12 +44,14 @@ o.spec("DesktopAlarmStorageTest", function () {
 			twoId: uint8ArrayToBase64(key3),
 			fourId: uint8ArrayToBase64(key4),
 		})
+
+		typeModelResolver = clientInitializedTypeModelResolver()
+		instancePipeline = instancePipelineFromTypeModelResolver(typeModelResolver)
+		const keyStoreFacade: DesktopKeyStoreFacade = makeKeyStoreFacade(new Uint8Array([1, 2, 3]))
+		desktopStorage = new DesktopAlarmStorage(confMock, cryptoMock, keyStoreFacade, instancePipeline, typeModelResolver)
 	})
 
 	o("getPushIdentifierSessionKey with uncached sessionKey", async function () {
-		const keyStoreFacade: DesktopKeyStoreFacade = makeKeyStoreFacade(new Uint8Array([1, 2, 3]))
-		const desktopStorage = new DesktopAlarmStorage(confMock, cryptoMock, keyStoreFacade, instancePipeline)
-
 		const pushIdentifier: IdTuple = ["oneId", "twoId"]
 		const key = await desktopStorage.getPushIdentifierSessionKey(pushIdentifier)
 
@@ -56,9 +60,7 @@ o.spec("DesktopAlarmStorageTest", function () {
 	})
 
 	o("getPushIdentifierSessionKey with cached sessionKey", async function () {
-		const keyStoreFacade: DesktopKeyStoreFacade = makeKeyStoreFacade(new Uint8Array([1, 2, 3]))
 		when(confMock.getVar(matchers.anything())).thenResolve(null)
-		const desktopStorage = new DesktopAlarmStorage(confMock, cryptoMock, keyStoreFacade, instancePipeline)
 		await desktopStorage.storePushIdentifierSessionKey("fourId", key4)
 
 		verify(confMock.setVar(DesktopConfigKey.pushEncSessionKeys, { fourId: uint8ArrayToBase64(encryptedKey) }), { times: 1 })
@@ -69,8 +71,6 @@ o.spec("DesktopAlarmStorageTest", function () {
 	})
 
 	o("getPushIdentifierSessionKey when sessionKey is unavailable", async function () {
-		const keyStoreFacade: DesktopKeyStoreFacade = makeKeyStoreFacade(new Uint8Array([1, 2, 3]))
-		const desktopStorage = new DesktopAlarmStorage(confMock, cryptoMock, keyStoreFacade, instancePipeline)
 		const pushIdentifier: IdTuple = ["fiveId", "sixId"]
 		const key1 = await desktopStorage.getPushIdentifierSessionKey(pushIdentifier)
 		o(key1).equals(null)
@@ -84,7 +84,7 @@ o.spec("DesktopAlarmStorageTest", function () {
 		const pushSessionKey = aes256RandomKey()
 		const pushIdentifierSessionEncSessionKey = encryptKey(pushSessionKey, notificationSessionKey)
 
-		const desktopStorage: DesktopAlarmStorage = new DesktopAlarmStorage(confMock, cryptoMock, keyStoreFacade, instancePipeline)
+		const desktopStorage: DesktopAlarmStorage = new DesktopAlarmStorage(confMock, cryptoMock, keyStoreFacade, instancePipeline, typeModelResolver)
 		await desktopStorage.storePushIdentifierSessionKey("fourId", bitArrayToUint8Array(pushSessionKey))
 		const pushIdentifier: IdTuple = ["threeId", "fourId"]
 		const pushIdentifierSessionKey = await desktopStorage.getPushIdentifierSessionKey(pushIdentifier)

--- a/test/tests/desktop/sse/TutaNotificationHandlerTest.ts
+++ b/test/tests/desktop/sse/TutaNotificationHandlerTest.ts
@@ -11,24 +11,19 @@ import { func, matchers, object, verify, when } from "testdouble"
 import { CredentialEncryptionMode } from "../../../../src/common/misc/credentials/CredentialEncryptionMode.js"
 import { ExtendedNotificationMode } from "../../../../src/common/native/common/generatedipc/ExtendedNotificationMode.js"
 import { createIdTupleWrapper, createNotificationInfo } from "../../../../src/common/api/entities/sys/TypeRefs.js"
-import { createTestEntity, mockFetchRequest } from "../../TestUtils.js"
+import { clientInitializedTypeModelResolver, createTestEntity, instancePipelineFromTypeModelResolver, mockFetchRequest } from "../../TestUtils.js"
 import tutanotaModelInfo from "../../../../src/common/api/entities/tutanota/ModelInfo.js"
 import { UnencryptedCredentials } from "../../../../src/common/native/common/generatedipc/UnencryptedCredentials.js"
 import { CredentialType } from "../../../../src/common/misc/credentials/CredentialType.js"
 import { Mail, MailAddressTypeRef, MailTypeRef } from "../../../../src/common/api/entities/tutanota/TypeRefs.js"
-import { EncryptedAlarmNotification } from "../../../../src/common/native/common/EncryptedAlarmNotification.js"
-import { OperationType } from "../../../../src/common/api/common/TutanotaConstants.js"
 import { ApplicationWindow } from "../../../../src/common/desktop/ApplicationWindow.js"
 import { SseInfo } from "../../../../src/common/desktop/sse/SseInfo.js"
 import { SseStorage } from "../../../../src/common/desktop/sse/SseStorage.js"
 import { createSystemMail } from "../../api/common/mail/CommonMailUtilsTest"
 import { InstancePipeline } from "../../../../src/common/api/worker/crypto/InstancePipeline"
-import { resolveClientTypeReference, resolveServerTypeReference } from "../../../../src/common/api/common/EntityFunctions"
 import { aes256RandomKey } from "@tutao/tutanota-crypto"
 
 type UndiciFetch = typeof undiciFetch
-
-const nativeInstancePipeline = new InstancePipeline(resolveClientTypeReference, resolveClientTypeReference)
 
 o.spec("TutaNotificationHandler", () => {
 	let wm: WindowManager
@@ -41,6 +36,7 @@ o.spec("TutaNotificationHandler", () => {
 	let fetch: UndiciFetch
 	let appVersion = "V_1"
 	let handler: TutaNotificationHandler
+	let nativeInstancePipeline: InstancePipeline
 
 	o.beforeEach(() => {
 		wm = object()
@@ -52,6 +48,8 @@ o.spec("TutaNotificationHandler", () => {
 		lang = object()
 		fetch = func<UndiciFetch>()
 		when(lang.get(matchers.anything())).thenDo((arg) => `translated:${arg}`)
+		const typeModelResolver = clientInitializedTypeModelResolver()
+		nativeInstancePipeline = instancePipelineFromTypeModelResolver(typeModelResolver)
 		handler = new TutaNotificationHandler(
 			wm,
 			nativeCredentialsFacade,
@@ -63,6 +61,7 @@ o.spec("TutaNotificationHandler", () => {
 			fetch,
 			appVersion,
 			nativeInstancePipeline,
+			typeModelResolver,
 		)
 	})
 

--- a/test/tests/desktop/sse/TutaSseFacadeTest.ts
+++ b/test/tests/desktop/sse/TutaSseFacadeTest.ts
@@ -23,10 +23,16 @@ import {
 	NotificationSessionKeyTypeRef,
 	SseConnectDataTypeRef,
 } from "../../../../src/common/api/entities/sys/TypeRefs.js"
-import { createTestEntity, mockFetchRequest, removeAggregateIds, removeFinalIvs } from "../../TestUtils.js"
+import {
+	clientInitializedTypeModelResolver,
+	createTestEntity,
+	instancePipelineFromTypeModelResolver,
+	mockFetchRequest,
+	removeAggregateIds,
+	removeFinalIvs,
+} from "../../TestUtils.js"
 import { SseInfo } from "../../../../src/common/desktop/sse/SseInfo.js"
 import { OperationType } from "../../../../src/common/api/common/TutanotaConstants"
-import { resolveClientTypeReference } from "../../../../src/common/api/common/EntityFunctions"
 import { InstancePipeline } from "../../../../src/common/api/worker/crypto/InstancePipeline"
 import { aes256RandomKey } from "@tutao/tutanota-crypto"
 import { StrippedEntity } from "../../../../src/common/api/common/utils/EntityUtils"
@@ -37,6 +43,7 @@ import { EncryptedMissedNotification } from "../../../../src/common/native/commo
 import { assertThrows } from "@tutao/tutanota-test-utils"
 import { CryptoError } from "@tutao/tutanota-crypto/error.js"
 import { AttributeModel } from "../../../../src/common/api/common/AttributeModel"
+import { TypeModelResolver } from "../../../../src/common/api/common/EntityFunctions"
 
 const APP_V = env.versionNumber
 
@@ -52,6 +59,8 @@ o.spec("TutaSseFacade", () => {
 	let fetch: typeof undiciFetch
 	let date: DateProvider
 	let nativeInstancePipeline: InstancePipeline
+	let typeModelResolver: TypeModelResolver
+
 	o.beforeEach(() => {
 		sseStorage = object()
 		notificationHandler = object()
@@ -60,8 +69,20 @@ o.spec("TutaSseFacade", () => {
 		alarmScheduler = object()
 		fetch = func<typeof undiciFetch>()
 		date = object()
-		nativeInstancePipeline = new InstancePipeline(resolveClientTypeReference, resolveClientTypeReference)
-		sseFacade = new TutaSseFacade(sseStorage, notificationHandler, sseClient, alarmStorage, alarmScheduler, APP_V, fetch, date, nativeInstancePipeline)
+		typeModelResolver = clientInitializedTypeModelResolver()
+		nativeInstancePipeline = instancePipelineFromTypeModelResolver(typeModelResolver)
+		sseFacade = new TutaSseFacade(
+			sseStorage,
+			notificationHandler,
+			sseClient,
+			alarmStorage,
+			alarmScheduler,
+			APP_V,
+			fetch,
+			date,
+			nativeInstancePipeline,
+			typeModelResolver,
+		)
 	})
 
 	function setupSseInfo(template: Partial<SseInfo> = {}): SseInfo {
@@ -254,7 +275,7 @@ o.spec("TutaSseFacade", () => {
 				missedNotification,
 				sk,
 			)) as unknown as ServerModelUntypedInstance
-			const encryptedMissedNotification = await EncryptedMissedNotification.from(untypedInstance)
+			const encryptedMissedNotification = await EncryptedMissedNotification.from(untypedInstance, typeModelResolver)
 			await sseFacade.handleAlarmNotification(encryptedMissedNotification)
 			verify(alarmScheduler.handleDeleteAlarm("alarmId"))
 		})
@@ -291,7 +312,7 @@ o.spec("TutaSseFacade", () => {
 				missedNotification,
 				sk,
 			)) as unknown as ServerModelUntypedInstance
-			const encryptedMissedNotification = await EncryptedMissedNotification.from(untypedInstance)
+			const encryptedMissedNotification = await EncryptedMissedNotification.from(untypedInstance, typeModelResolver)
 
 			await assertThrows(CryptoError, () => sseFacade.handleAlarmNotification(encryptedMissedNotification))
 			verify(alarmStorage.getNotificationSessionKey(anything()))
@@ -339,12 +360,12 @@ o.spec("TutaSseFacade", () => {
 				missedNotification,
 				sk,
 			)) as unknown as ServerModelUntypedInstance
-			const missedNotificationTypeModel = await resolveClientTypeReference(MissedNotificationTypeRef)
-			const alarmNotificationTypeModel = await resolveClientTypeReference(AlarmNotificationTypeRef)
+			const missedNotificationTypeModel = await typeModelResolver.resolveClientTypeReference(MissedNotificationTypeRef)
+			const alarmNotificationTypeModel = await typeModelResolver.resolveClientTypeReference(AlarmNotificationTypeRef)
 			const anAttrId = assertNotNull(AttributeModel.getAttributeId(missedNotificationTypeModel, "alarmNotifications"))
 			const eventStartAttrId = assertNotNull(AttributeModel.getAttributeId(alarmNotificationTypeModel, "eventStart"))
 			downcast<Array<UntypedInstance>>(untypedInstance[anAttrId])[0][eventStartAttrId] = stringToBase64("newDate")
-			const encryptedMissedNotification = await EncryptedMissedNotification.from(untypedInstance)
+			const encryptedMissedNotification = await EncryptedMissedNotification.from(untypedInstance, typeModelResolver)
 
 			await assertThrows(CryptoError, () => sseFacade.handleAlarmNotification(encryptedMissedNotification))
 			verify(alarmStorage.removePushIdentifierKey(anything()))

--- a/test/tests/mail/InboxRuleHandlerTest.ts
+++ b/test/tests/mail/InboxRuleHandlerTest.ts
@@ -64,7 +64,6 @@ o.spec("InboxRuleHandlerTest", function () {
 	})
 	o.spec("Test _findMatchingRule", function () {
 		const restClient: EntityRestClientMock = new EntityRestClientMock()
-		const entityClient = new EntityClient(restClient)
 		o("check FROM_EQUALS is applied to from", async function () {
 			const rules: InboxRule[] = [_createRule("sender@tuta.com", InboxRuleType.FROM_EQUALS, ["ruleTarget", "ruleTarget"])]
 

--- a/test/tests/mail/MailModelTest.ts
+++ b/test/tests/mail/MailModelTest.ts
@@ -17,6 +17,7 @@ import { getElementId, getListId } from "../../../src/common/api/common/utils/En
 import { MailModel } from "../../../src/mail-app/mail/model/MailModel.js"
 import { EventController } from "../../../src/common/api/main/EventController.js"
 import { MailFacade } from "../../../src/common/api/worker/facades/lazy/MailFacade.js"
+import { ClientModelInfo } from "../../../src/common/api/common/EntityFunctions"
 
 o.spec("MailModelTest", function () {
 	let notifications: Partial<Notifications>
@@ -44,7 +45,16 @@ o.spec("MailModelTest", function () {
 		when(logins.getUserController()).thenReturn(userController)
 
 		inboxRuleHandler = object()
-		model = new MailModel(downcast({}), mailboxModel, eventController, new EntityClient(restClient), logins, mailFacade, null, null)
+		model = new MailModel(
+			downcast({}),
+			mailboxModel,
+			eventController,
+			new EntityClient(restClient, ClientModelInfo.getNewInstanceForTestsOnly()),
+			logins,
+			mailFacade,
+			null,
+			null,
+		)
 		// not pretty, but works
 		// model.mailboxDetails(mailboxDetails as MailboxDetail[])
 	})
@@ -86,16 +96,12 @@ o.spec("MailModelTest", function () {
 		verify(mailFacade.markMails([mailId1, mailId2, mailId3], true))
 	})
 
-	function makeUpdate(arg: { instanceListId: string; instanceId: Id; operation: OperationType }): EntityUpdateData {
-		return Object.assign(
-			{},
-			{
-				typeId: MailTypeRef.typeId,
-				application: MailTypeRef.app,
-				instanceId: "instanceId",
-				type: "Mail",
-			},
-			arg,
-		)
+	function makeUpdate({ instanceId, instanceListId, operation }: { instanceListId: string; instanceId: Id; operation: OperationType }): EntityUpdateData {
+		return {
+			typeRef: MailTypeRef,
+			operation,
+			instanceListId,
+			instanceId,
+		}
 	}
 })

--- a/test/tests/mail/SendMailModelTest.ts
+++ b/test/tests/mail/SendMailModelTest.ts
@@ -49,7 +49,6 @@ import { MailboxDetail, MailboxModel } from "../../../src/common/mailFunctionali
 import { SendMailModel, TOO_MANY_VISIBLE_RECIPIENTS } from "../../../src/common/mailFunctionality/SendMailModel.js"
 import { RecipientField } from "../../../src/common/mailFunctionality/SharedMailUtils.js"
 import { getContactDisplayName } from "../../../src/common/contactsFunctionality/ContactUtils.js"
-import { PartialRecipient } from "../../../src/common/api/common/recipients/Recipient"
 
 const { anything, argThat } = matchers
 
@@ -571,17 +570,46 @@ o.spec("SendMailModel", function () {
 		})
 
 		o("nonmatching event", async function () {
-			await model.handleEntityEvent(downcast(CustomerAccountCreateDataTypeRef))
-			await model.handleEntityEvent(downcast(UserTypeRef))
-			await model.handleEntityEvent(downcast(CustomerTypeRef))
-			await model.handleEntityEvent(downcast(NotificationMailTypeRef))
-			await model.handleEntityEvent(downcast(ChallengeTypeRef))
-			await model.handleEntityEvent(downcast(MailTypeRef))
+			await model.handleEntityEvent({
+				typeRef: CustomerAccountCreateDataTypeRef,
+				operation: OperationType.CREATE,
+				instanceListId: "",
+				instanceId: "",
+			})
+			await model.handleEntityEvent({
+				typeRef: UserTypeRef,
+				operation: OperationType.CREATE,
+				instanceListId: "",
+				instanceId: "",
+			})
+			await model.handleEntityEvent({
+				typeRef: CustomerTypeRef,
+				operation: OperationType.CREATE,
+				instanceListId: "",
+				instanceId: "",
+			})
+			await model.handleEntityEvent({
+				typeRef: NotificationMailTypeRef,
+				operation: OperationType.CREATE,
+				instanceListId: "",
+				instanceId: "",
+			})
+			await model.handleEntityEvent({
+				typeRef: ChallengeTypeRef,
+				operation: OperationType.CREATE,
+				instanceListId: "",
+				instanceId: "",
+			})
+			await model.handleEntityEvent({
+				typeRef: MailTypeRef,
+				operation: OperationType.CREATE,
+				instanceListId: "",
+				instanceId: "",
+			})
 			verify(entity.load(anything(), anything(), anything()), { times: 0 })
 		})
 
 		o("contact updated email kept", async function () {
-			const { app, typeId } = ContactTypeRef
 			const [instanceListId, instanceId] = existingContact._id
 			const contactForUpdate = {
 				firstName: "newfirstname",
@@ -603,19 +631,16 @@ o.spec("SendMailModel", function () {
 			).thenResolve(createContact(Object.assign({ _id: existingContact._id } as Contact, contactForUpdate)))
 			await model.initWithTemplate({ to: recipients }, "somb", "", [], true, "a@b.c", false)
 			await model.handleEntityEvent({
-				application: app,
-				typeId: typeId,
+				typeRef: ContactTypeRef,
 				operation: OperationType.UPDATE,
 				instanceListId,
 				instanceId,
-				type: "Contact",
 			})
 			o(model.allRecipients().length).equals(2)
 			const updatedRecipient = model.allRecipients().find((r) => r.contact && isSameId(r.contact._id, existingContact._id))
 			o(updatedRecipient && updatedRecipient.name).equals(getContactDisplayName(downcast(contactForUpdate)))
 		})
 		o("contact updated email removed or changed", async function () {
-			const { app, typeId } = ContactTypeRef
 			const [instanceListId, instanceId] = existingContact._id
 			const contactForUpdate = {
 				firstName: "james",
@@ -639,28 +664,23 @@ o.spec("SendMailModel", function () {
 			)
 			await model.initWithTemplate({ to: recipients }, "b", "c", [], true, "", false)
 			await model.handleEntityEvent({
-				application: app,
-				typeId: typeId,
+				typeRef: ContactTypeRef,
 				operation: OperationType.UPDATE,
 				instanceListId,
 				instanceId,
-				type: "Contact",
 			})
 			o(model.allRecipients().length).equals(1)
 			const updatedContact = model.allRecipients().find((r) => r.contact && isSameId(r.contact._id, existingContact._id))
 			o(updatedContact ?? null).equals(null)
 		})
 		o("contact removed", async function () {
-			const { app, typeId } = ContactTypeRef
 			const [instanceListId, instanceId] = existingContact._id
 			await model.initWithTemplate({ to: recipients }, "subj", "", [], true, "a@b.c", false)
 			await model.handleEntityEvent({
-				application: app,
-				typeId: typeId,
+				typeRef: ContactTypeRef,
 				operation: OperationType.DELETE,
 				instanceListId,
 				instanceId,
-				type: "Contact",
 			})
 			o(model.allRecipients().length).equals(1)
 			const updatedContact = model.allRecipients().find((r) => r.contact && isSameId(r.contact._id, existingContact._id))

--- a/test/tests/mail/model/ConversationListModelTest.ts
+++ b/test/tests/mail/model/ConversationListModelTest.ts
@@ -347,12 +347,10 @@ o.spec("ConversationListModelTest", () => {
 			o(model.getLabelsForMail(someMail.mail)[1]).notDeepEquals(labels[1])
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailFolderTypeRef.app,
-				typeId: MailFolderTypeRef.typeId,
+				typeRef: MailFolderTypeRef,
 				instanceListId: getListId(labels[1]),
 				instanceId: getElementId(labels[1]),
 				operation: OperationType.DELETE,
-				type: "MailFolder",
 			}
 
 			entityUpdateData.operation = OperationType.UPDATE
@@ -369,12 +367,10 @@ o.spec("ConversationListModelTest", () => {
 			await model.loadInitial()
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailFolderTypeRef.app,
-				typeId: MailFolderTypeRef.typeId,
+				typeRef: MailFolderTypeRef,
 				instanceListId: getListId(labels[1]),
 				instanceId: getElementId(labels[1]),
 				operation: OperationType.DELETE,
-				type: "MailFolder",
 			}
 			entityUpdateData.operation = OperationType.DELETE
 
@@ -389,12 +385,10 @@ o.spec("ConversationListModelTest", () => {
 			const someMail: LoadedMail = model._getMailMap().get(elementIdPart(makeMailId(someIndex)))!
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailSetEntryTypeRef.app,
-				typeId: MailSetEntryTypeRef.typeId,
+				typeRef: MailSetEntryTypeRef,
 				instanceListId: listIdPart(someMail.mailSetEntryId),
 				instanceId: elementIdPart(someMail.mailSetEntryId),
 				operation: OperationType.DELETE,
-				type: "MailSetEntry",
 			}
 
 			const oldItems = model.mails
@@ -428,12 +422,10 @@ o.spec("ConversationListModelTest", () => {
 			})
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailSetEntryTypeRef.app,
-				typeId: MailSetEntryTypeRef.typeId,
+				typeRef: MailSetEntryTypeRef,
 				instanceListId: getListId(newEntry),
 				instanceId: getElementId(newEntry),
 				operation: OperationType.CREATE,
-				type: "MailSetEntry",
 			}
 
 			when(entityClient.load(MailSetEntryTypeRef, newEntry._id)).thenResolve(newEntry)
@@ -513,12 +505,10 @@ o.spec("ConversationListModelTest", () => {
 			const newItems = [...oldItems]
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailSetEntryTypeRef.app,
-				typeId: MailSetEntryTypeRef.typeId,
+				typeRef: MailSetEntryTypeRef,
 				instanceListId: mailSetEntriesListId,
 				instanceId: makeMailSetElementId(0),
 				operation: OperationType.DELETE,
-				type: "MailSetEntry",
 			}
 
 			o(model.mails).deepEquals(oldMails)
@@ -540,12 +530,10 @@ o.spec("ConversationListModelTest", () => {
 			const newItems = [oldMails[1]]
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailSetEntryTypeRef.app,
-				typeId: MailSetEntryTypeRef.typeId,
+				typeRef: MailSetEntryTypeRef,
 				instanceListId: mailSetEntriesListId,
 				instanceId: makeMailSetElementId(2),
 				operation: OperationType.DELETE,
-				type: "MailSetEntry",
 			}
 
 			o(model.mails).deepEquals(oldMails)
@@ -567,12 +555,10 @@ o.spec("ConversationListModelTest", () => {
 			const newItems = [oldMails[1]]
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailSetEntryTypeRef.app,
-				typeId: MailSetEntryTypeRef.typeId,
+				typeRef: MailSetEntryTypeRef,
 				instanceListId: mailSetEntriesListId,
 				instanceId: makeMailSetElementId(1),
 				operation: OperationType.DELETE,
-				type: "MailSetEntry",
 			}
 
 			o(model.mails).deepEquals(oldMails)
@@ -605,12 +591,10 @@ o.spec("ConversationListModelTest", () => {
 			mail.sets = [mailSet._id] // remove all labels
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailTypeRef.app,
-				typeId: MailTypeRef.typeId,
+				typeRef: MailTypeRef,
 				instanceListId: getListId(mail),
 				instanceId: getElementId(mail),
 				operation: OperationType.UPDATE,
-				type: "Mail",
 			}
 			when(entityClient.load(MailTypeRef, mail._id)).thenResolve(mail)
 
@@ -625,12 +609,10 @@ o.spec("ConversationListModelTest", () => {
 			await model.loadInitial()
 			const mail = { ...model.mails[2] }
 			const entityUpdateData: EntityUpdateData = {
-				application: MailTypeRef.app,
-				typeId: MailTypeRef.typeId,
+				typeRef: MailTypeRef,
 				instanceListId: getListId(mail),
 				instanceId: getElementId(mail),
 				operation: OperationType.UPDATE,
-				type: "Mail",
 			}
 			when(entityClient.load(MailTypeRef, mail._id)).thenResolve(mail)
 			entityUpdateData.operation = OperationType.DELETE

--- a/test/tests/mail/model/MailListModelTest.ts
+++ b/test/tests/mail/model/MailListModelTest.ts
@@ -307,12 +307,10 @@ o.spec("MailListModelTest", () => {
 			o(model.getLabelsForMail(someMail.mail)[1]).notDeepEquals(labels[1])
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailFolderTypeRef.app,
-				typeId: MailFolderTypeRef.typeId,
+				typeRef: MailFolderTypeRef,
 				instanceListId: getListId(labels[1]),
 				instanceId: getElementId(labels[1]),
 				operation: OperationType.DELETE,
-				type: "MailFolder",
 			}
 
 			entityUpdateData.operation = OperationType.UPDATE
@@ -329,12 +327,10 @@ o.spec("MailListModelTest", () => {
 			await model.loadInitial()
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailFolderTypeRef.app,
-				typeId: MailFolderTypeRef.typeId,
+				typeRef: MailFolderTypeRef,
 				instanceListId: getListId(labels[1]),
 				instanceId: getElementId(labels[1]),
 				operation: OperationType.DELETE,
-				type: "MailFolder",
 			}
 			entityUpdateData.operation = OperationType.DELETE
 
@@ -349,12 +345,10 @@ o.spec("MailListModelTest", () => {
 			const someMail = model._loadedMails()[someIndex]
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailSetEntryTypeRef.app,
-				typeId: MailSetEntryTypeRef.typeId,
+				typeRef: MailSetEntryTypeRef,
 				instanceListId: listIdPart(someMail.mailSetEntryId),
 				instanceId: elementIdPart(someMail.mailSetEntryId),
 				operation: OperationType.DELETE,
-				type: "MailSetEntry",
 			}
 
 			const oldItems = model.items
@@ -384,12 +378,10 @@ o.spec("MailListModelTest", () => {
 			})
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailSetEntryTypeRef.app,
-				typeId: MailSetEntryTypeRef.typeId,
+				typeRef: MailSetEntryTypeRef,
 				instanceListId: getListId(newEntry),
 				instanceId: getElementId(newEntry),
 				operation: OperationType.CREATE,
-				type: "MailSetEntry",
 			}
 
 			when(entityClient.load(MailSetEntryTypeRef, newEntry._id)).thenResolve(newEntry)
@@ -440,12 +432,10 @@ o.spec("MailListModelTest", () => {
 			mail.sets = [mailSet._id] // remove all labels
 
 			const entityUpdateData: EntityUpdateData = {
-				application: MailTypeRef.app,
-				typeId: MailTypeRef.typeId,
+				typeRef: MailTypeRef,
 				instanceListId: getListId(mail),
 				instanceId: getElementId(mail),
 				operation: OperationType.UPDATE,
-				type: "Mail",
 			}
 			when(entityClient.load(MailTypeRef, mail._id)).thenResolve(mail)
 
@@ -460,12 +450,10 @@ o.spec("MailListModelTest", () => {
 			await model.loadInitial()
 			const mail = { ...model.items[2] }
 			const entityUpdateData: EntityUpdateData = {
-				application: MailTypeRef.app,
-				typeId: MailTypeRef.typeId,
+				typeRef: MailTypeRef,
 				instanceListId: getListId(mail),
 				instanceId: getElementId(mail),
 				operation: OperationType.UPDATE,
-				type: "Mail",
 			}
 			when(entityClient.load(MailTypeRef, mail._id)).thenResolve(mail)
 			entityUpdateData.operation = OperationType.DELETE

--- a/test/tests/mail/view/ConversationViewModelTest.ts
+++ b/test/tests/mail/view/ConversationViewModelTest.ts
@@ -21,6 +21,7 @@ import { isSameId } from "../../../../src/common/api/common/utils/EntityUtils.js
 import { createTestEntity } from "../../TestUtils.js"
 import { MailboxDetail, MailboxModel } from "../../../../src/common/mailFunctionality/MailboxModel.js"
 import { MailModel } from "../../../../src/mail-app/mail/model/MailModel.js"
+import { ClientModelInfo } from "../../../../src/common/api/common/EntityFunctions"
 
 o.spec("ConversationViewModel", function () {
 	let conversation: ConversationEntry[]
@@ -55,7 +56,7 @@ o.spec("ConversationViewModel", function () {
 	async function makeViewModel(pMail: Mail): Promise<void> {
 		const factory = await viewModelFactory()
 		const mailboxProperties = createTestEntity(MailboxPropertiesTypeRef)
-		const entityClient = new EntityClient(entityRestClientMock)
+		const entityClient = new EntityClient(entityRestClientMock, ClientModelInfo.getNewInstanceForTestsOnly())
 
 		const eventController: EventController = {
 			addEntityListener: (listener) => {
@@ -248,12 +249,10 @@ o.spec("ConversationViewModel", function () {
 			await eventCallback(
 				[
 					{
-						application: "tutanota",
-						typeId: ConversationEntryTypeRef.typeId,
+						typeRef: ConversationEntryTypeRef,
 						operation: OperationType.CREATE,
 						instanceListId: listId,
 						instanceId: yetAnotherMail.conversationEntry[1],
-						type: "ConversationEntry",
 					},
 				],
 				"mailGroupId",
@@ -287,12 +286,10 @@ o.spec("ConversationViewModel", function () {
 			await eventCallback(
 				[
 					{
-						application: "tutanota",
-						typeId: ConversationEntryTypeRef.typeId,
+						typeRef: ConversationEntryTypeRef,
 						operation: OperationType.UPDATE,
 						instanceListId: listId,
 						instanceId: anotherMail.conversationEntry[1],
-						type: "ConversationEntry",
 					},
 				],
 				"mailGroupId",
@@ -315,12 +312,10 @@ o.spec("ConversationViewModel", function () {
 			await eventCallback(
 				[
 					{
-						application: "tutanota",
-						typeId: ConversationEntryTypeRef.typeId,
+						typeRef: ConversationEntryTypeRef,
 						operation: OperationType.CREATE,
 						instanceListId: listId,
 						instanceId: yetAnotherMail.conversationEntry[1],
-						type: "ConversationEntry",
 					},
 				],
 				"mailGroupId",
@@ -341,12 +336,10 @@ o.spec("ConversationViewModel", function () {
 			await eventCallback(
 				[
 					{
-						application: "tutanota",
-						typeId: ConversationEntryTypeRef.typeId,
+						typeRef: ConversationEntryTypeRef,
 						operation: OperationType.CREATE,
 						instanceListId: listId,
 						instanceId: yetAnotherMail.conversationEntry[1],
-						type: "ConversationEntry",
 					},
 				],
 				"mailGroupId",
@@ -382,12 +375,10 @@ o.spec("ConversationViewModel", function () {
 			await eventCallback(
 				[
 					{
-						application: "tutanota",
-						typeId: ConversationEntryTypeRef.typeId,
+						typeRef: ConversationEntryTypeRef,
 						operation: OperationType.UPDATE,
 						instanceListId: listId,
 						instanceId: trashDraftMail.conversationEntry[1],
-						type: "ConversationEntry",
 					},
 				],
 				"mailGroupId",

--- a/test/tests/misc/ClientDetectorTest.ts
+++ b/test/tests/misc/ClientDetectorTest.ts
@@ -2,6 +2,7 @@ import o from "@tutao/otest"
 import { client } from "../../../src/common/misc/ClientDetector.js"
 import { Mode } from "../../../src/common/api/common/Env.js"
 import { AppType, BrowserType, DeviceType } from "../../../src/common/misc/ClientConstants.js"
+import { withOverriddenEnv } from "../TestUtils"
 
 o.spec("ClientDetector test", function () {
 	o("ClientDetector detect chrome windows", () => {
@@ -196,14 +197,6 @@ o.spec("ClientDetector test", function () {
 		o(client.isMobileDevice()).equals(true)
 	})
 	o.spec("app", function () {
-		let prevMode
-		o.before(function () {
-			prevMode = env.mode
-			env.mode = Mode.App
-		})
-		o.after(function () {
-			env.mode = prevMode
-		})
 		o("ClientDetector the android 4 in app mode supported", () => {
 			client.init(
 				"Mozilla/5.0 (Linux U Android 4.0, de-de HTC_Desire_X Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
@@ -238,23 +231,19 @@ o.spec("ClientDetector test", function () {
 			o(client.device).equals(DeviceType.DESKTOP)
 			o(client.isMobileDevice()).equals(false)
 		})
-		o("ClientDetector firefox os is supported", () => {
-			env.mode = Mode.App
-			client.init("Mozilla/5.0 (Mobile rv:26.0) Gecko/26.0 Firefox/26.0", "Linux")
+		o("ClientDetector firefox os is supported", async () => {
+			await withOverriddenEnv({ mode: Mode.App }, () => client.init("Mozilla/5.0 (Mobile rv:26.0) Gecko/26.0 Firefox/26.0", "Linux"))
 			o(client.browser).equals(BrowserType.FIREFOX)
 			o(client.browserVersion).equals(26)
 			o(client.device).equals(DeviceType.OTHER_MOBILE)
 			o(client.isMobileDevice()).equals(true)
-			env.mode = Mode.Browser
 		})
-		o("ClientDetector firefox os tablet is supported", () => {
-			env.mode = Mode.App
-			client.init("Mozilla/5.0 (Tablet rv:26.0) Gecko/26.0 Firefox/26.0", "Linux")
+		o("ClientDetector firefox os tablet is supported", async () => {
+			await withOverriddenEnv({ mode: Mode.App }, () => client.init("Mozilla/5.0 (Tablet rv:26.0) Gecko/26.0 Firefox/26.0", "Linux"))
 			o(client.browser).equals(BrowserType.FIREFOX)
 			o(client.browserVersion).equals(26)
 			o(client.device).equals(DeviceType.OTHER_MOBILE)
 			o(client.isMobileDevice()).equals(true)
-			env.mode = Mode.Browser
 		})
 	})
 	o("old Chrome is not supported", function () {
@@ -282,61 +271,68 @@ o.spec("ClientDetector test", function () {
 })
 
 o.spec("ClientDetector AppType test", function () {
-	o.beforeEach(function () {
-		env.mode = Mode.App
-	})
-	o("ClientDetector detect calendar app on Android", () => {
-		client.init(
-			"Mozilla/5.0 (Linux Android 4.1.1 HTC Desire X Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36",
-			"Linux",
-			AppType.Calendar,
-		)
-		o(client.device).equals(DeviceType.ANDROID)
-		o(client.isMobileDevice()).equals(true)
-		o(client.getIdentifier()).equals("Android Calendar App")
-	})
-
-	o("ClientDetector detect calendar app on iPhone", () => {
-		client.init(
-			"Mozilla/5.0 (iPhone CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
-			"Linux",
-			AppType.Calendar,
-		)
-		o(client.device).equals(DeviceType.IPHONE)
-		o(client.isMobileDevice()).equals(true)
-		o(client.getIdentifier()).equals("iPhone Calendar App")
+	o("ClientDetector detect calendar app on Android", async () => {
+		await withOverriddenEnv({ mode: Mode.App }, () => {
+			client.init(
+				"Mozilla/5.0 (Linux Android 4.1.1 HTC Desire X Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36",
+				"Linux",
+				AppType.Calendar,
+			)
+			o(client.device).equals(DeviceType.ANDROID)
+			o(client.isMobileDevice()).equals(true)
+			o(client.getIdentifier()).equals("Android Calendar App")
+		})
 	})
 
-	o("ClientDetector detect mail app on Android", () => {
-		client.init(
-			"Mozilla/5.0 (Linux Android 4.1.1 HTC Desire X Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36",
-			"Linux",
-			AppType.Mail,
-		)
-		o(client.device).equals(DeviceType.ANDROID)
-		o(client.isMobileDevice()).equals(true)
-		o(client.getIdentifier()).equals("Android Mail App")
+	o("ClientDetector detect calendar app on iPhone", async () => {
+		await withOverriddenEnv({ mode: Mode.App }, () => {
+			client.init(
+				"Mozilla/5.0 (iPhone CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
+				"Linux",
+				AppType.Calendar,
+			)
+			o(client.device).equals(DeviceType.IPHONE)
+			o(client.isMobileDevice()).equals(true)
+			o(client.getIdentifier()).equals("iPhone Calendar App")
+		})
 	})
 
-	o("ClientDetector detect mail app on iPhone", () => {
-		client.init(
-			"Mozilla/5.0 (iPhone CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
-			"Linux",
-			AppType.Mail,
-		)
-		o(client.device).equals(DeviceType.IPHONE)
-		o(client.isMobileDevice()).equals(true)
-		o(client.getIdentifier()).equals("iPhone Mail App")
+	o("ClientDetector detect mail app on Android", async () => {
+		await withOverriddenEnv({ mode: Mode.App }, () => {
+			client.init(
+				"Mozilla/5.0 (Linux Android 4.1.1 HTC Desire X Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36",
+				"Linux",
+				AppType.Mail,
+			)
+			o(client.device).equals(DeviceType.ANDROID)
+			o(client.isMobileDevice()).equals(true)
+			o(client.getIdentifier()).equals("Android Mail App")
+		})
 	})
 
-	o("ClientDetector throws on wrong configuration", () => {
-		client.init(
-			"Mozilla/5.0 (iPhone CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
-			"Linux",
-			AppType.Integrated,
-		)
-		o(client.device).equals(DeviceType.IPHONE)
-		o(client.isMobileDevice()).equals(true)
-		o(() => client.getIdentifier()).throws("AppType.Integrated is not allowed for mobile apps")
+	o("ClientDetector detect mail app on iPhone", async () => {
+		await withOverriddenEnv({ mode: Mode.App }, () => {
+			client.init(
+				"Mozilla/5.0 (iPhone CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
+				"Linux",
+				AppType.Mail,
+			)
+			o(client.device).equals(DeviceType.IPHONE)
+			o(client.isMobileDevice()).equals(true)
+			o(client.getIdentifier()).equals("iPhone Mail App")
+		})
+	})
+
+	o("ClientDetector throws on wrong configuration", async () => {
+		await withOverriddenEnv({ mode: Mode.App }, () => {
+			client.init(
+				"Mozilla/5.0 (iPhone CPU iPhone OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
+				"Linux",
+				AppType.Integrated,
+			)
+			o(client.device).equals(DeviceType.IPHONE)
+			o(client.isMobileDevice()).equals(true)
+			o(() => client.getIdentifier()).throws("AppType.Integrated is not allowed for mobile apps")
+		})
 	})
 })

--- a/test/tests/misc/UsageTestModelTest.ts
+++ b/test/tests/misc/UsageTestModelTest.ts
@@ -32,6 +32,7 @@ import { UserController } from "../../../src/common/api/main/UserController.js"
 import { createUserSettingsGroupRoot, UserSettingsGroupRootTypeRef } from "../../../src/common/api/entities/tutanota/TypeRefs.js"
 import { EventController } from "../../../src/common/api/main/EventController.js"
 import { createTestEntity } from "../TestUtils.js"
+import { ClientModelInfo } from "../../../src/common/api/common/EntityFunctions"
 
 const { anything } = matchers
 
@@ -93,6 +94,7 @@ o.spec("UsageTestModel", function () {
 
 		ephemeralStorage = new EphemeralUsageTestStorage()
 		persistentStorage = new EphemeralUsageTestStorage()
+		let clientModelResolver = ClientModelInfo.getNewInstanceForTestsOnly()
 		usageTestModel = new UsageTestModel(
 			{
 				[StorageBehavior.Persist]: persistentStorage,
@@ -104,6 +106,7 @@ o.spec("UsageTestModel", function () {
 			loginControllerMock,
 			eventControllerMock,
 			() => usageTestController,
+			clientModelResolver,
 		)
 
 		replace(usageTestModel, "customerProperties", createTestEntity(CustomerPropertiesTypeRef, { usageDataOptedOut: false }))


### PR DESCRIPTION
Passing instances explicitly avoids the situations where some of them might not be initialized.

We also simplified the entity handling by converting entity updates to data with resolved types early so that the listening code doesn't have to deal with it.

We did fix some of the bad test practices, e.g. setting/restoring env incorrectly. This matters now because accessors for type model initializers check env.mode.