### PR TITLE
Web client: sort ServiceWorker filesToCache

### DIFF
--- a/buildSrc/buildWebapp.js
+++ b/buildSrc/buildWebapp.js
@@ -231,7 +231,7 @@ async function bundleServiceWorker(bundles, version, minify, buildDir, tsConfig)
 			{
 				name: "sw-banner",
 				banner() {
-					return `function filesToCache() { return ${JSON.stringify(filesToCache)} }
+					return `function filesToCache() { return ${JSON.stringify(filesToCache.sort())} }
 					function version() { return "${version}" }
 					function customDomainCacheExclusions() { return ${JSON.stringify(customDomainFileExclusions)} }`
 				},


### PR DESCRIPTION
This is intended to support [build reproducibility](https://reproducible-builds.org), providing a deterministic ordering (provided that the filenames themselves are produced deterministically by RollUp, which I believe they are) for the `filesToCache` list in the ServiceWorker script file.

Although I'm relatively confident in this fix, I haven't been able to build/test it locally yet, so I'm opening this PR in draft status.

May resolve #1016.