### PR TITLE
Have IndexedDbIndexer handle mail entity events

### DIFF
--- a/test/tests/api/worker/search/MailIndexerTest.ts
+++ b/test/tests/api/worker/search/MailIndexerTest.ts
@@ -455,25 +455,6 @@ o.spec("MailIndexer", () => {
 			return { mail, mailDetails: mailDetailsBlob.details, attachments: files }
 		}
 
-		o.spec("processEntityEvents", function () {
-			o.test("do not delete if mailIndexing is disabled", async function () {
-				await initWithEnabled(false)
-
-				const events = [createUpdate(OperationType.DELETE, mailListId, "3")]
-				await indexer.processEntityEvents(events, "group-id", "batch-id")
-				verify(entityClient.load(matchers.anything(), matchers.anything()), { times: 0 })
-				verify(backend.onMailDeleted(matchers.anything()), { times: 0 })
-			})
-
-			o.test("deletes if mailIndexing is enabled", async function () {
-				await initWithEnabled(true)
-
-				const events = [createUpdate(OperationType.DELETE, mailListId, "3")]
-				await indexer.processEntityEvents(events, "group-id", "batch-id")
-				verify(backend.onMailDeleted(matchers.anything()))
-			})
-		})
-
 		o.spec("afterMailCreated", () => {
 			o.test("no-op if mailIndexing is disabled", async () => {
 				await initWithEnabled(false)


### PR DESCRIPTION
We removed directly handling entity events from MailIndexer, as we want the events to be processed from offline storage, ensuring that events are not missed. However, in doing so, events from IndexedDbIndexer are ignored.

IndexedDbIndexer keeps track of its own batch ID, and we can simply call the same functions that CustomMailCacheHandler would have called before the batch ID is written.

Closes #9026