### PR TITLE
Handle GroupMember changes when loading calendars

### DIFF
--- a/src/calendar-app/calendar/search/model/CalendarSearchModel.ts
+++ b/src/calendar-app/calendar/search/model/CalendarSearchModel.ts
@@ -103,7 +103,7 @@ export class CalendarSearchModel {
 				await calendarModel.loadContactsBirthdays()
 			}
 
-			await calendarModel.loadMonthsIfNeeded(daysInMonths, monitor, this.cancelSignal)
+			await calendarModel.loadMonthsIfNeeded(daysInMonths, this.cancelSignal, monitor)
 			monitor.completed()
 
 			const eventsForDays = calendarModel.getEventsForMonths()()

--- a/src/calendar-app/calendar/view/CalendarViewModel.ts
+++ b/src/calendar-app/calendar/view/CalendarViewModel.ts
@@ -628,7 +628,7 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 	}
 
 	loadMonthsIfNeeded(daysInMonths: Array<Date>, progressMonitor: IProgressMonitor, canceled: Stream<boolean>): Promise<void> {
-		return this.eventsRepository.loadMonthsIfNeeded(daysInMonths, progressMonitor, canceled)
+		return this.eventsRepository.loadMonthsIfNeeded(daysInMonths, canceled, progressMonitor)
 	}
 
 	private doRedraw() {

--- a/src/mail-app/search/model/SearchModel.ts
+++ b/src/mail-app/search/model/SearchModel.ts
@@ -123,7 +123,7 @@ export class SearchModel {
 				await calendarModel.loadContactsBirthdays()
 			}
 
-			await calendarModel.loadMonthsIfNeeded(daysInMonths, monitor, this.cancelSignal)
+			await calendarModel.loadMonthsIfNeeded(daysInMonths, this.cancelSignal, monitor)
 			monitor.completed()
 
 			const eventsForDays = calendarModel.getEventsForMonths()()


### PR DESCRIPTION
We currently don't fetch the new memberships when the user joins/leaves a shared calendar.

This commit changes the logic of loadMonthsIfNeeded and starts listening for GroupMember entity events updates, so when a GroupMember is added or removed, the calendar related to that membership is also added or removed.