### PR TITLE
Collapse the quoted reply by default when replying to a mail thread

### DIFF
--- a/src/mail-app/mail/editor/MailEditor.ts
+++ b/src/mail-app/mail/editor/MailEditor.ts
@@ -96,6 +96,8 @@ import {
 import { mailLocator } from "../../mailLocator.js"
 
 import { handleRatingByEvent } from "../../../common/ratings/UserSatisfactionDialog.js"
+import { theme } from "../../../common/gui/theme"
+import { px, size } from "../../../common/gui/size"
 
 export type MailEditorAttrs = {
 	model: SendMailModel
@@ -157,6 +159,8 @@ export class MailEditor implements Component<MailEditorAttrs> {
 	// if we're set to block external content, but there is no content to block,
 	// we don't want to show the banner.
 	private blockedExternalContent: number = 0
+	private collapseQuotedReply: boolean = true
+	private collapsedReply: HTMLElement | null = null
 
 	constructor(vnode: Vnode<MailEditorAttrs>) {
 		const a = vnode.attrs
@@ -205,6 +209,9 @@ export class MailEditor implements Component<MailEditorAttrs> {
 			}
 
 			this.processInlineImages()
+			this.editor.squire.modifyDocument(() => {
+				this.processQuotedReply(editorDom)
+			})
 
 			// Add mutation observer to remove attachments when corresponding DOM element is removed
 			new MutationObserver(onEditorChanged).observe(this.editor.getDOM(), {
@@ -213,7 +220,14 @@ export class MailEditor implements Component<MailEditorAttrs> {
 				subtree: true,
 			})
 			// since the editor is the source for the body text, the model won't know if the body has changed unless we tell it
-			this.editor.addChangeListener(() => model.setBody(replaceInlineImagesWithCids(this.editor.getDOM()).innerHTML))
+			this.editor.addChangeListener(() => {
+				const editorDom = this.editor.getDOM()
+				this.editor.squire.modifyDocument(() => {
+					// we process with modifyDocument to not raise an input event as that would cause and infinite loop
+					this.processQuotedReply(editorDom)
+				})
+				model.setBody(this.getBodyHtml(editorDom))
+			})
 			this.editor.addEventListener("pasteImage", ({ detail }: ImagePasteEvent) => {
 				const items = Array.from(detail.clipboardData.items)
 				const imageItems = items.filter((item) => /image/.test(item.type))
@@ -301,6 +315,73 @@ export class MailEditor implements Component<MailEditorAttrs> {
 				m.redraw()
 			})
 		})
+	}
+
+	private processQuotedReply(dom: HTMLElement): void {
+		if (!this.collapseQuotedReply) {
+			return
+		}
+
+		const alreadyCollapsedReply = dom.querySelector("[tuta-collapsed-quote=true]")
+		const collapsableReply = dom.querySelector(".tutanota_quote .tutanota_quote")
+		if (collapsableReply != null) {
+			this.collapsedReply = collapsableReply as HTMLElement
+		}
+
+		const elementToReplace = collapsableReply ?? alreadyCollapsedReply
+		// we recreate the already collapsed reply to re-add the click handler that would otherwise be removed by undo
+		if (elementToReplace != null) {
+			const quoteWrap = document.createElement("div")
+			quoteWrap.setAttribute("tuta-collapsed-quote", "true")
+
+			elementToReplace.replaceWith(quoteWrap)
+
+			const quoteIndicator = document.createElement("div")
+			quoteIndicator.style.borderLeft = `2px solid ${theme.content_border}`
+			quoteIndicator.style.paddingLeft = "2px"
+			quoteIndicator.style.marginTop = px(size.vpad)
+
+			m.render(
+				quoteIndicator,
+				m(
+					".ml-button.fit-content",
+					{
+						style: {
+							borderRadius: "25%",
+							border: `1px solid ${theme.list_border}`,
+						},
+					},
+					m(IconButton, {
+						icon: Icons.More,
+						title: "showText_action",
+						size: ButtonSize.Normal,
+						click: () => this.expandQuotedReply(quoteWrap),
+					}),
+				),
+			)
+
+			quoteWrap.appendChild(quoteIndicator)
+		}
+	}
+
+	private expandQuotedReply(quoteWrap: HTMLElement): void {
+		this.collapseQuotedReply = false
+		this.editor.squire.modifyDocument(() => {
+			if (this.collapsedReply != null) {
+				quoteWrap.replaceWith(this.collapsedReply)
+				this.collapsedReply = null
+			}
+		})
+	}
+
+	private getBodyHtml(editorDom: HTMLElement): string {
+		const modifiedDom = replaceInlineImagesWithCids(editorDom)
+		if (this.collapsedReply != null) {
+			const collapsedQuote = modifiedDom.querySelector("[tuta-collapsed-quote=true]")
+			// note that the user may have deleted the quote, but if not, we can expand it here
+			collapsedQuote?.replaceWith(this.collapsedReply)
+		}
+		return modifiedDom.innerHTML
 	}
 
 	private downloadInlineImage(model: SendMailModel, cid: string) {

--- a/src/mail-app/mail/view/MailViewerViewModel.ts
+++ b/src/mail-app/mail/view/MailViewerViewModel.ts
@@ -862,7 +862,7 @@ export class MailViewerViewModel {
 
 		const mailSubject = this.getSubject() || ""
 		infoLine += lang.get("subject_label") + ": " + urlEncodeHtmlTags(mailSubject)
-		let body = infoLine + '<br><br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
+		const body = infoLine + '<br><br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
 		const { prependEmailSignature } = await import("../signature/Signature")
 		const senderMailAddress = await this.getSenderOfResponseMail()
 		return {
@@ -898,14 +898,14 @@ export class MailViewerViewModel {
 				address: mailAddressAndName.address,
 				contact: null,
 			})
-			let prefix = "Re: "
+			const prefix = "Re: "
 			const mailSubject = this.getSubject()
-			let subject = mailSubject ? (startsWith(mailSubject.toUpperCase(), prefix.toUpperCase()) ? mailSubject : prefix + mailSubject) : ""
-			let infoLine = formatDateTime(this.getDate()) + " " + lang.get("by_label") + " " + sender.address + ":"
-			let body = infoLine + '<br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
-			let toRecipients: MailAddress[] = []
-			let ccRecipients: MailAddress[] = []
-			let bccRecipients: MailAddress[] = []
+			const subject = mailSubject ? (startsWith(mailSubject.toUpperCase(), prefix.toUpperCase()) ? mailSubject : prefix + mailSubject) : ""
+			const infoLine = formatDateTime(this.getDate()) + " " + lang.get("by_label") + " " + sender.address + ":"
+			const body = infoLine + '<br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
+			const toRecipients: MailAddress[] = []
+			const ccRecipients: MailAddress[] = []
+			const bccRecipients: MailAddress[] = []
 
 			if (!this.logins.getUserController().isInternalUser() && this.isReceivedMail()) {
 				toRecipients.push(sender)


### PR DESCRIPTION
Replying to a long email thread causes lag issues on some mobile devices. This happens because each reply introduces another level of nesting.

This change collapses replies that are 2+ levels deep by default in the MailEditor. The thread can be expanded using a quote expander button.

Close #617

Co-authored-by: paw <paw-hub@users.noreply.github.com>