### PR TITLE
Change bump-version to only update tuta-sdk and node-mimimi

### DIFF
--- a/buildSrc/bump-version.js
+++ b/buildSrc/bump-version.js
@@ -73,7 +73,7 @@ async function bumpVersionInCargoWorkspace(newVersionString) {
 		console.log(`rust: Updated ${workspaceFilePath} package.version to ${newVersionString}`)
 		await fs.promises.writeFile(workspaceFilePath, newContents)
 		// regenerate the lockfile
-		await $`cargo update && cargo check --all`
+		await $`cargo update tuta-sdk tutao_node-mimimi && cargo check --all`
 	}
 }
 


### PR DESCRIPTION
When bumping version we ran into an issue with base64ct that got updated to version 1.8.0 which requires Rust 1.85. Rather than pinning dependencies, we decided to change bump-version to only update tuta-sdk and node-mimimi for now. Though we probably should revisit the matter at a later point.

Co-authored-by: paw <paw-hub@users.noreply.github.com>
Co-authored-by: ivk <ivk@tutao.de>