### PR TITLE
Correcting a misleading

### DIFF
--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -166,7 +166,7 @@ export default {
 		"birthdayEventAge_title": "{age} years old",
 		"birthdayEvent_title": "{name}'s birthday",
 		"birthday_alt": "Birthday",
-		"blockExternalContentSender_action": "Always block sender",
+		"blockExternalContentSender_action": "Never trust sender",
 		"blue_label": "Blue",
 		"bonusMonth_msg": "You have been granted {months} bonus months.",
 		"bonus_label": "Bonus",


### PR DESCRIPTION
"Always block sender" is misleading as it sounds like the user will prevent the sender from contacting the user. What this button actually does is preventing images from loading in emails from that specific sender.