### PR TITLE
Use one regex in splitTextForHighlighting

### DIFF
--- a/test/tests/api/common/utils/QueryTokenUtilsTest.ts
+++ b/test/tests/api/common/utils/QueryTokenUtilsTest.ts
@@ -23,7 +23,7 @@ o.spec("QueryTokenUtils", () => {
 			])
 		})
 	})
-	o.spec("highlightTextInQuery", () => {
+	o.spec("splitTextForHighlighting", () => {
 		o.test("exact match", () => {
 			o.check(splitTextForHighlighting("my very eager mother just sold us nine pizzas", splitQuery('"my very eager"'))).deepEquals([
 				{ text: "my very eager", highlighted: true },
@@ -60,6 +60,31 @@ o.spec("QueryTokenUtils", () => {
 				{ text: " mother just sold us nine ", highlighted: false },
 				{ text: "pizza", highlighted: true },
 				{ text: "s", highlighted: false },
+			])
+		})
+		o.test("tokens are substrings of other tokens", () => {
+			o.check(splitTextForHighlighting("is this a mail or a thesis", splitQuery("is this a mail or a thesis"))).deepEquals([
+				{ text: "is", highlighted: true },
+				{ text: " ", highlighted: false },
+				{ text: "this", highlighted: true },
+				{ text: " ", highlighted: false },
+				{ text: "a", highlighted: true },
+				{ text: " ", highlighted: false },
+				{ text: "mail", highlighted: true },
+				{ text: " ", highlighted: false },
+				{ text: "or", highlighted: true },
+				{ text: " ", highlighted: false },
+				{ text: "a", highlighted: true },
+				{ text: " ", highlighted: false },
+				{ text: "thesis", highlighted: true },
+			])
+			o.check(splitTextForHighlighting("is this a mail or a thesis", splitQuery('"is this a mail or a thesis"'))).deepEquals([
+				{ text: "is this a mail or a thesis", highlighted: true },
+			])
+		})
+		o.test("empty query", () => {
+			o.check(splitTextForHighlighting("this will just be returned back", [])).deepEquals([
+				{ text: "this will just be returned back", highlighted: false },
 			])
 		})
 	})


### PR DESCRIPTION
We can use a regex with a chained 'or' expression, and it will try to greedily match as much as possible.

This also simplifies the code a bit, removing one level of looping.

Closes #9142