### PR TITLE
fix version null check when loading public encryption keys 

### DIFF
--- a/src/common/api/worker/facades/PublicKeyProvider.ts
+++ b/src/common/api/worker/facades/PublicKeyProvider.ts
@@ -44,7 +44,7 @@ export class PublicKeyProvider {
 
 	async loadPubKey(pubKeyIdentifier: PublicKeyIdentifier, version: KeyVersion | null): Promise<Versioned<PublicKey>> {
 		const requestData = createPublicKeyGetIn({
-			version: version ? String(version) : null,
+			version: version != null ? String(version) : null,
 			identifier: pubKeyIdentifier.identifier,
 			identifierType: pubKeyIdentifier.identifierType,
 		})


### PR DESCRIPTION
ultimately this resulted in authentication failed status for tuta crypt messages

## Test Notes
- [ ] Send a mail to an account with TutaCrypt keys. (The recipient must not be logged-in).
- [ ] Rotate the sender group keys.
- [ ] Login as the recipient and show the mail.
- [ ] Verify it decrypts and there is no warning banner shown.