### PR TITLE
loadAndSelect in ConversationListModel should call onSingleSelection

### DIFF
--- a/src/mail-app/mail/model/ConversationListModel.ts
+++ b/src/mail-app/mail/model/ConversationListModel.ts
@@ -310,8 +310,11 @@ export class ConversationListModel implements MailSetListModel {
 			// variable so that the conversation can be selected, but then the mail we wanted is actually displayed.
 			if (!isSameId(conversation.getDisplayedMailId(), selectedMailId)) {
 				this.olderDisplayedSelectedMailOverride = selectedMailId
-				this.listModel.onSingleSelection(conversation)
 			}
+
+			// We aren't letting ListModel's loadAndSelect do the actual selection since the above case can happen, so
+			// we'll just select it here (as this is what ListModel would have done if it found it)
+			this.listModel.onSingleSelection(conversation)
 		}
 		return selectedMail
 	}

--- a/test/tests/mail/model/ConversationListModelTest.ts
+++ b/test/tests/mail/model/ConversationListModelTest.ts
@@ -346,10 +346,14 @@ o.spec("ConversationListModel", () => {
 		const unloadedMail = elementIdPart(makeMailId(1)) // a mail that will be on the bottom of the list
 		const mail = model.getMail(unloadedMail)
 		o.check(mail).equals(null)
+		o.check(model.getSelectedAsArray()).deepEquals([])
 
 		// Should now be loaded
 		const loadedMail = assertNotNull(await model.loadAndSelect(unloadedMail, () => false))
 		o.check(loadedMail).equals(model.getMail(unloadedMail))
+
+		// ...and selected
+		o.check(model.getSelectedAsArray()).deepEquals([loadedMail])
 	})
 
 	o.test("handle create events while already loaded", async () => {


### PR DESCRIPTION
We are not relying on the list model to do this, since we might have older mails get selected. In this case, we were already calling onSingleSelection, but not in the case where it was the latest mail of a conversation. We should unconditionally call this.

Closes #9208