### PR TITLE
fix free accounts not caching mails

### DIFF
--- a/src/mail-app/workerUtils/offline/MailOfflineCleaner.ts
+++ b/src/mail-app/workerUtils/offline/MailOfflineCleaner.ts
@@ -1,4 +1,4 @@
-import { assertNotNull, groupByAndMap } from "@tutao/tutanota-utils"
+import { assertNotNull, daysToMillis, groupByAndMap } from "@tutao/tutanota-utils"
 import {
 	constructMailSetEntryId,
 	elementIdPart,
@@ -30,7 +30,7 @@ export class MailOfflineCleaner implements OfflineStorageCleaner {
 			const user = await offlineStorage.get(UserTypeRef, null, userId)
 			// Free users always have default time range regardless of what is stored
 			const isFreeUser = user?.accountType === AccountType.FREE
-			const cutoffDate = isFreeUser || timeRangeDate == null ? new Date(now - OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS) : timeRangeDate
+			const cutoffDate = isFreeUser || timeRangeDate == null ? new Date(now - daysToMillis(OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS)) : timeRangeDate
 			this.cutOffId = constructMailSetEntryId(new Date(cutoffDate), GENERATED_MAX_ID)
 		}
 		return this.cutOffId


### PR DESCRIPTION
In case of a free account the MailOfflineCleaner.ts cutOffDate was always set to the current now() - 31 ms
(see OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS_MS).
This is obviously wrong, and it should be set to now() - 31 days in ms. This commit fixes the issue.