### PR TITLE
9235 handle splitscreen configchange

### DIFF
--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
 		<!-- we do not want to restart activity for most of the things. uiMode changes with dark mode. -->
 		<activity
 				android:name=".MainActivity"
-				android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|uiMode"
+				android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|uiMode|screenLayout|smallestScreenSize"
 				android:launchMode="singleInstance"
 				android:theme="@style/SplashTheme"
 				android:exported="true">


### PR DESCRIPTION
App were restarting when user split screen/resized. 
Fixed multi window configuration changes by adding "screenSize and smallestScreenSize" in android:configChanges which will receive a callback to onConfigurationChanged() instead of restarting app.

Close #9235