### PR TITLE
On three column layout, printing also prints the mailist

### DIFF
--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -2678,11 +2678,8 @@ styles.registerStyle("main", () => {
 				display: "initial",
 				position: "initial",
 			},
-			".view-column:nth-child(1), .view-column:nth-child(2)": {
-				display: "none",
-			},
 			".view-column": {
-				width: "100% !important",
+				display: "none",
 			},
 			".mail-viewer": {
 				overflow: "visible",
@@ -2714,7 +2711,7 @@ styles.registerStyle("main", () => {
 			".bottom-nav": {
 				display: "none",
 			},
-			".mobile .view-column:nth-child(2)": {
+			".view-column:nth-last-child(1)": {
 				display: "initial",
 			},
 			".folder-column": {


### PR DESCRIPTION
Usually mobile view have two column layout and while printing we only prints the mail viewing column and hides the maillist column. When
 it comes to tabPro or ipadPro there we have three column layout and
 only hides first colum layout and prints remaining two column layouts
 (which contains maillist and mailviewer column).

 Fixed by changing the styles, if it is mobile view and three column
 layout, hides the first two and only print the mailviewer column.

close #9211