### PR TITLE
[android] Fix crash on armeabi-v7a

### DIFF
--- a/libs/sqlcipher-android/README-android-sqlcipher.md
+++ b/libs/sqlcipher-android/README-android-sqlcipher.md
@@ -23,5 +23,5 @@ podman run --rm \
   -it android-sqlcipher
 # This will produce the artifact at build-sqlcipher/sqlcipher-android-4.7.2-release.aar
 # Move it to its final destination
-mv build-sqlcipher/sqlcipher-android-${SQLCIPHER_ANDROID_VERSION}-release.aar app-android/libs/sqlcipher-android.aar
+mv build-sqlcipher/sqlcipher-android-${SQLCIPHER_ANDROID_VERSION}-release.aar ../../app-android/libs/sqlcipher-android.aar
 ```

--- a/libs/sqlcipher-android/build-sqlcipher-android.sh
+++ b/libs/sqlcipher-android/build-sqlcipher-android.sh
@@ -5,7 +5,7 @@ set -exu
 # clone OpenSSL, needed as part of the build of both old and new sqlcipher
 git clone https://github.com/openssl/openssl
 pushd openssl
-git checkout openssl-3.5.0
+git checkout openssl-3.5.1
 popd
 
 # Clone the main SQLCipher repo


### PR DESCRIPTION
Caused by a bug in OpenSSL:
https://github.com/openssl/openssl/commit/b7f6519229a6002f944626ab3db216175dd0f142

The code for AES was reading from invalid place in memory instead of static memory region.

Bump OpenSSL used in sqlcipher-android to 3.5.1.

Fix #9224