### PR TITLE
[ios] Fix duplicates when syncing contacts created natively

### DIFF
--- a/app-ios/tutanota/Sources/Contacts/IosMobileContactsFacade.swift
+++ b/app-ios/tutanota/Sources/Contacts/IosMobileContactsFacade.swift
@@ -34,7 +34,7 @@ class IosMobileContactsFacade: MobileContactsFacade {
 		)
 		try contactList.insert(contacts: queryResult.newServerContacts)
 		try contactList.update(contacts: queryResult.existingServerContacts)
-		try contactList.insert(
+		try contactList.setContactMapping(
 			contacts: queryResult.nativeContactWithoutSourceId.map {
 				let serverId = $0.serverId
 				return $0.contact.toStructuredContact(serverId: serverId)
@@ -64,7 +64,7 @@ class IosMobileContactsFacade: MobileContactsFacade {
 
 		// For sync it normally wouldn't happen that we have a contact without source/server id but for existing contacts without
 		// hashes we want to write the hashes on the first run so we reuse this field.
-		try contactList.insert(
+		try contactList.setContactMapping(
 			contacts: matchResult.nativeContactWithoutSourceId.map {
 				let serverId = $0.serverId
 				return $0.contact.toStructuredContact(serverId: serverId)

--- a/app-ios/tutanota/Sources/Contacts/UserContactMapping.swift
+++ b/app-ios/tutanota/Sources/Contacts/UserContactMapping.swift
@@ -40,6 +40,18 @@ class UserContactList {
 	/// Returns the mapping between the iOS contact IDs and the Tuta server IDs
 	func getMapping() -> UserContactMapping { mappingData }
 
+	// Sets the mapping between:
+	// 	- the iOS contact IDs and the Tuta server IDs
+	//	- the iOS contact IDs and the contact Hashes
+	func setContactMapping(contacts: [StructuredContact]) {
+		for contact in contacts {
+			if let serverId = contact.id, let localIdentifier = contact.rawId {
+				mappingData.localContactIdentifierToServerId[localIdentifier] = serverId
+				mappingData.localContactIdentifierToHash[localIdentifier] = contact.stableHash()
+			}
+		}
+	}
+
 	/// Returns all of the contacts inside the contact list
 	func getAllContacts() throws -> [CNContact] { try nativeContactStoreFacade.getAllContacts(inGroup: getTutaContactGroup(), withSorting: nil) }
 


### PR DESCRIPTION
Contacts created outside of the mail app were being duplicated everytime contacts are synced.
This happens because `nativeContactWithoutSourceId` were being inserted repeatedly instead of just updating the contact mappings.

Close #8981 