### PR TITLE
9287 upgrade android

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -9,10 +9,10 @@ group = "de.tutao"
 
 android {
 	defaultConfig {
-		compileSdk 34
+		compileSdk 35
 		applicationId "de.tutao.tutanota"
 		minSdkVersion 26
-		targetSdkVersion 34
+		targetSdkVersion 35
 		versionCode 396517
 		versionName "299.250715.0"
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app-android/app/src/main/res/values-night-v35/styles.xml
+++ b/app-android/app/src/main/res/values-night-v35/styles.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+	<style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
+		<item name="android:colorPrimary">@color/green</item>
+		<item name="android:colorPrimaryDark">@color/green</item>
+		<item name="android:windowBackground">@color/darkLighter</item>
+		<item name="android:statusBarColor">@color/darkLighter</item>
+		<item name="android:windowLightStatusBar">false</item>
+		<item name="android:windowSplashScreenAnimatedIcon">
+			@drawable/ic_logo
+		</item>
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+	</style>
+</resources>

--- a/app-android/app/src/main/res/values-v35/styles.xml
+++ b/app-android/app/src/main/res/values-v35/styles.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+	<style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+		<item name="android:colorPrimary">@color/red</item>
+		<item name="android:colorPrimaryDark">@color/red</item>
+		<item name="android:statusBarColor">@color/white</item>
+		<item name="android:windowLightStatusBar">true</item>
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+	</style>
+
+	<style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
+		<item name="android:colorPrimary">@color/red</item>
+		<item name="android:colorPrimaryDark">@color/red</item>
+		<item name="android:windowBackground">@drawable/splash_background</item>
+		<item name="android:statusBarColor">@color/white</item>
+		<item name="android:windowLightStatusBar">true</item>
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+	</style>
+</resources>

--- a/app-android/calendar/build.gradle.kts
+++ b/app-android/calendar/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 		compileSdk = 35
 		applicationId = "de.tutao.calendar"
 		minSdk = 26
-		targetSdk = 34
+		targetSdk = 35
 		versionCode = 157
 		versionName = "299.250715.0"
 

--- a/app-android/calendar/src/main/res/values-night-v35/styles.xml
+++ b/app-android/calendar/src/main/res/values-night-v35/styles.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+	<style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
+		<item name="android:colorPrimary">@color/green</item>
+		<item name="android:colorPrimaryDark">@color/green</item>
+		<item name="android:windowBackground">@color/darkLighter</item>
+		<item name="android:statusBarColor">@color/darkLighter</item>
+		<item name="android:windowLightStatusBar">false</item>
+		<item name="android:windowSplashScreenAnimatedIcon">
+			@drawable/ic_logo_foreground
+		</item>
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+	</style>
+</resources>

--- a/app-android/calendar/src/main/res/values-v35/styles.xml
+++ b/app-android/calendar/src/main/res/values-v35/styles.xml
@@ -1,0 +1,24 @@
+<resources>
+
+	<!-- Base application theme. -->
+	<style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+		<item name="android:colorPrimary">@color/red</item>
+		<item name="android:colorPrimaryDark">@color/red</item>
+		<item name="android:statusBarColor">@color/white</item>
+		<item name="android:windowLightStatusBar">true</item>
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+	</style>
+
+	<style name="SplashTheme" parent="Theme.AppCompat.Light.NoActionBar">
+		<item name="android:colorPrimary">@color/red</item>
+		<item name="android:colorPrimaryDark">@color/red</item>
+		<item name="android:windowBackground">@drawable/splash_background</item>
+		<item name="android:statusBarColor">@color/white</item>
+		<item name="android:windowLightStatusBar">true</item>
+		<item name="android:windowSplashScreenAnimatedIcon">
+            @drawable/ic_logo_splash_foreground
+        </item>
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+	</style>
+
+</resources>


### PR DESCRIPTION
Upgrade targetingSDK version to latest version(stable version is 35)

One of the major feature in SDK35 is EdgeToEdgeEnforcement which means 
the app fills the whole screen (it no longer leaves some margins for the
 bottom Android buttons for example)
 
For now, this change can be disabled by adding 
"windowOptOutEdgeToEdgeEnforcement" option in the themes.xml file, but 
this option is temporary and need to be remove in the future.

Close #9287