### PR TITLE
Adds the option to duplicate an event

### DIFF
--- a/src/calendar-app/calendar/gui/eventpopup/CalendarEventPopup.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/CalendarEventPopup.ts
@@ -1,4 +1,4 @@
-import type { Shortcut } from "../../../../common/misc/KeyManager.js"
+import { Shortcut } from "../../../../common/misc/KeyManager.js"
 import m, { Children } from "mithril"
 import { px } from "../../../../common/gui/size.js"
 import { Icons } from "../../../../common/gui/base/icons/Icons.js"
@@ -53,6 +53,10 @@ export class CalendarEventPopup implements ModalComponent {
 
 	private readonly handleDeleteButtonClick: (ev: MouseEvent, receiver: HTMLElement) => void = async (ev: MouseEvent, receiver: HTMLElement) => {
 		showDeletePopup(this.model, ev, receiver, () => this.close())
+	}
+
+	private readonly handleCloneButtonClick: (ev: MouseEvent, receiver: HTMLElement) => void = (ev: MouseEvent, receiver: HTMLElement) => {
+		this.model.duplicateEvent()
 	}
 
 	private readonly handleEditButtonClick: (ev: MouseEvent, receiver: HTMLElement) => void = (ev: MouseEvent, receiver: HTMLElement) => {
@@ -126,7 +130,13 @@ export class CalendarEventPopup implements ModalComponent {
 				},
 			},
 			[
-				m(".flex.flex-end", [this.renderSendUpdateButton(), this.renderEditButton(), this.renderDeleteButton(), this.renderCloseButton()]),
+				m(".flex.flex-end", [
+					this.renderSendUpdateButton(),
+					this.renderDuplicateButton(),
+					this.renderEditButton(),
+					this.renderDeleteButton(),
+					this.renderCloseButton(),
+				]),
 				m(".flex-grow.scroll.visible-scrollbar", [
 					m(EventPreviewView, {
 						event: this.model.calendarEvent,
@@ -140,6 +150,11 @@ export class CalendarEventPopup implements ModalComponent {
 				]),
 			],
 		)
+	}
+
+	private renderDuplicateButton(): Children {
+		if (!this.model.canEdit) return null
+		return m(IconButton, { title: "duplicateEvent_label", icon: Icons.Copy, click: this.handleCloneButtonClick })
 	}
 
 	private renderEditButton(): Children {
@@ -238,5 +253,14 @@ export class CalendarEventPopup implements ModalComponent {
 		if (this.model.canDelete) {
 			this._shortcuts.push(remove)
 		}
+
+		this._shortcuts.push({
+			key: Keys.D,
+			ctrlOrCmd: true,
+			help: "duplicateEvent_label",
+			exec: () => {
+				this.model.duplicateEvent()
+			},
+		})
 	}
 }

--- a/src/calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.ts
@@ -262,6 +262,33 @@ export class CalendarEventPreviewViewModel {
 		}
 	}
 
+	async duplicateEvent() {
+		try {
+			const progenitor = await this.calendarModel.resolveCalendarEventProgenitor(this.calendarEvent)
+
+			if (!progenitor) {
+				throw new Error("Could not resolve progenitor.")
+			}
+
+			const newEventModel = await this.eventModelFactory(CalendarOperation.Create, progenitor)
+
+			if (!newEventModel) {
+				throw new Error("Failed clone and create a new event model.")
+			}
+			newEventModel.editModels.whenModel.deleteExcludedDates()
+			newEventModel.editModels.whoModel.resetGuestsStatus()
+
+			const eventEditor = new EventEditorDialog()
+			return await eventEditor.showNewCalendarEventEditDialog(newEventModel)
+		} catch (err) {
+			if (err instanceof NotFoundError) {
+				console.log("calendar event not found when clicking on the event")
+			} else {
+				throw err
+			}
+		}
+	}
+
 	async resolveSeriesModificationProperties() {
 		if (!this.calendarEvent.repeatRule) {
 			throw new Error("Editing a series without repeat rule")

--- a/src/calendar-app/calendar/view/CalendarMonthView.ts
+++ b/src/calendar-app/calendar/view/CalendarMonthView.ts
@@ -1,6 +1,6 @@
 import m, { Children, ClassComponent, Component, Vnode, VnodeDOM } from "mithril"
 import { px, size } from "../../../common/gui/size"
-import { EventTextTimeOption, WeekStart } from "../../../common/api/common/TutanotaConstants"
+import { EventTextTimeOption, Keys, WeekStart } from "../../../common/api/common/TutanotaConstants"
 import {
 	CalendarDay,
 	CalendarMonth,
@@ -41,9 +41,10 @@ import { client } from "../../../common/misc/ClientDetector"
 import { locator } from "../../../common/api/main/CommonLocator.js"
 import { PageView } from "../../../common/gui/base/PageView.js"
 import { DaysToEvents } from "../../../common/calendar/date/CalendarEventsRepository.js"
-import { isIOSApp } from "../../../common/api/common/Env"
+import { isAppleDevice, isIOSApp } from "../../../common/api/common/Env"
 import { getSafeAreaInsetBottom } from "../../../common/gui/HtmlUtils"
 import { getStartOfTheWeekOffset } from "../../../common/misc/weekOffset"
+import { Key } from "../../../common/misc/KeyManager.js"
 
 type CalendarMonthAttrs = {
 	selectedDate: Date
@@ -219,7 +220,14 @@ export class CalendarMonthView implements Component<CalendarMonthAttrs>, ClassCo
 				onmouseup: (mouseEvent: MouseEvent & { redraw?: boolean }) => {
 					mouseEvent.redraw = false
 
-					this.endDrag(mouseEvent)
+					let key
+					if (mouseEvent.metaKey && isAppleDevice()) {
+						key = Keys.META
+					} else if (mouseEvent.ctrlKey) {
+						key = Keys.CTRL
+					}
+
+					this.endDrag(mouseEvent, key)
 				},
 				onmouseleave: (mouseEvent: MouseEvent & { redraw?: boolean }) => {
 					mouseEvent.redraw = false
@@ -244,7 +252,7 @@ export class CalendarMonthView implements Component<CalendarMonthAttrs>, ClassCo
 		)
 	}
 
-	private endDrag(pos: MousePos) {
+	private endDrag(pos: MousePos, key?: Key) {
 		const dayUnderMouse = this.dayUnderMouse
 		const originalDate = this.eventDragHandler.originalEvent?.startTime
 
@@ -252,7 +260,7 @@ export class CalendarMonthView implements Component<CalendarMonthAttrs>, ClassCo
 			//make sure the date we move to also gets a time
 			const dateUnderMouse = Time.fromDate(originalDate).toDate(dayUnderMouse)
 
-			this.eventDragHandler.endDrag(dateUnderMouse, pos).catch(ofClass(UserError, showUserError))
+			this.eventDragHandler.endDrag(dateUnderMouse, pos, key).catch(ofClass(UserError, showUserError))
 		}
 	}
 

--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -3,8 +3,7 @@ import { AppHeaderAttrs, Header } from "../../../common/gui/Header.js"
 import { ColumnType, ViewColumn } from "../../../common/gui/base/ViewColumn"
 import { lang } from "../../../common/misc/LanguageViewModel"
 import { ViewSlider } from "../../../common/gui/nav/ViewSlider.js"
-import type { Key, Shortcut } from "../../../common/misc/KeyManager"
-import { isKeyPressed, keyManager } from "../../../common/misc/KeyManager"
+import { isKeyPressed, Key, keyboardEventToKeyPress, keyManager, Shortcut } from "../../../common/misc/KeyManager"
 import { Icons } from "../../../common/gui/base/icons/Icons"
 import {
 	base64ToBase64Url,
@@ -429,6 +428,12 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 										}
 										if (isKeyPressed(domEvent.key, Keys.DELETE) && !domEvent.repeat) {
 											this.openDeletePopup(event, domEvent)
+										}
+
+										const keyboardKeys = keyboardEventToKeyPress(domEvent)
+										if (keyboardKeys.ctrlOrCmd && isKeyPressed(keyboardKeys.key, Keys.D) && !domEvent.repeat) {
+											this.duplicateEvent(event)
+											domEvent.stopPropagation()
 										}
 									},
 									groupColors: this.viewModel.calendarColors,
@@ -1471,6 +1476,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 
 	private handleEventKeyDown(): CalendarEventBubbleKeyDownHandler {
 		return (calendarEvent, domEvent) => {
+			const keyboardKeys = keyboardEventToKeyPress(domEvent)
 			if (isKeyPressed(domEvent.key, Keys.RETURN, Keys.SPACE) && !domEvent.repeat) {
 				this.showCalendarEventPopupAtEvent(calendarEvent, domEvent.target as HTMLElement, this.htmlSanitizer)
 				domEvent.stopPropagation()
@@ -1480,6 +1486,12 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 				domEvent.stopPropagation()
 			}
 		}
+	}
+
+	private duplicateEvent(calendarEvent: CalendarEvent) {
+		locator.calendarEventPreviewModel(calendarEvent, this.viewModel.calendarInfos, []).then((eventPreviewModel: CalendarEventPreviewViewModel) => {
+			eventPreviewModel?.duplicateEvent()
+		})
 	}
 
 	private openDeletePopup(calendarEvent: CalendarEvent, domEvent: KeyboardEvent) {

--- a/src/calendar-app/calendar/view/EventDetailsView.ts
+++ b/src/calendar-app/calendar/view/EventDetailsView.ts
@@ -38,7 +38,12 @@ export class EventDetailsView implements Component<EventDetailsViewAttrs> {
 					highlightedStrings: attrs.highlightedStrings,
 				}),
 			),
-			m(".flex.mt-xs", [this.renderSendUpdateButton(), this.renderEditButton(attrs.editCallback), this.renderDeleteButton(attrs.deleteCallback)]),
+			m(".flex.mt-xs", [
+				this.renderSendUpdateButton(),
+				this.renderDuplicateButton(),
+				this.renderEditButton(attrs.editCallback),
+				this.renderDeleteButton(attrs.deleteCallback),
+			]),
 		])
 	}
 
@@ -69,10 +74,23 @@ export class EventDetailsView implements Component<EventDetailsViewAttrs> {
 		})
 	}
 
+	private renderDuplicateButton(): Children {
+		if (this.model == null || styles.isSingleColumnLayout()) return null
+		return m(IconButton, {
+			title: "duplicateEvent_label",
+			click: () => handleEventDuplicate(this.model!),
+			icon: Icons.Copy,
+		})
+	}
+
 	private async confirmDeleteClose(): Promise<void> {
 		if (!(await Dialog.confirm("deleteEventConfirmation_msg"))) return
 		await this.model?.deleteAll()
 	}
+}
+
+export async function handleEventDuplicate(previewModel: CalendarEventPreviewViewModel) {
+	return await previewModel.duplicateEvent()
 }
 
 export async function handleSendUpdatesClick(previewModel: CalendarEventPreviewViewModel | null) {

--- a/src/calendar-app/calendar/view/EventDragHandler.ts
+++ b/src/calendar-app/calendar/view/EventDragHandler.ts
@@ -6,6 +6,9 @@ import { showDropdownAtPosition } from "../../../common/gui/base/Dropdown.js"
 import { CalendarOperation } from "../gui/eventeditor-model/CalendarEventModel.js"
 
 import { newPromise } from "@tutao/tutanota-utils/dist/Utils"
+import { isKeyPressed, Key } from "../../../common/misc/KeyManager.js"
+import { Keys } from "../../../common/api/common/TutanotaConstants.js"
+import { isAppleDevice } from "../../../common/api/common/Env.js"
 
 const DRAG_THRESHOLD = 10
 export type MousePos = {
@@ -126,7 +129,7 @@ export class EventDragHandler {
 	 *
 	 * This function will only trigger when prepareDrag has been called
 	 */
-	async endDrag(dateUnderMouse: Date, pos: MousePos): Promise<void> {
+	async endDrag(dateUnderMouse: Date, pos: MousePos, pressedKey?: Key): Promise<void> {
 		this.draggingArea.classList.remove("cursor-grabbing")
 
 		if (this.dragging && this.data) {
@@ -142,12 +145,16 @@ export class EventDragHandler {
 			// not allowed to drag events where that's not the case.
 			// note that we're not allowing changing the whole series from dragging an altered instance.
 			const { repeatRule, recurrenceId } = dragData.originalEvent
-			// prettier-ignore
-			const mode = repeatRule != null
-				? await showModeSelectionDropdown(pos)
-				: recurrenceId != null
-					? CalendarOperation.EditThis
-					: CalendarOperation.EditAll
+			const ctrlOrCmd = isAppleDevice() ? Keys.META : Keys.CTRL
+			let mode: CalendarOperation | null = CalendarOperation.Create
+			if (!isKeyPressed(pressedKey?.code, ctrlOrCmd)) {
+				// prettier-ignore
+				mode = repeatRule != null
+					? await showModeSelectionDropdown(pos)
+					: recurrenceId != null
+						? CalendarOperation.EditThis
+						: CalendarOperation.EditAll
+			}
 
 			// If the date hasn't changed we still have to do the callback so the view model can cancel the drag
 			try {

--- a/src/calendar-app/calendar/view/MultiDayCalendarView.ts
+++ b/src/calendar-app/calendar/view/MultiDayCalendarView.ts
@@ -16,7 +16,7 @@ import {
 import { CalendarDayEventsView, calendarDayTimes } from "./CalendarDayEventsView"
 import { theme } from "../../../common/gui/theme"
 import { px, size } from "../../../common/gui/size"
-import { EventTextTimeOption, WeekStart } from "../../../common/api/common/TutanotaConstants"
+import { EventTextTimeOption, Keys, WeekStart } from "../../../common/api/common/TutanotaConstants"
 import { lang } from "../../../common/misc/LanguageViewModel"
 import { PageView } from "../../../common/gui/base/PageView"
 import type { CalendarEvent } from "../../../common/api/entities/tutanota/TypeRefs.js"
@@ -44,6 +44,8 @@ import { DateTime } from "luxon"
 import { Time } from "../../../common/calendar/date/Time.js"
 import { DaySelector } from "../gui/day-selector/DaySelector.js"
 import { getStartOfTheWeekOffset } from "../../../common/misc/weekOffset"
+import { isAppleDevice } from "../../../common/api/common/Env.js"
+import { Key } from "../../../common/misc/KeyManager.js"
 
 export type MultiDayCalendarViewAttrs = {
 	selectedDate: Date
@@ -230,7 +232,14 @@ export class MultiDayCalendarView implements Component<MultiDayCalendarViewAttrs
 				onmouseup: (mouseEvent: EventRedraw<MouseEvent>) => {
 					mouseEvent.redraw = false
 
-					this.endDrag(mouseEvent)
+					let key
+					if (mouseEvent.metaKey && isAppleDevice()) {
+						key = Keys.META
+					} else if (mouseEvent.ctrlKey) {
+						key = Keys.CTRL
+					}
+
+					this.endDrag(mouseEvent, key)
 				},
 				onmouseleave: (mouseEvent: EventRedraw<MouseEvent>) => {
 					mouseEvent.redraw = false
@@ -784,11 +793,11 @@ export class MultiDayCalendarView implements Component<MultiDayCalendarViewAttrs
 		)
 	}
 
-	private endDrag(pos: MousePos) {
+	private endDrag(pos: MousePos, key?: Key) {
 		this.isHeaderEventBeingDragged = false
 
 		if (this.dateUnderMouse) {
-			this.eventDragHandler.endDrag(this.dateUnderMouse, pos).catch(ofClass(UserError, showUserError))
+			this.eventDragHandler.endDrag(this.dateUnderMouse, pos, key).catch(ofClass(UserError, showUserError))
 		}
 	}
 

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -2045,3 +2045,4 @@ export type TranslationKeyType =
 	| "updateThisAndFutureEvents_action"
 	| "deleteThisAndFutureOccurrences_action"
 	| "deleteThisAndFutureOccurrencesConfirmation_msg"
+	| "duplicateEvent_label"

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -2070,5 +2070,6 @@ export default {
 		"updateThisAndFutureEvents_action": "Dieses und zukünftige Ereignisse aktualisiere",
 		"deleteThisAndFutureOccurrences_action": "Dieses und zukünftige Ereignisse löschen",
 		"deleteThisAndFutureOccurrencesConfirmation_msg": "Sind Sie sicher, dass Sie dieses und alle zukünftigen Ereignisse löschen wollen?",
+		"duplicateEvent_label": "Diesen Termin duplizieren",
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -2070,5 +2070,6 @@ export default {
         "updateThisAndFutureEvents_action": "Dieses und zukünftige Ereignisse aktualisiere",
         "deleteThisAndFutureOccurrences_action": "Dieses und zukünftige Ereignisse löschen",
         "deleteThisAndFutureOccurrencesConfirmation_msg": "Sind Sie sicher, dass Sie dieses und alle zukünftigen Ereignisse löschen wollen?",
+		"duplicateEvent_label": "Diesen Termin duplizieren",
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -2066,5 +2066,6 @@ export default {
 		"updateThisAndFutureEvents_action": "Update this and future events",
         "deleteThisAndFutureOccurrences_action": "Delete this and future events",
         "deleteThisAndFutureOccurrencesConfirmation_msg": "Are you sure you want to delete this and all future events?",
+		"duplicateEvent_label": "Duplicate this event",
 	}
 }


### PR DESCRIPTION
Now users can duplicate events by dragging and dropping it holding the CTRL key, clicking the Duplicate button during preview or pressing CTRL+D when previewing it