### PR TITLE
Collapse the quoted reply by default when replying to a mail thread

### DIFF
--- a/packages/tutanota-utils/lib/MathUtils.ts
+++ b/packages/tutanota-utils/lib/MathUtils.ts
@@ -1,3 +1,6 @@
+/**
+ * This supports negative n values. Native remainder operation does not
+ */
 export function mod(n: number, m: number): number {
 	return ((n % m) + m) % m
 }

--- a/src/common/gui/editor/Editor.ts
+++ b/src/common/gui/editor/Editor.ts
@@ -91,7 +91,7 @@ export class Editor implements ImageHandler, Component {
 	}
 
 	view(): Children {
-		return m(".selectable", {
+		return m(".selectable.text_editor", {
 			role: "textbox",
 			"aria-multiline": "true",
 			"data-testid": "text_editor",

--- a/src/common/misc/KeyManager.ts
+++ b/src/common/misc/KeyManager.ts
@@ -89,8 +89,13 @@ function isFocusable(e: HTMLElement) {
 	}
 	return (
 		e.style.display !== "none" &&
-		// check that none of the parents have hidden=true or aria-hidden=true
-		e.closest("[hidden]:not([hidden=false]), [aria-hidden]:not([aria-hidden=false]), [inert]:not([inert=false])") == null
+		e.closest(
+			// check that none of the parents have hidden=true or aria-hidden=true
+			`[hidden]:not([hidden=false]), [aria-hidden]:not([aria-hidden=false]), [inert]:not([inert=false])${
+				// links inside contenteditable aren't focusable without an explicit tabindex
+				e.tagName === "A" && e.getAttribute("tabindex") == null ? ", [contenteditable='true']" : ""
+			}`,
+		) == null
 	)
 }
 
@@ -150,7 +155,16 @@ export function focusNext(dom: HTMLElement): boolean {
 	return true
 }
 
-function createKeyIdentifier(key: string, modifiers?: { ctrlOrCmd?: boolean; ctrl?: boolean; alt?: boolean; shift?: boolean; meta?: boolean }): string {
+function createKeyIdentifier(
+	key: string,
+	modifiers?: {
+		ctrlOrCmd?: boolean
+		ctrl?: boolean
+		alt?: boolean
+		shift?: boolean
+		meta?: boolean
+	},
+): string {
 	return (
 		key +
 		(modifiers?.ctrlOrCmd ? "X" : "") +

--- a/src/mail-app/mail/view/MailViewerViewModel.ts
+++ b/src/mail-app/mail/view/MailViewerViewModel.ts
@@ -854,7 +854,7 @@ export class MailViewerViewModel {
 
 		const mailSubject = this.getSubject() || ""
 		infoLine += lang.get("subject_label") + ": " + urlEncodeHtmlTags(mailSubject)
-		let body = infoLine + '<br><br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
+		const body = infoLine + '<br><br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
 		const { prependEmailSignature } = await import("../signature/Signature")
 		const senderMailAddress = await this.getSenderOfResponseMail()
 		return {
@@ -890,14 +890,14 @@ export class MailViewerViewModel {
 				address: mailAddressAndName.address,
 				contact: null,
 			})
-			let prefix = "Re: "
+			const prefix = "Re: "
 			const mailSubject = this.getSubject()
-			let subject = mailSubject ? (startsWith(mailSubject.toUpperCase(), prefix.toUpperCase()) ? mailSubject : prefix + mailSubject) : ""
-			let infoLine = formatDateTime(this.getDate()) + " " + lang.get("by_label") + " " + sender.address + ":"
-			let body = infoLine + '<br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
-			let toRecipients: MailAddress[] = []
-			let ccRecipients: MailAddress[] = []
-			let bccRecipients: MailAddress[] = []
+			const subject = mailSubject ? (startsWith(mailSubject.toUpperCase(), prefix.toUpperCase()) ? mailSubject : prefix + mailSubject) : ""
+			const infoLine = formatDateTime(this.getDate()) + " " + lang.get("by_label") + " " + sender.address + ":"
+			const body = infoLine + '<br><blockquote class="tutanota_quote">' + this.getMailBody() + "</blockquote>"
+			const toRecipients: MailAddress[] = []
+			const ccRecipients: MailAddress[] = []
+			const bccRecipients: MailAddress[] = []
 
 			if (!this.logins.getUserController().isInternalUser() && this.isReceivedMail()) {
 				toRecipients.push(sender)


### PR DESCRIPTION
Replying to a long email thread causes lag issues on some mobile devices. This happens because each reply introduces another level of nesting.

This change collapses replies that are 2+ levels deep by default in the MailEditor. The thread can be expanded using a quote expander button.

Revert commit c771f4a53d0bbebabdfee23fccea5a698b67c840 as a starting point, and add correct handling of undo-redo and inline replies.

Close #9254