### PR TITLE
[Android] Fix login failure when biometrics are disabled on device

### DIFF
--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/AppLockAuthenticationException.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/AppLockAuthenticationException.kt
@@ -1,0 +1,3 @@
+package de.tutao.tutashared
+
+class AppLockAuthenticationException(message: String) : Exception(message)

--- a/src/common/api/common/error/AppLockAuthenticationError.ts
+++ b/src/common/api/common/error/AppLockAuthenticationError.ts
@@ -1,0 +1,5 @@
+export class AppLockAuthenticationError extends Error {
+	constructor(message: string) {
+		super(message)
+	}
+}

--- a/src/common/api/common/utils/ErrorUtils.ts
+++ b/src/common/api/common/utils/ErrorUtils.ts
@@ -57,6 +57,7 @@ import { MailImportError } from "../error/MailImportError.js"
 import { ExportError } from "../error/ExportError"
 import { KeyVerificationMismatchError } from "../error/KeyVerificationMismatchError"
 import { ServerModelsUnavailableError } from "../error/ServerModelsUnavailableError"
+import { AppLockAuthenticationError } from "../error/AppLockAuthenticationError"
 
 /**
  * Checks if the given instance (Entity or ParsedInstance) has an error in the _errors property which is usually written
@@ -155,6 +156,7 @@ const ErrorNameToType = {
 	NSURLErrorDomain: ConnectionError,
 	NSCocoaErrorDomain: Error,
 	"de.tutao.tutashared.CredentialAuthenticationException": CredentialAuthenticationError,
+	"de.tutao.tutashared.AppLockAuthenticationException": AppLockAuthenticationError,
 	"android.security.keystore.KeyPermanentlyInvalidatedException": KeyPermanentlyInvalidatedError,
 	"de.tutao.tutashared.KeyPermanentlyInvalidatedError": KeyPermanentlyInvalidatedError,
 	"de.tutao.tutashared.CredentialAuthenticationError": CredentialAuthenticationError,

--- a/src/common/login/AppLock.ts
+++ b/src/common/login/AppLock.ts
@@ -1,6 +1,7 @@
 import { MobileSystemFacade } from "../native/common/generatedipc/MobileSystemFacade.js"
 import { NativeCredentialsFacade } from "../native/common/generatedipc/NativeCredentialsFacade.js"
 import { CredentialEncryptionMode } from "../misc/credentials/CredentialEncryptionMode.js"
+import { AppLockMethod } from "../native/common/generatedipc/AppLockMethod"
 
 /**
  * Enforces app authentication via system mechanism e.g. system password or biometrics.
@@ -8,10 +9,12 @@ import { CredentialEncryptionMode } from "../misc/credentials/CredentialEncrypti
 export interface AppLock {
 	/** @throws CredentialAuthenticationError */
 	enforce(): Promise<void>
+	resetAppLockMethod(): Promise<void>
 }
 
 export class NoOpAppLock implements AppLock {
 	async enforce(): Promise<void> {}
+	async resetAppLockMethod(): Promise<void> {}
 }
 
 export class MobileAppLock implements AppLock {
@@ -26,5 +29,13 @@ export class MobileAppLock implements AppLock {
 			return
 		}
 		return this.mobileSystemFacade.enforceAppLock(await this.mobileSystemFacade.getAppLockMethod())
+	}
+
+	/**
+	 * If the selected AppLockMethod is not present in supportedAppLockMethods allow fallback to `None`, otherwise
+	 * it will keep on restricting user from loggingIn
+	 */
+	async resetAppLockMethod() {
+		await this.mobileSystemFacade.setAppLockMethod(AppLockMethod.None)
 	}
 }


### PR DESCRIPTION
If the user disables biometrics on their phone but the app’s 
`appLockMethod` is still set to biometrics, login attempts result in a 
`CredentialAuthenticationException`. This happens because the app still
 tries to use biometrics, which are no longer available.

Fixed by detecting `BiometricAuthenticationError`which clear stored 
credentials and setting `appLockMethod` to `None` to allow fallback
 authentication.

Close #9064 