### PR TITLE
Update snackbar for moving mail to spam

### DIFF
--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -2034,3 +2034,4 @@ export type TranslationKeyType =
 	| "zoomIn_action"
 	| "zoomOut_action"
 	| "emptyString_msg"
+	| "undoMoveMailReport_msg"

--- a/src/mail-app/mail/view/MailGuiUtils.ts
+++ b/src/mail-app/mail/view/MailGuiUtils.ts
@@ -15,7 +15,7 @@ import {
 	SYSTEM_GROUP_MAIL_ADDRESS,
 	SystemFolderType,
 } from "../../../common/api/common/TutanotaConstants"
-import { actuallyReportMails, getReportConfirmation } from "./MailReportDialog"
+import { getReportConfirmation } from "./MailReportDialog"
 import { DataFile } from "../../../common/api/common/DataFile"
 import { lang, Translation } from "../../../common/misc/LanguageViewModel"
 import { FileController } from "../../../common/file/FileController"
@@ -145,10 +145,11 @@ async function showUndoMoveMailSnackbar(
 		}
 
 		const clearUndoAction = lazyMemoized(() => mailViewModel.clearUndoActionIfPresent(undoAction))
+		const undoMessage = lang.getTranslation(targetFolder.folderType === MailSetKind.SPAM ? "undoMoveMailReport_msg" : "undoMoveMail_msg", {
+			"{folder}": getFolderName(targetFolder),
+		})
 		cancelSnackbar = showSnackBar({
-			message: lang.getTranslation("undoMoveMail_msg", {
-				"{folder}": getFolderName(targetFolder),
-			}),
+			message: undoMessage,
 			button: {
 				label: "undo_action",
 				click: async () => {
@@ -202,7 +203,6 @@ export async function moveMails({
 		const resolveMails = () => mailModel.loadAllMails(mailIds)
 
 		let undone = false
-		let skipShowingSnackbar = false
 		const shouldReportMails = await getReportAnswer(system, targetFolder, isReportable, mailboxModel, mailModel)
 
 		// If we have an undo (origin) folder and the destination and undo folder are not the same, we should allow the
@@ -220,13 +220,12 @@ export async function moveMails({
 				}
 				case MoveMailSnackbarResult.Replaced: {
 					undone = false
-					skipShowingSnackbar = true
 					break
 				}
 			}
 		}
 		if (!undone && shouldReportMails) {
-			await actuallyReportMails(MailReportType.SPAM, mailModel, resolveMails, skipShowingSnackbar)
+			await mailModel.reportMails(MailReportType.SPAM, resolveMails)
 			return true
 		} else {
 			return false

--- a/src/mail-app/mail/view/MailReportDialog.ts
+++ b/src/mail-app/mail/view/MailReportDialog.ts
@@ -67,11 +67,10 @@ export async function reportMailsAutomatically(
 	mailModel: MailModel,
 	mailboxDetails: MailboxDetail,
 	mails: () => Promise<ReadonlyArray<Mail>>,
-	skipShowingSnackbar: boolean = false,
 ): Promise<void> {
 	const shouldReportMails = await getReportConfirmation(mailReportType, mailboxModel, mailModel, mailboxDetails)
 	if (shouldReportMails) {
-		await actuallyReportMails(mailReportType, mailModel, mails, skipShowingSnackbar)
+		await mailModel.reportMails(mailReportType, mails)
 	}
 }
 
@@ -97,30 +96,4 @@ export async function getReportConfirmation(
 	}
 
 	return isReportable
-}
-
-export async function actuallyReportMails(
-	mailReportType: MailReportType,
-	mailModel: MailModel,
-	mails: () => Promise<ReadonlyArray<Mail>>,
-	skipShowingSnackbar: boolean = false,
-): Promise<void> {
-	// decides if a snackbar is shown to prevent the server request
-	if (skipShowingSnackbar) {
-		mailModel.reportMails(mailReportType, mails)
-	} else {
-		let undoClicked = false
-		showSnackBar({
-			message: "undoMailReport_msg",
-			button: {
-				label: "cancel_action",
-				click: () => (undoClicked = true),
-			},
-			onClose: () => {
-				if (!undoClicked) {
-					mailModel.reportMails(mailReportType, mails)
-				}
-			},
-		})
-	}
 }

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -2059,5 +2059,6 @@ export default {
 		"you_label": "Du",
 		"zoomIn_action": "Hereinzoomen",
 		"zoomOut_action": "Herauszoomen",
+		"undoMoveMailReport_msg": "The email(s) were moved to folder {folder} and will be reported in unencrypted form.",
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -2059,5 +2059,6 @@ export default {
 		"you_label": "Sie",
 		"zoomIn_action": "Hereinzoomen",
 		"zoomOut_action": "Herauszoomen",
+		"undoMoveMailReport_msg": "The email(s) were moved to folder {folder} and will be reported in unencrypted form.",
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -2055,5 +2055,6 @@ export default {
 		"you_label": "You",
 		"zoomIn_action": "Zoom In",
 		"zoomOut_action": "Zoom Out",
+		"undoMoveMailReport_msg": "The email(s) were moved to folder {folder} and will be reported in unencrypted form.",
 	}
 }


### PR DESCRIPTION
Removed the reporting snackbar and added a new message specifically for mails being moved to spam.

Close #9428