### PR TITLE
[SDK] Cache former key

### DIFF
--- a/tuta-sdk/rust/sdk/src/key_cache.rs
+++ b/tuta-sdk/rust/sdk/src/key_cache.rs
@@ -67,11 +67,7 @@ impl KeyCache {
 	pub fn put_group_key(&self, group_id: &GeneratedId, key: &VersionedAesKey) {
 		let mut lock = self.group_keys.write().unwrap();
 
-		let mut current_keys = if lock.get(group_id).is_some() {
-			lock.get(group_id).unwrap().clone()
-		} else {
-			HashMap::new()
-		};
+		let mut current_keys = lock.entry(group_id.clone()).or_default();
 
 		let key_version = key.version as i64;
 
@@ -81,7 +77,6 @@ impl KeyCache {
 		}
 
 		current_keys.insert(key_version, key.to_owned());
-		lock.insert(group_id.to_owned(), current_keys);
 	}
 
 	#[allow(clippy::unused_async)]

--- a/tuta-sdk/rust/sdk/src/key_cache.rs
+++ b/tuta-sdk/rust/sdk/src/key_cache.rs
@@ -3,13 +3,15 @@ use crate::crypto::Aes256Key;
 use crate::entities::generated::sys::User;
 use crate::GeneratedId;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::RwLock;
 
 #[allow(dead_code)]
 pub struct KeyCache {
-	current_group_keys: RwLock<HashMap<GeneratedId, VersionedAesKey>>,
+	group_keys: RwLock<HashMap<GeneratedId, HashMap<i64, VersionedAesKey>>>,
 	current_user_group_key: RwLock<Option<VersionedAesKey>>,
 	user_group_key_distribution_key: RwLock<Option<Aes256Key>>,
+	latest_group_key_version: AtomicI64,
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -17,9 +19,10 @@ pub struct KeyCache {
 impl KeyCache {
 	pub fn new() -> Self {
 		KeyCache {
-			current_group_keys: RwLock::new(HashMap::new()),
+			group_keys: RwLock::new(HashMap::new()),
 			current_user_group_key: RwLock::new(None),
 			user_group_key_distribution_key: RwLock::new(None),
+			latest_group_key_version: AtomicI64::new(-1),
 		}
 	}
 
@@ -45,18 +48,123 @@ impl KeyCache {
 			Some(user_group_key_distribution_key);
 	}
 
+	pub fn get_group_key_for_version(
+		&self,
+		group_id: &GeneratedId,
+		version: i64,
+	) -> Option<VersionedAesKey> {
+		let lock = self.group_keys.read().unwrap();
+		lock.get(group_id)?.get(&version).cloned()
+	}
+
 	pub fn get_current_group_key(&self, group_id: &GeneratedId) -> Option<VersionedAesKey> {
-		let lock = self.current_group_keys.read().unwrap();
-		lock.get(group_id).cloned()
+		self.get_group_key_for_version(
+			group_id,
+			self.latest_group_key_version.load(Ordering::Relaxed),
+		)
 	}
 
 	pub fn put_group_key(&self, group_id: &GeneratedId, key: &VersionedAesKey) {
-		let mut lock = self.current_group_keys.write().unwrap();
-		lock.insert(group_id.to_owned(), key.to_owned());
+		let mut lock = self.group_keys.write().unwrap();
+
+		let mut current_keys = if lock.get(group_id).is_some() {
+			lock.get(group_id).unwrap().clone()
+		} else {
+			HashMap::new()
+		};
+
+		let key_version = key.version as i64;
+
+		if self.latest_group_key_version.load(Ordering::Relaxed) < key_version {
+			self.latest_group_key_version
+				.store(key_version, Ordering::Relaxed);
+		}
+
+		current_keys.insert(key_version, key.to_owned());
+		lock.insert(group_id.to_owned(), current_keys);
 	}
 
 	#[allow(clippy::unused_async)]
 	pub async fn remove_outdated_group_keys(&self, _user: &User) {
 		todo!("key cache remove_outdated_group_keys")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::entities::generated::sys::GroupKeysRef;
+	use crate::util::test_utils::{generate_random_group, random_aes256_versioned_key};
+
+	mod get_group_key_for_version {
+		use super::*;
+
+		#[test]
+		fn should_not_find_key_on_cache() {
+			let group = generate_random_group(
+				None,
+				GroupKeysRef {
+					_id: Default::default(),
+					list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+				},
+			);
+
+			let key_cache = KeyCache::new();
+			assert_eq!(
+				key_cache.get_group_key_for_version(&group._id.clone().unwrap(), 0),
+				None
+			);
+		}
+
+		#[test]
+		fn should_insert_and_retrieve_key() {
+			let group = generate_random_group(
+				None,
+				GroupKeysRef {
+					_id: Default::default(),
+					list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+				},
+			);
+
+			let first_key_version: i64 = 0;
+			let first_key = random_aes256_versioned_key(first_key_version as u64);
+			let second_key = random_aes256_versioned_key(1);
+
+			let key_cache = KeyCache::new();
+			key_cache.put_group_key(&group._id.clone().unwrap(), &first_key);
+			key_cache.put_group_key(&group._id.clone().unwrap(), &second_key);
+
+			let retrieved_key = key_cache
+				.get_group_key_for_version(&group._id.clone().unwrap(), first_key_version)
+				.unwrap();
+			assert_eq!(retrieved_key, first_key);
+		}
+	}
+
+	mod get_current_group_key {
+		use super::*;
+		#[test]
+		fn should_retrieve_latest_key() {
+			let group = generate_random_group(
+				None,
+				GroupKeysRef {
+					_id: Default::default(),
+					list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+				},
+			);
+
+			let first_key_version = 0;
+			let first_key = random_aes256_versioned_key(first_key_version);
+			let second_key = random_aes256_versioned_key(1);
+
+			let key_cache = KeyCache::new();
+			key_cache.put_group_key(&group._id.clone().unwrap(), &first_key);
+			key_cache.put_group_key(&group._id.clone().unwrap(), &second_key);
+
+			let retrieved_key = key_cache
+				.get_current_group_key(&group._id.clone().unwrap())
+				.unwrap();
+			assert_eq!(retrieved_key, second_key);
+		}
 	}
 }

--- a/tuta-sdk/rust/sdk/src/key_cache.rs
+++ b/tuta-sdk/rust/sdk/src/key_cache.rs
@@ -175,6 +175,73 @@ mod tests {
 
 	mod get_current_group_key {
 		use super::*;
+
+		#[test]
+		fn no_saved_key_for_requested_group() {
+			let group_a = generate_random_group(
+				None,
+				GroupKeysRef {
+					_id: Default::default(),
+					list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+				},
+			);
+
+			let group_b = generate_random_group(
+				None,
+				GroupKeysRef {
+					_id: Default::default(),
+					list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+				},
+			);
+
+			let key_cache = KeyCache::new();
+			let group_a_key = random_aes256_versioned_key(0);
+			key_cache.put_group_key(&group_a._id.clone().unwrap(), &group_a_key);
+
+			let retrieved_key = key_cache.get_current_group_key(&group_b._id.clone().unwrap());
+			assert_eq!(retrieved_key, None);
+		}
+
+		#[test]
+		fn should_retrieve_latest_key_of_each_group() {
+			let group_a = generate_random_group(
+				None,
+				GroupKeysRef {
+					_id: Default::default(),
+					list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+				},
+			);
+
+			let group_b = generate_random_group(
+				None,
+				GroupKeysRef {
+					_id: Default::default(),
+					list: GeneratedId("list".to_owned()), // Refers to `former_keys`
+				},
+			);
+
+			let key_cache = KeyCache::new();
+			let group_a_key_old = random_aes256_versioned_key(0);
+			let group_a_key_latest = random_aes256_versioned_key(1);
+			let group_b_key_old = random_aes256_versioned_key(0);
+			let group_b_key_latest = random_aes256_versioned_key(1);
+
+			key_cache.put_group_key(&group_a._id.clone().unwrap(), &group_a_key_old);
+			key_cache.put_group_key(&group_a._id.clone().unwrap(), &group_a_key_latest);
+			key_cache.put_group_key(&group_b._id.clone().unwrap(), &group_b_key_old);
+			key_cache.put_group_key(&group_b._id.clone().unwrap(), &group_b_key_latest);
+
+			let retrieved_key = key_cache
+				.get_current_group_key(&group_a._id.clone().unwrap())
+				.unwrap();
+			assert_eq!(retrieved_key, group_a_key_latest);
+
+			let retrieved_key = key_cache
+				.get_current_group_key(&group_b._id.clone().unwrap())
+				.unwrap();
+			assert_eq!(retrieved_key, group_b_key_latest);
+		}
+
 		#[test]
 		fn should_retrieve_latest_key() {
 			let group = generate_random_group(

--- a/tuta-sdk/rust/sdk/src/key_loader_facade.rs
+++ b/tuta-sdk/rust/sdk/src/key_loader_facade.rs
@@ -465,47 +465,6 @@ mod tests {
 		)
 	}
 
-	fn make_key_cache_mock(
-		group: &Group,
-		current_group_key: &VersionedAesKey,
-		cached_keys: Vec<VersionedAesKey>,
-	) -> Arc<MockKeyCache> {
-		let mut key_cache_mock = MockKeyCache::default();
-		let group_key = current_group_key.clone();
-
-		key_cache_mock
-			.expect_get_current_group_key()
-			.returning(move |_| Some(group_key.clone()));
-
-		key_cache_mock
-			.expect_get_group_key_for_version()
-			.with(
-				predicate::eq(group._id.clone().unwrap()),
-				predicate::in_iter::<Vec<i64>, i64>((0..FORMER_KEYS as i64).collect()),
-			)
-			.return_const(None);
-
-		cached_keys.iter().for_each(|key| {
-			key_cache_mock
-				.expect_get_group_key_for_version()
-				.with(
-					predicate::eq(group._id.clone().unwrap()),
-					predicate::eq(key.version as i64),
-				)
-				.return_const(key.clone());
-
-			key_cache_mock
-				.expect_put_group_key()
-				.with(
-					predicate::eq(group._id.clone().unwrap()),
-					predicate::eq(key.clone()),
-				)
-				.times(0);
-		});
-
-		Arc::new(key_cache_mock)
-	}
-
 	fn make_mocks(
 		group: &Group,
 		current_group_key: &VersionedAesKey,

--- a/tuta-sdk/rust/sdk/src/user_facade.rs
+++ b/tuta-sdk/rust/sdk/src/user_facade.rs
@@ -60,10 +60,6 @@ impl UserFacade {
 		Ok(())
 	}
 
-	pub fn key_cache(&self) -> Arc<KeyCache> {
-		self.key_cache.clone()
-	}
-
 	fn set_user_group_key_distribution_key(&self, user_passphrase_key: GenericAesKey) {
 		let user = self.get_user();
 		let user_group_membership = &user.userGroup;

--- a/tuta-sdk/rust/sdk/src/user_facade_factory.rs
+++ b/tuta-sdk/rust/sdk/src/user_facade_factory.rs
@@ -1,0 +1,22 @@
+use crate::entities::generated::sys::User;
+#[cfg_attr(test, mockall_double::double)]
+use crate::key_cache::KeyCache;
+#[cfg_attr(test, mockall_double::double)]
+use crate::user_facade::UserFacade;
+use std::sync::Arc;
+
+pub struct UserFacadeFactory {
+	key_cache: Arc<KeyCache>,
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[allow(unused)]
+impl UserFacadeFactory {
+	pub fn new(key_cache: Arc<KeyCache>) -> Self {
+		UserFacadeFactory { key_cache }
+	}
+
+	pub fn create_user_facade(&self, user: User) -> UserFacade {
+		UserFacade::new(self.key_cache.clone(), user)
+	}
+}

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -116,6 +116,14 @@ pub fn random_aes256_key() -> Aes256Key {
 	Aes256Key::from_bytes(&random::<[u8; 32]>()).unwrap()
 }
 
+#[must_use]
+pub fn random_aes256_versioned_key(version: u64) -> VersionedAesKey {
+	VersionedAesKey {
+		object: random_aes256_key().into(),
+		version,
+	}
+}
+
 /// Moves the object T into heap and leaks it.
 #[inline(always)]
 pub fn leak<T>(what: T) -> &'static T {
@@ -443,6 +451,7 @@ macro_rules! collection {
         }};
     }
 
+use crate::crypto::key::VersionedAesKey;
 use crate::date::DateTime;
 use crate::entities::generated::tutanota::Contact;
 use crate::entities::{Entity, FinalIv};


### PR DESCRIPTION
This pull request introduces enhancements to the `KeyCache` architecture, adding cache to former group key, integrates a `UserFacadeFactory` for improved user facade creation, and expands testing utilities for key retrieval operations.

- **Refactored `KeyCache` structure**: Replaced `current_group_keys` with `group_keys` to support multiple key versions per group and added `latest_group_key_version` for tracking the latest version.
- **New methods in `KeyCache`**: Added `get_group_key_for_version` to retrieve specific key versions and updated `put_group_key` to manage multiple versions and update `latest_group_key_version`.
- **Introduced `UserFacadeFactory`**: Created a factory class to encapsulate the creation of `UserFacade` instances, simplifying dependency management by injecting `KeyCache`.
- **Removed redundant method in `UserFacade`**: Eliminated `key_cache()` method as `UserFacadeFactory` now manages `KeyCache` dependencies.