### PR TITLE
Fix delete action shown based on currentFolder regardless of mail folder

### DIFF
--- a/src/mail-app/mail/view/MailListView.ts
+++ b/src/mail-app/mail/view/MailListView.ts
@@ -415,7 +415,7 @@ export class MailListView implements Component<MailListViewAttrs> {
 		const actionableMails = await this.mailViewModel.getResolvedMails([listElement])
 		const currentFolder = this.mailViewModel.getFolder()
 
-		if (this.mailViewModel.currentFolderDeletesPermanently()) {
+		if (this.mailViewModel.isPermanentDeleteAllowed()) {
 			const wereDeleted = await promptAndDeleteMails(mailLocator.mailModel, actionableMails, assertNotNull(currentFolder)._id, () =>
 				this.mailViewModel.listModel?.selectNone(),
 			)

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -486,7 +486,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	}
 
 	private getDeleteMailsAction() {
-		if (this.mailViewModel.currentFolderDeletesPermanently()) {
+		if (this.mailViewModel.isPermanentDeleteAllowed()) {
 			return () => this.deleteSelectedMails()
 		} else {
 			return null
@@ -593,7 +593,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	}
 
 	private getShortcuts(): Array<Shortcut> {
-		const deleteOrTrashAction = () => (this.mailViewModel.currentFolderDeletesPermanently() ? this.deleteSelectedMails() : this.trashSelectedMails())
+		const deleteOrTrashAction = () => (this.mailViewModel.isPermanentDeleteAllowed() ? this.deleteSelectedMails() : this.trashSelectedMails())
 
 		return [
 			...listSelectionKeyboardShortcuts(MultiselectMode.Enabled, () => this.mailViewModel),

--- a/src/mail-app/mail/view/MailViewModel.ts
+++ b/src/mail-app/mail/view/MailViewModel.ts
@@ -396,9 +396,18 @@ export class MailViewModel {
 		}
 	}
 
-	currentFolderDeletesPermanently(): boolean {
-		const folder = this.getFolder()
-		return folder != null && (folder.folderType === MailSetKind.TRASH || folder.folderType === MailSetKind.SPAM)
+	/**
+	 * Permanent delete is only allowed when the mail is in the current folder and the current folder is Trash/Spam.
+	 */
+	isPermanentDeleteAllowed(): boolean {
+		const primaryMailFolder = this.conversationViewModel != null ? this.mailModel.getMailFolderForMail(this.conversationViewModel.primaryMail) : null
+		const currentFolder = this.getFolder()
+
+		if (primaryMailFolder != null && currentFolder != null && !isSameId(currentFolder._id, primaryMailFolder._id)) {
+			return false
+		} else {
+			return currentFolder != null && (currentFolder.folderType === MailSetKind.TRASH || currentFolder.folderType === MailSetKind.SPAM)
+		}
 	}
 
 	/**


### PR DESCRIPTION
Permanent delete should only be allowed when the mail is in the current folder and the current folder allows deletion (Trash/Spam). Otherwise, the trash action is shown instead.

Previously we only checked the current folder. Meaning, if the current folder is Trash/Spam, and we open a mail from notification, the delete action was shown, even though the mail was neither in Trash nor Spam.

Close #9431