### PR TITLE
Fix external image replacement serialization

### DIFF
--- a/packages/otest/lib/Assertion.ts
+++ b/packages/otest/lib/Assertion.ts
@@ -80,7 +80,11 @@ export class Assertion<T> {
 	satisfies(check: (value: T) => { pass: false; message: string } | { pass: true }): AssertionDescriber {
 		const result = check(this.actual)
 		if (!result.pass) {
-			return this.addError(`expected to satisfy condition: "${result.message}"`)
+			return this.addError(`expected
+${this.actual}
+to satisfy condition:
+${result.message}
+`)
 		}
 		return noop
 	}
@@ -96,7 +100,11 @@ export class Assertion<T> {
 	): Promise<AssertionDescriber> {
 		const result = await check(this.actual)
 		if (!result.pass) {
-			return this.addError(`expected to satisfy condition: "${result.message}"`)
+			return this.addError(`expected
+${this.actual}
+to satisfy condition:
+${result.message}
+`)
 		}
 		return noop
 	}
@@ -105,7 +113,10 @@ export class Assertion<T> {
 	notSatisfies(check: (value: T) => { pass: boolean; message: string }): AssertionDescriber {
 		const result = check(this.actual)
 		if (result.pass) {
-			return this.addError(`expected "${asString(this.actual)}" to NOT satisfy condition: "${result.message}"`)
+			return this.addError(`expected
+${asString(this.actual)}
+to NOT satisfy condition:
+${result.message}`)
 		}
 		return noop
 	}

--- a/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventModel.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventModel.ts
@@ -180,7 +180,7 @@ export async function makeCalendarEventModel(
 	showProgress: ShowProgressCallback = identity,
 	uiUpdateCallback: () => void = m.redraw,
 ): Promise<CalendarEventModel | null> {
-	const { htmlSanitizer } = await import("../../../../common/misc/HtmlSanitizer.js")
+	const { getHtmlSanitizer } = await import("../../../../common/misc/HtmlSanitizer.js")
 	const ownMailAddresses = getOwnMailAddressesWithDefaultSenderInFront(logins, mailboxDetail, mailboxProperties)
 	if (operation === CalendarOperation.DeleteAll || operation === CalendarOperation.EditAll) {
 		assertNonNull(initialValues.uid, "tried to edit/delete all with nonexistent uid")
@@ -226,7 +226,7 @@ export async function makeCalendarEventModel(
 		alarmModel: new CalendarEventAlarmModel(eventType, alarms, new DefaultDateProvider(), uiUpdateCallback),
 		location: new SimpleTextViewModel(initializationEvent.location, uiUpdateCallback),
 		summary: new SimpleTextViewModel(initializationEvent.summary, uiUpdateCallback),
-		description: new SanitizedTextViewModel(initializationEvent.description, htmlSanitizer, uiUpdateCallback),
+		description: new SanitizedTextViewModel(initializationEvent.description, getHtmlSanitizer(), uiUpdateCallback),
 	})
 
 	const recurrenceIds = async (uid?: string) =>

--- a/src/calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.ts
+++ b/src/calendar-app/calendar/gui/eventpopup/CalendarEventPreviewViewModel.ts
@@ -221,11 +221,11 @@ export class CalendarEventPreviewViewModel {
 	}
 
 	async sanitizeDescription(): Promise<void> {
-		const { htmlSanitizer } = await import("../../../../common/misc/HtmlSanitizer.js")
+		const { getHtmlSanitizer } = await import("../../../../common/misc/HtmlSanitizer.js")
 		this.sanitizedDescription = prepareCalendarDescription(
 			this.calendarEvent.description,
 			(s) =>
-				htmlSanitizer.sanitizeHTML(convertTextToHtml(s), {
+				getHtmlSanitizer().sanitizeHTML(convertTextToHtml(s), {
 					blockExternalContent: false,
 					highlightedStrings: this.highlightedStrings,
 				}).html,

--- a/src/calendar-app/calendar/view/CalendarInvites.ts
+++ b/src/calendar-app/calendar/view/CalendarInvites.ts
@@ -53,7 +53,7 @@ async function getParsedEvent(fileData: DataFile): Promise<ParsedIcalFileContent
 }
 
 export async function showEventDetails(event: CalendarEvent, eventBubbleRect: ClientRect, mail: Mail | null): Promise<void> {
-	const [latestEvent, { CalendarEventPopup }, { CalendarEventPreviewViewModel }, { htmlSanitizer }] = await Promise.all([
+	const [latestEvent, { CalendarEventPopup }, { CalendarEventPreviewViewModel }, { getHtmlSanitizer }] = await Promise.all([
 		getLatestEvent(event),
 		import("../gui/eventpopup/CalendarEventPopup.js"),
 		import("../gui/eventpopup/CalendarEventPreviewViewModel.js"),
@@ -94,7 +94,7 @@ export async function showEventDetails(event: CalendarEvent, eventBubbleRect: Cl
 		lazyIndexEntry,
 		editModelsFactory,
 	)
-	new CalendarEventPopup(viewModel, eventBubbleRect, htmlSanitizer).show()
+	new CalendarEventPopup(viewModel, eventBubbleRect, getHtmlSanitizer()).show()
 }
 
 export async function getEventsFromFile(file: TutanotaFile, invitedConfidentially: boolean): Promise<ParsedIcalFileContent> {
@@ -173,7 +173,12 @@ export class CalendarInviteHandler {
 		const responseModel = await this.getResponseModelForMail(previousMail, mailboxDetails, attendee.address.address)
 
 		try {
-			await notificationModel.send(eventClone, [], { responseModel, inviteModel: null, cancelModel: null, updateModel: null })
+			await notificationModel.send(eventClone, [], {
+				responseModel,
+				inviteModel: null,
+				cancelModel: null,
+				updateModel: null,
+			})
 		} catch (e) {
 			if (e instanceof UserError) {
 				await Dialog.message(lang.makeTranslation("confirm_msg", e.message))

--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -159,7 +159,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 
 		this.viewModel = attrs.calendarViewModel
 		this.currentViewType = deviceConfig.getDefaultCalendarView(userId) || CalendarViewType.MONTH
-		this.htmlSanitizer = import("../../../common/misc/HtmlSanitizer").then((m) => m.htmlSanitizer)
+		this.htmlSanitizer = import("../../../common/misc/HtmlSanitizer").then((m) => m.getHtmlSanitizer())
 		this.sidebarColumn = new ViewColumn(
 			{
 				view: () =>

--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -787,7 +787,7 @@ class CalendarLocator implements CommonLocator {
 				: new WebThemeFacade(deviceConfig)
 		const lazySanitizer = isTest()
 			? () => Promise.resolve(sanitizerStub as HtmlSanitizer)
-			: () => import("../common/misc/HtmlSanitizer").then(({ htmlSanitizer }) => htmlSanitizer)
+			: () => import("../common/misc/HtmlSanitizer").then(({ getHtmlSanitizer }) => getHtmlSanitizer())
 
 		this.themeController = new ThemeController(theme, selectedThemeFacade, lazySanitizer, AppType.Calendar)
 

--- a/src/common/gui/editor/HtmlEditor.ts
+++ b/src/common/gui/editor/HtmlEditor.ts
@@ -4,7 +4,7 @@ import { Editor } from "./Editor.js"
 import type { MaybeTranslation, TranslationKey } from "../../misc/LanguageViewModel"
 import { lang } from "../../misc/LanguageViewModel"
 import { px } from "../size"
-import { htmlSanitizer } from "../../misc/HtmlSanitizer"
+import { getHtmlSanitizer, HtmlSanitizer } from "../../misc/HtmlSanitizer"
 import { assertNotNull } from "@tutao/tutanota-utils"
 import { DropDownSelector } from "../base/DropDownSelector.js"
 import { RichTextToolbar, RichTextToolbarAttrs } from "../base/RichTextToolbar.js"
@@ -33,6 +33,8 @@ export class HtmlEditor implements Component {
 	private toolbarAttrs: Omit<RichTextToolbarAttrs, "editor"> = {}
 	private staticLineAmount: number | null = null // Static amount of lines the editor shall allow at all times
 
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
+
 	constructor(
 		private label?: MaybeTranslation,
 		private readonly injections?: () => Children,
@@ -40,7 +42,7 @@ export class HtmlEditor implements Component {
 		this.editor = new Editor(
 			null,
 			(html) =>
-				htmlSanitizer.sanitizeFragment(html, {
+				this.htmlSanitizer.sanitizeFragment(html, {
 					blockExternalContent: false,
 					allowRelativeLinks: this.areRelativeLinksAllowed,
 				}).fragment,
@@ -216,7 +218,7 @@ export class HtmlEditor implements Component {
 			}
 		} else {
 			if (this.domTextArea) {
-				return htmlSanitizer.sanitizeHTML(this.domTextArea.value, {
+				return this.htmlSanitizer.sanitizeHTML(this.domTextArea.value, {
 					blockExternalContent: false,
 					allowRelativeLinks: this.areRelativeLinksAllowed,
 				}).html

--- a/src/common/mailFunctionality/SendMailModel.ts
+++ b/src/common/mailFunctionality/SendMailModel.ts
@@ -900,9 +900,9 @@ export class SendMailModel {
 			const attachments = saveAttachments ? this.attachments : null
 
 			// We also want to create new drafts for drafts edited from trash or spam folder
-			const { htmlSanitizer } = await import("../misc/HtmlSanitizer.js")
+			const { getHtmlSanitizer } = await import("../misc/HtmlSanitizer.js")
 			const unsanitized_body = this.getBody()
-			const body = htmlSanitizer.sanitizeHTML(unsanitized_body, {
+			const body = getHtmlSanitizer().sanitizeHTML(unsanitized_body, {
 				// store the draft always with external links preserved. this reverts
 				// the draft-src and draft-srcset attribute stow.
 				blockExternalContent: false,

--- a/src/common/settings/EditNotificationEmailDialog.ts
+++ b/src/common/settings/EditNotificationEmailDialog.ts
@@ -11,7 +11,7 @@ import { DropDownSelector } from "../gui/base/DropDownSelector.js"
 import { TextField } from "../gui/base/TextField.js"
 import { showProgressDialog } from "../gui/dialogs/ProgressDialog.js"
 import { assertNotNull, LazyLoaded, memoized, neverNull, ofClass } from "@tutao/tutanota-utils"
-import { htmlSanitizer } from "../misc/HtmlSanitizer.js"
+import { getHtmlSanitizer } from "../misc/HtmlSanitizer.js"
 import { PayloadTooLargeError } from "../api/common/error/RestError.js"
 import { SegmentControl } from "../gui/base/SegmentControl.js"
 import { UserError } from "../api/main/UserError.js"
@@ -162,6 +162,7 @@ export function show(existingTemplate: NotificationMailTemplate | null, customer
 		senderDomain = "https://" + ((whitelabelDomainInfo && whitelabelDomainInfo.domain) || "app.tuta.com")
 		m.redraw()
 	})
+	const htmlSanitizer = getHtmlSanitizer()
 	// Even though savedHtml is always sanitized changing it might lead to mXSS
 	const sanitizePreview = memoized<(html: string) => string>((html) => {
 		return htmlSanitizer.sanitizeHTML(html).html

--- a/src/common/settings/keymanagement/FingerprintRenderers.ts
+++ b/src/common/settings/keymanagement/FingerprintRenderers.ts
@@ -1,4 +1,4 @@
-import { htmlSanitizer } from "../../misc/HtmlSanitizer"
+import { getHtmlSanitizer } from "../../misc/HtmlSanitizer"
 import QRCode from "qrcode-svg"
 import { KeyVerificationQrPayload } from "./KeyVerificationQrPayload"
 import { PublicKeyFingerprint } from "../../api/worker/facades/lazy/KeyVerificationFacade"
@@ -18,5 +18,5 @@ export function renderFingerprintAsQrCode(selfMailAddress: string, selfFingerpri
 		xmlDeclaration: false,
 	})
 
-	return htmlSanitizer.sanitizeSVG(qrCode.svg()).html
+	return getHtmlSanitizer().sanitizeSVG(qrCode.svg()).html
 }

--- a/src/common/settings/login/secondfactor/SecondFactorEditModel.ts
+++ b/src/common/settings/login/secondfactor/SecondFactorEditModel.ts
@@ -4,12 +4,12 @@ import { validateWebauthnDisplayName, WebauthnClient } from "../../../misc/2fa/w
 import { TotpSecret } from "@tutao/tutanota-crypto"
 import { assertNotNull, LazyLoaded, neverNull } from "@tutao/tutanota-utils"
 import { isApp } from "../../../api/common/Env.js"
-import { LanguageViewModel, TranslationKey } from "../../../misc/LanguageViewModel.js"
+import { TranslationKey } from "../../../misc/LanguageViewModel.js"
 import { SecondFactorType } from "../../../api/common/TutanotaConstants.js"
 import { ProgrammingError } from "../../../api/common/error/ProgrammingError.js"
 import { LoginFacade } from "../../../api/worker/facades/LoginFacade.js"
 import { UserError } from "../../../api/main/UserError.js"
-import { htmlSanitizer } from "../../../misc/HtmlSanitizer.js"
+import { getHtmlSanitizer } from "../../../misc/HtmlSanitizer.js"
 import QRCode from "qrcode-svg"
 
 export const enum VerificationStatus {
@@ -64,7 +64,7 @@ export class SecondFactorEditModel {
 
 			const totpQRCodeSvg = isApp()
 				? null
-				: htmlSanitizer.sanitizeSVG(
+				: getHtmlSanitizer().sanitizeSVG(
 						new QRCode({
 							height: 150,
 							width: 150,

--- a/src/common/sharing/GroupSharingUtils.ts
+++ b/src/common/sharing/GroupSharingUtils.ts
@@ -5,7 +5,7 @@ import { showProgressDialog } from "../gui/dialogs/ProgressDialog"
 import type { GroupSharingTexts } from "./GroupGuiUtils"
 import { getDefaultGroupName, getInvitationGroupType, getSharedGroupName } from "./GroupUtils"
 import { PartialRecipient, Recipients } from "../api/common/recipients/Recipient"
-import { getDefaultSender, getEnabledMailAddressesWithUser, getMailAddressDisplayText, getSenderNameForUser } from "../mailFunctionality/SharedMailUtils.js"
+import { getDefaultSender, getEnabledMailAddressesWithUser, getSenderNameForUser } from "../mailFunctionality/SharedMailUtils.js"
 
 export function sendShareNotificationEmail(sharedGroupInfo: GroupInfo, recipients: Array<PartialRecipient>, texts: GroupSharingTexts) {
 	locator.mailboxModel.getUserMailboxDetails().then((mailboxDetails) => {
@@ -82,8 +82,8 @@ export function sendRejectNotificationEmail(invitation: ReceivedGroupInvitation,
 }
 
 function _sendNotificationEmail(recipients: Recipients, subject: string, body: string, senderMailAddress: string) {
-	import("../misc/HtmlSanitizer").then(({ htmlSanitizer }) => {
-		const sanitizedBody = htmlSanitizer.sanitizeHTML(body, {
+	import("../misc/HtmlSanitizer").then(({ getHtmlSanitizer }) => {
+		const sanitizedBody = getHtmlSanitizer().sanitizeHTML(body, {
 			blockExternalContent: false,
 			allowRelativeLinks: false,
 			usePlaceholderForInlineImages: false,

--- a/src/common/subscription/TermsAndConditions.ts
+++ b/src/common/subscription/TermsAndConditions.ts
@@ -6,7 +6,7 @@ import { InfoLink, lang } from "../misc/LanguageViewModel"
 import { isApp } from "../api/common/Env"
 import { requestFromWebsite } from "../misc/Website"
 import { Dialog } from "../gui/base/Dialog"
-import { htmlSanitizer } from "../misc/HtmlSanitizer"
+import { getHtmlSanitizer } from "../misc/HtmlSanitizer"
 import { DialogHeaderBarAttrs } from "../gui/base/DialogHeaderBar"
 import { ButtonType } from "../gui/base/Button.js"
 import { locator } from "../api/main/CommonLocator.js"
@@ -72,7 +72,7 @@ export async function showServiceTerms(section: TermsSection, version: string) {
 	let sanitizedTerms: string
 
 	function getSection(): string {
-		return htmlSanitizer.sanitizeHTML(termsFromWebsite[visibleLang], {
+		return getHtmlSanitizer().sanitizeHTML(termsFromWebsite[visibleLang], {
 			blockExternalContent: false,
 		}).html
 	}

--- a/src/common/subscription/giftcards/GiftCardUtils.ts
+++ b/src/common/subscription/giftcards/GiftCardUtils.ts
@@ -16,7 +16,7 @@ import { Keys } from "../../api/common/TutanotaConstants"
 import { CURRENT_GIFT_CARD_TERMS_VERSION, renderTermsAndConditionsButton, TermsSection } from "../TermsAndConditions"
 import { IconButton } from "../../gui/base/IconButton.js"
 import { formatPrice } from "../PriceUtils.js"
-import { htmlSanitizer } from "../../misc/HtmlSanitizer.js"
+import { getHtmlSanitizer } from "../../misc/HtmlSanitizer.js"
 import { urlEncodeHtmlTags } from "../../misc/Formatter.js"
 import QRCode from "qrcode-svg"
 
@@ -271,7 +271,7 @@ function getGiftCardElement(svgDocument: Document, id: "price" | "qr-code" | "me
  * @param message The text to be displayed in the element.
  */
 function renderMessage(x: number, y: number, width: number, height: number, color: string, message: string): string {
-	const cleanMessage: string = htmlSanitizer.sanitizeHTML(urlEncodeHtmlTags(message)).html
+	const cleanMessage: string = getHtmlSanitizer().sanitizeHTML(urlEncodeHtmlTags(message)).html
 
 	const lineBreaks = cleanMessage.split(/\r\n|\r|\n/).length
 	const charLength = cleanMessage.length
@@ -310,7 +310,7 @@ function renderQRCode(x: number, y: number, width: number, height: number, link:
 		join: true,
 		pretty: false,
 	}).svg()
-	const qrCode = htmlSanitizer.sanitizeSVG(svg).html
+	const qrCode = getHtmlSanitizer().sanitizeSVG(svg).html
 
 	return `<svg x="${x}" y="${y}" width="${width}" height="${height}">${qrCode}</svg>`
 }

--- a/src/common/support/FaqModel.ts
+++ b/src/common/support/FaqModel.ts
@@ -3,7 +3,7 @@ import { lang, LanguageViewModel } from "../misc/LanguageViewModel"
 import { delay, downcast, LazyLoaded } from "@tutao/tutanota-utils"
 import { search } from "../api/common/utils/PlainTextSearch"
 import { ProgrammingError } from "../api/common/error/ProgrammingError.js"
-import { htmlSanitizer } from "../misc/HtmlSanitizer.js"
+import { getHtmlSanitizer, HtmlSanitizer } from "../misc/HtmlSanitizer.js"
 
 export type FaqEntry = {
 	id: string
@@ -32,6 +32,7 @@ export class FaqModel {
 	private faqLanguages: LanguageViewModelType | null = null
 	private lazyLoaded: LazyLoaded<void>
 	private websiteBaseUrl: string = "https://tuta.com"
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
 
 	private get faqLang(): LanguageViewModel {
 		if (this.faqLanguages == null) {
@@ -94,9 +95,9 @@ export class FaqModel {
 	private sanitizeEntry(result: SearchableFaqEntry): FaqEntry {
 		return {
 			id: result.id,
-			title: htmlSanitizer.sanitizeHTML(result.title).html,
-			tags: result.tags.split(", ").map((tag) => htmlSanitizer.sanitizeHTML(tag).html),
-			text: htmlSanitizer.sanitizeHTML(result.text, { blockExternalContent: false }).html,
+			title: this.htmlSanitizer.sanitizeHTML(result.title).html,
+			tags: result.tags.split(", ").map((tag) => this.htmlSanitizer.sanitizeHTML(tag).html),
+			text: this.htmlSanitizer.sanitizeHTML(result.text, { blockExternalContent: false }).html,
 		}
 	}
 

--- a/src/common/support/pages/ContactSupportPage.ts
+++ b/src/common/support/pages/ContactSupportPage.ts
@@ -7,7 +7,7 @@ import { locator } from "../../api/main/CommonLocator.js"
 import { lang } from "../../misc/LanguageViewModel.js"
 import { Card } from "../../gui/base/Card.js"
 import { LoginButton } from "../../gui/base/buttons/LoginButton.js"
-import { htmlSanitizer } from "../../misc/HtmlSanitizer.js"
+import { getHtmlSanitizer, HtmlSanitizer } from "../../misc/HtmlSanitizer.js"
 import { MailMethod, PlanTypeToName } from "../../api/common/TutanotaConstants.js"
 import type { SendMailModel } from "../../mailFunctionality/SendMailModel.js"
 import { convertTextToHtml } from "../../misc/Formatter.js"
@@ -31,6 +31,7 @@ type Props = {
 
 export class ContactSupportPage implements Component<Props> {
 	private sendMailModel: SendMailModel | undefined
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
 
 	private htmlEditor: HtmlEditor | null = null
 
@@ -221,7 +222,7 @@ export class ContactSupportPage implements Component<Props> {
 								? `${data.supportRequestHtml}${clientInfoString(new Date(), true).message}`
 								: data.supportRequestHtml
 							mailBody += `<br>Customer ID: ${customerId}`
-							const sanitisedBody = htmlSanitizer.sanitizeHTML(convertTextToHtml(mailBody), {
+							const sanitisedBody = this.htmlSanitizer.sanitizeHTML(convertTextToHtml(mailBody), {
 								blockExternalContent: true,
 							}).html
 

--- a/src/common/support/pages/SupportTopicPage.ts
+++ b/src/common/support/pages/SupportTopicPage.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component, Vnode } from "mithril"
 import { lang } from "../../misc/LanguageViewModel.js"
-import { htmlSanitizer } from "../../misc/HtmlSanitizer.js"
+import { getHtmlSanitizer, HtmlSanitizer } from "../../misc/HtmlSanitizer.js"
 import { convertTextToHtml } from "../../misc/Formatter.js"
 import { getContactSupportText, getTopicIssue, SupportDialogState } from "../SupportDialog.js"
 import { Dialog } from "../../gui/base/Dialog.js"
@@ -21,6 +21,8 @@ type Props = {
 }
 
 export class SupportTopicPage implements Component<Props> {
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
+
 	view({ attrs: { data, goToContactSupportPage, goToSolutionWasHelpfulPage } }: Vnode<Props>): Children {
 		const topic = data.selectedTopic()
 		if (topic == null) {
@@ -29,7 +31,7 @@ export class SupportTopicPage implements Component<Props> {
 
 		const languageTag = lang.languageTag
 		const solution = languageTag.includes("de") ? topic.solutionHtmlDE : topic.solutionHtmlEN
-		const sanitisedSolution = htmlSanitizer.sanitizeHTML(convertTextToHtml(solution), {
+		const sanitisedSolution = this.htmlSanitizer.sanitizeHTML(convertTextToHtml(solution), {
 			blockExternalContent: true,
 			allowRelativeLinks: true,
 		}).html

--- a/src/mail-app/knowledgebase/view/KnowledgeBaseEntryView.ts
+++ b/src/mail-app/knowledgebase/view/KnowledgeBaseEntryView.ts
@@ -2,7 +2,7 @@ import m, { Children, Component, Vnode } from "mithril"
 import type { KnowledgeBaseEntry } from "../../../common/api/entities/tutanota/TypeRefs.js"
 import { TemplateGroupRootTypeRef } from "../../../common/api/entities/tutanota/TypeRefs.js"
 import { memoized, neverNull, noOp, ofClass, startsWith } from "@tutao/tutanota-utils"
-import { htmlSanitizer } from "../../../common/misc/HtmlSanitizer.js"
+import { getHtmlSanitizer, HtmlSanitizer } from "../../../common/misc/HtmlSanitizer.js"
 import { Icons } from "../../../common/gui/base/icons/Icons.js"
 import { locator } from "../../../common/api/main/CommonLocator.js"
 import { getConfirmation } from "../../../common/gui/base/GuiUtils.js"
@@ -19,6 +19,8 @@ type KnowledgeBaseEntryViewAttrs = {
  *  Renders one knowledgeBase entry
  */
 export class KnowledgeBaseEntryView implements Component<KnowledgeBaseEntryViewAttrs> {
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
+
 	_sanitizedEntry: (arg0: KnowledgeBaseEntry) => {
 		content: string
 	}
@@ -26,7 +28,7 @@ export class KnowledgeBaseEntryView implements Component<KnowledgeBaseEntryViewA
 	constructor() {
 		this._sanitizedEntry = memoized((entry) => {
 			return {
-				content: htmlSanitizer.sanitizeHTML(entry.description, {
+				content: this.htmlSanitizer.sanitizeHTML(entry.description, {
 					blockExternalContent: true,
 				}).html,
 			}

--- a/src/mail-app/mail/editor/MailEditor.ts
+++ b/src/mail-app/mail/editor/MailEditor.ts
@@ -31,7 +31,7 @@ import { ExpanderPanel } from "../../../common/gui/base/Expander"
 import { windowFacade } from "../../../common/misc/WindowFacade"
 import { UserError } from "../../../common/api/main/UserError"
 import { showProgressDialog } from "../../../common/gui/dialogs/ProgressDialog"
-import { htmlSanitizer } from "../../../common/misc/HtmlSanitizer"
+import { getHtmlSanitizer, HtmlSanitizer } from "../../../common/misc/HtmlSanitizer"
 import { DropDownSelector } from "../../../common/gui/base/DropDownSelector.js"
 import {
 	Contact,
@@ -159,6 +159,8 @@ export class MailEditor implements Component<MailEditorAttrs> {
 	// we don't want to show the banner.
 	private blockedExternalContent: number = 0
 
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
+
 	constructor(vnode: Vnode<MailEditorAttrs>) {
 		const a = vnode.attrs
 		this.attrs = a
@@ -176,7 +178,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 		this.editor = new Editor(
 			200,
 			(html, isPaste) => {
-				const sanitized = htmlSanitizer.sanitizeFragment(html, {
+				const sanitized = this.htmlSanitizer.sanitizeFragment(html, {
 					blockExternalContent: !isPaste && this.blockExternalContent,
 				})
 				this.blockedExternalContent = sanitized.blockedExternalContent
@@ -555,7 +557,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 	private updateExternalContentStatus(status: ContentBlockingStatus) {
 		this.blockExternalContent = status === ContentBlockingStatus.Block || status === ContentBlockingStatus.AlwaysBlock
 
-		const sanitized = htmlSanitizer.sanitizeHTML(this.editor.getHTML(), {
+		const sanitized = this.htmlSanitizer.sanitizeHTML(this.editor.getHTML(), {
 			blockExternalContent: this.blockExternalContent,
 		})
 

--- a/src/mail-app/mail/export/Exporter.ts
+++ b/src/mail-app/mail/export/Exporter.ts
@@ -72,10 +72,11 @@ export async function exportMails(
 			if (cancelled) throw new CancelledError("export cancelled")
 		}
 
+		const { getHtmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
+		const htmlSanitizer = getHtmlSanitizer()
 		const downloadPromise = promiseMap(mails, async (mail) => {
 			checkAbortSignal()
 			try {
-				const { htmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
 				return await downloadMailBundle(mail, mailFacade, entityClient, fileController, htmlSanitizer, cryptoFacade)
 			} catch (e) {
 				errorMails.push(mail)

--- a/src/mail-app/mail/press/PressReleaseEditor.ts
+++ b/src/mail-app/mail/press/PressReleaseEditor.ts
@@ -10,7 +10,7 @@ import type { MailboxDetail } from "../../../common/mailFunctionality/MailboxMod
 import { Keys, MailMethod, TabIndex } from "../../../common/api/common/TutanotaConstants"
 import { progressIcon } from "../../../common/gui/base/Icon"
 import { Editor } from "../../../common/gui/editor/Editor"
-import { htmlSanitizer } from "../../../common/misc/HtmlSanitizer"
+import { getHtmlSanitizer, HtmlSanitizer } from "../../../common/misc/HtmlSanitizer"
 import { replaceInlineImagesWithCids } from "../view/MailGuiUtils"
 import { TextField } from "../../../common/gui/base/TextField.js"
 import { DialogHeaderBarAttrs } from "../../../common/gui/base/DialogHeaderBar"
@@ -218,12 +218,14 @@ export type PressReleaseFormAttrs = {
 export class PressReleaseForm implements Component<PressReleaseFormAttrs> {
 	editor: Editor
 
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
+
 	constructor(vnode: Vnode<PressReleaseFormAttrs>) {
 		const { bodyHtml } = vnode.attrs
 		this.editor = new Editor(
 			200,
 			(html, _) =>
-				htmlSanitizer.sanitizeFragment(html, {
+				this.htmlSanitizer.sanitizeFragment(html, {
 					blockExternalContent: false,
 				}).fragment,
 			null,

--- a/src/mail-app/mail/signature/Signature.ts
+++ b/src/mail-app/mail/signature/Signature.ts
@@ -1,7 +1,7 @@
 import { InfoLink, lang } from "../../../common/misc/LanguageViewModel"
 import type { TutanotaProperties } from "../../../common/api/entities/tutanota/TypeRefs.js"
 import { EmailSignatureType as TutanotaConstants } from "../../../common/api/common/TutanotaConstants"
-import { htmlSanitizer } from "../../../common/misc/HtmlSanitizer"
+import { getHtmlSanitizer } from "../../../common/misc/HtmlSanitizer"
 import type { LoginController } from "../../../common/api/main/LoginController"
 import { assertMainOrNode } from "../../../common/api/common/Env"
 import { LINE_BREAK } from "../../../common/mailFunctionality/SharedMailUtils.js"
@@ -12,7 +12,7 @@ export function getDefaultSignature(): string {
 	// add one line break to the default signature to add one empty line between signature and body
 	return (
 		LINE_BREAK +
-		htmlSanitizer.sanitizeHTML(
+		getHtmlSanitizer().sanitizeHTML(
 			lang.get("defaultEmailSignature_msg", {
 				"{1}": `<a href=${InfoLink.HomePageFreeSignup}>${InfoLink.HomePageFreeSignup}</a>`,
 			}),

--- a/src/mail-app/mail/view/MailGuiUtils.ts
+++ b/src/mail-app/mail/view/MailGuiUtils.ts
@@ -455,8 +455,8 @@ export async function loadInlineImages(fileController: FileController, attachmen
 	const inlineImages = new Map()
 	return promiseMap(filesToLoad, async (file) => {
 		let dataFile = await fileController.getAsDataFile(file)
-		const { htmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
-		dataFile = htmlSanitizer.sanitizeInlineAttachment(dataFile)
+		const { getHtmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
+		dataFile = getHtmlSanitizer().sanitizeInlineAttachment(dataFile)
 		const inlineImageReference = createInlineImageReference(dataFile, neverNull(file.cid))
 		inlineImages.set(inlineImageReference.cid, inlineImageReference)
 	}).then(() => inlineImages)

--- a/src/mail-app/mail/view/MailListView.ts
+++ b/src/mail-app/mail/view/MailListView.ts
@@ -268,13 +268,15 @@ export class MailListView implements Component<MailListViewAttrs> {
 			notDownloaded.map((f) => f.fileName),
 			new Set(downloaded.map((f) => f.fileName)),
 		)
+
+		const { getHtmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
+		const htmlSanitizer = getHtmlSanitizer()
 		const [newFiles, existingFiles] = await Promise.all([
 			// Download all the files that need downloading, wait for them, and then return the filename
 			promiseMap(notDownloaded, async ({ mail, fileName }) => {
 				const name = assertNotNull(deduplicatedNames[fileName].shift())
 				const key = mapKey(mail)
 				const downloadPromise = Promise.resolve().then(async () => {
-					const { htmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
 					const bundle = await downloadMailBundle(
 						mail,
 						locator.mailFacade,

--- a/src/mail-app/mail/view/MailViewerViewModel.ts
+++ b/src/mail-app/mail/view/MailViewerViewModel.ts
@@ -974,13 +974,13 @@ export class MailViewerViewModel {
 	}
 
 	private async sanitizeMailBody(mail: Mail, blockExternalContent: boolean): Promise<SanitizedFragment> {
-		const { htmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
+		const { getHtmlSanitizer } = await import("../../../common/misc/HtmlSanitizer")
 		const rawBody = this.getMailBody()
 		const urlified = await this.workerFacade.urlify(rawBody).catch((e) => {
 			console.warn("Failed to urlify mail body!", e)
 			return rawBody
 		})
-		const sanitizeResult = htmlSanitizer.sanitizeFragment(urlified, {
+		const sanitizeResult = getHtmlSanitizer().sanitizeFragment(urlified, {
 			blockExternalContent,
 			allowRelativeLinks: isTutanotaTeamMail(mail),
 			highlightedStrings: this.highlightedStrings,

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -988,7 +988,7 @@ class MailLocator implements CommonLocator {
 			isApp() || isDesktop() ? new NativeThemeFacade(new LazyLoaded<ThemeFacade>(async () => mailLocator.themeFacade)) : new WebThemeFacade(deviceConfig)
 		const lazySanitizer = isTest()
 			? () => Promise.resolve(sanitizerStub as HtmlSanitizer)
-			: () => import("../common/misc/HtmlSanitizer").then(({ htmlSanitizer }) => htmlSanitizer)
+			: () => import("../common/misc/HtmlSanitizer").then(({ getHtmlSanitizer }) => getHtmlSanitizer())
 
 		this.themeController = new ThemeController(theme, selectedThemeFacade, lazySanitizer, AppType.Mail)
 
@@ -1220,9 +1220,9 @@ class MailLocator implements CommonLocator {
 	}
 
 	readonly mailExportController: () => Promise<MailExportController> = lazyMemoized(async () => {
-		const { htmlSanitizer } = await import("../common/misc/HtmlSanitizer")
+		const { getHtmlSanitizer } = await import("../common/misc/HtmlSanitizer")
 		const { MailExportController } = await import("./native/main/MailExportController.js")
-		return new MailExportController(this.mailExportFacade, htmlSanitizer, this.exportFacade, this.logins, this.mailboxModel, await this.scheduler())
+		return new MailExportController(this.mailExportFacade, getHtmlSanitizer(), this.exportFacade, this.logins, this.mailboxModel, await this.scheduler())
 	})
 
 	async offlineStorageSettingsModel(): Promise<OfflineStorageSettingsModel | null> {

--- a/src/mail-app/settings/TemplateDetailsViewer.ts
+++ b/src/mail-app/settings/TemplateDetailsViewer.ts
@@ -13,7 +13,7 @@ import { locator } from "../../common/api/main/CommonLocator"
 import { EntityClient } from "../../common/api/common/EntityClient"
 import { TEMPLATE_SHORTCUT_PREFIX } from "../templates/model/TemplatePopupModel"
 import { ActionBar } from "../../common/gui/base/ActionBar.js"
-import { htmlSanitizer } from "../../common/misc/HtmlSanitizer.js"
+import { getHtmlSanitizer } from "../../common/misc/HtmlSanitizer.js"
 import { EntityUpdateData } from "../../common/api/common/utils/EntityUpdateUtils.js"
 import { UpdatableSettingsDetailsViewer } from "../../common/settings/Interfaces.js"
 
@@ -27,8 +27,12 @@ export class TemplateDetailsViewer implements UpdatableSettingsDetailsViewer {
 		private readonly entityClient: EntityClient,
 		readonly isReadOnly: lazy<boolean>,
 	) {
+		const htmlSanitizer = getHtmlSanitizer()
 		this.sanitizedContents = template.contents.map((emailTemplateContent) => ({
-			text: htmlSanitizer.sanitizeHTML(emailTemplateContent.text, { blockExternalContent: false, allowRelativeLinks: true }).html,
+			text: htmlSanitizer.sanitizeHTML(emailTemplateContent.text, {
+				blockExternalContent: false,
+				allowRelativeLinks: true,
+			}).html,
 			languageCodeTextId: languageByCode[getLanguageCode(emailTemplateContent)].textId,
 		}))
 	}

--- a/src/mail-app/templates/view/TemplateExpander.ts
+++ b/src/mail-app/templates/view/TemplateExpander.ts
@@ -6,7 +6,7 @@ import { isKeyPressed } from "../../../common/misc/KeyManager"
 import type { EmailTemplate } from "../../../common/api/entities/tutanota/TypeRefs.js"
 import { TEMPLATE_POPUP_HEIGHT } from "./TemplateConstants.js"
 import { memoized } from "@tutao/tutanota-utils"
-import { htmlSanitizer } from "../../../common/misc/HtmlSanitizer.js"
+import { getHtmlSanitizer, HtmlSanitizer } from "../../../common/misc/HtmlSanitizer.js"
 import { theme } from "../../../common/gui/theme.js"
 
 /**
@@ -19,9 +19,11 @@ export type TemplateExpanderAttrs = {
 }
 
 export class TemplateExpander implements Component<TemplateExpanderAttrs> {
+	private readonly htmlSanitizer: HtmlSanitizer = getHtmlSanitizer()
+
 	private readonly sanitizedText = memoized(
 		(text: string) =>
-			htmlSanitizer.sanitizeHTML(text, {
+			this.htmlSanitizer.sanitizeHTML(text, {
 				blockExternalContent: false,
 				allowRelativeLinks: true,
 			}).html,

--- a/test/tests/mail/MailUtilsSignatureTest.ts
+++ b/test/tests/mail/MailUtilsSignatureTest.ts
@@ -3,7 +3,7 @@ import { EmailSignatureType } from "../../../src/common/api/common/TutanotaConst
 import { mockAttribute, unmockAttribute } from "@tutao/tutanota-test-utils"
 import { downcast } from "@tutao/tutanota-utils"
 import { lang } from "../../../src/common/misc/LanguageViewModel.js"
-import { htmlSanitizer } from "../../../src/common/misc/HtmlSanitizer.js"
+import { getHtmlSanitizer } from "../../../src/common/misc/HtmlSanitizer.js"
 import type { LoginController } from "../../../src/common/api/main/LoginController.js"
 import { appendEmailSignature, prependEmailSignature } from "../../../src/mail-app/mail/signature/Signature.js"
 import { LINE_BREAK } from "../../../src/common/mailFunctionality/SharedMailUtils.js"
@@ -12,6 +12,7 @@ const TEST_DEFAULT_SIGNATURE = "--\nDefault signature"
 o.spec("MailUtilsSignatureTest", function () {
 	const mockedAttributes: any[] = []
 	o.before(function () {
+		const htmlSanitizer = getHtmlSanitizer()
 		mockedAttributes.push(
 			mockAttribute(lang, lang.get, function (key, obj) {
 				if (key === "defaultEmailSignature_msg") {
@@ -21,6 +22,8 @@ o.spec("MailUtilsSignatureTest", function () {
 				throw new Error("unexpected translation key: " + key)
 			}),
 		)
+
+		// this is cursed, we should refactor to not have to mock global sanitizer
 		mockedAttributes.push(
 			mockAttribute(htmlSanitizer, htmlSanitizer.sanitizeHTML, function (text) {
 				return {


### PR DESCRIPTION
Chromium changed how HTML is serialized:

https://developer.chrome.com/release-notes/138?

https://chromestatus.com/feature/6264983847174144

https://github.com/whatwg/html/issues/6235

Which caused some of our HTML sanitizing tests to fail.

To prevent any possible issues with serialization we instead create a Blob URL for our svg. This way we sidestep DOM serialization peculiarities. As a side effect DOM should be smaller.

Close #9465