### PR TITLE
Do not try to save bounds on window close

### DIFF
--- a/src/common/desktop/DesktopWindowManager.ts
+++ b/src/common/desktop/DesktopWindowManager.ts
@@ -110,7 +110,6 @@ export class WindowManager {
 		const w: ApplicationWindow = await this._newWindowFactory(noAutoLogin)
 		windows.unshift(w)
 		w.on("close", () => {
-			this.saveBounds(w.getBounds())
 			w.setUserId(null)
 		})
 			.on("closed", () => {


### PR DESCRIPTION
Saving the config so close to close easily results in it being empty

Fixes: #7021