### PR TITLE
Fix spelling errors in some variable names, param names and comments.

### DIFF
--- a/app-ios/TutanotaSharedFramework/Alarms/AlarmModel.swift
+++ b/app-ios/TutanotaSharedFramework/Alarms/AlarmModel.swift
@@ -18,14 +18,14 @@ public struct AlarmOccurence: Equatable {
 
 /// Something that can calculate when alarms should happen
 public protocol AlarmCalculator {
-	/// Calcuate the soonest alarm occurences up to the specified limits
+	/// Calculate the soonest alarm occurrences up to the specified limits
 	/// note: return type would ideally not be required to be boxed but it's the easiest until proper upper bound inference is available at runtime
 	/// see https://forums.swift.org/t/inferred-result-type-requires-explicit-coercion/59602/2
 	/// (alternatively we could always produce arrays)
 	func futureOccurrences(acrossAlarms alarms: [AlarmNotification], upToForEach: Int, upToOverall: Int) -> any BidirectionalCollection<AlarmOccurence>
 
-	/// Calculate upcoming alarm occurences for a single alarm
-	/// - Returns: lazy sequence of alarm occurences. It might be infinite if alarm repeats indefinitely!
+	/// Calculate upcoming alarm occurrences for a single alarm
+	/// - Returns: lazy sequence of alarm occurrences. It might be infinite if alarm repeats indefinitely!
 	func futureAlarmOccurrencesSequence(ofAlarm alarm: AlarmNotification) -> any Sequence<AlarmOccurence>
 }
 
@@ -48,7 +48,7 @@ public class AlarmModel: AlarmCalculator {
 		printLog("Handling \(singleEventAlarms.count) single event alarms and \(repeatingEventAlarms.count) repeating event alarms.")
 		for alarm in singleEventAlarms { occurrences += self.futureAlarmOccurrencesSequence(ofAlarm: alarm) }
 		for alarm in repeatingEventAlarms {
-			occurrences += prefix(self.futureAlarmOccurrencesSequence(ofAlarm: alarm), upToForEach)  // Get the first N future occurences. (N = uptoForEach)
+			occurrences += prefix(self.futureAlarmOccurrencesSequence(ofAlarm: alarm), upToForEach)  // Get the first N future occurrences. (N = uptoForEach)
 		}
 
 		occurrences.sort(by: { $0.eventOccurrenceTime < $1.eventOccurrenceTime })
@@ -57,30 +57,30 @@ public class AlarmModel: AlarmCalculator {
 
 	public func futureAlarmOccurrencesSequence(ofAlarm alarm: AlarmNotification) -> any Sequence<AlarmOccurence> {
 		if let repeatRule = alarm.repeatRule {
-			return self.futureOccurences(ofAlarm: alarm, withRepeatRule: repeatRule)
+			return self.futureOccurrences(ofAlarm: alarm, withRepeatRule: repeatRule)
 		} else {
 			let singleOcurrence = AlarmOccurence(occurrenceNumber: 0, eventOccurrenceTime: alarm.eventStart, alarm: alarm)
-			if shouldScheduleAlarmAt(ocurrenceTime: singleOcurrence.alarmOccurenceTime()) { return [singleOcurrence] } else { return [] }
+			if shouldScheduleAlarmAt(occurrenceTime: singleOcurrence.alarmOccurenceTime()) { return [singleOcurrence] } else { return [] }
 		}
 	}
 
-	private func futureOccurences(ofAlarm alarm: AlarmNotification, withRepeatRule: RepeatRule) -> some Sequence<AlarmOccurence> {
-		let occurencesAfterNow = occurencesOfRepeatingEvent(
+	private func futureOccurrences(ofAlarm alarm: AlarmNotification, withRepeatRule: RepeatRule) -> some Sequence<AlarmOccurence> {
+		let occurrencesAfterNow = occurrencesOfRepeatingEvent(
 			eventStart: alarm.eventStart,
 			eventEnd: alarm.eventEnd,
 			repeatRule: withRepeatRule,
 			localTimeZone: dateProvider.timeZone
 		)
 		.lazy  // trying to optimize it: do not calculate alarm occurence if event occurence itself is in the past
-		.filter { self.shouldScheduleAlarmAt(ocurrenceTime: $0.occurenceDate) }
+		.filter { self.shouldScheduleAlarmAt(occurrenceTime: $0.occurenceDate) }
 		.map { occurrence in AlarmOccurence(occurrenceNumber: occurrence.occurrenceNumber, eventOccurrenceTime: occurrence.occurenceDate, alarm: alarm) }
-		.filter { self.shouldScheduleAlarmAt(ocurrenceTime: $0.alarmOccurenceTime()) }
-		return occurencesAfterNow
+		.filter { self.shouldScheduleAlarmAt(occurrenceTime: $0.alarmOccurenceTime()) }
+		return occurrencesAfterNow
 	}
 
-	private func shouldScheduleAlarmAt(ocurrenceTime: Date) -> Bool { ocurrenceTime > dateProvider.now }
+	private func shouldScheduleAlarmAt(occurrenceTime: Date) -> Bool { occurrenceTime > dateProvider.now }
 
-	private func occurencesOfRepeatingEvent(eventStart: Date, eventEnd: Date, repeatRule: RepeatRule, localTimeZone: TimeZone) -> LazyEventSequence {
+	private func occurrencesOfRepeatingEvent(eventStart: Date, eventEnd: Date, repeatRule: RepeatRule, localTimeZone: TimeZone) -> LazyEventSequence {
 		var cal = Calendar.current
 		let calendarUnit = calendarUnit(for: repeatRule.frequency)
 

--- a/app-ios/TutanotaSharedFramework/Keychain/KeychainManager.swift
+++ b/app-ios/TutanotaSharedFramework/Keychain/KeychainManager.swift
@@ -76,7 +76,7 @@ public class KeychainManager: NSObject {
 	}
 
 	public func removePushIdentifierKeys() throws {
-		// TODO: Don't delete all of teh keyz when fingerprints
+		// TODO: Don't delete all of the keyz when fingerprints
 		let deleteQuery: [String: Any] = [kSecClass as String: kSecClassKey]
 		let status = SecItemDelete(deleteQuery as CFDictionary)
 		if status != errSecSuccess { throw TUTErrorFactory.createError("Could not delete the keys, status: \(status)") }
@@ -84,9 +84,9 @@ public class KeychainManager: NSObject {
 
 	/// Whether we should re-encrypt the data that was encrypt using keychain-bound keys.
 	public func requiresKeyAccessMigration() throws -> Bool {
-		// The presence of the new key is a sentiel as we assume that when it is available we don't need to use old keys
+		// The presence of the new key is a sentinel as we assume that when it is available we don't need to use old keys
 		// anymore.
-		// Theretically this method can prompt but since this key is guaranteed to be automatically available it should be safe to call.
+		// Theoretically this method can prompt but since this key is guaranteed to be automatically available it should be safe to call.
 		let key = try self.getKeychainKeyReference(withTag: Self.DATA_KEY_ALIAS, inContext: laContext())
 		return key == nil
 	}


### PR DESCRIPTION
Fix spelling errors in some variable names, param names and comments.