### PR TITLE
process pending group key updates during login with RolloutFacade

### DIFF
--- a/src/common/api/common/TutanotaConstants.ts
+++ b/src/common/api/common/TutanotaConstants.ts
@@ -1358,6 +1358,7 @@ export enum RolloutType {
 	SharedMailboxIdentityKeyCreation = "1",
 	AdminOrUserGroupKeyRotation = "2",
 	OtherGroupKeyRotation = "3",
+	GroupKeyUpdatePending = "4",
 }
 
 /**

--- a/src/common/api/worker/facades/KeyRotationFacade.ts
+++ b/src/common/api/worker/facades/KeyRotationFacade.ts
@@ -860,7 +860,7 @@ export class KeyRotationFacade {
 	 *
 	 * @param groupKeyUpdateIds MUST be in the same list
 	 */
-	async updateGroupMemberships(groupKeyUpdateIds: IdTuple[]): Promise<void> {
+	async updateGroupMembershipsInOneList(groupKeyUpdateIds: IdTuple[]): Promise<void> {
 		if (groupKeyUpdateIds.length < 1) return
 		console.log("handling group key update for groups: ", groupKeyUpdateIds)
 		const groupKeyUpdateInstances = await this.entityClient.loadMultiple(
@@ -868,6 +868,10 @@ export class KeyRotationFacade {
 			listIdPart(groupKeyUpdateIds[0]),
 			groupKeyUpdateIds.map((id) => elementIdPart(id)),
 		)
+		return this.updateGroupMemberships(groupKeyUpdateInstances)
+	}
+
+	async updateGroupMemberships(groupKeyUpdateInstances: GroupKeyUpdate[]): Promise<void> {
 		const groupKeyUpdates = groupKeyUpdateInstances.map((update) => this.prepareGroupMembershipUpdate(update))
 		const membershipPutIn = createMembershipPutIn({
 			groupKeyUpdates,

--- a/test/tests/api/worker/EventBusEventCoordinatorTest.ts
+++ b/test/tests/api/worker/EventBusEventCoordinatorTest.ts
@@ -257,7 +257,7 @@ o.spec("EventBusEventCoordinatorTest", () => {
 
 		await eventBusEventCoordinator.onEntityEventsReceived(updates, "batchId", "groupId")
 
-		verify(keyRotationFacadeMock.updateGroupMemberships([[instanceListId, instanceId]]))
+		verify(keyRotationFacadeMock.updateGroupMembershipsInOneList([[instanceListId, instanceId]]))
 		verify(userFacade.updateUser(user), { times: 0 })
 		verify(cacheManagementFacade.tryUpdatingUserGroupKey(), { times: 0 })
 		verify(eventController.onEntityUpdateReceived(updates, "groupId"))


### PR DESCRIPTION
helps not making an extra request to the list of group key updates during login

processing of group key update was broken when starting to remove the request to the GroupKeyRotationInfoService see #tutadb2366