### PR TITLE
Make sure the offline storage version is consistent with migrations

### DIFF
--- a/buildSrc/DevBuild.js
+++ b/buildSrc/DevBuild.js
@@ -24,12 +24,11 @@ const projectRoot = path.resolve(path.join(buildSrc, ".."))
  * @param host
  * @param desktop
  * @param clean
- * @param ignoreMigrations
  * @param networkDebugging
  * @param app {"mail"|"calendar"}
  * @returns {Promise<void>}
  */
-export async function runDevBuild({ stage, host, desktop, clean, ignoreMigrations, networkDebugging, app }) {
+export async function runDevBuild({ stage, host, desktop, clean, networkDebugging, app }) {
 	const isCalendarBuild = app === "calendar"
 	const tsConfig = isCalendarBuild ? "tsconfig-calendar-app.json" : "tsconfig.json"
 	const buildDir = isCalendarBuild ? "build-calendar-app" : "build"

--- a/make.js
+++ b/make.js
@@ -13,7 +13,6 @@ await program
 	.option("--desktop-build-only", "Assemble desktop client without starting")
 	.option("-v, --verbose", "activate verbose logging in desktop client")
 	.option("-s, --serve", "Start a local server to serve the website")
-	.option("--ignore-migrations", "Dont check offline database migrations.")
 	.option("--network-debugging", "activate network debugging, sending attributeNames and attributeIds in the json request/response payloads", false)
 	.option("-D, --dev-tools", "Start the desktop client with DevTools open")
 	.action(async (stage, host, options) => {
@@ -27,7 +26,7 @@ await program
 			host = "https://app.local.tuta.com:9000"
 		}
 
-		const { clean, watch, serve, startDesktop, desktopBuildOnly, ignoreMigrations, app, networkDebugging, devTools } = options
+		const { clean, watch, serve, startDesktop, desktopBuildOnly, app, networkDebugging, devTools } = options
 
 		if (serve) {
 			console.error("--serve is currently disabled, point any server to ./build directory instead or build desktop")
@@ -41,7 +40,6 @@ await program
 				watch,
 				serve,
 				desktop: startDesktop || desktopBuildOnly,
-				ignoreMigrations,
 				networkDebugging,
 				app,
 			})


### PR DESCRIPTION
There was a missing check that migrations bring the version to the latest one.

In addition, we were checking the version against non-populated metadata which worked accidentally on the first run because `undefined < 1 === true`.