### PR TITLE
Fixes event details page stuck

### DIFF
--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -548,6 +548,12 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			return null
 		}
 
+		if (!this.viewModel.eventPreviewModel && calendarLocator.syncTracker.isSyncDone()) {
+			this.viewSlider.focus(this.viewSlider.getMainColumn())
+			this.viewModel.setPreviewedEventId(null)
+			return null
+		}
+
 		if (!this.viewModel.eventPreviewModel) {
 			return m(".flex-center.items-center.full-height", progressIcon())
 		}
@@ -1354,7 +1360,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			const urlDateParam = args.date
 
 			if (urlDateParam) {
-				// Unlike JS Luxon assumes local time zone when parsing and not UTC. That's what we want
+				// Unlike JS, Luxon assumes local time zone when parsing and not UTC. That's what we want
 				const luxonDate = DateTime.fromISO(urlDateParam)
 
 				let date = new Date()
@@ -1405,6 +1411,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 							})
 						})
 					} catch (e) {
+						this.viewSlider.focus(this.viewSlider.getMainColumn())
 						console.warn("Failed to open event", eventIdParam)
 					}
 				} else if (!eventIdParam && this.viewSlider.focusedColumn === this.eventDetails) {


### PR DESCRIPTION
When an event from the widget, it might be that the event doesn't exist anymore in case it has been deleted in another client.

This commit updates the onNewUrl method to handle cases where an event might have been deleted from another client. If the initial sync has completed and no event details are found, it now correctly assumes that the event no longer exists.