### PR TITLE
Fix adding multiple guests to existing event on mobile

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/AndroidFileFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/AndroidFileFacade.kt
@@ -57,8 +57,18 @@ class AndroidFileFacade(
 	override suspend fun deleteFile(file: String) {
 		if (file.startsWith(Uri.fromFile(activity.filesDir).toString())) {
 			// we do not deleteAlarmNotification files that are not stored in our cache dir
-			if (!File(Uri.parse(file).path!!).delete()) {
-				throw Exception("could not delete file $file")
+			val fileInstance = File(Uri.parse(file).path!!)
+			try {
+				val deleted = fileInstance.delete()
+				if (!deleted && fileInstance.exists()) {
+					throw Exception("Could not delete file $file")
+				}
+				Log.d(TAG, "Deleted file: $fileInstance")
+			} catch (e: Exception) {
+				Log.e(
+					TAG,
+					"Error type: ${e.javaClass}\nError message: ${e.message}\nStack Trace: ${e.stackTraceToString()}\nCause: ${e.cause}"
+				)
 			}
 		}
 	}

--- a/app-android/calendar/src/main/java/de/tutao/calendar/AndroidFileFacade.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/AndroidFileFacade.kt
@@ -57,8 +57,18 @@ class AndroidFileFacade(
 	override suspend fun deleteFile(file: String) {
 		if (file.startsWith(Uri.fromFile(activity.filesDir).toString())) {
 			// we do not deleteAlarmNotification files that are not stored in our cache dir
-			if (!File(Uri.parse(file).path!!).delete()) {
-				throw Exception("could not delete file $file")
+			val fileInstance = File(Uri.parse(file).path!!)
+			try {
+				val deleted = fileInstance.delete()
+				if (!deleted && fileInstance.exists()) {
+					throw Exception("Could not delete file $file")
+				}
+				Log.d(TAG, "Deleted file: $fileInstance")
+			} catch (e: Exception) {
+				Log.e(
+					TAG,
+					"Error type: ${e.javaClass}\nError message: ${e.message}\nStack Trace: ${e.stackTraceToString()}\nCause: ${e.cause}"
+				)
 			}
 		}
 	}

--- a/app-ios/calendar/Sources/Files/IosFileFacade.swift
+++ b/app-ios/calendar/Sources/Files/IosFileFacade.swift
@@ -50,7 +50,12 @@ class IosFileFacade: FileFacade {
 		return returnfiles
 	}
 
-	func deleteFile(_ file: String) async throws { try FileManager.default.removeItem(atPath: file) }
+	func deleteFile(_ file: String) async throws {
+		do { try FileManager.default.removeItem(atPath: file) } catch {
+			if let err = error as? NSError, err.code == NSFileNoSuchFileError { return printLog("Tried to delete file \(file) that does not exist.") }
+			throw TUTErrorFactory.wrapNativeError(withDomain: FILES_ERROR_DOMAIN, message: "Failed to delete file \(file)", error: error)
+		}
+	}
 
 	func getName(_ file: String) async throws -> String {
 		let fileName = (file as NSString).lastPathComponent

--- a/app-ios/tutanota/Sources/Files/IosFileFacade.swift
+++ b/app-ios/tutanota/Sources/Files/IosFileFacade.swift
@@ -50,8 +50,12 @@ class IosFileFacade: FileFacade {
 		return returnfiles
 	}
 
-	func deleteFile(_ file: String) async throws { try FileManager.default.removeItem(atPath: file) }
-
+	func deleteFile(_ file: String) async throws {
+		do { try FileManager.default.removeItem(atPath: file) } catch {
+			if let err = error as? NSError, err.code == NSFileNoSuchFileError { return printLog("Tried to delete file \(file) that does not exist.") }
+			throw TUTErrorFactory.wrapNativeError(withDomain: FILES_ERROR_DOMAIN, message: "Failed to delete file \(file)", error: error)
+		}
+	}
 	func getName(_ file: String) async throws -> String {
 		let fileName = (file as NSString).lastPathComponent
 		if FileUtils.fileExists(atPath: file) {

--- a/src/calendar-app/calendar/gui/eventeditor-view/CalendarEventEditDialog.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-view/CalendarEventEditDialog.ts
@@ -14,7 +14,6 @@ import { AlarmInterval, getTimeFormatForUser, parseAlarmInterval } from "../../.
 import { client } from "../../../../common/misc/ClientDetector.js"
 import { assertNotNull, noOp, Thunk } from "@tutao/tutanota-utils"
 import { PosRect } from "../../../../common/gui/base/Dropdown.js"
-import { Mail } from "../../../../common/api/entities/tutanota/TypeRefs.js"
 import type { HtmlEditor } from "../../../../common/gui/editor/HtmlEditor.js"
 import { locator } from "../../../../common/api/main/CommonLocator.js"
 import { CalendarEventEditView, EditorPages } from "./CalendarEventEditView.js"
@@ -84,7 +83,7 @@ export class EventEditorDialog {
 	 * the generic way to open any calendar edit dialog. the caller should know what to do after the
 	 * dialog is closed.
 	 */
-	async showCalendarEventEditDialog(model: CalendarEventModel, responseMail: Mail | null, handler: EditDialogOkHandler): Promise<void> {
+	async showCalendarEventEditDialog(model: CalendarEventModel, handler: EditDialogOkHandler): Promise<void> {
 		const recipientsSearch = await locator.recipientsSearchModel()
 		const { HtmlEditor } = await import("../../../../common/gui/editor/HtmlEditor.js")
 		const groupSettings = locator.logins.getUserController().userSettingsGroupRoot.groupSettings
@@ -209,7 +208,7 @@ export class EventEditorDialog {
 			}
 		}
 
-		return this.showCalendarEventEditDialog(model, null, okAction)
+		return this.showCalendarEventEditDialog(model, okAction)
 	}
 
 	/**
@@ -221,7 +220,7 @@ export class EventEditorDialog {
 	 * @param identity the identity of the event to edit
 	 * @param responseMail a mail containing an invite and/or update for this event in case we need to reply to the organizer
 	 */
-	async showExistingCalendarEventEditDialog(model: CalendarEventModel, identity: CalendarEventIdentity, responseMail: Mail | null = null): Promise<void> {
+	async showExistingCalendarEventEditDialog(model: CalendarEventModel, identity: CalendarEventIdentity): Promise<void> {
 		let finished = false
 
 		if (identity.uid == null) {
@@ -259,7 +258,7 @@ export class EventEditorDialog {
 				}
 			}
 
-			this.showCalendarEventEditDialog(model, responseMail, okAction)
+			this.showCalendarEventEditDialog(model, okAction)
 		})
 	}
 

--- a/src/common/api/worker/facades/lazy/MailFacade.ts
+++ b/src/common/api/worker/facades/lazy/MailFacade.ts
@@ -500,7 +500,6 @@ export class MailFacade {
 				if (isApp() || isDesktop()) {
 					const { location } = await this.fileApp.writeDataFile(providedFile)
 					referenceTokens = await this.blobFacade.encryptAndUploadNative(ArchiveDataType.Attachments, location, senderMailGroupId, fileSessionKey)
-					await this.fileApp.deleteFile(location)
 				} else {
 					referenceTokens = await this.blobFacade.encryptAndUpload(ArchiveDataType.Attachments, providedFile.data, senderMailGroupId, fileSessionKey)
 				}
@@ -534,7 +533,7 @@ export class MailFacade {
 			.then((attachments) => attachments.filter(isNotNull))
 			.then((it) => {
 				// only delete the temporary files after all attachments have been uploaded
-				if (isApp()) {
+				if (isApp() || isDesktop()) {
 					this.fileApp.clearFileData().catch((e) => console.warn("Failed to clear files", e))
 				}
 


### PR DESCRIPTION
When adding a guest to an event that already had guests, creating the calendar invitation draft on mobile could throw an exception.

The issue occurred because each draft email attached an .ics file by creating a temp file, uploading it, and then deleting it. Multiple drafts ran in parallel, causing two drafts to attempt deleting the same file — the second one always failing.

This commit fixes the problem by deferring file deletion until after the promise completes and ensuring these operations run sequentially (invite, cancellation and update of an event).

Closes #9323