### PR TITLE
Fixes sorting on iOS Widget & SDK event generation 

### DIFF
--- a/app-ios/AgendaWidgetExtension/Data/WidgetModel.swift
+++ b/app-ios/AgendaWidgetExtension/Data/WidgetModel.swift
@@ -134,6 +134,7 @@ struct WidgetModel {
 				}
 		}
 
+		normalEvents.forEach { key, value in normalEvents[key] = value.sorted { $0.startDate.timeIntervalSince1970 < $1.startDate.timeIntervalSince1970 } }
 		return (normalEvents, longEvents)
 	}
 


### PR DESCRIPTION
Previously, events were grouped by calendar and sorted by time within each group by the SDK.

Now events are no longer grouped by calendar. Instead, all events are merged into a single list and sorted together by start time.

---

Previously, the SDK was incorrectly adding one week to past events, causing them to be included in the wrong week.

Now events in the past are allowed to be generated without modification. Events occurring before the N=0 event are now filtered out afterward.