### PR TITLE
[Android] Adds 16KB support

### DIFF
--- a/app-android/app/build.gradle
+++ b/app-android/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'com.android.application'
 	id 'kotlin-android'
-	id 'org.jetbrains.kotlin.plugin.serialization' version '1.9.21'
+	id 'org.jetbrains.kotlin.plugin.serialization' version '2.2.20'
 	id 'com.google.devtools.ksp'
 }
 
@@ -9,7 +9,7 @@ group = "de.tutao"
 
 android {
 	defaultConfig {
-		compileSdk 35
+		compileSdk 36
 		applicationId "de.tutao.tutanota"
 		minSdkVersion 26
 		targetSdkVersion 35
@@ -108,7 +108,7 @@ android {
 	}
 
 	namespace 'de.tutao.tutanota'
-	ndkVersion '26.1.10909125'
+	ndkVersion '28.2.13676358'
 }
 
 tasks.withType(Test).configureEach {
@@ -129,14 +129,14 @@ dependencies {
 	implementation "de.tutao:tutasdk"
 	implementation project(':tutashared')
 
-	implementation 'commons-io:commons-io:2.16.1'
+	implementation 'commons-io:commons-io:2.20.0'
 
-	implementation 'androidx.core:core-ktx:1.13.1'
+	implementation 'androidx.core:core-ktx:1.17.0'
 	implementation "androidx.activity:activity-ktx:$activity_version"
-	implementation "androidx.browser:browser:1.8.0"
+	implementation "androidx.browser:browser:1.9.0"
 	implementation "androidx.biometric:biometric:1.1.0"
 	implementation "androidx.core:core-splashscreen:1.0.1"
-	implementation "androidx.datastore:datastore-preferences:1.1.1"
+	implementation "androidx.datastore:datastore-preferences:1.1.7"
 
 	implementation "androidx.room:room-ktx:$room_version"
 	ksp "androidx.room:room-compiler:$room_version"
@@ -145,35 +145,35 @@ dependencies {
 	implementation(files("../libs/sqlcipher-android.aar"))
 
 
-	implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.3'
+	implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.9.4'
 
-	implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
+	implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0'
 	implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 	implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
 	// TLS1.3 backwards compatibility for Android < 10
-	implementation 'org.conscrypt:conscrypt-android:2.5.2'
-	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+	implementation 'org.conscrypt:conscrypt-android:2.5.3'
+	implementation 'com.squareup.okhttp3:okhttp:5.1.0'
 
-	implementation 'net.java.dev.jna:jna:5.14.0@aar'
+	implementation 'net.java.dev.jna:jna:5.18.0@aar'
 
 	testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-	testImplementation 'androidx.test.ext:junit-ktx:1.2.1'
+	testImplementation 'androidx.test.ext:junit-ktx:1.3.0'
 	testImplementation 'junit:junit:4.13.2'
-	testImplementation 'org.robolectric:robolectric:4.13'
-	testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
+	testImplementation 'org.robolectric:robolectric:4.16'
+	testImplementation 'org.mockito.kotlin:mockito-kotlin:6.0.0'
 	// JVM-based unit tests (that don't need a real device or emulator)
 	testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
 
-	androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito-inline-extended:2.28.1") {
+	androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito-inline-extended:2.28.6") {
 		exclude group: 'org.mockito', module: 'mockito-core'
 	}
-	androidTestImplementation "org.mockito:mockito-core:5.15.2"
-	androidTestImplementation "org.mockito.kotlin:mockito-kotlin:5.4.0"
-	androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-	androidTestImplementation 'androidx.test:runner:1.6.1'
-	androidTestImplementation 'androidx.test.ext:junit-ktx:1.2.1'
-	androidTestImplementation 'androidx.test:rules:1.6.1'
-	androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
-	androidTestImplementation 'androidx.room:room-testing:2.6.1'
+	androidTestImplementation "org.mockito:mockito-core:5.20.0"
+	androidTestImplementation "org.mockito.kotlin:mockito-kotlin:6.0.0"
+	androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+	androidTestImplementation 'androidx.test:runner:1.7.0'
+	androidTestImplementation 'androidx.test.ext:junit-ktx:1.3.0'
+	androidTestImplementation 'androidx.test:rules:1.7.0'
+	androidTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.20.0'
+	androidTestImplementation 'androidx.room:room-testing:2.8.0'
 }

--- a/app-android/build.gradle
+++ b/app-android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-	ext.kotlin_version = '2.0.0'
+	ext.kotlin_version = '2.2.20'
 	repositories {
 		google()
 		mavenCentral()
@@ -10,7 +10,7 @@ buildscript {
 	dependencies {
 		// This is what usually referred by as AGP.
 		// Make sure your Android Studio version supports it.
-		classpath 'com.android.tools.build:gradle:8.5.1'
+		classpath 'com.android.tools.build:gradle:8.9.3'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
 		// NOTE: Do not place your application dependencies here; they belong
@@ -19,9 +19,9 @@ buildscript {
 }
 
 plugins {
-	id 'com.google.devtools.ksp' version '2.0.0-1.0.23' apply false
-	id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
-	id 'org.mozilla.rust-android-gradle.rust-android' version '0.9.4' apply false
+	id 'com.google.devtools.ksp' version '2.2.20-2.0.3' apply false
+	id 'org.jetbrains.kotlin.android' version '2.2.20' apply false
+	id 'org.mozilla.rust-android-gradle.rust-android' version '0.9.6' apply false
 }
 
 allprojects {

--- a/app-android/calendar/build.gradle.kts
+++ b/app-android/calendar/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 	id("com.android.application")
 	id("org.jetbrains.kotlin.android")
 	id("kotlin-kapt")
-	id("org.jetbrains.kotlin.plugin.serialization") version "1.9.21"
-	id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" // this version matches the Kotlin version
+	id("org.jetbrains.kotlin.plugin.serialization") version "2.2.20"
+	id("org.jetbrains.kotlin.plugin.compose") version "2.2.20" // this version matches the Kotlin version
 }
 
 group = "de.tutao"
@@ -15,7 +15,7 @@ android {
 	namespace = "de.tutao.calendar"
 
 	defaultConfig {
-		compileSdk = 35
+		compileSdk = 36
 		applicationId = "de.tutao.calendar"
 		minSdk = 26
 		targetSdk = 35
@@ -155,29 +155,29 @@ android {
 			assets.srcDirs(files("$projectDir/schemas"))
 		}
 	}
-	ndkVersion = "26.1.10909125"
+	ndkVersion = "28.2.13676358"
 }
 
 dependencies {
-	implementation("androidx.appcompat:appcompat:1.7.0")
-	val room_version = "2.4.2"
-	val lifecycle_version = "2.4.1"
-	val activity_version = "1.4.0"
-	val coroutines_version = "1.8.0"
+	implementation("androidx.appcompat:appcompat:1.7.1")
+	val room_version = "2.8.0"
+	val lifecycle_version = "2.9.4"
+	val activity_version = "1.11.0"
+	val coroutines_version = "1.10.2"
 
 	implementation("de.tutao:tutasdk")
 	implementation(project(":tutashared"))
 
 	// Important: cannot be updated without additional measures as Android 6 and 7 do not have Java 9
 	//noinspection GradleDependency
-	implementation("commons-io:commons-io:2.5")
+	implementation("commons-io:commons-io:2.20.0")
 
-	implementation("androidx.core:core-ktx:1.8.0")
+	implementation("androidx.core:core-ktx:1.17.0")
 	implementation("androidx.activity:activity-ktx:$activity_version")
-	implementation("androidx.browser:browser:1.8.0")
+	implementation("androidx.browser:browser:1.9.0")
 	implementation("androidx.biometric:biometric:1.1.0")
 	implementation("androidx.core:core-splashscreen:1.0.1")
-	implementation("androidx.datastore:datastore-preferences:1.1.1")
+	implementation("androidx.datastore:datastore-preferences:1.1.7")
 
 	implementation("androidx.room:room-runtime:$room_version")
 	// For Kotlin use kapt instead of annotationProcessor
@@ -186,38 +186,38 @@ dependencies {
 
 	implementation(files("../libs/sqlcipher-android.aar"))
 
-	implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.4.1")
+	implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.9.4")
 	implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version")
 
-	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
-	implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.22")
+	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+	implementation("org.jetbrains.kotlin:kotlin-stdlib:2.2.20")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version")
 
 	// TLS1.3 backwards compatibility for Android < 10
-	implementation("org.conscrypt:conscrypt-android:2.5.2")
-	implementation("com.squareup.okhttp3:okhttp:4.11.0")
+	implementation("org.conscrypt:conscrypt-android:2.5.3")
+	implementation("com.squareup.okhttp3:okhttp:5.1.0")
 
-	implementation("net.java.dev.jna:jna:5.13.0@aar")
+	implementation("net.java.dev.jna:jna:5.18.0@aar")
 
-	testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.22")
-	testImplementation("androidx.test.ext:junit-ktx:1.1.3")
+	testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:2.2.20")
+	testImplementation("androidx.test.ext:junit-ktx:1.3.0")
 	testImplementation("junit:junit:4.13.2")
-	testImplementation("org.robolectric:robolectric:4.11.1")
-	testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
+	testImplementation("org.robolectric:robolectric:4.16")
+	testImplementation("org.mockito.kotlin:mockito-kotlin:6.0.0")
 	// JVM-based unit tests (that don't need a real device or emulator)
 	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version")
 
 	androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito-inline-extended:2.28.1") {
 		exclude(group = "org.mockito", module = "mockito-core")
 	}
-	androidTestImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
-	androidTestImplementation("org.mockito:mockito-core:5.15.2")
-	androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
-	androidTestImplementation("androidx.test:runner:1.4.0")
-	androidTestImplementation("androidx.test.ext:junit-ktx:1.1.3")
-	androidTestImplementation("androidx.test:rules:1.4.0")
-	androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-	androidTestImplementation("androidx.room:room-testing:2.4.2")
+	androidTestImplementation("org.mockito.kotlin:mockito-kotlin:6.0.0")
+	androidTestImplementation("org.mockito:mockito-core:5.20.0")
+	androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
+	androidTestImplementation("androidx.test:runner:1.7.0")
+	androidTestImplementation("androidx.test.ext:junit-ktx:1.3.0")
+	androidTestImplementation("androidx.test:rules:1.7.0")
+	androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.20.0")
+	androidTestImplementation("androidx.room:room-testing:2.8.0")
 
 	// Setup for Jetpack Compose
 	val composeBom = platform("androidx.compose:compose-bom:2025.01.01")
@@ -239,12 +239,12 @@ dependencies {
 	implementation("androidx.compose.material:material-icons-extended")
 
 	// Optional - Integration with activities
-	implementation("androidx.activity:activity-compose:1.10.1")
+	implementation("androidx.activity:activity-compose:1.11.0")
 	// Optional - Integration with ViewModels
-	implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+	implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.4")
 
 	// Jetpack WorkManager for background sync
-	implementation("androidx.work:work-runtime-ktx:2.10.0")
+	implementation("androidx.work:work-runtime-ktx:2.10.4")
 
 
 	// For interop APIs with Material 3

--- a/app-android/gradle/wrapper/gradle-wrapper.properties
+++ b/app-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/app-android/tutashared/build.gradle.kts
+++ b/app-android/tutashared/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 	id("com.android.library")
 	id("org.jetbrains.kotlin.android")
 	id("com.google.devtools.ksp")
-	id("org.jetbrains.kotlin.plugin.serialization") version "1.9.21"
+	id("org.jetbrains.kotlin.plugin.serialization") version "2.2.20"
 	id("kotlin-android")
 }
 
@@ -13,9 +13,7 @@ group = "de.tutao"
 
 android {
 	namespace = "de.tutao.tutashared"
-	compileSdk = 34
-
-
+	compileSdk = 36
 
 	defaultConfig {
 		minSdk = 26
@@ -74,7 +72,7 @@ android {
 		this.getByName("debug").assets.srcDirs(files("$projectDir/schemas"))
 	}
 
-	ndkVersion = "26.1.10909125"
+	ndkVersion = "28.2.13676358"
 }
 
 val tutanota3Root = layout.projectDirectory
@@ -115,6 +113,9 @@ cargo {
 	features {
 		defaultAnd(arrayOf("extension"))
 	}
+	exec = { spec, toolchain ->
+		spec.environment("RUSTFLAGS", "-C link-arg=-Wl,-z,max-page-size=16384")
+	}
 }
 
 tasks.whenTaskAdded {
@@ -127,20 +128,20 @@ tasks.whenTaskAdded {
 }
 
 dependencies {
-	val room_version = "2.6.1"
-	val lifecycle_version = "2.8.3"
-	val activity_version = "1.9.0"
-	val coroutines_version = "1.8.1"
-	val kotlin_version = "2.0.0"
+	val room_version = "2.8.0"
+	val lifecycle_version = "2.9.4"
+	val activity_version = "1.11.0"
+	val coroutines_version = "1.10.2"
+	val kotlin_version = "2.2.20"
 
-	implementation("commons-io:commons-io:2.16.1")
+	implementation("commons-io:commons-io:2.20.0")
 	implementation("de.tutao:tutasdk")
 
-	implementation("androidx.core:core-ktx:1.13.1")
+	implementation("androidx.core:core-ktx:1.17.0")
 	implementation("androidx.activity:activity-ktx:$activity_version")
-	implementation("androidx.browser:browser:1.8.0")
+	implementation("androidx.browser:browser:1.9.0")
 	implementation("androidx.biometric:biometric:1.1.0")
-	implementation("androidx.datastore:datastore-preferences:1.1.1")
+	implementation("androidx.datastore:datastore-preferences:1.1.7")
 
 	implementation("androidx.room:room-ktx:$room_version")
 	// For Kotlin use kapt instead of annotationProcessor
@@ -155,37 +156,37 @@ dependencies {
 	// module.
 	compileOnly(files("../libs/sqlcipher-android.aar"))
 
-	implementation("androidx.sqlite:sqlite-ktx:2.4.0")
+	implementation("androidx.sqlite:sqlite-ktx:2.6.0")
 
 	implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version")
 
-	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
+	implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version")
 
 	// TLS1.3 backwards compatibility for Android < 10
-	implementation("org.conscrypt:conscrypt-android:2.5.2")
-	implementation("com.squareup.okhttp3:okhttp:4.12.0")
+	implementation("org.conscrypt:conscrypt-android:2.5.3")
+	implementation("com.squareup.okhttp3:okhttp:5.1.0")
 
-	implementation("net.java.dev.jna:jna:5.14.0@aar")
+	implementation("net.java.dev.jna:jna:5.18.0@aar")
 
 	testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-	testImplementation("androidx.test.ext:junit-ktx:1.2.1")
+	testImplementation("androidx.test.ext:junit-ktx:1.3.0")
 	testImplementation("junit:junit:4.13.2")
-	testImplementation("org.robolectric:robolectric:4.13")
-	testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+	testImplementation("org.robolectric:robolectric:4.16")
+	testImplementation("org.mockito.kotlin:mockito-kotlin:6.0.0")
 	// JVM-based unit tests (that don't need a real device or emulator)
 	testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version")
 
-	androidTestImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+	androidTestImplementation("org.mockito.kotlin:mockito-kotlin:6.0.0")
 	androidTestImplementation("com.linkedin.dexmaker:dexmaker-mockito-inline-extended:2.28.1") {
 		exclude(group = "org.mockito", module = "mockito-core")
 	}
-	androidTestImplementation("org.mockito:mockito-core:5.15.2")
-	androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-	androidTestImplementation("androidx.test:runner:1.6.1")
-	androidTestImplementation("androidx.test.ext:junit-ktx:1.2.1")
-	androidTestImplementation("androidx.test:rules:1.6.1")
-	androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
-	androidTestImplementation("androidx.room:room-testing:2.6.1")
+	androidTestImplementation("org.mockito:mockito-core:5.20.0")
+	androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
+	androidTestImplementation("androidx.test:runner:1.7.0")
+	androidTestImplementation("androidx.test.ext:junit-ktx:1.3.0")
+	androidTestImplementation("androidx.test:rules:1.7.0")
+	androidTestImplementation("com.fasterxml.jackson.core:jackson-databind:2.20.0")
+	androidTestImplementation("androidx.room:room-testing:2.8.0")
 }

--- a/tuta-sdk/android/build.gradle
+++ b/tuta-sdk/android/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-	ext.kotlin_version = '2.0.0'
+	ext.kotlin_version = '2.2.0'
 	repositories {
 		google()
 		mavenCentral()
@@ -10,9 +10,9 @@ buildscript {
 	dependencies {
 		// This is what usually referred by as AGP.
 		// Make sure your Android Studio version supports it.
-		classpath 'com.android.tools.build:gradle:8.5.1'
+		classpath 'com.android.tools.build:gradle:8.9.3'
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-		classpath 'org.mozilla.rust-android-gradle:plugin:0.9.4'
+		classpath 'org.mozilla.rust-android-gradle:plugin:0.9.6'
 
 		// NOTE: Do not place your application dependencies here; they belong
 		// in the individual module build.gradle files

--- a/tuta-sdk/android/gradle/wrapper/gradle-wrapper.properties
+++ b/tuta-sdk/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tuta-sdk/android/sdk/build.gradle.kts
+++ b/tuta-sdk/android/sdk/build.gradle.kts
@@ -7,12 +7,12 @@ plugins {
 }
 
 dependencies {
-	implementation("net.java.dev.jna:jna:5.14.0@aar")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
-	implementation("androidx.annotation:annotation:1.8.0")
+	implementation("net.java.dev.jna:jna:5.18.0@aar")
+	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
+	implementation("androidx.annotation:annotation:1.9.1")
 	testImplementation("junit:junit:4.13.2")
-	androidTestImplementation("androidx.test.ext:junit:1.2.1")
-	androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+	androidTestImplementation("androidx.test.ext:junit:1.3.0")
+	androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 }
 
 val tutanota3Root = layout.projectDirectory
@@ -30,6 +30,9 @@ cargo {
 	targets = getABITargets()
 	profile = getActiveBuildType()
 	targetDirectory = tutanota3Root.dir("target").toString()
+	exec = { spec, toolchain ->
+		spec.environment("RUSTFLAGS", "-C link-arg=-Wl,-z,max-page-size=16384")
+	}
 }
 
 fun getActiveBuildType(): String {
@@ -111,7 +114,7 @@ android {
 		jvmTarget = "1.8"
 	}
 	sourceSets["main"].java.srcDirs(file("${layout.buildDirectory.asFile.get()}/generated-sources/tuta-sdk"))
-	ndkVersion = "26.1.10909125"
+	ndkVersion = "28.2.13676358"
 }
 
 tasks.register("generateBinding") {


### PR DESCRIPTION
Google now requires all Android apps to support 16KB page sizes until November to remain eligible for publishing on the Play Store.

This commit updates the Kotlin version, NDK, target and compile SDK versions, as well all third-party dependencies used by the apps, making our Apps compatibility with 16KB page size support.

Closes #9679