### PR TITLE
Only try to get existing metadata when upgrading db

### DIFF
--- a/src/common/api/worker/facades/lazy/ConfigurationDatabase.ts
+++ b/src/common/api/worker/facades/lazy/ConfigurationDatabase.ts
@@ -17,7 +17,6 @@ import { UserFacade } from "../UserFacade.js"
 import { EncryptedDbKeyBaseMetaData, EncryptedIndexerMetaData, Metadata, ObjectStoreName } from "../../search/IndexTables.js"
 import { DbError } from "../../../common/error/DbError.js"
 import { checkKeyVersionConstraints, KeyLoaderFacade } from "../KeyLoaderFacade.js"
-import type { QueuedBatch } from "../../EventQueue.js"
 import { _encryptKeyWithVersionedKey, VersionedKey } from "../../crypto/CryptoWrapper.js"
 import { EntityUpdateData, isUpdateForTypeRef } from "../../../common/utils/EntityUpdateUtils"
 
@@ -102,11 +101,9 @@ export class ConfigurationDatabase {
 					keyPath: "address",
 				})
 			}
-			const metaData =
-				(await loadEncryptionMetadata(dbFacade, id, keyLoaderFacade, ConfigurationMetaDataOS)) ||
-				(await initializeDb(dbFacade, id, keyLoaderFacade, ConfigurationMetaDataOS))
+			const metaData = await loadEncryptionMetadata(dbFacade, id, keyLoaderFacade, ConfigurationMetaDataOS)
 
-			if (event.oldVersion === 1) {
+			if (event.oldVersion === 1 && metaData) {
 				// migrate from plain, mac-and-static-iv aes256 to aes256 with mac
 				const transaction = await dbFacade.createTransaction(true, [ExternalImageListOS])
 				const entries = await transaction.getAll(ExternalImageListOS)


### PR DESCRIPTION
Initializing db in onupgrade could result in th db being created twice

Additionally if there was no metadata there is no reason to migrate it

fix #9681