### PR TITLE
[desktop] Fix memory leak when resizing the window

### DIFF
--- a/src/mail-app/mail/view/MailListView.ts
+++ b/src/mail-app/mail/view/MailListView.ts
@@ -305,6 +305,18 @@ export class MailListView implements Component<MailListViewAttrs> {
 		return newFiles.concat(existingFiles)
 	}
 
+	// listeners to indicate the when mod key is held, dragging will do something
+	private readonly onKeyDown = (event: KeyboardEvent) => {
+		if (isDragAndDropModifierHeld(event)) {
+			this._listDom?.classList.add("drag-mod-key")
+		}
+	}
+
+	private readonly onKeyUp = (event: KeyboardEvent) => {
+		// The event doesn't have a
+		this._listDom?.classList.remove("drag-mod-key")
+	}
+
 	view(vnode: Vnode<MailListViewAttrs>): Children {
 		this.attrs = vnode.attrs
 
@@ -319,18 +331,6 @@ export class MailListView implements Component<MailListViewAttrs> {
 			},
 		}
 
-		// listeners to indicate the when mod key is held, dragging will do something
-		const onKeyDown = (event: KeyboardEvent) => {
-			if (isDragAndDropModifierHeld(event)) {
-				this._listDom?.classList.add("drag-mod-key")
-			}
-		}
-
-		const onKeyUp = (event: KeyboardEvent) => {
-			// The event doesn't have a
-			this._listDom?.classList.remove("drag-mod-key")
-		}
-
 		const listModel = vnode.attrs.mailViewModel.listModel
 		return m(
 			".mail-list-wrapper",
@@ -339,14 +339,14 @@ export class MailListView implements Component<MailListViewAttrs> {
 					this._listDom = downcast(vnode.dom.firstChild)
 
 					if (canDoDragAndDropExport()) {
-						assertNotNull(document.body).addEventListener("keydown", onKeyDown)
-						assertNotNull(document.body).addEventListener("keyup", onKeyUp)
+						assertNotNull(document.body).addEventListener("keydown", this.onKeyDown)
+						assertNotNull(document.body).addEventListener("keyup", this.onKeyUp)
 					}
 				},
-				onbeforeremove: (vnode) => {
+				onremove: (vnode) => {
 					if (canDoDragAndDropExport()) {
-						assertNotNull(document.body).removeEventListener("keydown", onKeyDown)
-						assertNotNull(document.body).removeEventListener("keyup", onKeyUp)
+						assertNotNull(document.body).removeEventListener("keydown", this.onKeyDown)
+						assertNotNull(document.body).removeEventListener("keyup", this.onKeyUp)
 					}
 				},
 			},


### PR DESCRIPTION
MailListView would leak the DOM elements for the list items on every layout change.

There were two causes:
 - `onbeforeremove()` is only getting when the node loses its parent which never happens in our case because `MailListView` always renders the same list wrapper. Instead, we should have been using `onremove()` which is always called when the node is removed from the DOM
 - the second issue is that the event handlers were created on every render. Every render the attrs for the wrapper vnode would get updated and callback would get replaced with a new one that's also referencing the new event handler. The reference to the old event handler would get lost and never removed

We fixed it by replacing `onbeforeremove()` with `onremove()` and by making sure that the event handlers are stable class fields.

Close #9701