### PR TITLE
Fix mark mails as spam/phishing

### DIFF
--- a/src/mail-app/mail/model/MailModel.ts
+++ b/src/mail-app/mail/model/MailModel.ts
@@ -410,10 +410,6 @@ export class MailModel {
 		}
 	}
 
-	isMovingMailsFromSearchAllowed(): boolean {
-		return this.logins.getUserController().isInternalUser()
-	}
-
 	canManageLabels(): boolean {
 		return this.logins.getUserController().isInternalUser()
 	}

--- a/src/mail-app/mail/view/MailGuiUtils.ts
+++ b/src/mail-app/mail/view/MailGuiUtils.ts
@@ -87,7 +87,6 @@ interface MoveMailsParams {
 	mailIds: ReadonlyArray<IdTuple>
 	targetFolder: MailFolder
 	moveMode: MoveMode
-	reportType?: MailReportType
 }
 
 enum MoveMailSnackbarResult {

--- a/src/mail-app/mail/view/MailViewerUtils.ts
+++ b/src/mail-app/mail/view/MailViewerUtils.ts
@@ -344,8 +344,8 @@ export function getMailViewerMoreActions({
 	reportPhishing,
 }: {
 	viewModel: MailViewerViewModel
-	reportSpam: (() => unknown) | null
 	print: (() => unknown) | null
+	reportSpam: (() => unknown) | null
 	reportPhishing: (() => unknown) | null
 }): MailViewerMoreActions {
 	const actions: MailViewerMoreActions = {}


### PR DESCRIPTION
Fix marking conversation as spam only moves primaryMail to spam.
Close #9687

Fix marking mail as phishing doesn't update mail's phishing status.
Close #9700