### PR TITLE
[desktop] Fix opening files & directories on Linux

### DIFF
--- a/make.js
+++ b/make.js
@@ -48,8 +48,7 @@ await program
 				const buildDir = app === "calendar" ? "build-calendar-app" : "build"
 				const env = Object.assign({}, process.env, { ELECTRON_ENABLE_SECURITY_WARNINGS: "TRUE", ELECTRON_START_WITH_DEV_TOOLS: devTools })
 				// we don't want to quit here because we want to keep piping output to our stdout.
-				spawn("npx", [`electron --inspect=5858 ./${buildDir}/`], {
-					shell: true,
+				spawn("node_modules/.bin/electron", ["--inspect=5858", `./${buildDir}/`], {
 					stdio: "inherit",
 					env: options.verbose ? Object.assign({}, env, { ELECTRON_ENABLE_LOGGING: 1 }) : env,
 				})

--- a/src/common/desktop/CommandExecutor.ts
+++ b/src/common/desktop/CommandExecutor.ts
@@ -27,6 +27,11 @@ export interface ProcessParams {
 	 * By default, the current working directory will be used.
 	 */
 	currentDirectory?: string
+
+	/**
+	 * Environment variables to set on subprocesses
+	 */
+	env?: { [key: string]: string | undefined }
 }
 
 /**
@@ -134,6 +139,7 @@ export class CommandExecutor {
 			stdoutEncoding = ProcessIOEncoding.Utf8,
 			stderrEncoding = ProcessIOEncoding.Utf8,
 			currentDirectory,
+			env,
 		} = params
 
 		if (isNaN(timeout) || timeout < 0) {
@@ -145,6 +151,7 @@ export class CommandExecutor {
 			const process = this.childProcess.spawn(executable, args, {
 				timeout: timeout === 0 ? undefined : timeout,
 				cwd: currentDirectory,
+				env,
 			})
 
 			let stdout = initializeOutputBuffer(stdoutEncoding)

--- a/src/common/desktop/DesktopMain.ts
+++ b/src/common/desktop/DesktopMain.ts
@@ -330,7 +330,7 @@ async function createComponents(): Promise<Components> {
 			new DesktopDesktopSystemFacade(wm, window, sock),
 			new DesktopExportFacade(tfs, electron, conf, window, dragIcons, mailboxExportPersistence, fs, dateProvider, desktopExportLock),
 			new DesktopExternalCalendarFacade(electron.app.userAgentFallback),
-			new DesktopFileFacade(window, conf, dateProvider, customFetch, electron, tfs, fs, path),
+			new DesktopFileFacade(window, conf, dateProvider, customFetch, electron, tfs, fs, path, commandExecutor, process),
 			new DesktopInterWindowEventFacade(window, wm),
 			nativeCredentialsFacade,
 			desktopCrypto,

--- a/src/common/desktop/export/DesktopExportFacade.ts
+++ b/src/common/desktop/export/DesktopExportFacade.ts
@@ -206,7 +206,7 @@ export class DesktopExportFacade implements ExportFacade {
 		if (exportState == null || exportState.type !== "finished") {
 			throw new ProgrammingError("Export is not finished")
 		}
-		await this.electron.shell.openPath(exportState.exportDirectoryPath)
+		this.electron.shell.showItemInFolder(exportState.exportDirectoryPath)
 	}
 
 	private async getExportDirectoryPath(): Promise<string> {


### PR DESCRIPTION
Electron uses xdg-open to open files. On GNOME it will try to use gio open which reads user configs from a few files. To detect those config files it uses `XDG_CURRENT_DESKTOP` env variable.

Electron overwrites `XDG_CURRENT_DESKTOP` to enable some compatibility functions in Chromium. This breaks gio because it can't locate the config files for default apps. It can be reproduced on Ubuntu with GNOME. There is a fix in Electron to restore the env for opening files, but it doesn't work.

We worked around that by invoking xdg-open directly with correct env.

Additionally, we fixed opening the directories having the same issue and getting stuck by using showItemInFolder instead. This also has an additional benefit of highlighting the file in the file manager.

Close #9696