### PR TITLE
Adds conflicting events information to Event Banner

### DIFF
--- a/src/calendar-app/calendar/model/CalendarModel.ts
+++ b/src/calendar-app/calendar/model/CalendarModel.ts
@@ -118,7 +118,7 @@ import {
 	SyncStatus,
 } from "../../../common/calendar/gui/ImportExportUtils.js"
 import { UserError } from "../../../common/api/main/UserError.js"
-import { lang } from "../../../common/misc/LanguageViewModel.js"
+import { LanguageViewModel } from "../../../common/misc/LanguageViewModel.js"
 import { NativePushServiceApp } from "../../../common/native/main/NativePushServiceApp.js"
 import { SyncTracker } from "../../../common/api/main/SyncTracker.js"
 import { CacheMode } from "../../../common/api/worker/rest/EntityRestClient"
@@ -234,6 +234,7 @@ export class CalendarModel {
 		private readonly pushService: NativePushServiceApp | null,
 		private readonly syncTracker: SyncTracker,
 		private readonly requestWidgetRefresh: () => void,
+		private readonly lang: LanguageViewModel,
 	) {
 		this.readProgressMonitor = oneShotProgressMonitorGenerator(progressTracker, logins.getUserController())
 		eventController.addEntityListener((updates, eventOwnerGroupId) => this.entityEventsReceived(updates, eventOwnerGroupId))
@@ -252,7 +253,7 @@ export class CalendarModel {
 	private createBirthdayCalendarInfo(): BirthdayCalendarInfo {
 		return {
 			id: `${this.logins.getUserController().userId}#${BIRTHDAY_CALENDAR_BASE_ID}`,
-			name: lang.get("birthdayCalendar_label"),
+			name: this.lang.get("birthdayCalendar_label"),
 			color: this.logins.getUserController().userSettingsGroupRoot.birthdayCalendarColor ?? DEFAULT_BIRTHDAY_CALENDAR_COLOR,
 			type: CalendarType.Birthday,
 			contactGroupId: getFirstOrThrow(this.logins.getUserController().getContactGroupMemberships()).group,
@@ -570,7 +571,7 @@ export class CalendarModel {
 		}
 
 		if (skippedCalendars.size) {
-			let errorMessage = lang.get("iCalSync_error") + (longErrorMessage ? "\n\n" : "")
+			let errorMessage = this.lang.get("iCalSync_error") + (longErrorMessage ? "\n\n" : "")
 			for (const [group, details] of skippedCalendars.entries()) {
 				if (longErrorMessage) errorMessage += `${details.calendarName} - ${details.error.message}\n`
 				this.deviceConfig.updateLastSync(group, SyncStatus.Failed)
@@ -1371,13 +1372,13 @@ export class CalendarModel {
 	}
 
 	getBirthdayEventTitle(contactName: string) {
-		return lang.get("birthdayEvent_title", {
+		return this.lang.get("birthdayEvent_title", {
 			"{name}": contactName,
 		})
 	}
 
 	getAgeString(age: number) {
-		return lang.get("birthdayEventAge_title", { "{age}": age })
+		return this.lang.get("birthdayEventAge_title", { "{age}": age })
 	}
 }
 

--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -117,6 +117,7 @@ import { GroupSettingsModel } from "../common/sharing/model/GroupSettingsModel"
 import { IdentityKeyCreator } from "../common/api/worker/facades/lazy/IdentityKeyCreator"
 import { PublicIdentityKeyProvider } from "../common/api/worker/facades/PublicIdentityKeyProvider"
 import { WhitelabelThemeGenerator } from "../common/gui/WhitelabelThemeGenerator"
+import { lang } from "../common/misc/LanguageViewModel.js"
 
 assertMainOrNode()
 
@@ -837,6 +838,7 @@ class CalendarLocator implements CommonLocator {
 			() => {
 				this.systemFacade.requestWidgetRefresh()
 			},
+			lang,
 		)
 	})
 

--- a/src/common/misc/GroupColors.ts
+++ b/src/common/misc/GroupColors.ts
@@ -1,14 +1,20 @@
 import { memoized } from "@tutao/tutanota-utils"
 import { UserSettingsGroupRoot } from "../api/entities/tutanota/TypeRefs"
 import { isValidColorCode } from "../gui/base/Color"
-import { defaultCalendarColor } from "../api/common/TutanotaConstants"
+import { BIRTHDAY_CALENDAR_BASE_ID, DEFAULT_BIRTHDAY_CALENDAR_COLOR, defaultCalendarColor } from "../api/common/TutanotaConstants"
 
-export const getGroupColors = memoized((userSettingsGroupRoot: UserSettingsGroupRoot) => {
-	return userSettingsGroupRoot.groupSettings.reduce((acc, { group, color }) => {
+export const getGroupColors = memoized((userId: Id, userSettingsGroupRoot: UserSettingsGroupRoot) => {
+	const calendarColors: Map<string, string> = userSettingsGroupRoot.groupSettings.reduce((acc, { group, color }) => {
 		if (!isValidColorCode("#" + color)) {
 			color = defaultCalendarColor
 		}
 		acc.set(group, color)
 		return acc
 	}, new Map())
+
+	const birthdayCalendarId = `${userId}#${BIRTHDAY_CALENDAR_BASE_ID}`
+	const color = userSettingsGroupRoot.birthdayCalendarColor ?? DEFAULT_BIRTHDAY_CALENDAR_COLOR
+	calendarColors.set(birthdayCalendarId, color)
+
+	return calendarColors
 })

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -96,6 +96,7 @@ export type TranslationKeyType =
 	| "ageConfirmation_msg"
 	| "agenda_label"
 	| "allDay_label"
+	| "allDayEvents_label"
 	| "allowBatteryPermission_msg"
 	| "allowContactReadWrite_msg"
 	| "allowContactSynchronization"
@@ -2105,3 +2106,4 @@ export type TranslationKeyType =
 	| "confirmOverwriteDraft_msg"
 	| "overwrite_action"
 	| "confirmCreateNewDraftOverAutosavedDraft_msg"
+	| "conflicts_label"

--- a/src/mail-app/gui/date/EventBannerImpl.ts
+++ b/src/mail-app/gui/date/EventBannerImpl.ts
@@ -5,18 +5,7 @@ import { ParsedIcalFileContentData } from "../../../calendar-app/calendar/view/C
 import { CalendarEventsRepository } from "../../../common/calendar/date/CalendarEventsRepository"
 import { CalendarAttendeeStatus, CalendarMethod, SECOND_MS } from "../../../common/api/common/TutanotaConstants"
 import m, { ChildArray, Children, ClassComponent, Vnode, VnodeDOM } from "mithril"
-import {
-	base64ToBase64Url,
-	clone,
-	filterNull,
-	getHourOfDay,
-	getStartOfDay,
-	isNotEmpty,
-	isNotNull,
-	isSameDay,
-	partition,
-	stringToBase64,
-} from "@tutao/tutanota-utils"
+import { base64ToBase64Url, clone, filterNull, getHourOfDay, getStartOfDay, isNotNull, isSameDay, partition, stringToBase64 } from "@tutao/tutanota-utils"
 import {
 	EventConflictRenderPolicy,
 	TIME_SCALE_BASE_VALUE,
@@ -202,45 +191,68 @@ export class EventBannerImpl implements ClassComponent<EventBannerImplAttrs> {
 								},
 							},
 							[
-								m(
-									".flex.flex-column.mb-s",
-									{
-										class: agenda && agenda.conflictCount > 1 ? "nav-button" : undefined,
-										onclick: () =>
-											agenda && agenda.conflictCount > 1 ? (this.displayConflictingAgenda = !this.displayConflictingAgenda) : null,
-									},
-									[
-										m(".flex", [
-											m(Icon, {
-												icon: Icons.Time,
-												container: "div",
-												class: "mr-xsm mt-xxs",
-												style: { fill: theme.on_surface },
-												size: IconSize.Medium,
-											}),
-											m("span.b.h5", lang.get("timeOverview_title")),
-										]),
-										agenda
-											? m(".flex.mt-hpad-small", [
-													m(Icon, {
-														icon: hasConflict ? Icons.AlertCircle : Icons.CheckCircleFilled,
-														container: "div",
-														class: "mr-xsm",
+								m(".flex.flex-column.mb-s", [
+									m(".flex", [
+										m(Icon, {
+											icon: Icons.Time,
+											container: "div",
+											class: "mr-xsm mt-xxs",
+											style: { fill: theme.on_surface },
+											size: IconSize.Medium,
+										}),
+										m("span.b.h5", lang.get("timeOverview_title")),
+									]),
+									agenda
+										? m(".mb-s", [
+												m(
+													".flex.mt-hpad-small.fit-content",
+													{
+														class: agenda && agenda.conflictCount > 1 ? "nav-button" : undefined,
+														onclick: () =>
+															agenda && agenda.conflictCount > 1
+																? (this.displayConflictingAgenda = !this.displayConflictingAgenda)
+																: null,
+													},
+													[
+														m(Icon, {
+															icon: hasConflict ? Icons.AlertCircle : Icons.CheckCircleFilled,
+															container: "div",
+															class: "mr-xsm",
+															style: {
+																fill: hasConflict ? theme.warning : theme.success,
+															},
+															size: IconSize.Medium,
+														}),
+														this.renderConflictInfoText(agenda.regularEvents.length, agenda.allDayEvents.length),
+													],
+												),
+												m(
+													"",
+													{
 														style: {
-															fill: hasConflict ? theme.warning : theme.success,
+															"margin-left": px(size.icon_size_large + size.vpad_xsm),
 														},
-														size: IconSize.Medium,
-													}),
-													this.renderConflictInfoText(
-														agenda.conflictCount,
-														event.startTime,
-														agenda.allDayEvents,
-														agenda.regularEvents,
-													),
-												])
-											: null,
-									],
-								),
+													},
+													[
+														m(
+															ExpanderPanel,
+															{
+																expanded: this.displayConflictingAgenda,
+															},
+															m(".selectable", [
+																agenda.regularEvents && agenda.regularEvents.length > 0
+																	? this.renderNormalConflictingEvents(event.startTime, agenda.regularEvents)
+																	: null,
+																agenda.allDayEvents.length > 0
+																	? this.renderAllDayConflictingEvents(event.startTime, agenda.allDayEvents)
+																	: null,
+															]),
+														),
+													],
+												),
+											])
+										: null,
+								]),
 								agenda
 									? m(TimeView, {
 											events: this.filterOutOfRangeEvents(timeRange, events, eventFocusBound, timeInterval),
@@ -259,52 +271,64 @@ export class EventBannerImpl implements ClassComponent<EventBannerImplAttrs> {
 		)
 	}
 
-	private renderConflictInfoText(
-		conflictCount: number,
-		eventDate: Date,
-		allDayEvents: Array<TimeViewEventWrapper>,
-		conflictingRegularEvents?: Array<TimeViewEventWrapper>,
-	) {
-		const hasOnlyAllDayConflicts = conflictCount > 0 && conflictCount === allDayEvents.length
-		return m(".mb-s", [
-			m(
-				".small.flex.gap-vpad-xs-15.items-center",
-				{
+	private renderConflictInfoText(normalEventsConflictCount: number, allDayEventsConflictCount: number) {
+		const hasAllDayEvent = allDayEventsConflictCount > 0
+		const hasOnlyAllDayConflicts = normalEventsConflictCount === 0 && allDayEventsConflictCount > 0
+
+		const stringParts: Array<string> = []
+
+		if (normalEventsConflictCount && !this.displayConflictingAgenda) {
+			stringParts.push(normalEventsConflictCount.toString(), lang.getTranslationText("simultaneousEvents_msg"))
+		}
+
+		if (hasAllDayEvent && !this.displayConflictingAgenda) {
+			if (normalEventsConflictCount) {
+				stringParts.push(`+${allDayEventsConflictCount}`)
+			} else {
+				stringParts.push(`${allDayEventsConflictCount}`)
+			}
+
+			stringParts.push(`${lang.getTranslationText("allDay_label").toLowerCase()}`)
+		}
+
+		if (this.displayConflictingAgenda) {
+			stringParts.push((normalEventsConflictCount + allDayEventsConflictCount).toString(), lang.getTranslationText("conflicts_label"))
+		}
+
+		return m(
+			".small.flex.gap-vpad-xs.items-center.fit-content",
+			{
+				style: {
+					"line-height": px(19.5),
+				},
+			},
+			[
+				m("span.b", stringParts.join(" ")),
+				m(Icon, {
+					icon: BootIcons.Expand,
+					container: "div",
+					class: `fit-content`,
+					size: IconSize.Medium,
 					style: {
-						"line-height": px(19.5),
+						fill: theme.on_surface,
+						rotate: this.displayConflictingAgenda ? "180deg" : "0deg",
 					},
-				},
-				[
-					!hasOnlyAllDayConflicts
-						? m(
-								"span",
-								conflictCount > 0
-									? [m("strong", conflictCount), ` ${lang.get("simultaneousEvents_msg")}`]
-									: lang.get("noSimultaneousEvents_msg"),
-							)
-						: null,
-					isNotEmpty(allDayEvents)
-						? m(
-								"span.border-radius.pt-xxs.pb-xxs.plr-sm.text-break",
-								{ style: { color: theme.on_warning_container, "background-color": theme.warning_container } },
-								[
-									m("strong", allDayEvents.length === 1 ? `1 ${lang.get("allDay_label").toLowerCase()}: ` : `${allDayEvents.length} `),
-									allDayEvents.length === 1 ? allDayEvents[0].event.summary : lang.get("allDay_label").toLowerCase(),
-								],
-							)
-						: null,
-				],
-			),
-			m(
-				ExpanderPanel,
-				{
-					expanded: this.displayConflictingAgenda,
-				},
-				m(".selectable.mt-xs", [
-					allDayEvents.map((l) => this.buildConflictingEventInfoText(eventDate, l)),
-					conflictingRegularEvents?.map((l) => this.buildConflictingEventInfoText(eventDate, l)),
-				]),
-			),
+				}),
+			],
+		)
+	}
+
+	private renderAllDayConflictingEvents(referenceDate: Date, conflictingAllDayEvents: Array<TimeViewEventWrapper>) {
+		return m("", [
+			m("strong.small.content-fg", `${conflictingAllDayEvents.length} ${lang.getTranslationText("allDayEvents_label")}`),
+			conflictingAllDayEvents?.map((l) => this.buildConflictingEventInfoText(referenceDate, l, true)),
+		])
+	}
+
+	private renderNormalConflictingEvents(referenceDate: Date, conflictingRegularEvents: Array<TimeViewEventWrapper>) {
+		return m("", [
+			m("strong.small.content-fg", `${conflictingRegularEvents.length} ${lang.getTranslationText("simultaneousEvents_msg")}`),
+			conflictingRegularEvents?.map((l) => this.buildConflictingEventInfoText(referenceDate, l, false)),
 		])
 	}
 
@@ -330,19 +354,9 @@ export class EventBannerImpl implements ClassComponent<EventBannerImplAttrs> {
 		return timeParts
 	}
 
-	private buildConflictingEventInfoText(referenceDate: Date, eventWrapper: TimeViewEventWrapper) {
-		console.log(eventWrapper.color)
-		return m(".flex.items-center", [
-			m(".icon-small.circle", {
-				style: {
-					backgroundColor: eventWrapper.color,
-				},
-			}),
-			m(".flex.items-center.ml-xsm", [
-				m(".small.selectable.faded-text", `${eventWrapper.event.summary}:`),
-				m(".small.selectable.faded-text.b.ml-s", this.getTimeParts(referenceDate, eventWrapper).join(" - ")),
-			]),
-		])
+	private buildConflictingEventInfoText(referenceDate: Date, eventWrapper: TimeViewEventWrapper, isAllDay: boolean) {
+		const timeText = !isAllDay ? this.getTimeParts(referenceDate, eventWrapper).join(" - ") : ""
+		return m(".small.selectable", `• ${eventWrapper.event.summary} ${timeText}`)
 	}
 
 	private buildReplySection(

--- a/src/mail-app/mail/view/MailViewerHeader.ts
+++ b/src/mail-app/mail/view/MailViewerHeader.ts
@@ -344,7 +344,10 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 
 	private renderEventBanner(viewModel: MailViewerViewModel): Children {
 		const eventAttachment = viewModel.getCalendarEventAttachment()
-		const groupColors: Map<Id, string> = getGroupColors(viewModel.logins.getUserController().userSettingsGroupRoot)
+		const groupColors: Map<Id, string> = getGroupColors(
+			viewModel.logins.getUserController().user._id,
+			viewModel.logins.getUserController().userSettingsGroupRoot,
+		)
 
 		return eventAttachment
 			? m(

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -152,6 +152,7 @@ import { PublicIdentityKeyProvider } from "../common/api/worker/facades/PublicId
 import { WhitelabelThemeGenerator } from "../common/gui/WhitelabelThemeGenerator"
 import { UndoModel } from "./UndoModel"
 import { GroupSettingsModel } from "../common/sharing/model/GroupSettingsModel"
+import { lang } from "../common/misc/LanguageViewModel.js"
 
 assertMainOrNode()
 
@@ -1047,6 +1048,7 @@ class MailLocator implements CommonLocator {
 			!isBrowser() ? this.pushService : null,
 			this.syncTracker,
 			noOp,
+			lang,
 		)
 	})
 

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -2130,5 +2130,7 @@ export default {
 		"confirmOverwriteDraft_msg": "This draft was opened for editing on {opened}, but a newer version was retrieved from the server on {updated}.\n\nWould you like to overwrite the newer draft with this one, discard this draft, or cancel saving this draft?",
 		"overwrite_action": "Overwrite",
 		"confirmCreateNewDraftOverAutosavedDraft_msg": "There are unsaved changes to a draft that will be lost.",
+		"allDayEvents_label": "ganztags Termine",
+		"conflicts_label": "Konfliktes"
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -2130,5 +2130,7 @@ export default {
 		"confirmOverwriteDraft_msg": "This draft was opened for editing on {opened}, but a newer version was retrieved from the server on {updated}.\n\nWould you like to overwrite the newer draft with this one, discard this draft, or cancel saving this draft?",
 		"overwrite_action": "Overwrite",
 		"confirmCreateNewDraftOverAutosavedDraft_msg": "There are unsaved changes to a draft that will be lost.",
+		"allDayEvents_label": "ganztags Termine",
+		"conflicts_label": "Konfliktes"
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -2126,5 +2126,7 @@ export default {
 		"confirmOverwriteDraft_msg": "This draft was opened for editing on {opened}, but a newer version was retrieved from the server on {updated}.\n\nWould you like to overwrite the newer draft with this one, discard this draft, or cancel saving this draft?",
 		"overwrite_action": "Overwrite",
 		"confirmCreateNewDraftOverAutosavedDraft_msg": "There are unsaved changes to a draft that will be lost.",
+		"allDayEvents_label": "all day events",
+		"conflicts_label": "conflicts"
 	}
 }

--- a/test/tests/calendar/CalendarModelTest.ts
+++ b/test/tests/calendar/CalendarModelTest.ts
@@ -48,6 +48,7 @@ import { SyncTracker } from "../../../src/common/api/main/SyncTracker.js"
 import { ClientModelInfo } from "../../../src/common/api/common/EntityFunctions"
 import { EntityRestClient } from "../../../src/common/api/worker/rest/EntityRestClient"
 import { eventHasSameFields } from "../../../src/common/calendar/gui/ImportExportUtils"
+import { LanguageViewModel } from "../../../src/common/misc/LanguageViewModel.js"
 
 o.spec("CalendarModel", function () {
 	const noPatchesAndInstance: Pick<EntityUpdateData, "instance" | "patches"> = {
@@ -928,6 +929,7 @@ function init({
 	syncTracker = makeSyncTracker(),
 }): CalendarModel {
 	const lazyScheduler = async () => alarmScheduler
+	const langMock: LanguageViewModel = object()
 
 	return new CalendarModel(
 		notifications,
@@ -951,5 +953,6 @@ function init({
 		}),
 		syncTracker,
 		() => {},
+		langMock,
 	)
 }


### PR DESCRIPTION
When receiving an event invitation, users may have more than just one conflicting event, but we show only one inside the time overview.

This commit adds an expandable panel to the event banner, allowing users to expand it by clicking in the warning info and quickly see which events, along the already displayed one, are conflicting with the invitation.

Closes #9726