### PR TITLE
[ios] Add notification counter badge to app icon

### DIFF
--- a/app-ios/TutanotaSharedFramework/Notifications/NotificationStorage.swift
+++ b/app-ios/TutanotaSharedFramework/Notifications/NotificationStorage.swift
@@ -7,6 +7,7 @@ private let LAST_PROCESSED_NOTIFICAION_ID_KEY = "lastProcessedNotificationId"
 private let LAST_MISSED_NOTIFICATION_CHECK_TIME = "lastMissedNotificationCheckTime"
 private let EXTENDED_NOTIFICATION_MODE = "extendedNotificationMode"
 private let RECEIVE_CALENDAR_NOTIFICATION_CONFIG = "receiveCalendarNotificationConfig"
+private let NOTIFICAITON_COUNT_KEY = "notificationCount"
 
 public class NotificationStorage {
 	private let userPreferencesProvider: UserPreferencesProvider
@@ -78,6 +79,13 @@ public class NotificationStorage {
 		get { self.userPreferencesProvider.getObject(forKey: LAST_MISSED_NOTIFICATION_CHECK_TIME) as! Date? }
 		set { return self.userPreferencesProvider.setValue(newValue, forKey: LAST_MISSED_NOTIFICATION_CHECK_TIME) }
 	}
+
+	/// Count of email notifications received but not viewed
+	public var notificationCount: Int { get { self.userPreferencesProvider.getObject(forKey: NOTIFICAITON_COUNT_KEY) as! Int? ?? 0 } }
+
+	public func incrementNotificationCount() { self.userPreferencesProvider.setValue(self.notificationCount + 1, forKey: NOTIFICAITON_COUNT_KEY) }
+
+	public func resetNotificaitonCount() { self.userPreferencesProvider.setValue(0, forKey: NOTIFICAITON_COUNT_KEY) }
 
 	public func clear() {
 		TUTSLog("UserPreference clear")

--- a/app-ios/TutanotaSharedFramework/Notifications/SdkRestClient.swift
+++ b/app-ios/TutanotaSharedFramework/Notifications/SdkRestClient.swift
@@ -28,6 +28,14 @@ public class SdkRestClient: RestClient {
 	private func mapExceptionToError(e: Error) -> RestClientError {
 		// why we don't match on e? see: sdkFileClient::mapExceptionToError
 		TUTSLog("Exception in SdkRestClient: \(e). Assuming .Unknown")
+		if let e = e as? URLError {
+			switch e.code {
+			case .notConnectedToInternet, .timedOut, .cannotFindHost, .networkConnectionLost, URLError.Code.notConnectedToInternet,
+				URLError.Code.dnsLookupFailed:
+				return .NetworkError
+			default: break
+			}
+		}
 		return RestClientError.Unknown
 	}
 }

--- a/app-ios/calendar/Sources/AppDelegate.swift
+++ b/app-ios/calendar/Sources/AppDelegate.swift
@@ -13,6 +13,8 @@ public let TUTA_CALENDAR_INTEROP_SCHEME = "tutacalendar"
 	private var viewController: ViewController!
 	private let urlSession: URLSession = makeUrlSession()
 
+	private var notificationStorage: NotificationStorage!
+
 	func registerForPushNotifications() async throws -> String {
 		#if targetEnvironment(simulator)
 			return ""
@@ -37,7 +39,7 @@ public let TUTA_CALENDAR_INTEROP_SCHEME = "tutacalendar"
 		spawnTransactionFinisher()
 
 		let userPreferencesProvider = UserPreferencesProviderImpl()
-		let notificationStorage = NotificationStorage(userPreferencesProvider: userPreferencesProvider)
+		self.notificationStorage = NotificationStorage(userPreferencesProvider: userPreferencesProvider)
 		let keychainManager = KeychainManager(keyGenerator: KeyGenerator())
 		let keychainEncryption = KeychainEncryption(keychainManager: keychainManager)
 		let dateProvider = SystemDateProvider()

--- a/app-ios/tutanota/Sources/AppDelegate.swift
+++ b/app-ios/tutanota/Sources/AppDelegate.swift
@@ -16,6 +16,8 @@ public let MAILTO_SCHEME = "mailto"
 	private var viewController: ViewController!
 	private let urlSession: URLSession = makeUrlSession()
 
+	private var notificationStorage: NotificationStorage!
+
 	@MainActor func registerForPushNotifications() async throws -> String {
 		#if targetEnvironment(simulator)
 			return ""
@@ -32,7 +34,7 @@ public let MAILTO_SCHEME = "mailto"
 		spawnTransactionFinisher()
 
 		let userPreferencesProvider = UserPreferencesProviderImpl()
-		let notificationStorage = NotificationStorage(userPreferencesProvider: userPreferencesProvider)
+		self.notificationStorage = NotificationStorage(userPreferencesProvider: userPreferencesProvider)
 		let keychainManager = KeychainManager(keyGenerator: KeyGenerator())
 		let keychainEncryption = KeychainEncryption(keychainManager: keychainManager)
 		let dateProvider: SystemDateProvider = SystemDateProvider()
@@ -92,7 +94,10 @@ public let MAILTO_SCHEME = "mailto"
 		return true
 	}
 
-	func applicationWillEnterForeground(_ application: UIApplication) { UIApplication.shared.applicationIconBadgeNumber = 0 }
+	func applicationWillEnterForeground(_ application: UIApplication) {
+		UIApplication.shared.applicationIconBadgeNumber = 0
+		self.notificationStorage.resetNotificaitonCount()
+	}
 
 	func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
 		let stringToken = deviceTokenAsString(deviceToken: deviceToken)


### PR DESCRIPTION
Add a persistent counter that is incremented from notification extension. The counter is reset on app being put into foreground.

Close #1757