### PR TITLE
Stop creating trusted_identities table

### DIFF
--- a/src/common/api/worker/facades/IdentityKeyTrustDatabase.ts
+++ b/src/common/api/worker/facades/IdentityKeyTrustDatabase.ts
@@ -16,10 +16,9 @@ import { LoginFacade } from "./LoginFacade"
  * Defines tables created for this interface
  */
 export const KeyVerificationTableDefinitions: Record<string, OfflineStorageTable> = Object.freeze({
-	trusted_identities: {
+	identity_store: {
 		definition:
-			// TODO remove this table
-			"CREATE TABLE IF NOT EXISTS trusted_identities (mailAddress TEXT NOT NULL, fingerprint TEXT NOT NULL, keyVersion INTEGER NOT NULL, keyType INTEGER NOT NULL, PRIMARY KEY (mailAddress, keyVersion))",
+			"CREATE TABLE IF NOT EXISTS identity_store (mailAddress TEXT NOT NULL, publicIdentityKey BLOB NOT NULL, identityKeyVersion INTEGER NOT NULL, identityKeyType INTEGER NOT NULL, sourceOfTrust INTEGER NOT NULL, PRIMARY KEY (mailAddress, identityKeyVersion))",
 		purgedWithCache: false,
 	},
 })

--- a/src/common/api/worker/offline/OfflineStorage.ts
+++ b/src/common/api/worker/offline/OfflineStorage.ts
@@ -139,11 +139,6 @@ export const TableDefinitions = Object.freeze({
 			"CREATE TABLE IF NOT EXISTS blob_element_entities (type TEXT NOT NULL, listId TEXT NOT NULL, elementId TEXT NOT NULL, ownerGroup TEXT, entity BLOB NOT NULL, PRIMARY KEY (type, listId, elementId))",
 		purgedWithCache: true,
 	},
-	identity_store: {
-		definition:
-			"CREATE TABLE IF NOT EXISTS identity_store (mailAddress TEXT NOT NULL, publicIdentityKey BLOB NOT NULL, identityKeyVersion INTEGER NOT NULL, identityKeyType INTEGER NOT NULL, sourceOfTrust INTEGER NOT NULL, PRIMARY KEY (mailAddress, identityKeyVersion))",
-		purgedWithCache: false,
-	},
 } as const) satisfies Record<string, OfflineStorageTable>
 
 type Range = { lower: Id; upper: Id }

--- a/src/common/api/worker/offline/migrations/offline-v8.ts
+++ b/src/common/api/worker/offline/migrations/offline-v8.ts
@@ -1,12 +1,13 @@
 import { OfflineMigration } from "../OfflineStorageMigrator.js"
 import { OfflineStorage, TableDefinitions } from "../OfflineStorage.js"
 import { SqlCipherFacade } from "../../../../native/common/generatedipc/SqlCipherFacade"
+import { KeyVerificationTableDefinitions } from "../../facades/IdentityKeyTrustDatabase"
 
 export const offline8: OfflineMigration = {
 	version: 8,
 	async migrate(storage: OfflineStorage, sqlCipherFacade: SqlCipherFacade) {
 		console.log("migrating from trusted_identities to identity_store")
 		await sqlCipherFacade.run(`DROP TABLE IF EXISTS trusted_identities`, [])
-		await sqlCipherFacade.run(TableDefinitions.identity_store.definition, [])
+		await sqlCipherFacade.run(KeyVerificationTableDefinitions.identity_store.definition, [])
 	},
 }


### PR DESCRIPTION
This table has been replaced by identity_store, however they are both still created, in different ways. The way trusted_identities was created seems to be more aligned with compartmentalization, so we use that for identity_store.

tuta#2614