### PR TITLE
fix race condition when requesting identity keys for the first time

### DIFF
--- a/test/tests/api/worker/facades/IdentityKeyTrustDatabaseTest.ts
+++ b/test/tests/api/worker/facades/IdentityKeyTrustDatabaseTest.ts
@@ -108,9 +108,29 @@ o.spec("IdentityKeyTrustDatabaseTest", function () {
 
 			// @formatter:off
 			const query =
-				"\n\t\t\tINSERT INTO identity_store (mailAddress, publicIdentityKey, identityKeyVersion, identityKeyType, sourceOfTrust)\n\t\t\tVALUES (?, ?, ?, ?, ?)"
+				"\n\t\t\tINSERT INTO identity_store (mailAddress, publicIdentityKey, identityKeyVersion, identityKeyType, sourceOfTrust)\n\t\t\tSELECT ?,\n\t\t\t\t?,\n\t\t\t\t?,\n\t\t\t\t?,\n\t\t\t\t?\n\t\t\tWHERE NOT EXISTS\n\t\t\t(SELECT 1 FROM identity_store WHERE mailAddress = ?\n\t\t\t\tAND publicIdentityKey = ?\n\t\t\t\tAND identityKeyVersion = ?\n\t\t\t\tAND identityKeyType = ?\n\t\t\t\tAND sourceOfTrust = ?)"
 			// @formatter:on
 			const params: TaggedSqlValue[] = [
+				{
+					type: SqlType.String,
+					value: TRUSTED_MAIL_ADDRESS,
+				},
+				{
+					type: SqlType.Bytes,
+					value: PUBLIC_KEY_BYTES,
+				},
+				{
+					type: SqlType.Number,
+					value: 0,
+				},
+				{
+					type: SqlType.Number,
+					value: SigningKeyPairType.Ed25519,
+				},
+				{
+					type: SqlType.Number,
+					value: IdentityKeySourceOfTrust.TOFU,
+				},
 				{
 					type: SqlType.String,
 					value: TRUSTED_MAIL_ADDRESS,


### PR DESCRIPTION
when putting the same mail address into different recipient fields and saving a draft there is an error when re-opening the draft later on a client that does not yet have the recipient's identity key. the identity key is then requested multiple times from the server in parallel, and we try to insert it multiple times into the tofu db. this failed. now we handle this as a noop if the row is exactly the same, we insert the new row if non exists for the primary key and we fail if there is a row for the primary key but it is not the same.
 this makes sure we do not accidentally override a key while handling the race condition gracefully.

tuta#2563