### PR TITLE
Fix SingleFactorEditDialog duplicating entries

### DIFF
--- a/packages/tutanota-utils/lib/Utils.ts
+++ b/packages/tutanota-utils/lib/Utils.ts
@@ -344,6 +344,24 @@ export function throttleStart<F extends (...args: any[]) => Promise<any>>(period
 	}) as F
 }
 
+/**
+ * Returns an async function that will only be executed once until it has settled. Subsequent calls will return the
+ * original promise if it hasn't yet resolved.
+ *
+ * If the function throws before it can be awaited, it will not be caught.
+ */
+export function singleAsync<T, R>(fn: () => Promise<R>): () => Promise<R> {
+	let promise: Promise<R> | null = null
+	return async () => {
+		if (promise != null) {
+			return promise
+		} else {
+			promise = fn().finally(() => (promise = null))
+			return promise
+		}
+	}
+}
+
 export function randomIntFromInterval(min: number, max: number): number {
 	return Math.floor(Math.random() * (max - min + 1) + min)
 }

--- a/packages/tutanota-utils/lib/index.ts
+++ b/packages/tutanota-utils/lib/index.ts
@@ -183,6 +183,7 @@ export {
 	isSessionStorageAvailable,
 	assertValidURL,
 	createResizeObserver,
+	singleAsync,
 } from "./Utils.js"
 export type {
 	Callback,

--- a/src/common/settings/login/secondfactor/SecondFactorEditDialog.ts
+++ b/src/common/settings/login/secondfactor/SecondFactorEditDialog.ts
@@ -44,6 +44,9 @@ export class SecondFactorEditDialog {
 	}
 
 	async okAction(): Promise<void> {
+		if (!this.dialog.visible) {
+			return
+		}
 		try {
 			const user = await this.model.save()
 			if (user != null) this.finalize(user)
@@ -148,7 +151,7 @@ export class SecondFactorEditDialog {
 				helpLabel: () => this.statusMessage(),
 				autocompleteAs: Autocomplete.oneTimeCode,
 				oninput: (newValue) => this.model.onTotpValueChange(newValue),
-				onReturnKeyPressed: () => this.model.save(),
+				onReturnKeyPressed: () => this.okAction(),
 			}),
 		])
 	}

--- a/src/common/settings/login/secondfactor/SecondFactorEditModel.ts
+++ b/src/common/settings/login/secondfactor/SecondFactorEditModel.ts
@@ -2,7 +2,7 @@ import { EntityClient } from "../../../api/common/EntityClient.js"
 import { createSecondFactor, GroupInfoTypeRef, U2fRegisteredDevice, User } from "../../../api/entities/sys/TypeRefs.js"
 import { validateWebauthnDisplayName, WebauthnClient } from "../../../misc/2fa/webauthn/WebauthnClient.js"
 import type { TotpSecret } from "@tutao/tutanota-crypto"
-import { assertNotNull, LazyLoaded, neverNull } from "@tutao/tutanota-utils"
+import { assertNotNull, LazyLoaded, neverNull, singleAsync } from "@tutao/tutanota-utils"
 import { isApp } from "../../../api/common/Env.js"
 import { TranslationKey } from "../../../misc/LanguageViewModel.js"
 import { SecondFactorType } from "../../../api/common/TutanotaConstants.js"
@@ -158,7 +158,7 @@ export class SecondFactorEditModel {
 	 * returns the user that the second factor was created in case any follow-up operations
 	 * are needed
 	 */
-	async save(): Promise<User | null> {
+	save = singleAsync(async () => {
 		this.setDefaultNameIfNeeded()
 		if (this.selectedType === SecondFactorType.webauthn) {
 			// Prevent starting in parallel
@@ -208,7 +208,7 @@ export class SecondFactorEditModel {
 		}
 		await this.entityClient.setup(assertNotNull(this.user.auth).secondFactors, sf, this.token ? { token: this.token } : undefined)
 		return this.user
-	}
+	})
 
 	/** see https://github.com/google/google-authenticator/wiki/Key-Uri-Format */
 	private async getOtpAuthUrl(secret: string): Promise<string> {


### PR DESCRIPTION
Fixes the return key not closing the TOTP dialog.

Ensures that SingleFactorEditModel#save can only be called once at a time.

Closes #9789