### PR TITLE
Standardize MIME Header Capitalization

### DIFF
--- a/src/mail-app/mail/export/emlUtils.ts
+++ b/src/mail-app/mail/export/emlUtils.ts
@@ -74,7 +74,7 @@ export function mailToEml(mail: MailBundle): string {
 
 	const isHtml = /<\/?[a-z][\s\S]*>/i.test(mail.body.trim()) // very simple HTML detection
 
-	lines.push(`Content-Type: text/${isHtml ? "html" : "plain"}; charset=UTF-8`, "Content-transfer-encoding: base64", "")
+	lines.push(`Content-Type: text/${isHtml ? "html" : "plain"}; charset=UTF-8`, "Content-Transfer-Encoding: base64", "")
 
 	for (let bodyLine of breakIntoLines(stringToBase64(mail.body))) {
 		lines.push(bodyLine)
@@ -95,7 +95,7 @@ export function mailToEml(mail: MailBundle): string {
 		)
 
 		if (attachment.cid) {
-			lines.push("Content-Id: <" + attachment.cid + ">")
+			lines.push("Content-ID: <" + attachment.cid + ">")
 		}
 
 		lines.push("")

--- a/test/tests/mail/export/ExporterTest.ts
+++ b/test/tests/mail/export/ExporterTest.ts
@@ -34,7 +34,7 @@ Content-Type: multipart/related; boundary="------------79Bu5A16qPEYcVIZL@tutanot
 \r\n\
 --------------79Bu5A16qPEYcVIZL@tutanota\r\n\
 Content-Type: text/plain; charset=UTF-8\r\n\
-Content-transfer-encoding: base64\r\n\
+Content-Transfer-Encoding: base64\r\n\
 \r\n\
 \r\n\
 --------------79Bu5A16qPEYcVIZL@tutanota--`
@@ -75,7 +75,7 @@ Content-Type: multipart/related; boundary="------------79Bu5A16qPEYcVIZL@tutanot
 \r\n\
 --------------79Bu5A16qPEYcVIZL@tutanota\r\n\
 Content-Type: text/plain; charset=UTF-8\r\n\
-Content-transfer-encoding: base64\r\n\
+Content-Transfer-Encoding: base64\r\n\
 \r\n\
 SSBhbSBhIHBsYWluIGJvZHkh\r\n\
 \r\n\
@@ -138,7 +138,7 @@ Content-Type: multipart/related; boundary="------------79Bu5A16qPEYcVIZL@tutanot
 \r\n\
 --------------79Bu5A16qPEYcVIZL@tutanota\r\n\
 Content-Type: text/html; charset=UTF-8\r\n\
-Content-transfer-encoding: base64\r\n\
+Content-Transfer-Encoding: base64\r\n\
 \r\n\
 SeKAmW0gdGhlIER1ZGUsIHNvIHRoYXTigJlzIHdoYXQgeW91IGNhbGwgbWUuIFRoYXQgb3IsIHVoLC\r\n\
 BIaXMgRHVkZW5lc3MsIG9yIHVoLCBEdWRlciwgb3IgRWwgRHVkZXJpbm8sIGlmIHlvdeKAmXJlIG5v\r\n\
@@ -159,7 +159,7 @@ Content-Type: image/png;\r\n\
 Content-Transfer-Encoding: base64\r\n\
 Content-Disposition: attachment;\r\n\
  filename==?UTF-8?B?aWNvbjEweDEwLnBuZw==?=\r\n\
-Content-Id: <123cid>\r\n\
+Content-ID: <123cid>\r\n\
 \r\n\
 iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAMAAAC67D+PAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAA\r\n\
 B6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAgVBMVEWgHiCgHh+gHiEAAACfHyGg\r\n\
@@ -233,7 +233,7 @@ Content-Type: multipart/related; boundary="------------79Bu5A16qPEYcVIZL@tutanot
 \r\n\
 --------------79Bu5A16qPEYcVIZL@tutanota\r\n\
 Content-Type: text/plain; charset=UTF-8\r\n\
-Content-transfer-encoding: base64\r\n\
+Content-Transfer-Encoding: base64\r\n\
 \r\n\
 \r\n\
 --------------79Bu5A16qPEYcVIZL@tutanota--`


### PR DESCRIPTION
In this PR, I propose the use of standardized MIME header capitalization in the mailToEml export function. Some headers used lowercase variants (e.g. Content-transfer-encoding, Content-Id), which were functionally correct but inconsistent and not aligned with conventional RFC formatting. Now ensured all MIME header names use canonical casing per RFC 2045