### PR TITLE
Hide time pickers when "All Day" toggle is enabled in event editor

### DIFF
--- a/src/calendar-app/calendar/gui/eventeditor-view/EventTimeEditor.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-view/EventTimeEditor.ts
@@ -70,22 +70,24 @@ export class EventTimeEditor implements Component<EventTimeEditorAttrs> {
 								disabled: attrs.disabled,
 							}),
 						),
-						m(
-							".rel",
-							{
-								style: {
-									overflow: "visible",
-								},
-							},
-							m(TimePicker, {
-								classes: appClasses,
-								time: editModel.startTime,
-								onTimeSelected: (time) => (editModel.startTime = time),
-								timeFormat,
-								disabled: attrs.disabled || attrs.editModel.isAllDay,
-								ariaLabel: lang.get("startTime_label"),
-							}),
-						),
+						!attrs.editModel.isAllDay
+							? m(
+									".rel",
+									{
+										style: {
+											overflow: "visible",
+										},
+									},
+									m(TimePicker, {
+										classes: appClasses,
+										time: editModel.startTime,
+										onTimeSelected: (time) => (editModel.startTime = time),
+										timeFormat,
+										disabled: attrs.disabled,
+										ariaLabel: lang.get("startTime_label"),
+									}),
+								)
+							: null,
 						m("", lang.get("dateTo_label")),
 						m(
 							`${isApp() ? "" : ".pl-vpad-l"}`,
@@ -99,22 +101,24 @@ export class EventTimeEditor implements Component<EventTimeEditorAttrs> {
 								disabled: attrs.disabled,
 							}),
 						),
-						m(
-							".rel",
-							{
-								style: {
-									overflow: "visible",
-								},
-							},
-							m(TimePicker, {
-								classes: appClasses,
-								time: editModel.endTime,
-								onTimeSelected: (time) => (editModel.endTime = time),
-								timeFormat,
-								disabled: attrs.disabled || attrs.editModel.isAllDay,
-								ariaLabel: lang.get("endTime_label"),
-							}),
-						),
+						!attrs.editModel.isAllDay
+							? m(
+									".rel",
+									{
+										style: {
+											overflow: "visible",
+										},
+									},
+									m(TimePicker, {
+										classes: appClasses,
+										time: editModel.endTime,
+										onTimeSelected: (time) => (editModel.endTime = time),
+										timeFormat,
+										disabled: attrs.disabled,
+										ariaLabel: lang.get("endTime_label"),
+									}),
+								)
+							: null,
 					]),
 				]),
 			]),


### PR DESCRIPTION
## Description

This PR fixes a UX issue where the event editor shows "00:00" time input fields even when the "All Day" toggle is enabled.

Fixes #9817

## Changes

**File**: `src/calendar-app/calendar/gui/eventeditor-view/EventTimeEditor.ts`
- Added conditional rendering for TimePicker components
- Time pickers now only render when `!attrs.editModel.isAllDay`

## Impact

**Before**: All-day events show disabled time fields with "00:00"
**After**: All-day events show only date fields, time fields are hidden

## Testing

- [x] When "All Day" toggle is OFF: time pickers are visible and functional
- [x] When "All Day" toggle is ON: time pickers are hidden completely
- [x] Date pickers remain visible in both cases

## Notes

- Frontend-only fix, no backend changes required
- Minimal and low-risk change
- Follows existing conditional rendering patterns
