### PR TITLE
Fix crash when editing client-only calendars like buildin Birthdays

### DIFF
--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -1242,7 +1242,9 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			okAction: (dialog, properties) => this.handleModifiedCalendar(dialog, properties, calendarInfo, existingGroupSettings, userSettingsGroupRoot),
 			okTextId: "save_action",
 			calendarProperties: {
-				nameData: await this.viewModel.getCalendarNameData(calendarInfo.groupInfo),
+				nameData: isClientOnlyCalendar(groupInfo.group)
+					? { kind: "single", name: deviceConfig.getClientOnlyCalendars().get(groupInfo.group)?.name ?? "" }
+					: await this.viewModel.getCalendarNameData(calendarInfo.groupInfo),
 				color: colorValue.substring(1),
 				alarms: existingGroupSettings?.defaultAlarmsList.map((alarm) => parseAlarmInterval(alarm.trigger)) ?? [],
 				sourceUrl: existingGroupSettings?.sourceUrl ?? null,


### PR DESCRIPTION
Client-only calendars (Birthdays, etc.) are stored locally in DeviceConfig and don't exist on the server. When trying to edit such calendars, the code was attempting to fetch calendar name data from the server, resulting in a BadRequestError 400.

This fix checks if the calendar is client-only before fetching name data. For client-only calendars, it retrieves the name directly from DeviceConfig instead of making a server request.

Fixes issue where clicking edit on the Birthdays calendar would crash the app.

#9819 