### PR TITLE
Fix crash when editing client-only calendars like Birthdays

### DIFF
--- a/src/calendar-app/calendar/view/CalendarView.ts
+++ b/src/calendar-app/calendar/view/CalendarView.ts
@@ -1242,9 +1242,7 @@ export class CalendarView extends BaseTopLevelView implements TopLevelView<Calen
 			okAction: (dialog, properties) => this.handleModifiedCalendar(dialog, properties, calendarInfo, existingGroupSettings, userSettingsGroupRoot),
 			okTextId: "save_action",
 			calendarProperties: {
-				nameData: isClientOnlyCalendar(groupInfo.group)
-					? { kind: "single", name: deviceConfig.getClientOnlyCalendars().get(groupInfo.group)?.name ?? "" }
-					: await this.viewModel.getCalendarNameData(calendarInfo.groupInfo),
+				nameData: await this.viewModel.getCalendarNameData(calendarInfo.groupInfo),
 				color: colorValue.substring(1),
 				alarms: existingGroupSettings?.defaultAlarmsList.map((alarm) => parseAlarmInterval(alarm.trigger)) ?? [],
 				sourceUrl: existingGroupSettings?.sourceUrl ?? null,

--- a/src/calendar-app/calendar/view/CalendarViewModel.ts
+++ b/src/calendar-app/calendar/view/CalendarViewModel.ts
@@ -270,6 +270,10 @@ export class CalendarViewModel implements EventDragHandlerCallbacks {
 	}
 
 	async getCalendarNameData(groupInfo: GroupInfo): Promise<GroupNameData> {
+		if (isClientOnlyCalendar(groupInfo.group)) {
+			const name = deviceConfig.getClientOnlyCalendars().get(groupInfo.group)?.name ?? ""
+			return { kind: "single", name }
+		}
 		const groupSettingModel = await this.groupSettingsModel()
 		return groupSettingModel.getGroupNameData(groupInfo)
 	}


### PR DESCRIPTION
Client-only calendars (Birthdays, etc.) are stored locally in DeviceConfig and don't exist on the server. When trying to edit such calendars, the code was attempting to fetch calendar name data from the server, resulting in a BadRequestError 400.

This fix checks if the calendar is client-only before fetching name data. For client-only calendars, it retrieves the name directly from DeviceConfig instead of making a server request.

Fixes issue where clicking edit on the Birthdays calendar would crash the app.

Fixes #9819