### PR TITLE
Fix logic error when handling Contact updates in the SendMailModel

### DIFF
--- a/src/mail-app/mail/editor/MailEditor.ts
+++ b/src/mail-app/mail/editor/MailEditor.ts
@@ -1142,6 +1142,7 @@ async function createMailEditorDialog(model: SendMailModel, blockExternalContent
 			return
 		} else {
 			// If the mail is unchanged and there /is/ a preexisting draft, there was no change and the mail is already saved
+			model.clearLocalAutosave()
 			saveStatus = stream<SaveStatus>({ status: SaveStatusEnum.Saved })
 		}
 


### PR DESCRIPTION
The mail was always marked as changed when receiving a contact type

entity update, even though there might not have been a change

Close #9788