### PR TITLE
[ios] fix repo-internal symlink

### DIFF
--- a/app-ios/TutanotaSharedFramework/Crypto/rand_entropy.h
+++ b/app-ios/TutanotaSharedFramework/Crypto/rand_entropy.h
@@ -1,1 +1,1 @@
-../../../app-android/app/src/main/cpp/helpers/rand.h
+../../../app-android/tutashared/src/main/cpp/helpers/rand.h


### PR DESCRIPTION
this seems to have been forgotten when the calendar project was created.

The fact that nobody noticed may suggest that this file is actually not needed anymore.