### PR TITLE
Replace non-standard VALUE=DATETIME with RFC-compliant DATE-TIME in calendar export

### DIFF
--- a/src/calendar-app/calendar/export/CalendarExporter.ts
+++ b/src/calendar-app/calendar/export/CalendarExporter.ts
@@ -86,7 +86,7 @@ export function serializeEvent(event: CalendarEvent, alarms: Array<UserAlarmInfo
 			event.recurrenceId != null
 				? isAllDay
 					? `RECURRENCE-ID;VALUE=DATE:${formatDate(getAllDayDateLocal(event.recurrenceId), localZone)}`
-					: `RECURRENCE-ID;VALUE=DATETIME:${formatDateTimeUTC(event.recurrenceId)}`
+					: `RECURRENCE-ID:${formatDateTimeUTC(event.recurrenceId)}`
 				: [],
 		)
 		.concat(event.description && event.description !== "" ? `DESCRIPTION:${serializeIcalText(event.description)}` : [])


### PR DESCRIPTION
With this pull request, the non‑standard VALUE=DATETIME parameter from RECURRENCE‑ID is removed in accordance with RFC 5545. The correct value type is DATE‑TIME, which is also the default, so the VALUE parameter can be omitted entirely for date‑time values. 