### PR TITLE
[build] Switch to version of wasm-pack that builds lazily

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,7 +83,7 @@
 				"testdouble": "3.20.2",
 				"typescript": "5.8.3",
 				"typescript-eslint": "8.34.0",
-				"wasm-pack": "git+https://github.com/tutao/wasm-pack.git#69f8269704aaccd8294edbb33e819687dfc227bf",
+				"wasm-pack": "git+https://github.com/tutao/wasm-pack.git#b1e0e982fee26803ba6b8a8c29197d2a8cdd93f3",
 				"xhr2": "0.2.1",
 				"zx": "8.5.5"
 			},
@@ -94,6 +94,9 @@
 			"optionalDependencies": {
 				"dmg-license": "^1.0.11"
 			}
+		},
+		"../../.../wasm-pack": {
+			"extraneous": true
 		},
 		"@signalapp/sqlcipher": {
 			"extraneous": true
@@ -11823,10 +11826,9 @@
 		},
 		"node_modules/wasm-pack": {
 			"version": "0.13.1",
-			"resolved": "git+ssh://git@github.com/tutao/wasm-pack.git#69f8269704aaccd8294edbb33e819687dfc227bf",
-			"integrity": "sha512-4+8SE1a4/IQ9iQvPm/XSr2r0kFnJmKBaHNa5FI2OhSRE2k9D9zQsqmV1VSrpppZ0xM08tLRu+YtJgTOFDTI0SQ==",
+			"resolved": "git+ssh://git@github.com/tutao/wasm-pack.git#b1e0e982fee26803ba6b8a8c29197d2a8cdd93f3",
+			"integrity": "sha512-K6xW1nMtqGy3CYmgTAcdmw3j9yngqSTB4jeCdEHgqS8FnbHAjYqrkMTtYu114Yi8IO5Mpm6WMDwLIoGLcNQuDA==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"wasm-pack": "run.js"

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"typescript-eslint": "8.34.0",
 		"xhr2": "0.2.1",
 		"zx": "8.5.5",
-		"wasm-pack": "git+https://github.com/tutao/wasm-pack.git#69f8269704aaccd8294edbb33e819687dfc227bf"
+		"wasm-pack": "git+https://github.com/tutao/wasm-pack.git#b1e0e982fee26803ba6b8a8c29197d2a8cdd93f3"
 	},
 	"workspaces": [
 		"./packages/*"


### PR DESCRIPTION
We run `npm ci` often but we compile code to wasm with wasm-pack very rarely.