### PR TITLE
[ios] Fix resetting badge on app startup

### DIFF
--- a/app-ios/TutanotaNotificationExtension/NotificationService.swift
+++ b/app-ios/TutanotaNotificationExtension/NotificationService.swift
@@ -11,7 +11,7 @@ class NotificationService: UNNotificationServiceExtension {
 	private var contentHandler: ((UNNotificationContent) -> Void)?
 	private var bestAttemptContent: UNMutableNotificationContent?
 	private let urlSession: URLSession = makeUrlSession()
-	private let logger = Logger(subsystem: "Notifications", category: "Notifications")
+	private let logger = Logger(subsystem: "TutaNotifications", category: "Notifications")
 
 	override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
 		self.contentHandler = contentHandler

--- a/app-ios/calendar/Sources/AppDelegate.swift
+++ b/app-ios/calendar/Sources/AppDelegate.swift
@@ -88,12 +88,16 @@ public let TUTA_CALENDAR_INTEROP_SCHEME = "tutacalendar"
 	}
 
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+		// if running unit tests, skip all setup and return
+		#if DEBUG
+			if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil { return true }
+		#endif
 		TUTSLog("Start Tuta Calendar with launch options: \(String(describing: launchOptions))")
 		self.start()
 		return true
 	}
 
-	func applicationWillEnterForeground(_ application: UIApplication) { UIApplication.shared.applicationIconBadgeNumber = 0 }
+	func applicationDidBecomeActive(_ application: UIApplication) { UIApplication.shared.applicationIconBadgeNumber = 0 }
 
 	func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
 		if let callback = self.pushTokenCallback {

--- a/app-ios/tutanota/Sources/AppDelegate.swift
+++ b/app-ios/tutanota/Sources/AppDelegate.swift
@@ -83,9 +83,11 @@ public let MAILTO_SCHEME = "mailto"
 	}
 
 	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+		// if running unit tests, skip all setup and return
 		#if DEBUG
 			if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil { return true }
 		#endif
+
 		TUTSLog("Start Tutanota with launch options: \(String(describing: launchOptions))")
 		try! migrateToSharedstorage()
 		self.registerNotificationCategories()
@@ -94,7 +96,11 @@ public let MAILTO_SCHEME = "mailto"
 		return true
 	}
 
-	func applicationWillEnterForeground(_ application: UIApplication) {
+	func applicationDidBecomeActive(_ application: UIApplication) {
+		// if running unit tests do not try to use components that might not be there
+		#if DEBUG
+			if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil { return }
+		#endif
 		UIApplication.shared.applicationIconBadgeNumber = 0
 		self.notificationStorage.resetNotificaitonCount()
 	}


### PR DESCRIPTION
`applicationWillEnterForeground` is not getting called on app startup, only on transition from background to foreground state. This means the counter would only get reset when the app would come foreground from background state.

We did not notice it as notifications are also reset via NativePushFacade.

We fixed it by using `applicationDidBecomeActive` instead. It it a different lifecycle event but it also works, perhaps even better.

Close #9922