### PR TITLE
Add move to spam shortcut

### DIFF
--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -673,6 +673,22 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 				help: "deleteEmails_action",
 			},
 			{
+				key: Keys.DELETE,
+				shift: true,
+				exec: () => {
+					this.moveMailsToSystemFolder(MailSetKind.SPAM)
+				},
+				help: "spam_move_action",
+			},
+			{
+				key: Keys.BACKSPACE,
+				shift: true,
+				exec: () => {
+					this.moveMailsToSystemFolder(MailSetKind.SPAM)
+				},
+				help: "spam_move_action",
+			},
+			{
 				key: Keys.A,
 				exec: () => {
 					this.moveMailsToSystemFolder(MailSetKind.ARCHIVE)

--- a/src/mail-app/search/view/SearchView.ts
+++ b/src/mail-app/search/view/SearchView.ts
@@ -1167,6 +1167,18 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 				help: "delete_action",
 			},
 			{
+				key: Keys.DELETE,
+				shift: true,
+				exec: () => this.moveSelectedToSystemFolder(MailSetKind.SPAM),
+				help: "spam_move_action",
+			},
+			{
+				key: Keys.BACKSPACE,
+				shift: true,
+				exec: () => this.moveSelectedToSystemFolder(MailSetKind.SPAM),
+				help: "spam_move_action",
+			},
+			{
 				key: Keys.A,
 				exec: () => this.moveSelectedToSystemFolder(MailSetKind.ARCHIVE),
 				help: "archive_action",


### PR DESCRIPTION
Add `Shift+Del` and `Shift+Backspace` to move mails to spam folder.

Close #9961

Co-authored-by: paw <paw-hub@users.noreply.github.com>