### PR TITLE
Write icon files without preserving attributes

### DIFF
--- a/src/common/desktop/integration/DesktopIntegratorLinux.ts
+++ b/src/common/desktop/integration/DesktopIntegratorLinux.ts
@@ -208,8 +208,8 @@ TryExec=${this.packagePath}`
 		])
 			.then(() => {
 				return Promise.all([
-					this._fs.promises.copyFile(this.iconSourcePath64, this.iconTargetPath64),
-					this._fs.promises.copyFile(this.iconSourcePath512, this.iconTargetPath512),
+					this._fs.promises.readFile(this.iconSourcePath64).then((file) => this._fs.promises.writeFile(this.iconTargetPath64, file)),
+					this._fs.promises.readFile(this.iconSourcePath512).then((file) => this._fs.promises.writeFile(this.iconTargetPath512, file)),
 				])
 			})
 			.then(() => {

--- a/test/tests/desktop/integration/DesktopIntegratorTest.ts
+++ b/test/tests/desktop/integration/DesktopIntegratorTest.ts
@@ -75,7 +75,7 @@ o.spec("DesktopIntegrator", () => {
 			setApplicationMenu: () => {},
 		},
 	}
-	let writtenFiles, copiedFiles, deletedFiles, createdDirectories
+	let writtenFiles, copiedFiles, deletedFiles, createdDirectories, readFiles
 
 	const fsExtra = {
 		writeFileSync(file, content, opts) {
@@ -125,6 +125,10 @@ o.spec("DesktopIntegrator", () => {
 				writtenFiles.push({ file, content, opts })
 				return Promise.resolve()
 			},
+			readFile(file) {
+				readFiles.push(file)
+				return Promise.resolve(new Uint8Array())
+			},
 			unlink(path, cb) {
 				deletedFiles.push(path)
 				if (cb) {
@@ -136,8 +140,6 @@ o.spec("DesktopIntegrator", () => {
 		},
 	}
 
-	let itemToReturn: string | undefined = undefined
-
 	const wm = {}
 
 	const standardMocks = () => {
@@ -145,6 +147,7 @@ o.spec("DesktopIntegrator", () => {
 		copiedFiles = []
 		deletedFiles = []
 		createdDirectories = []
+		readFiles = []
 
 		// node modules
 		const electronMock = n.mock<typeof import("electron")>("electron", electron).set()
@@ -328,21 +331,22 @@ o.spec("DesktopIntegrator", () => {
 			o(fsExtraMock.promises.mkdir.args[0]).equals("/app/path/file/.local/share/applications")
 			o(writtenFiles).deepEquals([
 				{
+					file: "/app/path/file/.local/share/icons/hicolor/64x64/apps/appName.png",
+					content: new Uint8Array(),
+					opts: undefined,
+				},
+				{
+					file: "/app/path/file/.local/share/icons/hicolor/512x512/apps/appName.png",
+					content: new Uint8Array(),
+					opts: undefined,
+				},
+				{
 					file: "/app/path/file/.local/share/applications/appName.desktop",
 					content: desktopEntry,
 					opts: { encoding: "utf-8" },
 				},
 			])
-			o(copiedFiles).deepEquals([
-				{
-					from: "/exec/path/resources/icons/logo-solo-red-small.png",
-					to: "/app/path/file/.local/share/icons/hicolor/64x64/apps/appName.png",
-				},
-				{
-					from: "/exec/path/resources/icons/logo-solo-red.png",
-					to: "/app/path/file/.local/share/icons/hicolor/512x512/apps/appName.png",
-				},
-			])
+			o(readFiles).deepEquals(["/exec/path/resources/icons/logo-solo-red-small.png", "/exec/path/resources/icons/logo-solo-red.png"])
 		})
 
 		o("runIntegration without integration, clicked yes, no no_integration, checked", async function () {
@@ -365,21 +369,22 @@ o.spec("DesktopIntegrator", () => {
 					opts: { encoding: "utf-8", flag: "a" },
 				},
 				{
+					file: "/app/path/file/.local/share/icons/hicolor/64x64/apps/appName.png",
+					content: new Uint8Array(),
+					opts: undefined,
+				},
+				{
+					file: "/app/path/file/.local/share/icons/hicolor/512x512/apps/appName.png",
+					content: new Uint8Array(),
+					opts: undefined,
+				},
+				{
 					file: "/app/path/file/.local/share/applications/appName.desktop",
 					content: desktopEntry,
 					opts: { encoding: "utf-8" },
 				},
 			])
-			o(copiedFiles).deepEquals([
-				{
-					from: "/exec/path/resources/icons/logo-solo-red-small.png",
-					to: "/app/path/file/.local/share/icons/hicolor/64x64/apps/appName.png",
-				},
-				{
-					from: "/exec/path/resources/icons/logo-solo-red.png",
-					to: "/app/path/file/.local/share/icons/hicolor/512x512/apps/appName.png",
-				},
-			])
+			o(readFiles).deepEquals(["/exec/path/resources/icons/logo-solo-red-small.png", "/exec/path/resources/icons/logo-solo-red.png"])
 		})
 
 		o("runIntegration without integration, clicked no, not checked", async function () {
@@ -445,21 +450,22 @@ o.spec("DesktopIntegrator", () => {
 			)
 			o(writtenFiles).deepEquals([
 				{
+					file: "/app/path/file/.local/share/icons/hicolor/64x64/apps/appName.png",
+					content: new Uint8Array(),
+					opts: undefined,
+				},
+				{
+					file: "/app/path/file/.local/share/icons/hicolor/512x512/apps/appName.png",
+					content: new Uint8Array(),
+					opts: undefined,
+				},
+				{
 					file: "/app/path/file/.local/share/applications/appName.desktop",
 					content: desktopEntry,
 					opts: { encoding: "utf-8" },
 				},
 			])
-			o(copiedFiles).deepEquals([
-				{
-					from: "/exec/path/resources/icons/logo-solo-red-small.png",
-					to: "/app/path/file/.local/share/icons/hicolor/64x64/apps/appName.png",
-				},
-				{
-					from: "/exec/path/resources/icons/logo-solo-red.png",
-					to: "/app/path/file/.local/share/icons/hicolor/512x512/apps/appName.png",
-				},
-			])
+			o(readFiles).deepEquals(["/exec/path/resources/icons/logo-solo-red-small.png", "/exec/path/resources/icons/logo-solo-red.png"])
 		})
 
 		o("runIntegration with integration, matching version", async function () {


### PR DESCRIPTION
The _desktop integrator_ copies two files on client startup: `~/.local/share/icons/hicolor/{64x64,512x512}/apps/tutanota-desktop.png`. This causes an issue on systems, where program files are stored as read-only, like NixOS. The target files get the read-only flags of the source files, and the following issue occurs on the next client startup, when the file is attempted to be overridden:

```
[2025-11-21T21:55:24.893Z] unhandled rejection
[2025-11-21T21:55:24.893Z] unexpected error: Error: EACCES: permission denied, copyfile '/nix/store/hfxz9hxhgjw41xww3j2rrvipccgaswxi-tutanota-desktop-314.251111.0-extracted/resources/icons/logo-solo-red.png' -> '/home/jel/.local/share/icons/hicolor/512x512/apps/tutanota-desktop.png'
    at async Object.copyFile (node:internal/fs/promises:623:10)
    at async Promise.all (index 1) {
  errno: -13,
  code: 'EACCES',
  syscall: 'copyfile',
  path: '/nix/store/hfxz9hxhgjw41xww3j2rrvipccgaswxi-tutanota-desktop-314.251111.0-extracted/resources/icons/logo-solo-red.png',
  dest: '/home/jel/.local/share/icons/hicolor/512x512/apps/tutanota-desktop.png'
}
```

<details>
<summary>Screenshots of popups that show up on every client launch</summary>

![](https://github.com/user-attachments/assets/2fdb16fb-8135-4f15-bffe-e6f4186f028b)

![](https://github.com/user-attachments/assets/a7db8b95-3d86-4a7e-8ef4-6848a0bd0a12)
</details

I have resolved this issue by reading the file to memory, and then writing it to disk, which doesn't preserve file attributes. This should not affect performance in case of small icon files. Another approach could be to call [`chmod`](https://nodejs.org/api/fs.html#fspromiseschmodpath-mode) on each file before or after copying it. I can implement it if you believe it's better.