### PR TITLE
Don't have all mails loaded at once with SQLite search

### DIFF
--- a/packages/tutanota-utils/lib/ArrayUtils.ts
+++ b/packages/tutanota-utils/lib/ArrayUtils.ts
@@ -615,3 +615,24 @@ export function compare(first: Uint8Array, second: Uint8Array): number {
 
 	return 0
 }
+
+/**
+ * Split the array at the given index, returning the left and right side.
+ *
+ * The element at the given index will be included in the right side if it exists. For example, splitting at index 3 for
+ * `[0,1,2,3,4,5]` returns `[[0,1,2], [3,4,5]]`
+ *
+ * If `index >= array.length` then the right side will be an empty array, and the left side will be a shallow copy of
+ * {@link array}.
+ *
+ * @param {Array} array array to split
+ * @param {number} index index to split at (exclusive for left side, inclusive for right side)
+ * @returns An array containing two arrays: all elements from 0 to {@link index} (exclusive), and all elements from
+ *          {@link index} to the end.
+ */
+export function splitArrayAt<T>(array: readonly T[], index: number): [T[], T[]] {
+	const left = array.slice(0, index)
+	const right = array.slice(index)
+
+	return [left, right]
+}

--- a/packages/tutanota-utils/lib/index.ts
+++ b/packages/tutanota-utils/lib/index.ts
@@ -46,6 +46,7 @@ export {
 	zeroOut,
 	compare,
 	collectToMap,
+	splitArrayAt,
 } from "./ArrayUtils.js"
 export { AsyncResult } from "./AsyncResult.js"
 export {

--- a/packages/tutanota-utils/test/ArrayUtilsTest.ts
+++ b/packages/tutanota-utils/test/ArrayUtilsTest.ts
@@ -18,6 +18,7 @@ import {
 	lazyNumberRange,
 	partition,
 	partitionAsync,
+	splitArrayAt,
 	splitInChunks,
 	symmetricDifference,
 } from "../lib/index.js"
@@ -927,5 +928,30 @@ o.spec("array utils", function () {
 		o(arrayHashUnsigned(new Uint8Array([123]))).equals(123)
 
 		o(arrayHashUnsigned(new Uint8Array([1, 2, 4]))).equals(1027)
+	})
+
+	o.spec("splitArrayAt", () => {
+		o.test("splits in middle", () => {
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 0)).deepEquals([[], [0, 1, 2, 3, 4, 5]])
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 1)).deepEquals([[0], [1, 2, 3, 4, 5]])
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 2)).deepEquals([
+				[0, 1],
+				[2, 3, 4, 5],
+			])
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 3)).deepEquals([
+				[0, 1, 2],
+				[3, 4, 5],
+			])
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 4)).deepEquals([
+				[0, 1, 2, 3],
+				[4, 5],
+			])
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 5)).deepEquals([[0, 1, 2, 3, 4], [5]])
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 6)).deepEquals([[0, 1, 2, 3, 4, 5], []])
+		})
+		o.test("out of bounds splits", () => {
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], -1000)).deepEquals([[], [0, 1, 2, 3, 4, 5]])
+			o.check(splitArrayAt([0, 1, 2, 3, 4, 5], 1000)).deepEquals([[0, 1, 2, 3, 4, 5], []])
+		})
 	})
 })

--- a/src/calendar-app/calendar/search/model/CalendarSearchModel.ts
+++ b/src/calendar-app/calendar/search/model/CalendarSearchModel.ts
@@ -1,7 +1,7 @@
 import stream from "mithril/stream"
 import Stream from "mithril/stream"
 import type { SearchRestriction, SearchResult } from "../../../../common/api/worker/search/SearchTypes"
-import { arrayEquals, assertNonNull, assertNotNull, incrementMonth, isSameTypeRef, lazyAsync, tokenize } from "@tutao/tutanota-utils"
+import { arrayEquals, assertNonNull, assertNotNull, incrementMonth, isEmpty, isSameTypeRef, lazyAsync, tokenize } from "@tutao/tutanota-utils"
 import { assertMainOrNode } from "../../../../common/api/common/Env"
 import { listIdPart } from "../../../../common/api/common/utils/EntityUtils.js"
 import { IProgressMonitor } from "../../../../common/api/common/utils/ProgressMonitor.js"
@@ -285,7 +285,8 @@ export function areResultsForTheSameQuery(a: SearchResult, b: SearchResult) {
 
 export function hasMoreResults(searchResult: SearchResult): boolean {
 	return (
-		searchResult.moreResults.length > 0 ||
-		(searchResult.lastReadSearchIndexRow.length > 0 && searchResult.lastReadSearchIndexRow.every(([word, id]) => id !== 0))
+		!isEmpty(searchResult.moreResults) ||
+		!isEmpty(searchResult.moreResultsEntries) ||
+		(!isEmpty(searchResult.lastReadSearchIndexRow) && searchResult.lastReadSearchIndexRow.every(([word, id]) => id !== 0))
 	)
 }

--- a/src/common/api/worker/search/SearchTypes.ts
+++ b/src/common/api/worker/search/SearchTypes.ts
@@ -140,7 +140,7 @@ export type SearchResult = {
 	currentIndexTimestamp: number
 	maxResults?: number
 	moreResults: Array<MoreResultsIndexEntry>
-	moreResultsEntries: []
+	moreResultsEntries: IdTuple[]
 	lastReadSearchIndexRow: Array<[string, number | null]>
 	// array of pairs (token, lastReadSearchIndexRowOldestElementTimestamp) lastRowReadSearchIndexRow: null = no result read, 0 = no more search results????
 	matchWordOrder: boolean

--- a/src/mail-app/search/model/SearchModel.ts
+++ b/src/mail-app/search/model/SearchModel.ts
@@ -4,7 +4,7 @@ import { CalendarEvent, CalendarEventTypeRef, MailTypeRef } from "../../../commo
 import { NOTHING_INDEXED_TIMESTAMP } from "../../../common/api/common/TutanotaConstants"
 import { DbError } from "../../../common/api/common/error/DbError"
 import type { SearchIndexStateInfo, SearchRestriction, SearchResult } from "../../../common/api/worker/search/SearchTypes"
-import { arrayEquals, assertNonNull, assertNotNull, incrementMonth, isSameTypeRef, lazyAsync, ofClass, tokenize } from "@tutao/tutanota-utils"
+import { arrayEquals, assertNonNull, assertNotNull, incrementMonth, isEmpty, isSameTypeRef, lazyAsync, ofClass, tokenize } from "@tutao/tutanota-utils"
 import { assertMainOrNode } from "../../../common/api/common/Env"
 import { listIdPart } from "../../../common/api/common/utils/EntityUtils.js"
 import { IProgressMonitor } from "../../../common/api/common/utils/ProgressMonitor.js"
@@ -339,7 +339,8 @@ export function areResultsForTheSameQuery(a: SearchResult, b: SearchResult) {
 
 export function hasMoreResults(searchResult: SearchResult): boolean {
 	return (
-		searchResult.moreResults.length > 0 ||
-		(searchResult.lastReadSearchIndexRow.length > 0 && searchResult.lastReadSearchIndexRow.every(([word, id]) => id !== 0))
+		!isEmpty(searchResult.moreResults) ||
+		!isEmpty(searchResult.moreResultsEntries) ||
+		(!isEmpty(searchResult.lastReadSearchIndexRow) && searchResult.lastReadSearchIndexRow.every(([word, id]) => id !== 0))
 	)
 }

--- a/src/mail-app/workerUtils/index/SearchFacade.ts
+++ b/src/mail-app/workerUtils/index/SearchFacade.ts
@@ -23,8 +23,6 @@ export interface SearchFacade {
 	/**
 	 * Get more search results in case search did not return everything.
 	 *
-	 * This may be a no-op on some implementations which would return everything upfront anyway.
-	 *
 	 * @param searchResult search result from search()
 	 * @param moreResultCount number of results
 	 */


### PR DESCRIPTION
We can have all of the IDs loaded at once since those are small, but having all of the mail instances loaded at once can lead to OOM on low RAM devices like phones.

Instead we can hold back all of the results and extend it as we load more results.

Closes #9976