### PR TITLE
fix race conditions when displaying an explicit mail target

### DIFF
--- a/src/common/misc/ClientDetector.ts
+++ b/src/common/misc/ClientDetector.ts
@@ -134,7 +134,7 @@ export class ClientDetector {
 	 */
 	isSupported(): boolean {
 		this.syntaxChecks()
-		return this.isSupportedBrowserVersion() && this.testBuiltins() && this.websockets() && this.testCss()
+		return this.isSupportedBrowserVersion() && this.testBuiltins() && this.websockets() && this.testCss() && this.lookBehindRegex()
 	}
 
 	isMobileDevice(): boolean {
@@ -182,6 +182,15 @@ export class ClientDetector {
 	 */
 	xhr2(): boolean {
 		return "XMLHttpRequest" in window
+	}
+
+	lookBehindRegex(): boolean {
+		try {
+			;/(?<=([ab]+)([bc]+))$/.exec("abc")
+			return true
+		} catch (e) {
+			return false
+		}
 	}
 
 	indexedDb(): boolean {


### PR DESCRIPTION
When displaying an explicit mail target, e.g. by clicking on a notification, we were sometimes displaying the mailMoved_msg snack bar instead of displaying the mail, even though we would have been able to display the mail. This led to cases where the explicit mail target was not shown or quickly disappeared again. This commit fixes the issue by either loading the mail from the listModel, cache or entityClient, in this order, only once. We can display an explicit mail target, even when the mail has been moved, because the listId of the mail does not correspond to the folder the mail is in anymore. This has changed with the introduction of MailSets.

Furthermore, this commit ensures that the correct folder for the sticky mail is displayed after closing the mail after closing the mail. Previously, we were always displaying the user inbox folder on mobile after closing the mail.