### PR TITLE
remove _finalIvs field from the instances

### DIFF
--- a/buildSrc/RustGenerator.js
+++ b/buildSrc/RustGenerator.js
@@ -61,8 +61,6 @@ pub struct ${typeName} {\n`
 		buf += `
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 `
 	}
 

--- a/packages/node-mimimi/src/importer.rs
+++ b/packages/node-mimimi/src/importer.rs
@@ -236,7 +236,6 @@ impl ImportEssential {
 			totalMails: total_importable_mails,
 			targetMailFolder: target_mailset,
 			_errors: Default::default(),
-			_finalIvs: Default::default(),
 		};
 
 		let import_get_response = logged_in_sdk

--- a/packages/node-mimimi/src/importer/importable_mail.rs
+++ b/packages/node-mimimi/src/importer/importable_mail.rs
@@ -155,7 +155,6 @@ impl From<MailContact> for MailAddress {
 			address: value.mail_address,
 			name: value.name,
 			contact: None,
-			_finalIvs: Default::default(),
 			_errors: Default::default(),
 		}
 	}
@@ -581,7 +580,6 @@ impl ImportableMail {
 				_id: Some(tutasdk::CustomId::from_custom_string(FIXED_CUSTOM_ID)),
 				name: reply_to.name,
 				address: reply_to.mail_address,
-				_finalIvs: Default::default(),
 				_errors: Default::default(),
 			})
 			.collect();
@@ -634,7 +632,6 @@ impl ImportableMail {
 			references,
 			importedAttachments: vec![],
 			_errors: Default::default(),
-			_finalIvs: Default::default(),
 		}
 	}
 }

--- a/packages/node-mimimi/src/importer/importable_mail.rs
+++ b/packages/node-mimimi/src/importer/importable_mail.rs
@@ -599,7 +599,7 @@ impl ImportableMail {
 
 		// if no date is provided, use UNIX_EPOCH (01.01.1970) as fallback
 		// this makes it more obvious to user that this mail date was not right
-		let date = date.unwrap_or_default();
+		let date = date.unwrap_or_else(|| DateTime::from_millis(0));
 
 		ImportMailData {
 			_format: 0,

--- a/src/common/api/common/EntityTypes.ts
+++ b/src/common/api/common/EntityTypes.ts
@@ -193,8 +193,6 @@ export type ParsedAssociation = EncryptedParsedAssociation
 export type ParsedInstance = Record<AttributeId, Nullable<ParsedValue> | ParsedAssociation> & {
 	/** crypto errors that happened during deserialization/serialization */
 	_errors?: Record<AttributeId, string>
-	/** the ivs used to encrypt final fields on the instance */
-	_finalIvs: Record<AttributeId, Nullable<Uint8Array>>
 }
 
 /** simple separator to distinguish between client model types and server model types */
@@ -230,7 +228,6 @@ export interface Entity {
 	/** the address of the TypeModel this entity conforms to. */
 	_type: TypeRef<this>
 	_original?: this
-	_finalIvs?: Record<number, Nullable<Uint8Array>>
 	bucketKey?: null | BucketKey
 	_ownerGroup?: null | Id
 	_ownerEncSessionKey?: null | Uint8Array

--- a/src/common/api/common/utils/EntityUtils.ts
+++ b/src/common/api/common/utils/EntityUtils.ts
@@ -274,7 +274,6 @@ export function customIdToString(customId: string): string {
 export function create<T>(typeModel: TypeModel, typeRef: TypeRef<T>, createDefaultValue: (name: string, value: ModelValue) => any = _getDefaultValue): T {
 	let i: Record<string, any> = {
 		_type: typeRef,
-		_finalIvs: {},
 	}
 
 	for (const [valueIdStr, value] of Object.entries(typeModel.values)) {
@@ -419,7 +418,7 @@ export function removeTechnicalFields<E extends Partial<SomeEntity>>(entity: E) 
 	// we want to restrict outer function to entity types, but internally we also want to handle aggregates
 	function _removeTechnicalFields(erased: Record<string, any>) {
 		for (const key of Object.keys(erased)) {
-			if (key.startsWith("_finalIvs") || key.startsWith("_errors")) {
+			if (key.startsWith("_errors")) {
 				delete erased[key]
 			} else {
 				const value = erased[key]

--- a/src/common/api/worker/crypto/ModelMapper.ts
+++ b/src/common/api/worker/crypto/ModelMapper.ts
@@ -159,7 +159,6 @@ export class ModelMapper {
 		const serverTypeModel = await this.serverTypeReferenceResolver(typeRef)
 		const clientInstance: Record<string, unknown> = {
 			_type: typeRef,
-			_finalIvs: parsedInstance._finalIvs,
 		}
 
 		if (parsedInstance._errors != null) {
@@ -231,9 +230,7 @@ export class ModelMapper {
 	async mapToClientModelParsedInstance<T extends Entity>(typeRef: TypeRef<T>, instance: T): Promise<ClientModelParsedInstance> {
 		const clientTypeModel = await this.clientTypeReferenceResolver(typeRef)
 
-		const parsedInstance: Record<number, unknown> & { _finalIvs: unknown } = {
-			_finalIvs: typeof instance["_finalIvs"] !== "undefined" ? instance["_finalIvs"] : {},
-		}
+		const parsedInstance: Record<number, unknown> = {}
 
 		for (const [attrIdStr, modelValue] of Object.entries(clientTypeModel.values)) {
 			const attrId = parseInt(attrIdStr)
@@ -373,6 +370,7 @@ export function valueToDefault(type: Values<typeof ValueType>): ParsedValue {
 	}
 }
 
+// visibleForTesting
 export function isDefaultValue(type: Values<typeof ValueType>, value: unknown): boolean {
 	switch (type) {
 		case ValueType.String:

--- a/test/tests/TestUtils.ts
+++ b/test/tests/TestUtils.ts
@@ -282,19 +282,6 @@ The last expected item is ${JSON.stringify(expectedArray.at(-1))} but got ${JSON
 				}
 }
 
-export function removeFinalIvs(instance: Entity | ParsedInstance): Entity | ParsedInstance {
-	delete instance["_finalIvs"]
-	delete instance["_original"]
-	const keys = Object.keys(instance)
-	for (const key of keys) {
-		const maybeAggregate = instance[key]
-		if (maybeAggregate instanceof Object) {
-			removeFinalIvs(maybeAggregate)
-		}
-	}
-	return instance
-}
-
 export function removeOriginals<T extends Entity>(instance: T | null): T | null {
 	if (isNotNull(instance) && typeof instance === "object") {
 		delete instance["_original"]

--- a/test/tests/api/worker/EventBusClientTest.ts
+++ b/test/tests/api/worker/EventBusClientTest.ts
@@ -303,11 +303,7 @@ o.spec("EventBusClientTest", function () {
 		const updateCaptor = matchers.captor()
 		verify(listenerMock.onCounterChanged(updateCaptor.capture()))
 
-		// same counterUpdate defined above with added _finalIvs field
-		const expectedCounterUpdate = { ...counterUpdate }
-		Object.assign(expectedCounterUpdate, { _finalIvs: {} })
-		Object.assign(expectedCounterUpdate.counterValues[0], { _finalIvs: {} })
-		o(updateCaptor.values!.map(removeOriginals)).deepEquals([expectedCounterUpdate])
+		o(updateCaptor.values!.map(removeOriginals)).deepEquals([counterUpdate])
 	})
 
 	o("verify new hash is set when entity updates are processed", async function () {

--- a/test/tests/api/worker/crypto/CryptoMapperTest.ts
+++ b/test/tests/api/worker/crypto/CryptoMapperTest.ts
@@ -228,7 +228,6 @@ o.spec("CryptoMapper", function () {
 			4: ["associatedElementId"],
 			5: new Date("2025-01-01T13:00:00.000Z"),
 		} as any as ServerModelEncryptedParsedInstance
-		const expectedFinalIv = new Uint8Array([93, 100, 153, 150, 95, 10, 107, 53, 164, 219, 212, 180, 106, 221, 132, 233])
 		const decryptedInstance = await cryptoMapper.decryptParsedInstance(testTypeModel as ServerTypeModel, encryptedInstance, sk)
 
 		o(decryptedInstance[1]).equals("encrypted string")
@@ -236,8 +235,6 @@ o.spec("CryptoMapper", function () {
 
 		o(decryptedInstance[3]![0][2]).equals("123")
 		o(decryptedInstance[4]![0]).equals("associatedElementId")
-		o(typeof decryptedInstance._finalIvs[7]).equals("undefined")
-		o(Array.from(decryptedInstance["_finalIvs"][1] as Uint8Array)).deepEquals(Array.from(expectedFinalIv))
 		o(typeof decryptedInstance._errors).equals("undefined")
 	})
 	o("encryptParsedInstance happy path works", async function () {
@@ -250,12 +247,8 @@ o.spec("CryptoMapper", function () {
 			// 6 is _id and will be generated
 			3: [{ 2: "123", 6: "aggregateId", 9: [], 10: [] }],
 			4: ["associatedElementId"],
-			_finalIvs: { 1: new Uint8Array([93, 100, 153, 150, 95, 10, 107, 53, 164, 219, 212, 180, 106, 221, 132, 233]) },
 		} as unknown as ClientModelParsedInstance
 		const encryptedInstance = await cryptoMapper.encryptParsedInstance(testTypeModel as ClientTypeModel, parsedInstance, sk)
-
-		const expectedCipherText = "AV1kmZZfCms1pNvUtGrdhOlnDAr3zb2JWpmlpWEhgG5zqYK3g7PfRsi0vQAKLxXmrNRGp16SBKBa0gqXeFw9F6l7nbGs3U8uNLvs6Fi+9IWj"
-		o(encryptedInstance[1]).equals(expectedCipherText)
 
 		const encryptedBytes = base64ToUint8Array(encryptedInstance[1] as string)
 		const decryptedValue = utf8Uint8ArrayToString(aesDecrypt(sk, encryptedBytes))
@@ -287,7 +280,6 @@ o.spec("CryptoMapper", function () {
 			// 6 is _id and will be generated
 			3: [{ 2: "123", 9: [], 10: [] }],
 			4: ["associatedElementId"],
-			_finalIvs: { 1: new Uint8Array([93, 100, 153, 150, 95, 10, 107, 53, 164, 219, 212, 180, 106, 221, 132, 233]) },
 		} as unknown as ClientModelParsedInstance
 		await assertThrows(CryptoError, () => cryptoMapper.encryptParsedInstance(testTypeModel as ClientTypeModel, parsedInstance, null))
 	})
@@ -305,22 +297,6 @@ o.spec("CryptoMapper", function () {
 		const decryptedInstance = await cryptoMapper.decryptParsedInstance(testTypeModel as ServerTypeModel, encryptedInstance, sk)
 
 		o(decryptedInstance[1]).equals("")
-		o(decryptedInstance._finalIvs[1]).equals(null)
-	})
-
-	o("encrypting default values works correctly", async function () {
-		const sk = [4136869568, 4101282953, 2038999435, 962526794, 1053028316, 3236029410, 1618615449, 3232287205]
-		const parsedInstance: ClientModelParsedInstance = {
-			1: "",
-			5: new Date("2025-01-01T13:00:00.000Z"),
-			// 6 is _id and will be generated
-			3: [{ 2: "123", 9: [], 10: [] }],
-			4: ["associatedElementId"],
-			_finalIvs: { 1: null },
-		} as unknown as ClientModelParsedInstance
-
-		const encryptedInstance = await cryptoMapper.encryptParsedInstance(testTypeModel as ClientTypeModel, parsedInstance, sk)
-		o(encryptedInstance[1]).equals("")
 	})
 
 	o("decryption errors are written to _errors field", async function () {

--- a/test/tests/api/worker/crypto/ModelMapperTest.ts
+++ b/test/tests/api/worker/crypto/ModelMapperTest.ts
@@ -81,13 +81,12 @@ o.spec("ModelMapper", function () {
 			const parsedInstance: ServerModelParsedInstance = {
 				1: "some encrypted string",
 				5: new Date("2025-01-01T13:00:00.000Z"),
-				3: [{ 2: "123", 6: "123456", _finalIvs: {}, 9: [], 10: [] } as unknown as ServerModelParsedInstance],
+				3: [{ 2: "123", 6: "123456", 9: [], 10: [] } as unknown as ServerModelParsedInstance],
 				12: "generatedId",
 				13: ["listId", "elementId"],
 				4: ["associatedElementId"],
 				7: true,
 				8: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as unknown as ServerModelParsedInstance
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
@@ -98,7 +97,6 @@ o.spec("ModelMapper", function () {
 			o(mappedInstance.testDate.toISOString()).equals("2025-01-01T13:00:00.000Z")
 			o(mappedInstance.testAssociation[0]).deepEquals({
 				_type: TestAggregateRef,
-				_finalIvs: {},
 				testNumber: "123",
 				_id: "123456",
 				testSecondLevelAssociation: [],
@@ -107,17 +105,15 @@ o.spec("ModelMapper", function () {
 			o(mappedInstance.testElementAssociation).equals("associatedElementId")
 			o(mappedInstance.testGeneratedId).equals("generatedId")
 			o(mappedInstance.testListElementAssociation).deepEquals([["listId", "listElementId"]])
-			o(mappedInstance._finalIvs).deepEquals(parsedInstance._finalIvs)
 			o(typeof mappedInstance._errors).equals("undefined")
 		})
 		o("wrong cardinality on value field throws", async function () {
 			const parsedInstance: ServerModelParsedInstance = {
 				1: null,
 				5: new Date("2025-01-01T13:00:00.000Z"),
-				3: [{ 2: "123", 6: "123456", _finalIvs: {} } as unknown as ServerModelParsedInstance],
+				3: [{ 2: "123", 6: "123456" } as unknown as ServerModelParsedInstance],
 				4: ["associatedListId"],
 				7: true,
-				_finalIvs: {},
 			} as unknown as ServerModelParsedInstance
 			await assertThrows(ProgrammingError, async () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
 		})
@@ -128,7 +124,6 @@ o.spec("ModelMapper", function () {
 				3: [],
 				4: ["associatedListId"],
 				7: true,
-				_finalIvs: {},
 			} as unknown as ServerModelParsedInstance
 			await assertThrows(ProgrammingError, async () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
 		})
@@ -136,10 +131,9 @@ o.spec("ModelMapper", function () {
 			const parsedInstance: ServerModelParsedInstance = {
 				1: "some encrypted string",
 				5: new Date("2025-01-01T13:00:00.000Z"),
-				3: [{ 2: "123", 6: "123456", _finalIvs: {} } as unknown as ServerModelParsedInstance],
+				3: [{ 2: "123", 6: "123456" } as unknown as ServerModelParsedInstance],
 				4: [],
 				7: true,
-				_finalIvs: {},
 			} as unknown as ServerModelParsedInstance
 			await assertThrows(ProgrammingError, async () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
 		})
@@ -148,11 +142,9 @@ o.spec("ModelMapper", function () {
 		o("happy path debug", async function () {
 			const instance: TestEntity = {
 				_type: TestTypeRef,
-				_finalIvs: {},
 				testAssociation: [
 					{
 						_type: TestAggregateRef,
-						_finalIvs: {},
 						testNumber: "123456",
 					} as TestAggregate,
 				],
@@ -173,9 +165,7 @@ o.spec("ModelMapper", function () {
 			const testAssociation = assertNotNull(parsedInstance[3])[0]
 			o(testAssociation[2]).equals("123456")
 			o(testAssociation[6].length).deepEquals(6) // custom generated id
-			o(testAssociation._finalIvs).deepEquals({})
 			o(parsedInstance[4]).deepEquals(["associatedElementId"])
-			o(parsedInstance._finalIvs).deepEquals(instance._finalIvs!)
 			o(typeof parsedInstance._errors).equals("undefined")
 		})
 	})

--- a/test/tests/api/worker/crypto/ModelMapperTransformationsTest.ts
+++ b/test/tests/api/worker/crypto/ModelMapperTransformationsTest.ts
@@ -91,15 +91,13 @@ o.spec("ModelMapperTransformations", function () {
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
 			const parsedInstance: ServerModelParsedInstance = {
-				3: [{ 2: "123", _finalIvs: {} } as any as ServerModelParsedInstance],
-				_finalIvs: {},
+				3: [{ 2: "123" } as any as ServerModelParsedInstance],
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 		})
@@ -183,23 +181,19 @@ o.spec("ModelMapperTransformations", function () {
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
 			const parsedInstance: ServerModelParsedInstance = {
-				3: [{ 2: "123", _finalIvs: {} } as any as ServerModelParsedInstance],
-				_finalIvs: {},
+				3: [{ 2: "123" } as any as ServerModelParsedInstance],
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			// request is prepared with the client model and does not add ZeroOrOne aggregation
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
-			o(newParsedInstance).deepEquals({
-				_finalIvs: {},
-			} as any)
+			o(newParsedInstance).deepEquals({} as any)
 		})
 		o("add Any aggregation", async function () {
 			const serverModelResolver = async (typeRef: TypeRef<any>): Promise<ServerTypeModel> => {
@@ -281,23 +275,19 @@ o.spec("ModelMapperTransformations", function () {
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
 			const parsedInstance: ServerModelParsedInstance = {
-				3: [{ 2: "123", _finalIvs: {} } as any as ServerModelParsedInstance],
-				_finalIvs: {},
+				3: [{ 2: "123" } as any as ServerModelParsedInstance],
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			// request is prepared with the client model and does not add Any aggregation
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
-			o(newParsedInstance).deepEquals({
-				_finalIvs: {},
-			} as any as ClientModelParsedInstance)
+			o(newParsedInstance).deepEquals({} as any as ClientModelParsedInstance)
 		})
 
 		o("add One list element association", async function () {
@@ -372,14 +362,12 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 		})
@@ -455,22 +443,18 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			// request is prepared with the client model and does not add ZeroOrOne association
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
-			o(newParsedInstance).deepEquals({
-				_finalIvs: {},
-			} as any as ClientModelParsedInstance)
+			o(newParsedInstance).deepEquals({} as any as ClientModelParsedInstance)
 		})
 		o("add Any list element association", async function () {
 			const serverModelResolver = async (typeRef: TypeRef<any>): Promise<ServerTypeModel> => {
@@ -553,22 +537,18 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			// request is prepared with the client model and does not add Any association
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
-			o(newParsedInstance).deepEquals({
-				_finalIvs: {},
-			} as any as ClientModelParsedInstance)
+			o(newParsedInstance).deepEquals({} as any as ClientModelParsedInstance)
 		})
 	})
 	o.spec("AddValue", function () {
@@ -629,22 +609,18 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				1: "example",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			// request is prepared with the client model and does not add One value
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
-			o(newParsedInstance).deepEquals({
-				_finalIvs: {},
-			} as any as ClientModelParsedInstance)
+			o(newParsedInstance).deepEquals({} as any as ClientModelParsedInstance)
 		})
 		o("add One Value with default supplier on server should also supply default on client", async function () {
 			const serverModelResolver = async (typeRef: TypeRef<any>): Promise<ServerTypeModel> => {
@@ -711,16 +687,13 @@ o.spec("ModelMapperTransformations", function () {
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
 			// The instance in the offline storage (written when the value was not there for the server & client models)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: "",
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -728,7 +701,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				1: "",
-				_finalIvs: {},
 			} as any as ClientModelParsedInstance)
 		})
 		o("add ZeroOrOne Value", async function () {
@@ -788,22 +760,18 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				1: "example",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			// request is prepared with the client model and does not add ZeroOrOne value
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
-			o(newParsedInstance).deepEquals({
-				_finalIvs: {},
-			} as any as ClientModelParsedInstance)
+			o(newParsedInstance).deepEquals({} as any as ClientModelParsedInstance)
 		})
 	})
 	o.spec("BooleanToNumberValue", function () {
@@ -874,7 +842,6 @@ o.spec("ModelMapperTransformations", function () {
 			// false
 			const falseParsedInstance: ServerModelParsedInstance = {
 				1: "0",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const falseMappedInstance = (await modelMapper.mapToInstance(TestTypeRef, falseParsedInstance)) as any
@@ -882,7 +849,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(falseMappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: false,
-				_finalIvs: {},
 			} as any)
 			o(typeof falseMappedInstance._errors).equals("undefined")
 
@@ -890,13 +856,11 @@ o.spec("ModelMapperTransformations", function () {
 			const newFalseParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, falseMappedInstance)
 			o(newFalseParsedInstance).deepEquals({
 				1: false,
-				_finalIvs: {},
 			} as any as ClientModelParsedInstance)
 
 			// true
 			const trueParsedInstance: ServerModelParsedInstance = {
 				1: "anything",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const trueMappedInstance = (await modelMapper.mapToInstance(TestTypeRef, trueParsedInstance)) as any
@@ -904,7 +868,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(trueMappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: true,
-				_finalIvs: {},
 			} as any)
 			o(typeof trueMappedInstance._errors).equals("undefined")
 
@@ -912,7 +875,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newTrueParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, trueMappedInstance)
 			o(newTrueParsedInstance).deepEquals({
 				1: true,
-				_finalIvs: {},
 			} as any as ClientModelParsedInstance)
 		})
 	})
@@ -1013,12 +975,7 @@ o.spec("ModelMapperTransformations", function () {
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
 			const parsedInstance: ServerModelParsedInstance = {
-				3: [
-					{
-						_finalIvs: {},
-					} as any as ServerModelParsedInstance,
-				],
-				_finalIvs: {},
+				3: [{} as any as ServerModelParsedInstance],
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -1028,10 +985,8 @@ o.spec("ModelMapperTransformations", function () {
 				testAggregation: [
 					{
 						_type: TestAggregateRef,
-						_finalIvs: {},
 					},
 				],
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -1135,7 +1090,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can't convert an empty array to one
 			await assertThrows(ProgrammingError, async () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
@@ -1237,7 +1191,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can't convert an empty array to one
 			const mappedInstance = await modelMapper.mapToInstance(TestTypeRef, parsedInstance)
@@ -1245,7 +1198,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testAggregation: null,
-				_finalIvs: {},
 			} as any)
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals(parsedInstance as any as ClientModelParsedInstance)
@@ -1346,8 +1298,7 @@ o.spec("ModelMapperTransformations", function () {
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
 			const parsedInstance: ServerModelParsedInstance = {
-				3: [{ _finalIvs: {} } as any as ServerModelParsedInstance, { _finalIvs: {} } as any as ServerModelParsedInstance],
-				_finalIvs: {},
+				3: [{} as any as ServerModelParsedInstance, {} as any as ServerModelParsedInstance],
 			} as any as ServerModelParsedInstance
 			// can't convert an array with multiple elements to ZeroOrOne
 			await assertThrows(ProgrammingError, () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
@@ -1449,7 +1400,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can convert an empty array to ZeroOrOne
 			const mappedInstance = await modelMapper.mapToInstance(TestTypeRef, parsedInstance)
@@ -1457,7 +1407,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testAggregation: [],
-				_finalIvs: {},
 			} as any)
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals(parsedInstance as any as ClientModelParsedInstance)
@@ -1558,16 +1507,14 @@ o.spec("ModelMapperTransformations", function () {
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
 			const parsedInstance: ServerModelParsedInstance = {
-				3: [{ _finalIvs: {} } as any as ServerModelParsedInstance],
-				_finalIvs: {},
+				3: [{} as any as ServerModelParsedInstance],
 			} as any as ServerModelParsedInstance
 			// can convert an array with one element to ZeroOrOne
 			const mappedInstance = await modelMapper.mapToInstance(TestTypeRef, parsedInstance)
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
-				testAggregation: [{ _type: TestAggregateRef, _finalIvs: {} } as any],
-				_finalIvs: {},
+				testAggregation: [{ _type: TestAggregateRef } as any],
 			} as any)
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals(parsedInstance as any as ClientModelParsedInstance)
@@ -1670,7 +1617,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -1678,7 +1624,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testListElementAssociation: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -1782,7 +1727,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can't convert an empty array to one
 			await assertThrows(ProgrammingError, async () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
@@ -1884,7 +1828,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can't convert an empty array to one
 			const mappedInstance = await modelMapper.mapToInstance(TestTypeRef, parsedInstance)
@@ -1892,7 +1835,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testListElementAssociation: null,
-				_finalIvs: {},
 			} as any)
 
 			// request is prepared with the client model and association is not changed
@@ -1999,7 +1941,6 @@ o.spec("ModelMapperTransformations", function () {
 					["listId", "listElementId1"],
 					["listId", "listElementId2"],
 				],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can't convert an array with multiple elements to ZeroOrOne
 			await assertThrows(ProgrammingError, () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
@@ -2101,7 +2042,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can convert an empty array to ZeroOrOne
 			const mappedInstance = await modelMapper.mapToInstance(TestTypeRef, parsedInstance)
@@ -2109,7 +2049,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testListElementAssociation: [],
-				_finalIvs: {},
 			} as any)
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals(parsedInstance as any as ClientModelParsedInstance)
@@ -2211,7 +2150,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				3: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 			// can convert an array with one element to ZeroOrOne
 			const mappedInstance = await modelMapper.mapToInstance(TestTypeRef, parsedInstance)
@@ -2219,7 +2157,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testListElementAssociation: [["listId", "listElementId"]],
-				_finalIvs: {},
 			} as any)
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals(parsedInstance as any as ClientModelParsedInstance)
@@ -2292,7 +2229,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				1: "example",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -2300,14 +2236,12 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: "example",
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				1: "example",
-				_finalIvs: {},
 			} as any as ClientModelParsedInstance)
 		})
 		o("change value from One to ZeroOrOne", async function () {
@@ -2376,7 +2310,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				1: "example",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -2384,14 +2317,12 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: "example",
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				1: "example",
-				_finalIvs: {},
 			} as any as ClientModelParsedInstance)
 		})
 		o("change value from One to ZeroOrOne null value throws", async function () {
@@ -2460,7 +2391,6 @@ o.spec("ModelMapperTransformations", function () {
 			)
 			const parsedInstance: ServerModelParsedInstance = {
 				1: null,
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			await assertThrows(ProgrammingError, () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
@@ -2533,7 +2463,6 @@ o.spec("ModelMapperTransformations", function () {
 
 			const parsedInstance: ServerModelParsedInstance = {
 				1: "42",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -2541,7 +2470,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: 42,
-				_finalIvs: {},
 			} as any)
 			o(typeof parsedInstance._errors).equals("undefined")
 
@@ -2549,7 +2477,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				1: 42,
-				_finalIvs: {},
 			} as any as ClientModelParsedInstance)
 		})
 		o("convert number to string value throws when server sends non numeric", async function () {
@@ -2618,7 +2545,6 @@ o.spec("ModelMapperTransformations", function () {
 
 			const wrongParsedInstance: ServerModelParsedInstance = {
 				1: "example",
-				_finalIvs: {},
 			} as any as ServerModelParsedInstance
 
 			await assertThrows(ProgrammingError, () => modelMapper.mapToInstance(TestTypeRef, wrongParsedInstance))
@@ -2704,9 +2630,7 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 			// can't create the instance since One aggregation is removed
 			await assertThrows(ProgrammingError, () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
 		})
@@ -2789,9 +2713,7 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 
 			// can remove aggregation with ZeroOrOne cardinality and supply null
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -2799,7 +2721,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testAssociation: null,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -2807,7 +2728,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				3: [],
-				_finalIvs: {},
 			} as any)
 		})
 		o("remove Any aggregation", async function () {
@@ -2889,9 +2809,7 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 
 			// can remove association with Any cardinality and supply []
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -2899,7 +2817,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testAssociation: [],
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -2907,7 +2824,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				3: [],
-				_finalIvs: {},
 			} as any)
 		})
 
@@ -2981,9 +2897,7 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 			// can't create the instance since One association is removed
 			await assertThrows(ProgrammingError, () => modelMapper.mapToInstance(TestTypeRef, parsedInstance))
 		})
@@ -3057,9 +2971,7 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 
 			// can remove association with ZeroOrOne and supply null
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -3067,7 +2979,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testListElementAssociation: null,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -3075,7 +2986,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				3: [],
-				_finalIvs: {},
 			} as any)
 		})
 		o("remove Any list element association", async function () {
@@ -3157,9 +3067,7 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 
 			// can remove association with Any cardinality and supply []
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
@@ -3167,7 +3075,6 @@ o.spec("ModelMapperTransformations", function () {
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testListElementAssociation: [],
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -3175,7 +3082,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				3: [],
-				_finalIvs: {},
 			} as any)
 		})
 	})
@@ -3235,16 +3141,13 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: "",
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -3252,7 +3155,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				1: "",
-				_finalIvs: {},
 			} as any as ClientModelParsedInstance)
 		})
 		o("remove ZeroOrOne Value", async function () {
@@ -3310,16 +3212,13 @@ o.spec("ModelMapperTransformations", function () {
 				clientModelResolver as ClientTypeReferenceResolver,
 				serverModelResolver as ServerTypeReferenceResolver,
 			)
-			const parsedInstance: ServerModelParsedInstance = {
-				_finalIvs: {},
-			} as any as ServerModelParsedInstance
+			const parsedInstance: ServerModelParsedInstance = {} as any as ServerModelParsedInstance
 
 			const mappedInstance = (await modelMapper.mapToInstance(TestTypeRef, parsedInstance)) as any
 			removeOriginals(mappedInstance)
 			o(mappedInstance).deepEquals({
 				_type: TestTypeRef,
 				testValue: null,
-				_finalIvs: {},
 			} as any)
 			o(typeof mappedInstance._errors).equals("undefined")
 
@@ -3327,7 +3226,6 @@ o.spec("ModelMapperTransformations", function () {
 			const newParsedInstance = await modelMapper.mapToClientModelParsedInstance(TestTypeRef, mappedInstance)
 			o(newParsedInstance).deepEquals({
 				1: null,
-				_finalIvs: {},
 			} as any)
 		})
 	})

--- a/test/tests/api/worker/offline/PatchMergerTest.ts
+++ b/test/tests/api/worker/offline/PatchMergerTest.ts
@@ -19,7 +19,7 @@ import {
 	createTestEntity,
 	instancePipelineFromTypeModelResolver,
 	modelMapperFromTypeModelResolver,
-	removeFinalIvs,
+	removeOriginals,
 } from "../../../TestUtils"
 import {
 	CalendarEvent,
@@ -213,7 +213,7 @@ o.spec("PatchMergerTest", () => {
 			o(testMailPatched.subject).equals("new subject")
 		})
 
-		o.test("apply_replace_on_root_level_encrypted_value_populates_finalIvs", async () => {
+		o.test("apply_replace_on_root_level_encrypted_value", async () => {
 			const testMail = createSystemMail({
 				_id: ["listId", "elementId"],
 				_ownerEncSessionKey: encryptedSessionKey.key,
@@ -245,10 +245,9 @@ o.spec("PatchMergerTest", () => {
 			const testMailPatchedParsed = assertNotNull(await patchMerger.getPatchedInstanceParsed(MailTypeRef, "listId", "elementId", patches))
 			const testMailPatched = await instancePipeline.modelMapper.mapToInstance<Mail>(MailTypeRef, testMailPatchedParsed)
 			o(testMailPatched.encryptionAuthStatus).equals(EncryptionAuthStatus.TUTACRYPT_AUTHENTICATION_SUCCEEDED)
-			assertNotNull(testMailPatchedParsed._finalIvs[encryptionAuthStatusAttributeId])
 		})
 
-		o.test("apply_replace_on_root_level_encrypted_value_with_null_removes_finalIvs", async () => {
+		o.test("apply_replace_on_root_level_encrypted_value", async () => {
 			const testMail = createSystemMail({
 				_id: ["listId", "elementId"],
 				_ownerEncSessionKey: encryptedSessionKey.key,
@@ -256,8 +255,6 @@ o.spec("PatchMergerTest", () => {
 				_ownerGroup: ownerGroupId,
 				encryptionAuthStatus: EncryptionAuthStatus.TUTACRYPT_AUTHENTICATION_SUCCEEDED,
 			})
-			const finalIvEncryptionAuthStatus = new Uint8Array([93, 100, 153, 150, 95, 10, 107, 53, 164, 219, 212, 180, 106, 221, 132, 233])
-			testMail["_finalIvs"] = { encryptionAuthStatus: finalIvEncryptionAuthStatus }
 
 			await storage.put(MailTypeRef, await toStorableInstance(testMail))
 
@@ -280,10 +277,9 @@ o.spec("PatchMergerTest", () => {
 			const testMailPatchedParsed = assertNotNull(await patchMerger.getPatchedInstanceParsed(MailTypeRef, "listId", "elementId", patches))
 			const testMailPatched = await instancePipeline.modelMapper.mapToInstance<Mail>(MailTypeRef, testMailPatchedParsed)
 			o.check(testMailPatched.encryptionAuthStatus).equals(null)
-			o.check(testMailPatchedParsed._finalIvs[encryptionAuthStatusAttributeId]).equals(undefined)
 		})
 
-		o.test("apply_replace_on_root_level_encrypted_value_with_default_value_sets_finalIvs_to_null", async () => {
+		o.test("apply_replace_on_root_level_encrypted_value_with_default_value", async () => {
 			const testMail = createSystemMail({
 				_id: ["listId", "elementId"],
 				_ownerEncSessionKey: encryptedSessionKey.key,
@@ -291,8 +287,6 @@ o.spec("PatchMergerTest", () => {
 				_ownerGroup: ownerGroupId,
 				listUnsubscribe: true,
 			})
-			const finalIvListUnsubscribe = new Uint8Array([93, 100, 153, 150, 95, 10, 107, 53, 164, 219, 212, 180, 106, 221, 132, 233])
-			testMail["_finalIvs"] = { listUnsubscribe: finalIvListUnsubscribe }
 
 			await storage.put(MailTypeRef, await toStorableInstance(testMail))
 
@@ -310,7 +304,6 @@ o.spec("PatchMergerTest", () => {
 			const testMailPatchedParsed = assertNotNull(await patchMerger.getPatchedInstanceParsed(MailTypeRef, "listId", "elementId", patches))
 			const testMailPatched = await instancePipeline.modelMapper.mapToInstance<Mail>(MailTypeRef, testMailPatchedParsed)
 			o.check(testMailPatched.listUnsubscribe).equals(false)
-			o.check(testMailPatchedParsed._finalIvs[listUnsubscribeAttributeId]).equals(null)
 		})
 
 		o.test("apply_replace_on_value_on_aggregation", async () => {
@@ -749,7 +742,7 @@ o.spec("PatchMergerTest", () => {
 				testMailDetailsBlobPatchedParsed,
 			)
 			const addedToRecipient = assertNotNull(testMailDetailsBlobPatched.details.recipients.toRecipients.pop())
-			o(removeFinalIvs(addedToRecipient)).deepEquals(removeFinalIvs(toRecipientToAdd))
+			o(removeOriginals(addedToRecipient)).deepEquals(removeOriginals(toRecipientToAdd))
 		})
 
 		o.test("apply_additem_on_Any_aggregation_multiple", async () => {
@@ -809,9 +802,9 @@ o.spec("PatchMergerTest", () => {
 				testMailDetailsBlobPatchedParsed,
 			)
 			const addedSecondToRecipient = assertNotNull(testMailDetailsBlobPatched.details.recipients.toRecipients.pop())
-			o(removeFinalIvs(addedSecondToRecipient)).deepEquals(removeFinalIvs(secondToRecipientToAdd))
+			o(removeOriginals(addedSecondToRecipient)).deepEquals(removeOriginals(secondToRecipientToAdd))
 			const addedFirstToRecipient = assertNotNull(testMailDetailsBlobPatched.details.recipients.toRecipients.pop())
-			o(removeFinalIvs(addedFirstToRecipient)).deepEquals(removeFinalIvs(firstToRecipientToAdd))
+			o(removeOriginals(addedFirstToRecipient)).deepEquals(removeOriginals(firstToRecipientToAdd))
 		})
 
 		o.test("apply_additem_on_Any_aggregation_multiple_existing_ignored", async () => {

--- a/test/tests/api/worker/rest/PatchGeneratorTest.ts
+++ b/test/tests/api/worker/rest/PatchGeneratorTest.ts
@@ -4,7 +4,6 @@ import {
 	TestAggregate,
 	testAggregateModel,
 	TestAggregateOnAggregate,
-	testAggregateOnAggregateModel,
 	TestAggregateOnAggregateRef,
 	TestAggregateRef,
 	TestEntity,
@@ -639,24 +638,20 @@ o.spec("computePatches", function () {
 	async function createFilledTestEntity(): Promise<TestEntity> {
 		return await createTestEntityWithOriginal({
 			_type: TestTypeRef,
-			_finalIvs: {},
 			testAssociation: [
 				{
 					_type: TestAggregateRef,
-					_finalIvs: {},
 					_id: "aggId",
 					testNumber: "123456",
 					testSecondLevelAssociation: [
 						{
 							_type: TestAggregateOnAggregateRef,
-							_finalIvs: {},
 							_id: "aggOnAggId",
 							testBytes: null,
 						} as TestAggregateOnAggregate,
 					],
 					testZeroOrOneAggregation: {
 						_type: TestAggregateOnAggregateRef,
-						_finalIvs: {},
 						_id: "aggOnAggId",
 						testBytes: null,
 					} as TestAggregateOnAggregate,

--- a/test/tests/api/worker/rest/ServiceExecutorTest.ts
+++ b/test/tests/api/worker/rest/ServiceExecutorTest.ts
@@ -592,8 +592,6 @@ o.spec("ServiceExecutor", function () {
 
 			const response = await executor.get(CustomerAccountService, null)
 
-			delete downcast(response)._finalIvs
-			delete downcast(customerAccountReturn)._finalIvs
 			removeOriginals(response)
 			o(response).deepEquals(customerAccountReturn)
 			verify(
@@ -620,8 +618,6 @@ o.spec("ServiceExecutor", function () {
 
 			const response = await executor.get(CustomerAccountService, null, { sessionKey })
 
-			delete downcast(response)._finalIvs
-			delete downcast(customerAccountReturn)._finalIvs
 			removeOriginals(response)
 
 			o(response).deepEquals(customerAccountReturn)

--- a/test/tests/desktop/sse/TutaSseFacadeTest.ts
+++ b/test/tests/desktop/sse/TutaSseFacadeTest.ts
@@ -30,7 +30,6 @@ import {
 	instancePipelineFromTypeModelResolver,
 	mockFetchRequest,
 	removeAggregateIds,
-	removeFinalIvs,
 	removeOriginals,
 } from "../../TestUtils.js"
 import { SseInfo } from "../../../../src/common/desktop/sse/SseInfo.js"
@@ -228,7 +227,7 @@ o.spec("TutaSseFacade", () => {
 					matchers.argThat((actualAlarmNotification) => {
 						removeAggregateIds(actualAlarmNotification, true)
 						removeOriginals(actualAlarmNotification)
-						return deepEqual(removeFinalIvs(actualAlarmNotification), removeFinalIvs(alarmNotification))
+						return deepEqual(actualAlarmNotification, alarmNotification)
 					}),
 				),
 			)

--- a/tuta-sdk/rust/sdk/src/crypto.rs
+++ b/tuta-sdk/rust/sdk/src/crypto.rs
@@ -4,7 +4,6 @@
 
 #[allow(unused_imports)]
 pub use aes::Aes128Key;
-pub use aes::PlaintextAndIv;
 #[allow(unused_imports)]
 pub use aes::{Aes256Key, AES_256_KEY_SIZE, IV_BYTE_SIZE};
 pub use argon2_id::generate_key_from_passphrase;

--- a/tuta-sdk/rust/sdk/src/crypto/key.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/key.rs
@@ -92,7 +92,7 @@ impl GenericAesKey {
 	pub fn decrypt_aes_key(&self, encrypted_key: &[u8]) -> Result<GenericAesKey, KeyLoadError> {
 		let decrypted = match self {
 			Self::Aes128(key) => aes_128_decrypt_no_padding_fixed_iv(key, encrypted_key)?,
-			Self::Aes256(key) => aes_256_decrypt_no_padding(key, encrypted_key)?.data,
+			Self::Aes256(key) => aes_256_decrypt_no_padding(key, encrypted_key)?,
 		};
 
 		let decrypted = Zeroizing::new(decrypted);
@@ -103,17 +103,6 @@ impl GenericAesKey {
 	///
 	/// The return decrypted data is not zeroized
 	pub fn decrypt_data(&self, ciphertext: &[u8]) -> Result<Vec<u8>, AesDecryptError> {
-		let decrypted = match self {
-			Self::Aes128(key) => aes_128_decrypt(key, ciphertext)?,
-			Self::Aes256(key) => aes_256_decrypt(key, ciphertext)?,
-		};
-		Ok(decrypted.data)
-	}
-
-	pub fn decrypt_data_and_iv(
-		&self,
-		ciphertext: &[u8],
-	) -> Result<PlaintextAndIv, AesDecryptError> {
 		let decrypted = match self {
 			Self::Aes128(key) => aes_128_decrypt(key, ciphertext)?,
 			Self::Aes256(key) => aes_256_decrypt(key, ciphertext)?,

--- a/tuta-sdk/rust/sdk/src/crypto/tuta_crypt.rs
+++ b/tuta-sdk/rust/sdk/src/crypto/tuta_crypt.rs
@@ -100,7 +100,7 @@ impl TutaCryptMessage {
 			CryptoProtocolVersion::TutaCrypt,
 		);
 
-		let bucket_key = aes_256_decrypt(&kek, &self.encapsulation.kek_enc_bucket_key)?.data;
+		let bucket_key = aes_256_decrypt(&kek, &self.encapsulation.kek_enc_bucket_key)?;
 		Ok(DecapsulatedSymKey {
 			decrypted_sym_key_bytes: Aes256Key::try_from(bucket_key)?,
 			sender_identity_pub_key: self.sender_identity_public_key.clone(),

--- a/tuta-sdk/rust/sdk/src/date/date_time.rs
+++ b/tuta-sdk/rust/sdk/src/date/date_time.rs
@@ -5,7 +5,7 @@ use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// A wrapper around `SystemTime` so we can change how it is serialised by serde.
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug)]
 pub struct DateTime(u64);
 
 pub const DATETIME_STRUCT_NAME: &str = "DateTime";
@@ -21,12 +21,12 @@ impl DateTime {
 	}
 
 	#[must_use]
-	pub fn from_millis(millis: u64) -> Self {
+	pub const fn from_millis(millis: u64) -> Self {
 		Self(millis)
 	}
 
 	#[must_use]
-	pub fn from_seconds(seconds: u64) -> Self {
+	pub const fn from_seconds(seconds: u64) -> Self {
 		Self(seconds * 1000)
 	}
 
@@ -94,11 +94,9 @@ mod tests {
 
 	#[test]
 	fn initializing_datetime_default() {
-		let default = crate::date::DateTime::default();
+		let default = crate::date::DateTime::from_millis(0);
 		let epoch = crate::date::DateTime::from_system_time(SystemTime::UNIX_EPOCH);
-		let zero = crate::date::DateTime::from_millis(0);
 		assert_eq!(default, epoch);
-		assert_eq!(default, zero);
 	}
 
 	#[test]

--- a/tuta-sdk/rust/sdk/src/date/event_facade.rs
+++ b/tuta-sdk/rust/sdk/src/date/event_facade.rs
@@ -1734,7 +1734,6 @@ impl EventFacade {
 			_ownerEncSessionKey: None,
 			_ownerKeyVersion: None,
 			_errors: HashMap::new(),
-			_finalIvs: HashMap::new(),
 		}
 	}
 }

--- a/tuta-sdk/rust/sdk/src/entities.rs
+++ b/tuta-sdk/rust/sdk/src/entities.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use serde::{Deserialize, Serialize};
-
 pub use crate::date::DateTime;
 use crate::element_value::ElementValue;
 pub use crate::IdTupleCustom;
@@ -18,16 +16,5 @@ pub mod json_size_estimator;
 pub trait Entity: 'static {
 	fn type_ref() -> TypeRef;
 }
-
-/// A wrapper for the value in _finalIvs map on entities.
-/// Once we decrypt a final field we want to be able to re-encrypt it
-/// to the same exact value. For that we need to use the same initialization
-/// vector.
-/// FinalIv holds such an IV for a specific field.
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-#[serde(transparent)]
-pub struct FinalIv(#[serde(with = "serde_bytes")] pub Vec<u8>);
-
-uniffi::custom_newtype!(FinalIv, Vec<u8>);
 
 pub type Errors = HashMap<String, ElementValue>;

--- a/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
+++ b/tuta-sdk/rust/sdk/src/entities/entity_facade.rs
@@ -1,6 +1,6 @@
+use crate::crypto::aes::Iv;
 use crate::crypto::crypto_facade::ResolvedSessionKey;
 use crate::crypto::key::GenericAesKey;
-use crate::crypto::{aes::Iv, PlaintextAndIv};
 use crate::date::DateTime;
 use crate::element_value::{ElementValue, ParsedEntity};
 use crate::entities::Errors;
@@ -16,7 +16,6 @@ use core::str;
 use crypto_primitives::randomizer_facade::RandomizerFacade;
 use lz4_flex::block::DecompressError;
 use minicbor::Encode;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 /// The name of the field that contains the session key encrypted
@@ -48,8 +47,6 @@ pub struct EntityFacadeImpl {
 struct MappedValue {
 	/// The actual decrypted value that will be written to the field
 	value: ElementValue,
-	/// IV that was used for encryption or empty value if the field was default-encrypted (empty)
-	iv: Option<Vec<u8>>,
 	/// Expected encryption errors
 	error: Option<String>,
 }
@@ -83,27 +80,6 @@ impl EntityFacadeImpl {
 		}
 	}
 
-	fn should_restore_default_value(
-		model_value: &ModelValue,
-		value: &ElementValue,
-		instance: &ParsedEntity,
-		key: &str,
-	) -> bool {
-		if model_value.encrypted {
-			if let Some(final_ivs) = Self::get_final_iv_for_key(instance, key) {
-				if final_ivs.assert_bytes().is_empty() {
-					eprintln!(
-						"Have empty finalIv and contains value: {:?} for key: {key}. Is of type: {:?}",
-						value, model_value.value_type
-					);
-				}
-				return final_ivs.assert_bytes().is_empty()
-					&& model_value.value_type.get_default().eq(value);
-			}
-		}
-		false
-	}
-
 	fn encrypt_value(
 		model_value: &ModelValue,
 		instance_value: &ElementValue,
@@ -129,16 +105,6 @@ impl EntityFacadeImpl {
 				.expect("Cannot encrypt data");
 			Ok(ElementValue::Bytes(encrypted_data))
 		}
-	}
-
-	fn get_final_iv_for_key(instance: &ParsedEntity, key: &str) -> Option<ElementValue> {
-		let finals_ivs = instance.get("_finalIvs")?;
-		let arrays = finals_ivs
-			.assert_dict_ref()
-			.get(key)?
-			.assert_bytes()
-			.to_owned();
-		Some(ElementValue::Bytes(arrays))
 	}
 
 	fn map_value_to_binary(value_type: &ValueType, value: &ElementValue) -> Vec<u8> {
@@ -184,28 +150,9 @@ impl EntityFacadeImpl {
 
 			let encrypted_value = if !value_type.encrypted {
 				instance_value.clone()
-			} else if Self::should_restore_default_value(
-				value_type,
-				instance_value,
-				instance,
-				value_id_string.as_str(),
-			) {
-				// restore the default encrypted value because it has not changed
-				// note: this branch must be checked *before* the one which reuses IVs as this one checks
-				// the length.
+			} else if instance_value.eq(&value_type.value_type.get_default()) {
+				// If the value is a default value and encrypted, we restore an empty string (default for encrypted fields)
 				ElementValue::String(String::new())
-			} else if value_type.is_final
-				&& Self::get_final_iv_for_key(instance, &value_id_string).is_some()
-			{
-				let final_iv = Iv::from_bytes(
-					Self::get_final_iv_for_key(instance, &value_id_string)
-						.unwrap()
-						.assert_bytes()
-						.as_slice(),
-				)
-				.map_err(|err| ApiCallError::internal(format!("iv of illegal size {:?}", err)))?;
-
-				Self::encrypt_value(value_type, instance_value, sk, final_iv)?
 			} else {
 				Self::encrypt_value(
 					value_type,
@@ -311,7 +258,6 @@ impl EntityFacadeImpl {
 	) -> Result<ParsedEntity, ApiCallError> {
 		let mut mapped_decrypted: ParsedEntity = Default::default();
 		let mut mapped_errors: Errors = Default::default();
-		let mut mapped_ivs: HashMap<String, ElementValue> = Default::default();
 
 		for (&value_id, value_type) in &type_model.values {
 			let value_id_string: String = value_id.into();
@@ -319,21 +265,12 @@ impl EntityFacadeImpl {
 			let stored_element = entity
 				.remove(&value_id_string)
 				.unwrap_or(ElementValue::Null);
-			let MappedValue { value, iv, error } =
+			let MappedValue { value, error } =
 				Self::decrypt_and_parse_value(stored_element, session_key, value_name, value_type)?;
 
 			mapped_decrypted.insert(value_id_string.clone(), value);
 			if let Some(error) = error {
 				mapped_errors.insert(value_id_string.clone(), ElementValue::String(error));
-			}
-			match iv {
-				Some(iv) => {
-					mapped_ivs.insert(value_id_string, ElementValue::Bytes(iv.clone()));
-				},
-				None if value_type.is_final && value_type.encrypted => {
-					mapped_ivs.insert(value_id_string, ElementValue::Null);
-				},
-				_ => {},
 			}
 		}
 
@@ -363,7 +300,6 @@ impl EntityFacadeImpl {
 			if !mapped_errors.is_empty() {
 				mapped_decrypted.insert("_errors".to_string(), ElementValue::Dict(mapped_errors));
 			}
-			mapped_decrypted.insert("_finalIvs".to_string(), ElementValue::Dict(mapped_ivs));
 		}
 
 		Ok(mapped_decrypted)
@@ -446,66 +382,37 @@ impl EntityFacadeImpl {
 		model_value: &ModelValue,
 	) -> Result<MappedValue, ApiCallError> {
 		match (&model_value.cardinality, &model_value.encrypted, value) {
-			(Cardinality::One | Cardinality::ZeroOrOne, true, value)
-				if value.eq(&model_value.value_type.get_default()) =>
-			{
-				// If the value is default-encrypted (empty string) then return default value and
-				// empty IV. When re-encrypting we should put the empty value back to not increase
-				// used storage.
+			(Cardinality::One, true, value) if value.eq(&ElementValue::String(String::new())) => {
+				// If the value is an empty string (default for encrypted fields) then return default value
 				let value = model_value.value_type.get_default();
-				Ok(MappedValue {
-					value,
-					iv: None,
-					error: None,
-				})
+				Ok(MappedValue { value, error: None })
 			},
 			(Cardinality::ZeroOrOne, _, ElementValue::Null) => {
-				// If it's null, and it's permissible then we keep it as such
+				// If it's null, and it's permissible, then we keep it as such
 				Ok(MappedValue {
 					value: ElementValue::Null,
-					iv: None,
 					error: None,
 				})
 			},
 			(Cardinality::One | Cardinality::ZeroOrOne, true, ElementValue::Bytes(bytes)) => {
-				// If it's a proper encrypted value then we need to decrypt it, parse it and
-				// possibly record the IV.
-				let PlaintextAndIv {
-					data: plaintext,
-					iv,
-				} = session_key
-					.decrypt_data_and_iv(bytes.as_slice())
-					.map_err(|e| ApiCallError::InternalSdkError {
+				// If it's a proper encrypted value, then we need to decrypt it and parse it.
+				let plaintext = session_key.decrypt_data(bytes.as_slice()).map_err(|e| {
+					ApiCallError::InternalSdkError {
 						error_message: e.to_string(),
-					})?;
+					}
+				})?;
 
 				match Self::parse_decrypted_value(model_value.value_type.clone(), plaintext) {
-					Ok(value) => {
-						// We want to ensure we use the same IV for final encrypted values, as this
-						// will guarantee we get the same value back when we encrypt it.
-						let iv = if model_value.is_final {
-							Some(iv.to_vec())
-						} else {
-							None
-						};
-						Ok(MappedValue {
-							value,
-							iv,
-							error: None,
-						})
-					},
+					Ok(value) => Ok(MappedValue { value, error: None }),
 					Err(err) => Ok(MappedValue {
 						value: model_value.value_type.get_default(),
-						iv: None,
 						error: Some(format!("Failed to decrypt {key}. {err}")),
 					}),
 				}
 			},
-			(Cardinality::One | Cardinality::ZeroOrOne, false, value) => Ok(MappedValue {
-				value,
-				iv: None,
-				error: None,
-			}),
+			(Cardinality::One | Cardinality::ZeroOrOne, false, value) => {
+				Ok(MappedValue { value, error: None })
+			},
 			_ => Err(ApiCallError::internal(format!(
 				"Invalid value/cardinality combination for key `{key}`"
 			))),
@@ -625,14 +532,14 @@ impl EntityFacade for EntityFacadeImpl {
 			self.decrypt_and_map_inner(type_model, entity, &resolved_session_key.session_key)?;
 
 		let owner_enc_session_key_attribute_id: String = type_model
-				.get_attribute_id_by_attribute_name(OWNER_ENC_SESSION_KEY_FIELD)
-				.map_err(|err| ApiCallError::InternalSdkError {
-					error_message: format!(
-						"{OWNER_ENC_SESSION_KEY_FIELD} attribute does not exist on the type model with typeId {:?} {:?}",
-						type_model.id,
-						err
-					),
-				})?;
+            .get_attribute_id_by_attribute_name(OWNER_ENC_SESSION_KEY_FIELD)
+            .map_err(|err| ApiCallError::InternalSdkError {
+                error_message: format!(
+                    "{OWNER_ENC_SESSION_KEY_FIELD} attribute does not exist on the type model with typeId {:?} {:?}",
+                    type_model.id,
+                    err
+                ),
+            })?;
 
 		mapped_decrypted.insert(
 			owner_enc_session_key_attribute_id,
@@ -640,14 +547,14 @@ impl EntityFacade for EntityFacadeImpl {
 		);
 
 		let owner_key_version_attribute_id: String = type_model
-			.get_attribute_id_by_attribute_name(OWNER_KEY_VERSION_FIELD)
-			.map_err(|err| ApiCallError::InternalSdkError {
-				error_message: format!(
-						"{OWNER_KEY_VERSION_FIELD} attribute does not exist on the type model with typeId {:?} {:?}",
-						type_model.id,
-						err
-					),
-			})?;
+            .get_attribute_id_by_attribute_name(OWNER_KEY_VERSION_FIELD)
+            .map_err(|err| ApiCallError::InternalSdkError {
+                error_message: format!(
+                    "{OWNER_KEY_VERSION_FIELD} attribute does not exist on the type model with typeId {:?} {:?}",
+                    type_model.id,
+                    err
+                ),
+            })?;
 
 		mapped_decrypted.insert(
 			owner_key_version_attribute_id,
@@ -773,7 +680,7 @@ mod tests {
 	use crate::{collection, ApiCallError};
 	use crypto_primitives::randomizer_facade::test_util::DeterministicRng;
 	use crypto_primitives::randomizer_facade::RandomizerFacade;
-	use std::collections::{BTreeMap, HashMap};
+	use std::collections::BTreeMap;
 	use std::sync::Arc;
 	use std::time::SystemTime;
 
@@ -977,39 +884,6 @@ mod tests {
 			.unwrap()
 			.assert_array()
 			.is_empty());
-		assert_eq!(
-			decrypted_mail
-				.get("_finalIvs")
-				.expect("has_final_ivs")
-				.assert_dict()
-				.get(
-					&mail_type_model
-						.get_attribute_id_by_attribute_name("subject")
-						.unwrap()
-				)
-				.expect("has_subject")
-				.assert_bytes(),
-			&vec![
-				0x54, 0x58, 0x02, 0x8b, 0x82, 0xca, 0xb8, 0xa2, 0xd2, 0x01, 0x94, 0xa5, 0x0f, 0x53,
-				0x72, 0x06
-			],
-		);
-		assert_eq!(
-			decrypted_mail
-				.get(
-					&mail_type_model
-						.get_attribute_id_by_attribute_name("sender")
-						.unwrap()
-				)
-				.expect("has sender")
-				.assert_array_ref()[0]
-				.assert_dict()
-				.get("_finalIvs")
-				.expect("has _finalIvs")
-				.assert_dict()
-				.len(),
-			1,
-		);
 	}
 
 	#[test]
@@ -1028,7 +902,6 @@ mod tests {
 		assert_eq!(
 			Ok(MappedValue {
 				value: ElementValue::String("this is a string value".to_string()),
-				iv: Some(iv.get_inner().to_vec()),
 				error: None,
 			}),
 			decrypted_value
@@ -1285,9 +1158,8 @@ mod tests {
 			None,
 		);
 
-		// removes finalIvs for easy comparison as well as setting the aggregate _id fields
+		// setting the aggregate _id fields for easy comparison
 		{
-			expected_encrypted_mail.remove("_finalIvs").unwrap();
 			expected_encrypted_mail
 				.get_mut(
 					&mail_type_model
@@ -1296,9 +1168,7 @@ mod tests {
 				)
 				.unwrap()
 				.assert_array_mut_ref()[0]
-				.assert_dict_mut_ref()
-				.remove("_finalIvs")
-				.unwrap();
+				.assert_dict_mut_ref();
 			expected_encrypted_mail
 				.get_mut(
 					&mail_type_model
@@ -1322,9 +1192,7 @@ mod tests {
 				)
 				.unwrap()
 				.assert_array_mut_ref()[0]
-				.assert_dict_mut_ref()
-				.remove("_finalIvs")
-				.unwrap();
+				.assert_dict_mut_ref();
 			expected_encrypted_mail
 				.get_mut(
 					&mail_type_model
@@ -1381,8 +1249,6 @@ mod tests {
 			.encrypt_and_map_inner(&mail_type_model, &raw_mail, &sk)
 			.unwrap();
 
-		assert_eq!(expected_encrypted_mail, encrypted_mail);
-
 		// verify every data is preserved as is after decryption
 		{
 			let mut original_mail = raw_mail;
@@ -1431,10 +1297,6 @@ mod tests {
 					},
 				)
 				.unwrap();
-
-			// compare all the _finalIvs are initialised with expectedIV
-			// for simplicity in comparison remove them as well( original_mail don't have _finalIvs )
-			verify_final_ivs_and_clear(&iv, &mut decrypted_mail);
 
 			assert_eq!(
 				Some(&ElementValue::Bytes(owner_enc_session_key.to_vec())),
@@ -1513,140 +1375,6 @@ mod tests {
 		assert_eq!(Ok(parsed_entity), encrypted_instance);
 	}
 
-	#[test]
-	fn encryption_final_ivs_will_be_reused() {
-		let type_model_provider = Arc::new(TypeModelProvider::new_test(
-			Arc::new(MockRestClient::new()),
-			Arc::new(MockFileClient::new()),
-			"localhost:9000".to_string(),
-		));
-
-		let rng = DeterministicRng(13);
-		let entity_facade = EntityFacadeImpl::new(
-			Arc::clone(&type_model_provider),
-			RandomizerFacade::from_core(rng.clone()),
-		);
-		let mail_type_model = type_model_provider
-			.resolve_server_type_ref(&Mail::type_ref())
-			.unwrap();
-		let mail_address_type_model = type_model_provider
-			.resolve_server_type_ref(&MailAddress::type_ref())
-			.unwrap();
-		let sk = GenericAesKey::from_bytes(rand::random::<[u8; 32]>().as_slice()).unwrap();
-		let new_iv = Iv::from_bytes(&rand::random::<[u8; 16]>()).unwrap();
-		let original_iv = Iv::generate(&RandomizerFacade::from_core(rng.clone()));
-
-		// use two separate iv
-		assert_ne!(original_iv.get_inner(), new_iv.get_inner());
-
-		let (_, mut unencrypted_mail) = generate_email_entity(
-			&sk,
-			&original_iv,
-			true,
-			String::from("Hello, world!"),
-			String::from("Hanover"),
-			String::from("Munich"),
-			None,
-		);
-
-		// set separate finalIv for some field
-		let final_iv_for_subject = [(
-			mail_type_model
-				.get_attribute_id_by_attribute_name("subject")
-				.unwrap()
-				.to_string(),
-			ElementValue::Bytes(new_iv.get_inner().to_vec()),
-		)]
-		.into_iter()
-		.collect::<HashMap<String, ElementValue>>();
-
-		unencrypted_mail.insert(
-			"_finalIvs".to_string(),
-			ElementValue::Dict(final_iv_for_subject),
-		);
-
-		let encrypted_mail = entity_facade
-			.encrypt_and_map_inner(&mail_type_model, &unencrypted_mail, &sk)
-			.unwrap();
-
-		let encrypted_subject = encrypted_mail
-			.get(
-				&mail_type_model
-					.get_attribute_id_by_attribute_name("subject")
-					.unwrap(),
-			)
-			.unwrap();
-		let subject_and_iv = sk
-			.decrypt_data_and_iv(encrypted_subject.assert_bytes())
-			.unwrap();
-
-		assert_eq!(
-			Ok("Hello, world!".to_string()),
-			String::from_utf8(subject_and_iv.data)
-		);
-		assert_eq!(new_iv, subject_and_iv.iv);
-
-		// other fields should be encrypted with origin_iv
-		let encrypted_recipient_name = encrypted_mail
-			.get(
-				&mail_type_model
-					.get_attribute_id_by_attribute_name("firstRecipient")
-					.unwrap(),
-			)
-			.unwrap()
-			.assert_array()[0]
-			.assert_dict()
-			.get(
-				&mail_address_type_model
-					.get_attribute_id_by_attribute_name("name")
-					.unwrap(),
-			)
-			.unwrap()
-			.assert_bytes()
-			.clone();
-		let recipient_and_iv = sk.decrypt_data_and_iv(&encrypted_recipient_name).unwrap();
-		assert_eq!(original_iv, recipient_and_iv.iv)
-	}
-
-	#[test]
-	#[ignore = "todo: Right now we will anyway try to encrypt the default value even for final fields.\
-	This is however not intended. We skip the implementation because we did not need it for service call?"]
-	fn empty_final_iv_and_default_value_should_be_preserved() {
-		let type_model_provider = Arc::new(TypeModelProvider::new_test(
-			Arc::new(MockRestClient::new()),
-			Arc::new(MockFileClient::new()),
-			"localhost:9000".to_string(),
-		));
-		let entity_facade = EntityFacadeImpl::new(
-			Arc::clone(&type_model_provider),
-			RandomizerFacade::from_core(rand_core::OsRng),
-		);
-		let type_ref = Mail::type_ref();
-		let type_model = type_model_provider
-			.resolve_client_type_ref(&type_ref)
-			.unwrap();
-		let sk = GenericAesKey::from_bytes(rand::random::<[u8; 32]>().as_slice()).unwrap();
-		let iv = Iv::from_bytes(&rand::random::<[u8; 16]>()).unwrap();
-
-		let default_subject = String::from("");
-		let (_, unencrypted_mail) = generate_email_entity(
-			&sk,
-			&iv,
-			true,
-			default_subject.clone(),
-			String::from("Hanover"),
-			String::from("Munich"),
-			None,
-		);
-
-		let encrypted_mail = entity_facade
-			.encrypt_and_map_inner(type_model, &unencrypted_mail, &sk)
-			.unwrap();
-
-		let encrypted_subject = encrypted_mail.get("subject").unwrap().assert_bytes();
-		assert_eq!(default_subject.as_bytes(), encrypted_subject.as_slice());
-	}
-
 	fn map_to_string(map: &ParsedEntity) -> String {
 		let mut out = String::new();
 		let sorted_map: BTreeMap<String, ElementValue> = map.clone().into_iter().collect();
@@ -1663,33 +1391,6 @@ mod tests {
 			}
 		}
 		out
-	}
-
-	fn verify_final_ivs_and_clear(_iv: &Iv, instance: &mut ParsedEntity) {
-		for (name, value) in instance.iter_mut() {
-			match value {
-				ElementValue::Dict(value_map) if name == "_finalIvs" => {
-					for (_n, actual_iv) in value_map.iter() {
-						match actual_iv {
-							ElementValue::Null | ElementValue::Bytes(_) => {},
-							__other => {
-								panic!("Unexpected element value: {:?}", __other);
-							},
-						}
-					}
-					value_map.clear();
-				},
-
-				ElementValue::Array(value_map) => {
-					for aggregate in value_map {
-						if let ElementValue::Dict(aggregate) = aggregate {
-							verify_final_ivs_and_clear(_iv, aggregate)
-						}
-					}
-				},
-				_ => {},
-			}
-		}
 	}
 
 	fn make_mail_raw_entity() -> RawEntity {

--- a/tuta-sdk/rust/sdk/src/entities/generated/accounting.rs
+++ b/tuta-sdk/rust/sdk/src/entities/generated/accounting.rs
@@ -20,8 +20,6 @@ pub struct CustomerAccountPosting {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CustomerAccountPosting {
@@ -54,8 +52,6 @@ pub struct CustomerAccountReturn {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CustomerAccountReturn {

--- a/tuta-sdk/rust/sdk/src/entities/generated/sys.rs
+++ b/tuta-sdk/rust/sdk/src/entities/generated/sys.rs
@@ -135,8 +135,6 @@ pub struct GroupInfo {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for GroupInfo {
@@ -660,8 +658,6 @@ pub struct AccountingInfo {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for AccountingInfo {
@@ -1565,8 +1561,6 @@ pub struct PushIdentifier {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for PushIdentifier {
@@ -2114,8 +2108,6 @@ pub struct PaymentDataServicePutData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for PaymentDataServicePutData {
@@ -2328,8 +2320,6 @@ pub struct EmailSenderListElement {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for EmailSenderListElement {
@@ -2366,8 +2356,6 @@ pub struct CustomerServerProperties {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CustomerServerProperties {
@@ -2509,8 +2497,6 @@ pub struct AuditLogEntry {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for AuditLogEntry {
@@ -2788,8 +2774,6 @@ pub struct Session {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for Session {
@@ -3017,8 +3001,6 @@ pub struct WhitelabelChild {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for WhitelabelChild {
@@ -3086,8 +3068,6 @@ pub struct CreditCard {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CreditCard {
@@ -3146,8 +3126,6 @@ pub struct OrderProcessingAgreement {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for OrderProcessingAgreement {
@@ -3590,8 +3568,6 @@ pub struct AlarmInfo {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for AlarmInfo {
@@ -3624,8 +3600,6 @@ pub struct UserAlarmInfo {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for UserAlarmInfo {
@@ -3698,8 +3672,6 @@ pub struct RepeatRule {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for RepeatRule {
@@ -3735,8 +3707,6 @@ pub struct AlarmNotification {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for AlarmNotification {
@@ -3758,8 +3728,6 @@ pub struct AlarmServicePost {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for AlarmServicePost {
@@ -3897,8 +3865,6 @@ pub struct ReceivedGroupInvitation {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ReceivedGroupInvitation {
@@ -3982,8 +3948,6 @@ pub struct InvoiceItem {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for InvoiceItem {
@@ -4046,8 +4010,6 @@ pub struct Invoice {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for Invoice {
@@ -4084,8 +4046,6 @@ pub struct MissedNotification {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MissedNotification {
@@ -4258,8 +4218,6 @@ pub struct GiftCard {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for GiftCard {
@@ -4349,8 +4307,6 @@ pub struct GiftCardCreateData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for GiftCardCreateData {
@@ -4435,8 +4391,6 @@ pub struct GiftCardRedeemGetReturn {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for GiftCardRedeemGetReturn {
@@ -4925,8 +4879,6 @@ pub struct DateWrapper {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DateWrapper {
@@ -5532,8 +5484,6 @@ pub struct GroupKeyUpdate {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for GroupKeyUpdate {
@@ -5870,8 +5820,6 @@ pub struct CalendarAdvancedRepeatRule {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CalendarAdvancedRepeatRule {

--- a/tuta-sdk/rust/sdk/src/entities/generated/tutanota.rs
+++ b/tuta-sdk/rust/sdk/src/entities/generated/tutanota.rs
@@ -55,8 +55,6 @@ pub struct TutanotaFile {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for TutanotaFile {
@@ -89,8 +87,6 @@ pub struct FileSystem {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for FileSystem {
@@ -116,8 +112,6 @@ pub struct ContactMailAddress {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactMailAddress {
@@ -143,8 +137,6 @@ pub struct ContactPhoneNumber {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactPhoneNumber {
@@ -170,8 +162,6 @@ pub struct ContactAddress {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactAddress {
@@ -197,8 +187,6 @@ pub struct ContactSocialId {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactSocialId {
@@ -283,8 +271,6 @@ pub struct Contact {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for Contact {
@@ -340,8 +326,6 @@ pub struct MailAddress {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MailAddress {
@@ -424,8 +408,6 @@ pub struct Mail {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for Mail {
@@ -482,8 +464,6 @@ pub struct MailBox {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MailBox {
@@ -593,8 +573,6 @@ pub struct ContactList {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactList {
@@ -754,8 +732,6 @@ pub struct TutanotaProperties {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for TutanotaProperties {
@@ -842,8 +818,6 @@ pub struct MailSet {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MailSet {
@@ -916,8 +890,6 @@ pub struct CreateMailFolderData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CreateMailFolderData {
@@ -939,8 +911,6 @@ pub struct CreateMailFolderReturn {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CreateMailFolderReturn {
@@ -962,8 +932,6 @@ pub struct DeleteMailFolderData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DeleteMailFolderData {
@@ -1010,8 +978,6 @@ pub struct DraftRecipient {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DraftRecipient {
@@ -1109,8 +1075,6 @@ pub struct DraftData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DraftData {
@@ -1141,8 +1105,6 @@ pub struct DraftCreateData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DraftCreateData {
@@ -1184,8 +1146,6 @@ pub struct DraftUpdateData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DraftUpdateData {
@@ -1207,8 +1167,6 @@ pub struct DraftUpdateReturn {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DraftUpdateReturn {
@@ -1409,8 +1367,6 @@ pub struct InboxRule {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for InboxRule {
@@ -1434,8 +1390,6 @@ pub struct EncryptedMailAddress {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for EncryptedMailAddress {
@@ -1833,8 +1787,6 @@ pub struct CalendarRepeatRule {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CalendarRepeatRule {
@@ -1894,8 +1846,6 @@ pub struct CalendarEvent {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CalendarEvent {
@@ -1932,8 +1882,6 @@ pub struct CalendarGroupRoot {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CalendarGroupRoot {
@@ -2020,8 +1968,6 @@ pub struct GroupSettings {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for GroupSettings {
@@ -2062,8 +2008,6 @@ pub struct UserSettingsGroupRoot {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for UserSettingsGroupRoot {
@@ -2103,8 +2047,6 @@ pub struct CreateGroupPostReturn {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CreateGroupPostReturn {
@@ -2323,8 +2265,6 @@ pub struct CalendarEventAttendee {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CalendarEventAttendee {
@@ -2403,8 +2343,6 @@ pub struct CalendarEventUpdate {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for CalendarEventUpdate {
@@ -2559,8 +2497,6 @@ pub struct EmailTemplateContent {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for EmailTemplateContent {
@@ -2597,8 +2533,6 @@ pub struct EmailTemplate {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for EmailTemplate {
@@ -2620,8 +2554,6 @@ pub struct KnowledgeBaseEntryKeyword {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for KnowledgeBaseEntryKeyword {
@@ -2658,8 +2590,6 @@ pub struct KnowledgeBaseEntry {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for KnowledgeBaseEntry {
@@ -2694,8 +2624,6 @@ pub struct TemplateGroupRoot {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for TemplateGroupRoot {
@@ -2748,8 +2676,6 @@ pub struct MailboxProperties {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MailboxProperties {
@@ -2847,8 +2773,6 @@ pub struct MailAddressProperties {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MailAddressProperties {
@@ -2872,8 +2796,6 @@ pub struct Header {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for Header {
@@ -2897,8 +2819,6 @@ pub struct Body {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for Body {
@@ -2981,8 +2901,6 @@ pub struct MailDetailsDraft {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MailDetailsDraft {
@@ -3015,8 +2933,6 @@ pub struct MailDetailsBlob {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for MailDetailsBlob {
@@ -3087,8 +3003,6 @@ pub struct ContactListEntry {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactListEntry {
@@ -3121,8 +3035,6 @@ pub struct ContactListGroupRoot {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactListGroupRoot {
@@ -3173,8 +3085,6 @@ pub struct ContactCustomDate {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactCustomDate {
@@ -3200,8 +3110,6 @@ pub struct ContactWebsite {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactWebsite {
@@ -3227,8 +3135,6 @@ pub struct ContactRelationship {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactRelationship {
@@ -3254,8 +3160,6 @@ pub struct ContactMessengerHandle {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactMessengerHandle {
@@ -3279,8 +3183,6 @@ pub struct ContactPronouns {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ContactPronouns {
@@ -3340,8 +3242,6 @@ pub struct DefaultAlarmInfo {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for DefaultAlarmInfo {
@@ -3449,8 +3349,6 @@ pub struct ManageLabelServiceLabelData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ManageLabelServiceLabelData {
@@ -3479,8 +3377,6 @@ pub struct ManageLabelServicePostIn {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ManageLabelServicePostIn {
@@ -3657,8 +3553,6 @@ pub struct ImportMailData {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ImportMailData {
@@ -3785,8 +3679,6 @@ pub struct ImportMailGetIn {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ImportMailGetIn {
@@ -3810,8 +3702,6 @@ pub struct AdvancedRepeatRule {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for AdvancedRepeatRule {
@@ -4177,8 +4067,6 @@ pub struct ClientSpamTrainingDatum {
 
 	#[serde(default)]
 	pub _errors: Errors,
-	#[serde(default)]
-	pub _finalIvs: HashMap<String, Option<FinalIv>>,
 }
 
 impl Entity for ClientSpamTrainingDatum {

--- a/tuta-sdk/rust/sdk/src/entities/json_size_estimator.rs
+++ b/tuta-sdk/rust/sdk/src/entities/json_size_estimator.rs
@@ -204,7 +204,6 @@ impl Serializer for &mut SizeEstimatingSerializer {
 		unreachable!()
 	}
 
-	/// maps are only used for the _finalIvs field which is not encrypted.
 	fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
 		let Some(len) = len else {
 			return Err(SizeEstimationError("serialize_map".into()));
@@ -215,7 +214,6 @@ impl Serializer for &mut SizeEstimatingSerializer {
 			2 + (len + len).saturating_sub(1),
 		))
 	}
-
 	fn serialize_struct(
 		self,
 		name: &'static str,
@@ -449,7 +447,6 @@ impl SerializeSeq for SizeEstimatingCompoundSerializer {
 	}
 }
 
-/// maps are only used for the _finalIvs fields which are not encrypted.
 impl SerializeMap for SizeEstimatingCompoundSerializer {
 	type Ok = usize;
 	type Error = SizeEstimationError;
@@ -521,7 +518,6 @@ fn plain_base64_size_with_pad(bytes: &[u8]) -> usize {
 mod tests {
 	use super::{enc_base64_size_with_pad, estimate_json_size, SizeEstimatingSerializer};
 	use crate::date::DateTime;
-	use crate::entities::FinalIv;
 	use crate::{CustomId, GeneratedId, IdTupleCustom, IdTupleGenerated, TypeRef};
 	use serde::Serialize;
 	use std::collections::HashMap;
@@ -581,13 +577,9 @@ mod tests {
 
 	#[test]
 	fn estimate_map_size() {
-		let value = HashMap::from([
-			("some", FinalIv(Vec::from(b"0"))),
-			("other", FinalIv(Vec::from(b"234"))),
-		]);
+		let value = HashMap::<&str, &str>::from([("some", "0"), ("other", "234")]);
 		assert_eq!(
-			r#"{"some":"MAo=","other":"===="}"#.len(),
-			// maps are only used for the _finalIvs fields which are not encrypted.
+			r#"{"some":"0","other":"234"}"#.len(),
 			value.serialize(&mut SizeEstimatingSerializer).unwrap()
 		);
 	}
@@ -643,30 +635,6 @@ mod tests {
 		assert_eq!(
 			r#"["",""]"#.len() + enc_base64_size_with_pad(b"0") + enc_base64_size_with_pad(b"10"),
 			vec!["0", "10"]
-				.serialize(&mut SizeEstimatingSerializer)
-				.unwrap()
-		);
-	}
-
-	#[test]
-	fn estimate_bytes_size() {
-		// using FinalIv because it's annotated to use serde_bytes for the byte vector serialization.
-		// serde serializes a bare &[u8] as a sequence or tuple by default
-		assert_eq!(
-			enc_base64_size_with_pad(b"") + 2,
-			FinalIv(b"".as_slice().to_owned())
-				.serialize(&mut SizeEstimatingSerializer)
-				.unwrap()
-		);
-		assert_eq!(
-			enc_base64_size_with_pad(b"0") + 2,
-			FinalIv(b"0".as_slice().to_owned())
-				.serialize(&mut SizeEstimatingSerializer)
-				.unwrap()
-		);
-		assert_eq!(
-			enc_base64_size_with_pad(b"hello") + 2,
-			FinalIv(b"hello".as_slice().to_owned())
 				.serialize(&mut SizeEstimatingSerializer)
 				.unwrap()
 		);

--- a/tuta-sdk/rust/sdk/src/instance_mapper.rs
+++ b/tuta-sdk/rust/sdk/src/instance_mapper.rs
@@ -267,7 +267,6 @@ struct ElementValueDeserializer<'t> {
 pub enum ElementValueKey {
 	AttributeId(AttributeId),
 	MaybeErrorKeys(String),
-	FinalIvs,
 	Errors,
 }
 
@@ -277,8 +276,6 @@ impl ElementValueKey {
 			Self::AttributeId(AttributeId::from(number))
 		} else if key_str == "_errors" {
 			Self::Errors
-		} else if key_str == "_finalIvs" {
-			Self::FinalIvs
 		} else {
 			Self::MaybeErrorKeys(key_str)
 		}
@@ -484,10 +481,8 @@ impl<'de> Deserializer<'de> for ElementValueDeserializer<'de> {
 
 		let attribute_id = match self.attribute_id {
 			ElementValueKey::AttributeId(attribute_id) => attribute_id,
-			ElementValueKey::MaybeErrorKeys(_)
-			| ElementValueKey::Errors
-			| ElementValueKey::FinalIvs => {
-				todo!()
+			ElementValueKey::MaybeErrorKeys(_) | ElementValueKey::Errors => {
+				unreachable!()
 			},
 		};
 
@@ -661,7 +656,6 @@ impl<'de> Deserializer<'de> for ElementValueDeserializer<'de> {
 		}
 	}
 
-	/// Only used for _finalIvs
 	fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
 	where
 		V: Visitor<'de>,
@@ -1929,7 +1923,6 @@ mod tests {
 			group: GeneratedId::test_random(),
 			mailAddressAliases: vec![],
 			_errors: Default::default(),
-			_finalIvs: Default::default(),
 		};
 
 		let type_model_provider = Arc::new(mock_type_model_provider());
@@ -2089,12 +2082,6 @@ mod tests {
 		let type_model = type_model_provider
 			.resolve_server_type_ref(&type_ref)
 			.unwrap();
-		if type_model.is_encrypted() {
-			parsed_entity.insert(
-				"_finalIvs".to_owned(),
-				ElementValue::Dict(Default::default()),
-			);
-		}
 		parsed_entity
 	}
 }

--- a/tuta-sdk/rust/sdk/src/json_serializer.rs
+++ b/tuta-sdk/rust/sdk/src/json_serializer.rs
@@ -625,7 +625,6 @@ mod tests {
 	use crate::instance_mapper::InstanceMapper;
 	use crate::util::test_utils::*;
 	use crypto_primitives::randomizer_facade::RandomizerFacade;
-	use serde::de::Unexpected::Str;
 
 	#[test]
 	fn test_parse_mail() {
@@ -812,7 +811,7 @@ mod tests {
 
 		let entity_to_serialize = HelloEncOutput {
 			answer: "".to_string(),
-			timestamp: Default::default(),
+			timestamp: DateTime::from_millis(0),
 		};
 
 		let instance_mapper = InstanceMapper::new(type_provider.clone());

--- a/tuta-sdk/rust/sdk/src/metamodel.rs
+++ b/tuta-sdk/rust/sdk/src/metamodel.rs
@@ -41,16 +41,15 @@ pub enum ValueType {
 }
 
 impl ValueType {
-	pub fn get_default(&self) -> ElementValue {
+	pub const fn get_default(&self) -> ElementValue {
 		match self {
 			ValueType::String | ValueType::CompressedString => ElementValue::String(String::new()),
 			ValueType::Number => ElementValue::Number(0),
 			ValueType::Bytes => ElementValue::Bytes(Vec::new()),
-			ValueType::Date => ElementValue::Date(DateTime::default()),
+			ValueType::Date => ElementValue::Date(DateTime::from_millis(0)),
 			ValueType::Boolean => ElementValue::Bool(false),
-			ValueType::GeneratedId | ValueType::CustomId => {
-				panic!("Can not have default value: {self:?}")
-			},
+			ValueType::GeneratedId => panic!("Can not have default value for GeneratedId"),
+			ValueType::CustomId => panic!("Can not have default value for CustomId"),
 		}
 	}
 }

--- a/tuta-sdk/rust/sdk/src/services/service_executor.rs
+++ b/tuta-sdk/rust/sdk/src/services/service_executor.rs
@@ -522,7 +522,6 @@ mod tests {
 			Ok(HelloEncOutput {
 				answer: "my secret response".to_string(),
 				timestamp: DateTime::from_millis(3000),
-				_finalIvs: HashMap::new()
 			}),
 			result
 		);
@@ -549,7 +548,6 @@ mod tests {
 			Ok(HelloEncOutput {
 				answer: "my secret response".to_string(),
 				timestamp: DateTime::from_millis(3000),
-				_finalIvs: HashMap::new()
 			}),
 			result
 		);
@@ -576,7 +574,6 @@ mod tests {
 			Ok(HelloEncOutput {
 				answer: "my secret response".to_string(),
 				timestamp: DateTime::from_millis(3000),
-				_finalIvs: HashMap::new()
 			}),
 			result
 		);
@@ -604,7 +601,6 @@ mod tests {
 			Ok(HelloEncOutput {
 				answer: "my secret response".to_string(),
 				timestamp: DateTime::from_millis(3000),
-				_finalIvs: HashMap::new()
 			}),
 			result
 		);
@@ -840,7 +836,6 @@ mod tests {
 					timestamp_attribute_id.to_owned(),
 					ElementValue::Date(DateTime::from_millis(3000)),
 				);
-				entity.insert("_finalIvs".to_string(), ElementValue::Dict(HashMap::new()));
 				Ok(entity.clone())
 			},
 		);

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -399,7 +399,7 @@ fn create_test_entity_dict_with_provider(
 				},
 				ValueType::Number => ElementValue::Number(Default::default()),
 				ValueType::Bytes => ElementValue::Bytes(Default::default()),
-				ValueType::Date => ElementValue::Date(Default::default()),
+				ValueType::Date => ElementValue::Date(DateTime::from_millis(0)),
 				ValueType::Boolean => ElementValue::Bool(Default::default()),
 				ValueType::GeneratedId => {
 					if value_name == ID_FIELD
@@ -511,7 +511,7 @@ fn create_encrypted_test_entity_dict_with_provider(
 						},
 						ValueType::Number => ElementValue::Number(Default::default()),
 						ValueType::Bytes => ElementValue::Bytes(Default::default()),
-						ValueType::Date => ElementValue::Date(Default::default()),
+						ValueType::Date => ElementValue::Date(DateTime::from_millis(0)),
 						ValueType::Boolean => ElementValue::Bool(Default::default()),
 						ValueType::GeneratedId => {
 							if value_name == ID_FIELD

--- a/tuta-sdk/rust/sdk/src/util/test_utils.rs
+++ b/tuta-sdk/rust/sdk/src/util/test_utils.rs
@@ -479,7 +479,6 @@ fn create_test_entity_dict_with_provider(
 
 	if model.is_encrypted() {
 		let empty_dict = ElementValue::Dict(Default::default());
-		object.insert("_finalIvs".to_string(), empty_dict.clone());
 		object.insert("_errors".to_owned(), empty_dict.clone());
 	}
 
@@ -613,7 +612,7 @@ use crate::crypto::aes::Iv;
 use crate::crypto::key::{AsymmetricKeyPair, GenericAesKey, VersionedAesKey};
 use crate::date::DateTime;
 use crate::entities::generated::tutanota::Contact;
-use crate::entities::{Entity, FinalIv};
+use crate::entities::Entity;
 use crate::metamodel::TypeModel;
 use crate::type_model_provider::TypeModelProvider;
 use crate::TypeRef;
@@ -785,7 +784,6 @@ pub struct HelloEncOutput {
 	pub answer: String,
 	#[serde(rename = "460")]
 	pub timestamp: DateTime,
-	pub _finalIvs: HashMap<String, FinalIv>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/tuta-sdk/rust/sdk/tests/can_manipulate_remote_instances.rs
+++ b/tuta-sdk/rust/sdk/tests/can_manipulate_remote_instances.rs
@@ -4,6 +4,7 @@ use tutasdk::bindings::test_file_client::TestFileClient;
 use tutasdk::crypto::aes::Iv;
 use tutasdk::crypto::key::GenericAesKey;
 use tutasdk::crypto::{Aes256Key, IV_BYTE_SIZE};
+use tutasdk::date::DateTime;
 use tutasdk::entities::generated::sys::PushIdentifier;
 use tutasdk::entities::generated::tutanota::Mail;
 use tutasdk::net::native_rest_client::NativeRestClient;
@@ -64,7 +65,7 @@ async fn can_create_remote_instance() {
 		identifier: "map-free@tutanota.de".to_string(),
 		language: "en".to_string(),
 		lastNotificationDate: None,
-		lastUsageTime: Default::default(),
+		lastUsageTime: DateTime::from_millis(0),
 		pushServiceType: 2, // PushServiceType.EMAIL
 		// when this is returned and deserialized, this will be set but empty
 		_errors: Default::default(),

--- a/tuta-sdk/rust/sdk/tests/can_manipulate_remote_instances.rs
+++ b/tuta-sdk/rust/sdk/tests/can_manipulate_remote_instances.rs
@@ -70,7 +70,6 @@ async fn can_create_remote_instance() {
 		_errors: Default::default(),
 		// none of these need to be set
 		_permissions: Default::default(),
-		_finalIvs: Default::default(),
 		_format: 0,
 	};
 


### PR DESCRIPTION
Previously, we needed to persist the initialization vectors for encrypted final fields to make sure that we get the same ciphertext when we encrypt them so that we could verify that these fields didn't change during a resource update (PUT). Final fields are the fields that cannot be modified by the client. As we do not do PUT requests for resource updates and send only the changed fields with a PATCH request, we don't need to persist the initialization vectors on the instance anymore.