### PR TITLE
Add Ctrl+W keyboard shortcut to close window

### DIFF
--- a/src/common/api/common/TutanotaConstants.ts
+++ b/src/common/api/common/TutanotaConstants.ts
@@ -984,6 +984,10 @@ export const Keys = Object.freeze({
 		code: "v",
 		name: "V",
 	},
+	W: {
+		code: "w",
+		name: "W",
+	},
 	Z: {
 		code: "z",
 		name: "Z",

--- a/src/common/desktop/ApplicationWindow.ts
+++ b/src/common/desktop/ApplicationWindow.ts
@@ -104,6 +104,13 @@ export class ApplicationWindow {
 					help: "resetZoomFactor_action",
 				},
 				{
+					key: Keys.W,
+					ctrl: !isMac,
+					meta: isMac,
+					exec: () => this._browserWindow.close(),
+					help: "close_alt",
+				},
+				{
 					key: Keys.Q,
 					ctrl: !isMac,
 					meta: isMac,


### PR DESCRIPTION
Right the only way to close the window is using the window manager decorations or quitting the applications. Having Ctrl+W is a pretty standard keyboard shortcut and helps users of environments such as hyprland which have no native window title bars by default.

Happy to fix any issues or suggestions.