### PR TITLE
Web client: sort ServerWorker bundle filenames

### DIFF
--- a/buildSrc/buildWebapp.js
+++ b/buildSrc/buildWebapp.js
@@ -210,11 +210,13 @@ async function bundleServiceWorker(bundles, version, minify, buildDir) {
 		// we always include English
 		// we still cache native-common even though we don't need it because worker has to statically depend on it
 		.concat(
-			bundles.filter(
-				(it) =>
-					it.startsWith("translation-en") ||
-					(!it.startsWith("translation") && !it.startsWith("native-main") && !it.startsWith("SearchInPageOverlay")),
-			),
+			bundles
+				.filter(
+					(it) =>
+						it.startsWith("translation-en") ||
+						(!it.startsWith("translation") && !it.startsWith("native-main") && !it.startsWith("SearchInPageOverlay")),
+				)
+				.sort(),
 		)
 		.concat(["images/logo-favicon.png", "images/logo-favicon-152.png", "images/logo-favicon-196.png", "images/font.ttf"])
 	const swBundle = await rollup({


### PR DESCRIPTION
Contributes-to #1016.

Edit: remove 'May resolve ...' text; there are other, unrelated side-by-side build differences evident in the diffoscope output for more recent F-Droid verification builds.