### PR TITLE
Do not make overlay display as none if there are no overlays

### DIFF
--- a/src/common/gui/base/Overlay.ts
+++ b/src/common/gui/base/Overlay.ts
@@ -81,7 +81,6 @@ export const overlay: Component<OverlayParentAttrs> = {
 			{
 				inert: !visible,
 				style: {
-					display: visible ? "" : "none",
 					"margin-top": "env(safe-area-inset-top)", // insets for iPhone X
 					// keep the bottom nav bar clear & inset for iOS
 					"margin-bottom": styles.isUsingBottomNavigation() ? px(component_size.bottom_nav_bar + getSafeAreaInsetBottom()) : "unset",


### PR DESCRIPTION
This prevents exit animations from finishing which can result in stale overlays stacking on top of each other.

Closes #10196