### PR TITLE
Set "Accept-Language" request header when synchronizing external calendars

### DIFF
--- a/src/calendar-app/calendar/gui/EditCalendarDialog.ts
+++ b/src/calendar-app/calendar/gui/EditCalendarDialog.ts
@@ -37,7 +37,10 @@ export const defaultCalendarProperties: Readonly<CalendarProperties> & {
 export async function handleUrlSubscription(calendarModel: CalendarModel, url: string): Promise<string | Error> {
 	if (!locator.logins.isFullyLoggedIn()) return new Error("notFullyLoggedIn_msg")
 
-	const externalIcalStr: string | Error = await calendarModel.fetchExternalCalendar(url).catch((e) => e as Error)
+	const externalIcalStr: string | Error = await calendarModel.fetchExternalCalendar(url).catch((e) => {
+		console.log("fetching external calendar failed", e)
+		return e as Error
+	})
 	if (externalIcalStr instanceof Error || externalIcalStr.trim() === "") return new Error("fetchingExternalCalendar_error")
 
 	if (!isIcal(externalIcalStr)) return new Error("invalidICal_error")

--- a/src/calendar-app/calendar/model/CalendarModel.ts
+++ b/src/calendar-app/calendar/model/CalendarModel.ts
@@ -508,6 +508,7 @@ export class CalendarModel {
 				parsedExternalEvents = parseCalendarStringData(externalCalendar, getTimeZone()).contents
 			} catch (error) {
 				let calendarName = calendar.name
+				console.log("failed to sync external calendar", error)
 				if (!calendarName) {
 					const calendars = await this.getCalendarInfos()
 					calendarName = calendars.get(calendar.group)?.groupInfo.name!

--- a/src/common/desktop/ipc/DesktopExternalCalendarFacade.ts
+++ b/src/common/desktop/ipc/DesktopExternalCalendarFacade.ts
@@ -7,11 +7,15 @@ export class DesktopExternalCalendarFacade implements ExternalCalendarFacade {
 	constructor(private readonly userAgent: string) {}
 
 	async fetchExternalCalendar(url: string): Promise<string> {
-		const response = await fetch(url, {
+		const requestHeaders = {
 			method: "GET",
-			headers: { "User-Agent": this.userAgent },
-		})
-		if (!response.ok) throw new Error(`Failed to fetch external calendar ${response.statusText}`)
+			headers: {
+				"User-Agent": this.userAgent,
+				"Accept-Language": "en",
+			},
+		}
+		const response = await fetch(url, requestHeaders)
+		if (!response.ok) throw new Error(`Failed to fetch external calendar statusCode: ${response.status} message: ${response.statusText}`)
 		return await response.text()
 	}
 }


### PR DESCRIPTION
We set the request header "Accept-Language" explicitly as some ics file provider seem to expect that header field. We experienced some cases were an ical server returned an error in case the field is not set.

There might be more headers that we could set, but for a quick fix we decided to just set the minimum header fields.

fixes #10244