### PR TITLE
fix mail search field filter not working for from/to fields

### DIFF
--- a/src/common/api/worker/offline/OfflineStorageMigrator.ts
+++ b/src/common/api/worker/offline/OfflineStorageMigrator.ts
@@ -9,6 +9,7 @@ import { offline8 } from "./migrations/offline-v8"
 import { ProgrammingError } from "../../common/error/ProgrammingError"
 import { offline9 } from "./migrations/offline-v9"
 import { offline10 } from "./migrations/offline-v10"
+import { offline11 } from "./migrations/offline-v11"
 
 export interface OfflineMigration {
 	readonly version: number
@@ -22,11 +23,11 @@ export interface OfflineMigration {
  * Normally you should only add them to the end of the list but with offline ones it can be a bit tricky since they change the db structure itself so sometimes
  * they should rather be in the beginning.
  */
-export const OFFLINE_STORAGE_MIGRATIONS: ReadonlyArray<OfflineMigration> = [offline5, offline6, offline7, offline8, offline9, offline10]
+export const OFFLINE_STORAGE_MIGRATIONS: ReadonlyArray<OfflineMigration> = [offline5, offline6, offline7, offline8, offline9, offline10, offline11]
 
 // in cases where the actual migration is not there anymore (we clean up old migrations no client would apply anymore)
 // and we create a new offline database, we still need to set the offline version to the current value.
-export const CURRENT_OFFLINE_VERSION = 10
+export const CURRENT_OFFLINE_VERSION = 11
 
 /**
  * Migrator for the offline storage between different versions of model. It is tightly couples to the versions of API entities: every time we make an

--- a/src/common/api/worker/offline/migrations/offline-v11.ts
+++ b/src/common/api/worker/offline/migrations/offline-v11.ts
@@ -1,0 +1,60 @@
+import { OfflineStorage } from "../OfflineStorage.js"
+import { SqlCipherFacade } from "../../../../native/common/generatedipc/SqlCipherFacade.js"
+import { OfflineMigration } from "../OfflineStorageMigrator.js"
+import { AppType } from "../../../../misc/ClientConstants"
+import { NOTHING_INDEXED_TIMESTAMP } from "../../../common/TutanotaConstants"
+import { sql } from "../Sql"
+import { assertNotNull } from "@tutao/tutanota-utils"
+import { untagSqlValue } from "../SqlValue"
+
+/**
+ * Adds sender and recipient columns to content_mail_index for proper field filtering.
+ * FTS5 contentless tables ignore column filters, so we need to store these fields
+ * separately to filter by them using regular SQL WHERE clauses.
+ *
+ * Since we're adding new required columns, we need to recreate the table and
+ * reset the search index to be rebuilt.
+ */
+export const offline11: OfflineMigration = {
+	version: 11,
+	async migrate(_: OfflineStorage, sqlCipherFacade: SqlCipherFacade): Promise<void> {
+		if (APP_TYPE === AppType.Mail || APP_TYPE === AppType.Integrated) {
+			console.log("Migrating content_mail_index to add sender/recipient columns for field filtering...")
+
+			const tableExists = async (tableName: string): Promise<boolean> => {
+				const { query, params } = sql`SELECT COUNT(*) as metadata_exists
+                                            FROM sqlite_schema
+                                            WHERE name = ${tableName}`
+				const result = assertNotNull(await sqlCipherFacade.get(query, params))
+				return untagSqlValue(result["metadata_exists"]) === 1
+			}
+
+			// Drop and recreate content_mail_index with new columns
+			if (await tableExists("content_mail_index")) {
+				await sqlCipherFacade.run(`DROP TABLE content_mail_index`, [])
+			}
+
+			// Create the table with the new schema including sender/recipient columns
+			await sqlCipherFacade.run(
+				`CREATE TABLE IF NOT EXISTS content_mail_index (receivedDate NUMBER NOT NULL, sets STRING NOT NULL, sender STRING NOT NULL DEFAULT '', toRecipients STRING NOT NULL DEFAULT '', ccRecipients STRING NOT NULL DEFAULT '', bccRecipients STRING NOT NULL DEFAULT '')`,
+				[],
+			)
+
+			// Also clear the FTS5 mail_index since it needs to be rebuilt along with content_mail_index
+			if (await tableExists("mail_index")) {
+				const { query, params } = sql`DELETE
+                                            FROM mail_index`
+				await sqlCipherFacade.run(query, params)
+			}
+
+			// Reset search group data to trigger re-indexing
+			if (await tableExists("search_group_data")) {
+				const { query, params } = sql`UPDATE search_group_data
+                                              SET indexedTimestamp = ${NOTHING_INDEXED_TIMESTAMP}`
+				await sqlCipherFacade.run(query, params)
+			}
+
+			console.log("content_mail_index migration completed, search index will be rebuilt")
+		}
+	},
+}


### PR DESCRIPTION
FTS5 contentless tables ignore column filters (e.g., {sender} : term), which caused the "From" and "To" search filters to return incorrect results. When searching for an email address with the "From" filter, emails where that address appeared in the "To" field were also returned.

This fix:
- Stores sender and recipient fields in content_mail_index table
- Adds SQL WHERE clause filtering to verify matches are in the correct field after FTS5 returns results
- Includes a database migration (v11) to add the new columns and trigger re-indexing of existing mail data

The fix applies to the "from" and "to" field filters. The "subject", "body", and "attachment" filters continue to use FTS5 matching only since those fields are not duplicated in content_mail_index.

Attached is a screenshot of my search for my email address as sender and how the results also return other emails, since the information appears in multiple emails, for example, in the recipient field as well.
<img width="1800" height="922" alt="image" src="https://github.com/user-attachments/assets/5d7d96ac-0968-47f2-bba9-b42957cfa4dd" />
