### PR TITLE
invalidate server_type_models.json if there are errors in resumeSession

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/AndroidFileFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/AndroidFileFacade.kt
@@ -173,6 +173,13 @@ class AndroidFileFacade(
 		return data
 	}
 
+	@Throws(IOException::class)
+	override suspend fun deleteFromAppDir(path: String) {
+		val file = File(activity.filesDir, path)
+		val fullPath = file.toUri().toString()
+		this.deleteFile(fullPath)
+	}
+
 	// @see: https://developer.android.com/reference/android/support/v4/content/FileProvider.html
 	override suspend fun open(location: String, mimeType: String) {
 		val file = location.toUri().let { uri ->

--- a/app-android/calendar/src/main/java/de/tutao/calendar/AndroidFileFacade.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/AndroidFileFacade.kt
@@ -173,6 +173,13 @@ class AndroidFileFacade(
 		return data
 	}
 
+	@Throws(IOException::class)
+	override suspend fun deleteFromAppDir(path: String) {
+		val file = File(activity.filesDir, path)
+		val fullPath = file.toUri().toString()
+		this.deleteFile(fullPath)
+	}
+
 	// @see: https://developer.android.com/reference/android/support/v4/content/FileProvider.html
 	override suspend fun open(location: String, mimeType: String) {
 		val file = location.toUri().let { uri ->

--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/FileFacade.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/FileFacade.kt
@@ -114,6 +114,12 @@ interface FileFacade {
 		path: String,
 	): DataWrapper
 	/**
+	 * Delete file from given path relative to app data folder
+	 */
+	suspend fun deleteFromAppDir(
+		path: String,
+	): Unit
+	/**
 	 * read the file at the given location into a DataFile. Returns null if reading fails for any reason.
 	 */
 	suspend fun readDataFile(

--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/FileFacadeReceiveDispatcher.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/FileFacadeReceiveDispatcher.kt
@@ -160,6 +160,13 @@ class FileFacadeReceiveDispatcher(
 				)
 				return json.encodeToString(result)
 			}
+			"deleteFromAppDir" -> {
+				val path: String = json.decodeFromString(arg[0])
+				val result: Unit = this.facade.deleteFromAppDir(
+					path,
+				)
+				return json.encodeToString(result)
+			}
 			"readDataFile" -> {
 				val filePath: String = json.decodeFromString(arg[0])
 				val result: DataFile? = this.facade.readDataFile(

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/CommonNativeFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/CommonNativeFacade.swift
@@ -16,7 +16,7 @@ public protocol CommonNativeFacade {
 		_ addresses: [String],
 		_ subject: String,
 		_ mailToUrlString: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Opens the mailbox of an address, optionally to an email specified by requestedPath
 	 */
@@ -24,29 +24,29 @@ public protocol CommonNativeFacade {
 		_ userId: String,
 		_ address: String,
 		_ requestedPath: String?
-	) async throws
+	) async throws -> Void
 	func openCalendar(
 		_ userId: String,
 		_ action: CalendarOpenAction?,
 		_ dateIso: String?,
 		_ eventId: String?
-	) async throws
+	) async throws -> Void
 	func openContactEditor(
 		_ contactId: String
-	) async throws
+	) async throws -> Void
 	func showAlertDialog(
 		_ translationKey: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * All local alarms have been deleted, reschedule alarms for the current user.
 	 */
 	func invalidateAlarms(
-	) async throws
+	) async throws -> Void
 	/**
 	 * Called when the system theme preference has changed
 	 */
 	func updateTheme(
-	) async throws
+	) async throws -> Void
 	/**
 	 * prompt the user to enter a new password and a confirmation, taking an optional old password into account
 	 */
@@ -65,24 +65,24 @@ public protocol CommonNativeFacade {
 	 */
 	func handleFileImport(
 		_ filesUris: [String]
-	) async throws
+	) async throws -> Void
 	/**
 	 * Open a specified path inside settings
 	 */
 	func openSettings(
 		_ path: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Open the Send Logs dialog
 	 */
 	func sendLogs(
 		_ logs: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Download has progressed
 	 */
 	func downloadProgress(
 		_ fileId: String,
 		_ bytes: Int
-	) async throws
+	) async throws -> Void
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/CommonNativeFacadeSendDispatcher.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/CommonNativeFacadeSendDispatcher.swift
@@ -13,7 +13,7 @@ public class CommonNativeFacadeSendDispatcher : CommonNativeFacade {
 		_ addresses: [String],
 		_ subject: String,
 		_ mailToUrlString: String
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(filesUris))
@@ -23,14 +23,14 @@ public class CommonNativeFacadeSendDispatcher : CommonNativeFacade {
 		args.append(toJson(mailToUrlString))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("createMailEditor")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func openMailBox(
 		_ userId: String,
 		_ address: String,
 		_ requestedPath: String?
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(userId))
@@ -38,7 +38,7 @@ public class CommonNativeFacadeSendDispatcher : CommonNativeFacade {
 		args.append(toJson(requestedPath))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("openMailBox")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func openCalendar(
@@ -46,7 +46,7 @@ public class CommonNativeFacadeSendDispatcher : CommonNativeFacade {
 		_ action: CalendarOpenAction?,
 		_ dateIso: String?,
 		_ eventId: String?
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(userId))
@@ -55,47 +55,47 @@ public class CommonNativeFacadeSendDispatcher : CommonNativeFacade {
 		args.append(toJson(eventId))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("openCalendar")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func openContactEditor(
 		_ contactId: String
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(contactId))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("openContactEditor")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func showAlertDialog(
 		_ translationKey: String
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(translationKey))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("showAlertDialog")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func invalidateAlarms(
-	) async throws
+	) async throws -> Void
 		{
 		let args = [String]()
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("invalidateAlarms")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func updateTheme(
-	) async throws
+	) async throws -> Void
 		{
 		let args = [String]()
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("updateTheme")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func promptForNewPassword(
@@ -126,48 +126,48 @@ public class CommonNativeFacadeSendDispatcher : CommonNativeFacade {
 	
 	 public func handleFileImport(
 		_ filesUris: [String]
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(filesUris))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("handleFileImport")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func openSettings(
 		_ path: String
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(path))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("openSettings")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func sendLogs(
 		_ logs: String
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(logs))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("sendLogs")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func downloadProgress(
 		_ fileId: String,
 		_ bytes: Int
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(fileId))
 		args.append(toJson(bytes))
 		let encodedFacadeName = toJson("CommonNativeFacade")
 		let encodedMethodName = toJson("downloadProgress")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/CommonSystemFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/CommonSystemFacade.swift
@@ -11,13 +11,13 @@ public protocol CommonSystemFacade {
 	 * Must be called before any other methods are called.
 	 */
 	func initializeRemoteBridge(
-	) async throws
+	) async throws -> Void
 	/**
 	 * Reload the webpage with the specified query arguments.
 	 */
 	func reload(
 		_ query: [String : String]
-	) async throws
+	) async throws -> Void
 	/**
 	 * Returns the log contents of the native process.
 	 */

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/FileFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/FileFacade.swift
@@ -13,7 +13,7 @@ public protocol FileFacade {
 	func open(
 		_ location: String,
 		_ mimeType: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Opens OS file picker. Returns the list of URIs for the selected files. add a list of extensions (without dot) to filter the options.
 	 */
@@ -34,7 +34,7 @@ public protocol FileFacade {
 	) async throws -> [String]
 	func deleteFile(
 		_ file: String
-	) async throws
+	) async throws -> Void
 	func getName(
 		_ file: String
 	) async throws -> String
@@ -76,7 +76,7 @@ public protocol FileFacade {
 		_ fileUri: String
 	) async throws -> String
 	func clearFileData(
-	) async throws
+	) async throws -> Void
 	/**
 	 * given a list of chunk file locations, will re-join them in order to reconstruct a single file and returns the location of that file on disk.
 	 */
@@ -103,13 +103,19 @@ public protocol FileFacade {
 	func writeToAppDir(
 		_ content: DataWrapper,
 		_ path: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Read file from given path relative to app data folder
 	 */
 	func readFromAppDir(
 		_ path: String
 	) async throws -> DataWrapper
+	/**
+	 * Delete file from given path relative to app data folder
+	 */
+	func deleteFromAppDir(
+		_ path: String
+	) async throws -> Void
 	/**
 	 * read the file at the given location into a DataFile. Returns null if reading fails for any reason.
 	 */

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/FileFacadeReceiveDispatcher.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/FileFacadeReceiveDispatcher.swift
@@ -138,6 +138,12 @@ public class FileFacadeReceiveDispatcher {
 				path
 			)
 			return toJson(result)
+		case "deleteFromAppDir":
+			let path = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
+			try await self.facade.deleteFromAppDir(
+				path
+			)
+			return "null"
 		case "readDataFile":
 			let filePath = try! JSONDecoder().decode(String.self, from: arg[0].data(using: .utf8)!)
 			let result = try await self.facade.readDataFile(

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/IosGlobalDispatcher.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/IosGlobalDispatcher.swift
@@ -43,7 +43,7 @@ public class IosGlobalDispatcher {
 		self.webAuthnFacade = WebAuthnFacadeReceiveDispatcher(facade: webAuthnFacade)
 	}
 	
-	public func dispatch(facadeName: String, methodName: String, args: [String]) async throws -> String {
+	public func dispatch(facadeName: String, methodName: String, args: Array<String>) async throws -> String {
 		switch facadeName {
 			case "CommonSystemFacade":
 				return try await self.commonSystemFacade.dispatch(method: methodName, arg: args)

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileContactsFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileContactsFacade.swift
@@ -19,7 +19,7 @@ public protocol MobileContactsFacade {
 	func saveContacts(
 		_ username: String,
 		_ contacts: [StructuredContact]
-	) async throws
+	) async throws -> Void
 	/**
 	 * Sync all Tuta contacts with system's contact book, this operation includes Inserts, Updates and Deletions
 	 */
@@ -45,7 +45,7 @@ public protocol MobileContactsFacade {
 	func deleteContacts(
 		_ username: String,
 		_ contactId: String?
-	) async throws
+	) async throws -> Void
 	/**
 	 * Whether contacts can be persisted locally
 	 */
@@ -62,5 +62,5 @@ public protocol MobileContactsFacade {
 	 */
 	func deleteLocalContacts(
 		_ contacts: [String]
-	) async throws
+	) async throws -> Void
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileFacade.swift
@@ -17,11 +17,11 @@ public protocol MobileFacade {
 	 */
 	func visibilityChange(
 		_ visibility: Bool
-	) async throws
+	) async throws -> Void
 	/**
 	 * iOS: called when keyboard opens/closes/resizes. Passes the height of the keyboard.
 	 */
 	func keyboardSizeChanged(
 		_ newSize: Int
-	) async throws
+	) async throws -> Void
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileFacadeSendDispatcher.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileFacadeSendDispatcher.swift
@@ -19,24 +19,24 @@ public class MobileFacadeSendDispatcher : MobileFacade {
 	
 	 public func visibilityChange(
 		_ visibility: Bool
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(visibility))
 		let encodedFacadeName = toJson("MobileFacade")
 		let encodedMethodName = toJson("visibilityChange")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 	 public func keyboardSizeChanged(
 		_ newSize: Int
-	) async throws
+	) async throws -> Void
 		{
 		var args = [String]()
 		args.append(toJson(newSize))
 		let encodedFacadeName = toJson("MobileFacade")
 		let encodedMethodName = toJson("keyboardSizeChanged")
-		_ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
+		let _ = try await self.transport.sendRequest(requestType: "ipc",  args: [encodedFacadeName, encodedMethodName] + args)
 		}
 	
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/MobilePaymentsFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/MobilePaymentsFacade.swift
@@ -24,7 +24,7 @@ public protocol MobilePaymentsFacade {
 	 * Display a view for the user to configure their subscription.
 	 */
 	func showSubscriptionConfigView(
-	) async throws
+	) async throws -> Void
 	/**
 	 * Check if the latest transaction using the current Store Account belongs to the user
 	 */

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileSystemFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/MobileSystemFacade.swift
@@ -11,7 +11,7 @@ public protocol MobileSystemFacade {
 	 * Redirect the user to Phone's Settings
 	 */
 	func goToSettings(
-	) async throws
+	) async throws -> Void
 	/**
 	 * Open URI in the OS.
 	 */
@@ -36,23 +36,23 @@ public protocol MobileSystemFacade {
 	 */
 	func requestPermission(
 		_ permission: PermissionType
-	) async throws
+	) async throws -> Void
 	func getAppLockMethod(
 	) async throws -> AppLockMethod
 	func setAppLockMethod(
 		_ method: AppLockMethod
-	) async throws
+	) async throws -> Void
 	func enforceAppLock(
 		_ method: AppLockMethod
-	) async throws
+	) async throws -> Void
 	func getSupportedAppLockMethods(
 	) async throws -> [AppLockMethod]
 	func openMailApp(
 		_ query: String
-	) async throws
+	) async throws -> Void
 	func openCalendarApp(
 		_ query: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Returns the date and time the app was installed as a string with milliseconds in UNIX epoch.
 	 */
@@ -62,18 +62,18 @@ public protocol MobileSystemFacade {
 	 * Requests the system in-app rating dialog to be displayed
 	 */
 	func requestInAppRating(
-	) async throws
+	) async throws -> Void
 	/**
 	 * Sends a refresh signal to the native side, updating widget last sync
 	 */
 	func requestWidgetRefresh(
-	) async throws
+	) async throws -> Void
 	/**
 	 * Sends the URL from the remote origin to be stored on the device
 	 */
 	func storeServerRemoteOrigin(
 		_ origin: String
-	) async throws
+	) async throws -> Void
 	func print(
-	) async throws
+	) async throws -> Void
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/NativeCredentialsFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/NativeCredentialsFacade.swift
@@ -16,26 +16,26 @@ public protocol NativeCredentialsFacade {
 	 */
 	func store(
 		_ credentials: UnencryptedCredentials
-	) async throws
+	) async throws -> Void
 	/**
 	 * Store already encrypted credentials
 	 */
 	func storeEncrypted(
 		_ credentials: PersistedCredentials
-	) async throws
+	) async throws -> Void
 	func loadByUserId(
 		_ id: String
 	) async throws -> UnencryptedCredentials?
 	func deleteByUserId(
 		_ id: String
-	) async throws
+	) async throws -> Void
 	func getCredentialEncryptionMode(
 	) async throws -> CredentialEncryptionMode?
 	func setCredentialEncryptionMode(
 		_ encryptionMode: CredentialEncryptionMode
-	) async throws
+	) async throws -> Void
 	func clear(
-	) async throws
+	) async throws -> Void
 	/**
 	 * Migrate existing credentials to native db
 	 */
@@ -43,5 +43,5 @@ public protocol NativeCredentialsFacade {
 		_ credentials: [PersistedCredentials],
 		_ encryptionMode: CredentialEncryptionMode,
 		_ credentialsKey: DataWrapper
-	) async throws
+	) async throws -> Void
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/NativeInterface.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/NativeInterface.swift
@@ -8,3 +8,4 @@ public protocol NativeInterface {
 public func toJson<T>(_ thing: T) -> String where T : Encodable {
 	return String(data: try! JSONEncoder().encode(thing), encoding: .utf8)!
 }
+

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/NativePushFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/NativePushFacade.swift
@@ -15,32 +15,32 @@ public protocol NativePushFacade {
 		_ sseOrigin: String,
 		_ pushIdentifierId: String,
 		_ pushIdentifierSessionKey: DataWrapper
-	) async throws
+	) async throws -> Void
 	func removeUser(
 		_ userId: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Called at some point after login to initialize push notifications.
 	 */
 	func initPushNotifications(
-	) async throws
+	) async throws -> Void
 	func closePushNotifications(
 		_ addressesArray: [String]
-	) async throws
+	) async throws -> Void
 	func scheduleAlarms(
 		_ alarmNotificationsWireFormat: String,
 		_ newDeviceSessionKey: String
-	) async throws
+	) async throws -> Void
 	/**
 	 * Unschedule and remove alarms belonging to a specific user from the persistent storage
 	 */
 	func invalidateAlarmsForUser(
 		_ userId: String
-	) async throws
+	) async throws -> Void
 	func setExtendedNotificationConfig(
 		_ userId: String,
 		_ mode: ExtendedNotificationMode
-	) async throws
+	) async throws -> Void
 	func getExtendedNotificationConfig(
 		_ userId: String
 	) async throws -> ExtendedNotificationMode
@@ -50,7 +50,7 @@ public protocol NativePushFacade {
 	func setReceiveCalendarNotificationConfig(
 		_ pushIdentifier: String,
 		_ value: Bool
-	) async throws
+	) async throws -> Void
 	func getReceiveCalendarNotificationConfig(
 		_ pushIdentifier: String
 	) async throws -> Bool

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/SqlCipherFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/SqlCipherFacade.swift
@@ -7,16 +7,16 @@ public protocol SqlCipherFacade {
 	func openDb(
 		_ userId: String,
 		_ dbKey: DataWrapper
-	) async throws
+	) async throws -> Void
 	func closeDb(
-	) async throws
+	) async throws -> Void
 	func deleteDb(
 		_ userId: String
-	) async throws
+	) async throws -> Void
 	func run(
 		_ query: String,
 		_ params: [TaggedSqlValue]
-	) async throws
+	) async throws -> Void
 	/**
 	 * get a single object or null if the query returns nothing
 	 */

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/ThemeFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/ThemeFacade.swift
@@ -8,12 +8,12 @@ public protocol ThemeFacade {
 	) async throws -> [[String : String]]
 	func setThemes(
 		_ themes: [[String : String]]
-	) async throws
+	) async throws -> Void
 	func getThemePreference(
 	) async throws -> String?
 	func setThemePreference(
 		_ themePreference: String
-	) async throws
+	) async throws -> Void
 	func prefersDark(
 	) async throws -> Bool
 }

--- a/app-ios/TutanotaSharedFramework/GeneratedIpc/WebAuthnFacade.swift
+++ b/app-ios/TutanotaSharedFramework/GeneratedIpc/WebAuthnFacade.swift
@@ -23,7 +23,7 @@ public protocol WebAuthnFacade {
 	 * cancels the current sign/registration operation
 	 */
 	func abortCurrentOperation(
-	) async throws
+	) async throws -> Void
 	/**
 	 * return whether this platform supports webAuthn
 	 */

--- a/app-ios/calendar/Sources/Files/IosFileFacade.swift
+++ b/app-ios/calendar/Sources/Files/IosFileFacade.swift
@@ -189,6 +189,12 @@ class IosFileFacade: FileFacade {
 		return try self.readFile(filePath.path)
 	}
 
+	func deleteFromAppDir(_ path: String) async throws {
+		let supportDir = try FileUtils.getApplicationSupportFolder()
+		let filePath = supportDir.appendingPathComponent(path)
+		try await self.deleteFile(filePath.path)
+	}
+
 	private func clearDirectory(folderPath: String) async throws {
 		let fileManager = FileManager.default
 		let folderUrl = URL(fileURLWithPath: folderPath)

--- a/app-ios/tutanota/Sources/Files/IosFileFacade.swift
+++ b/app-ios/tutanota/Sources/Files/IosFileFacade.swift
@@ -188,6 +188,12 @@ class IosFileFacade: FileFacade {
 		return try self.readFile(filePath.path)
 	}
 
+	func deleteFromAppDir(_ path: String) async throws {
+		let supportDir = try FileUtils.getApplicationSupportFolder()
+		let filePath = supportDir.appendingPathComponent(path)
+		try await self.deleteFile(filePath.path)
+	}
+
 	private func clearDirectory(folderPath: String) async throws {
 		let fileManager = FileManager.default
 		let folderUrl = URL(fileURLWithPath: folderPath)

--- a/ipc-schema/facades/FileFacade.json
+++ b/ipc-schema/facades/FileFacade.json
@@ -187,6 +187,15 @@
 			],
 			"ret": "bytes"
 		},
+		"deleteFromAppDir": {
+			"doc": "Delete file from given path relative to app data folder",
+			"arg": [
+				{
+					"path": "string"
+				}
+			],
+			"ret": "void"
+		},
 		"readDataFile": {
 			"doc": "read the file at the given location into a DataFile. Returns null if reading fails for any reason.",
 			"arg": [

--- a/src/calendar-app/workerUtils/worker/CalendarWorkerLocator.ts
+++ b/src/calendar-app/workerUtils/worker/CalendarWorkerLocator.ts
@@ -237,7 +237,7 @@ export async function initLocator(worker: CalendarWorkerImpl, browserData: Brows
 				locator.sqlCipherFacade,
 				new InterWindowEventFacadeSendDispatcher(worker),
 				dateProvider,
-				new OfflineStorageMigrator(OFFLINE_STORAGE_MIGRATIONS),
+				new OfflineStorageMigrator(OFFLINE_STORAGE_MIGRATIONS, locator.applicationTypesFacade),
 				new CalendarOfflineCleaner(),
 				locator.instancePipeline.modelMapper,
 				typeModelResolver,
@@ -474,6 +474,7 @@ export async function initLocator(worker: CalendarWorkerImpl, browserData: Brows
 		locator.cacheManagement,
 		typeModelResolver,
 		locator.rolloutFacade,
+		locator.applicationTypesFacade,
 	)
 
 	locator.userManagement = lazyMemoized(async () => {

--- a/src/common/api/worker/facades/ApplicationTypesFacade.ts
+++ b/src/common/api/worker/facades/ApplicationTypesFacade.ts
@@ -41,7 +41,8 @@ export class ApplicationTypesFacade {
 	private lastInvoked = 0
 	private deferredRequests: Array<DeferredObject<ApplicationTypesGetOut>>
 
-	private readonly persistenceFilePath: string = "server_type_models.json"
+	private readonly APPLICATION_TYPES_PATH: string = "server_type_models.json"
+	private readonly APPLICATION_TYPES_PATH_SDK: string = "server_type_models_sdk.json"
 
 	constructor(
 		private readonly restClient: RestClient,
@@ -103,7 +104,7 @@ export class ApplicationTypesFacade {
 		if (isDesktop() || isApp()) {
 			try {
 				const fileContent = stringToUtf8Uint8Array(newApplicationTypesJsonString)
-				await this.fileFacade.writeToAppDir(fileContent, this.persistenceFilePath)
+				await this.fileFacade.writeToAppDir(fileContent, this.APPLICATION_TYPES_PATH)
 			} catch (err_to_ignore) {
 				console.error(`Failed to persist server model: ${err_to_ignore}`)
 			}
@@ -118,7 +119,7 @@ export class ApplicationTypesFacade {
 		// when the web app is started and store it in memory
 		if (isDesktop() || isApp()) {
 			try {
-				const applicationTypesJsonData = await this.fileFacade.readFromAppDir(this.persistenceFilePath)
+				const applicationTypesJsonData = await this.fileFacade.readFromAppDir(this.APPLICATION_TYPES_PATH)
 				const applicationTypesHash = this.computeApplicationTypesHash(applicationTypesJsonData)
 				console.log(`initializing server model from local json data. Hash: ${applicationTypesHash}`)
 				const applicationTypesJson = uint8ArrayToString("utf-8", applicationTypesJsonData)
@@ -157,5 +158,10 @@ export class ApplicationTypesFacade {
 		for (let deferredRequest of deferredRequests) {
 			deferredRequest.reject(e)
 		}
+	}
+
+	async invalidateApplicationTypes() {
+		await this.fileFacade.deleteFromAppDir(this.APPLICATION_TYPES_PATH)
+		await this.fileFacade.deleteFromAppDir(this.APPLICATION_TYPES_PATH_SDK)
 	}
 }

--- a/src/common/api/worker/offline/migrations/offline-v11.ts
+++ b/src/common/api/worker/offline/migrations/offline-v11.ts
@@ -1,0 +1,12 @@
+import { OfflineMigration } from "../OfflineStorageMigrator.js"
+import { OfflineStorage } from "../OfflineStorage.js"
+import { SqlCipherFacade } from "../../../../native/common/generatedipc/SqlCipherFacade"
+import { ApplicationTypesFacade } from "../../facades/ApplicationTypesFacade"
+
+export const offline11: OfflineMigration = {
+	version: 11,
+	async migrate(storage: OfflineStorage, sqlCipherFacade: SqlCipherFacade, applicationTypesFacade: ApplicationTypesFacade) {
+		console.log("removing applicationTypes json files to re-initialize from server")
+		await applicationTypesFacade.invalidateApplicationTypes()
+	},
+}

--- a/src/common/desktop/files/DesktopFileFacade.ts
+++ b/src/common/desktop/files/DesktopFileFacade.ts
@@ -302,6 +302,22 @@ export class DesktopFileFacade implements FileFacade {
 		return this.fs.readFileSync(fullPath)
 	}
 
+	async deleteFromAppDir(fileName: string): Promise<void> {
+		const userDataDir = this.electron.app.getPath("userData")
+
+		const resolvedBase = this.path.resolve(userDataDir)
+		const resolvedTarget = this.path.resolve(userDataDir, fileName)
+		if (!resolvedTarget.startsWith(resolvedBase + this.path.sep)) {
+			return
+		}
+
+		try {
+			await this.fs.promises.unlink(resolvedTarget)
+		} catch (e) {
+			// ignore the error if the file does not exist
+		}
+	}
+
 	// this is used to read unencrypted data from arbitrary locations
 	async readDataFile(uriOrPath: FileUri): Promise<DataFile | null> {
 		try {

--- a/src/common/native/common/generatedipc/FileFacade.ts
+++ b/src/common/native/common/generatedipc/FileFacade.ts
@@ -84,6 +84,11 @@ export interface FileFacade {
 	readFromAppDir(path: string): Promise<Uint8Array>
 
 	/**
+	 * Delete file from given path relative to app data folder
+	 */
+	deleteFromAppDir(path: string): Promise<void>
+
+	/**
 	 * read the file at the given location into a DataFile. Returns null if reading fails for any reason.
 	 */
 	readDataFile(filePath: string): Promise<DataFile | null>

--- a/src/common/native/common/generatedipc/FileFacadeReceiveDispatcher.ts
+++ b/src/common/native/common/generatedipc/FileFacadeReceiveDispatcher.ts
@@ -90,6 +90,10 @@ export class FileFacadeReceiveDispatcher {
 				const path: string = arg[0]
 				return this.facade.readFromAppDir(path)
 			}
+			case "deleteFromAppDir": {
+				const path: string = arg[0]
+				return this.facade.deleteFromAppDir(path)
+			}
 			case "readDataFile": {
 				const filePath: string = arg[0]
 				return this.facade.readDataFile(filePath)

--- a/src/common/native/common/generatedipc/FileFacadeSendDispatcher.ts
+++ b/src/common/native/common/generatedipc/FileFacadeSendDispatcher.ts
@@ -61,6 +61,9 @@ export class FileFacadeSendDispatcher implements FileFacade {
 	async readFromAppDir(...args: Parameters<FileFacade["readFromAppDir"]>) {
 		return this.transport.invokeNative("ipc", ["FileFacade", "readFromAppDir", ...args])
 	}
+	async deleteFromAppDir(...args: Parameters<FileFacade["deleteFromAppDir"]>) {
+		return this.transport.invokeNative("ipc", ["FileFacade", "deleteFromAppDir", ...args])
+	}
 	async readDataFile(...args: Parameters<FileFacade["readDataFile"]>) {
 		return this.transport.invokeNative("ipc", ["FileFacade", "readDataFile", ...args])
 	}

--- a/src/mail-app/workerUtils/worker/WorkerLocator.ts
+++ b/src/mail-app/workerUtils/worker/WorkerLocator.ts
@@ -355,7 +355,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 				locator.sqlCipherFacade,
 				new InterWindowEventFacadeSendDispatcher(worker),
 				dateProvider,
-				new OfflineStorageMigrator(OFFLINE_STORAGE_MIGRATIONS),
+				new OfflineStorageMigrator(OFFLINE_STORAGE_MIGRATIONS, locator.applicationTypesFacade),
 				new MailOfflineCleaner(),
 				locator.instancePipeline.modelMapper,
 				typeModelResolver,
@@ -658,6 +658,7 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 		locator.cacheManagement,
 		typeModelResolver,
 		locator.rolloutFacade,
+		locator.applicationTypesFacade,
 	)
 
 	locator.search = lazyMemoized(async () => {

--- a/test/tests/api/worker/facades/LoginFacadeTest.ts
+++ b/test/tests/api/worker/facades/LoginFacadeTest.ts
@@ -191,6 +191,7 @@ o.spec("LoginFacadeTest", function () {
 			async () => cacheManagmentFacadeMock,
 			typeModelResolver,
 			rolloutFacade,
+			object(),
 		)
 
 		eventBusClientMock = instance(EventBusClient)

--- a/test/tests/api/worker/offline/OfflineStorageMigratorTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageMigratorTest.ts
@@ -12,17 +12,20 @@ import { verify } from "@tutao/tutanota-test-utils"
 import { ProgrammingError } from "../../../../../src/common/api/common/error/ProgrammingError.js"
 import { SqlCipherFacade } from "../../../../../src/common/native/common/generatedipc/SqlCipherFacade.js"
 import { maxBy } from "@tutao/tutanota-utils"
+import { ApplicationTypesFacade } from "../../../../../src/common/api/worker/facades/ApplicationTypesFacade"
 
 o.spec("OfflineStorageMigrator", function () {
 	let migrations: OfflineMigration[]
 	let migrator: OfflineStorageMigrator
 	let storage: OfflineStorage
 	let sqlCipherFacade: SqlCipherFacade
+	let applicationTypesFacadeMock: ApplicationTypesFacade
 
 	o.beforeEach(function () {
 		migrations = []
 		storage = instance(OfflineStorage)
-		migrator = new OfflineStorageMigrator(migrations)
+		applicationTypesFacadeMock = object()
+		migrator = new OfflineStorageMigrator(migrations, applicationTypesFacadeMock)
 		sqlCipherFacade = object()
 	})
 
@@ -36,7 +39,7 @@ o.spec("OfflineStorageMigrator", function () {
 
 		await migrator.migrate(storage, sqlCipherFacade)
 		verify(storage.setCurrentOfflineSchemaVersion(CURRENT_OFFLINE_VERSION))
-		verify(migration.migrate(matchers.anything(), matchers.anything()), { times: 0 })
+		verify(migration.migrate(matchers.anything(), matchers.anything(), matchers.anything()), { times: 0 })
 	})
 
 	o.test("when the model version is written it is not overwritten", async function () {
@@ -58,7 +61,7 @@ o.spec("OfflineStorageMigrator", function () {
 
 		await migrator.migrate(storage, sqlCipherFacade)
 
-		verify(migration.migrate(storage, sqlCipherFacade))
+		verify(migration.migrate(storage, sqlCipherFacade, applicationTypesFacadeMock))
 		verify(storage.setCurrentOfflineSchemaVersion(CURRENT_OFFLINE_VERSION))
 	})
 
@@ -73,7 +76,7 @@ o.spec("OfflineStorageMigrator", function () {
 
 		await o.check(() => migrator.migrate(storage, sqlCipherFacade)).asyncThrows(ProgrammingError)
 
-		verify(migration.migrate(matchers.anything(), matchers.anything()), { times: 0 })
+		verify(migration.migrate(matchers.anything(), matchers.anything(), matchers.anything()), { times: 0 })
 		verify(storage.setCurrentOfflineSchemaVersion(matchers.anything()), { times: 0 })
 	})
 

--- a/test/tests/api/worker/offline/OfflineStorageTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageTest.ts
@@ -65,6 +65,7 @@ import { TypeModelResolver } from "../../../../../src/common/api/common/EntityFu
 import { SqlCipherFacade } from "../../../../../src/common/native/common/generatedipc/SqlCipherFacade"
 import { expandId } from "../../../../../src/common/api/worker/rest/RestClientIdUtils"
 import { BlobArchiveRefTypeRef, createBlobArchiveRef } from "../../../../../src/common/api/entities/storage/TypeRefs"
+import { ApplicationTypesFacade } from "../../../../../src/common/api/worker/facades/ApplicationTypesFacade"
 
 function incrementMailSetEntryId(mailSetEntryId, mailId, ms: number) {
 	const { receiveDate } = deconstructMailSetEntryId(mailSetEntryId)
@@ -103,11 +104,12 @@ o.spec("OfflineStorageDb", function () {
 	let typeModelResolver: TypeModelResolver
 	let modelMapper: ModelMapper
 	let customCacheHandlerMap: CustomCacheHandlerMap
+	let applicationTypesFacadeMock: ApplicationTypesFacade
 
 	o.beforeEach(async function () {
 		// integrity checks do not work with in-memory databases
 		dbFacade = new DesktopSqlCipher(databasePath, false)
-
+		applicationTypesFacadeMock = object<ApplicationTypesFacade>()
 		dateProviderMock = object<DateProvider>()
 		migratorMock = instance(OfflineStorageMigrator)
 		interWindowEventSenderMock = instance(InterWindowEventFacadeSendDispatcher)


### PR DESCRIPTION
We invalidate the server type models JSON files if we encounter errors during resumeSession in LoginFacade, which is called when we resume an existing session and load the user from cache. The server type models did not include the drive application because of a hotfix and therefore we were throwing assertNotNull errors while fetching drive related instances from the server. We now delete the JSON files so that we fetch them from the server again in case there are errors during resumeSession so that we have the correct server type models.

Additionally, we add an offline migration offline-v11 to delete the existing server type models files on the first login after the client update so that we fetch them from the server again.