### PR TITLE
Drive: deselect items by clicking on empty space

### DIFF
--- a/src/drive-app/drive/view/DriveFolderContent.ts
+++ b/src/drive-app/drive/view/DriveFolderContent.ts
@@ -23,6 +23,7 @@ export interface DriveFolderSelectionEvents {
 	onSelectPrevious: (item: FolderItem) => unknown
 	onSelectNext: (item: FolderItem) => unknown
 	onSelectAll: () => unknown
+	onSelectNone: () => unknown
 	onRangeSelectionTowards: (item: FolderItem) => unknown
 }
 
@@ -289,6 +290,9 @@ export class DriveFolderContent implements Component<DriveFolderContentAttrs> {
 					"grid-column-end": "8",
 					display: "grid",
 					"grid-template-columns": "subgrid",
+				},
+				onclick: (e: MouseEvent) => {
+					e.stopPropagation()
 				},
 			},
 			[

--- a/src/drive-app/drive/view/DriveFolderContentEntry.ts
+++ b/src/drive-app/drive/view/DriveFolderContentEntry.ts
@@ -133,6 +133,8 @@ export class DriveFolderContentEntry implements Component<DriveFolderContentEntr
 					onDropInto(item, event)
 				},
 				onclick: (event: MouseEvent) => {
+					event.stopPropagation()
+
 					if (event.detail === 1) {
 						if (event.shiftKey) {
 							onRangeSelectionTowards(item)

--- a/src/drive-app/drive/view/DriveFolderView.ts
+++ b/src/drive-app/drive/view/DriveFolderView.ts
@@ -125,6 +125,9 @@ export class DriveFolderView implements Component<DriveFolderViewAttrs> {
 					dropdown.setOrigin(new DomRectReadOnlyPolyfilled(e.clientX, e.clientY, 0, 0))
 					modal.displayUnique(dropdown, false)
 				},
+				onclick: (e: MouseEvent) => {
+					selectionEvents.onSelectNone()
+				},
 			},
 			this.draggedOver ? this.renderDropView() : null,
 			m(DriveFolderNav, {

--- a/src/drive-app/drive/view/DriveView.ts
+++ b/src/drive-app/drive/view/DriveView.ts
@@ -339,6 +339,9 @@ export class DriveView extends BaseTopLevelView implements TopLevelView<DriveVie
 									onSelectAll: () => {
 										this.driveViewModel.selectAll()
 									},
+									onSelectNone: () => {
+										this.driveViewModel.selectNone()
+									},
 									onSelectNext: () => {},
 									onSelectPrevious: () => {},
 									onSingleSelection: (item) => {


### PR DESCRIPTION
This matches the behaviour of other file managers: when having one or more items selected, clicking on empty space in the folder view clears the selection.