### PR TITLE
Fix failing login with stored credentials throwing error on web

### DIFF
--- a/src/common/api/worker/facades/ApplicationTypesFacade.ts
+++ b/src/common/api/worker/facades/ApplicationTypesFacade.ts
@@ -161,7 +161,9 @@ export class ApplicationTypesFacade {
 	}
 
 	async invalidateApplicationTypes() {
-		await this.fileFacade.deleteFromAppDir(this.APPLICATION_TYPES_PATH)
-		await this.fileFacade.deleteFromAppDir(this.APPLICATION_TYPES_PATH_SDK)
+		if (isDesktop() || isApp()) {
+			await this.fileFacade.deleteFromAppDir(this.APPLICATION_TYPES_PATH)
+			await this.fileFacade.deleteFromAppDir(this.APPLICATION_TYPES_PATH_SDK)
+		}
 	}
 }


### PR DESCRIPTION
`invalidateApplicationTypes()` did not check if the app is running in browser before trying to delete cached application types.

Close #10328