### PR TITLE
fix eventHasSameFields in ImportExportUtils.ts not comparing correctly

### DIFF
--- a/src/common/api/common/utils/EntityUtils.ts
+++ b/src/common/api/common/utils/EntityUtils.ts
@@ -418,7 +418,7 @@ export function removeTechnicalFields<E extends Partial<SomeEntity>>(entity: E) 
 	// we want to restrict outer function to entity types, but internally we also want to handle aggregates
 	function _removeTechnicalFields(erased: Record<string, any>) {
 		for (const key of Object.keys(erased)) {
-			if (key.startsWith("_errors")) {
+			if (TECHNICAL_FIELDS.includes(key)) {
 				delete erased[key]
 			} else {
 				const value = erased[key]
@@ -513,6 +513,7 @@ export const SENDER_ID = 111
 export const ATTACHMENTS_ID = 115
 
 export const IDENTITY_FIELDS = ["_id", "_ownerGroup", "_ownerEncSessionKey", "_ownerKeyVersion", "_permissions"]
+export const TECHNICAL_FIELDS = ["_original", "_errors"]
 
 export function isCustomIdType(typeModel: TypeModel): boolean {
 	const _idValue = get_IdValue(typeModel)

--- a/test/tests/calendar/gui/ImportExportUtilsTest.ts
+++ b/test/tests/calendar/gui/ImportExportUtilsTest.ts
@@ -52,12 +52,29 @@ o.spec("ImportExportUtilsTest", function () {
 			eventA._id = ["listId", "elementId"]
 			o.check(eventHasSameFields(eventA, eventB)).equals(true)
 		})
+		o.test("calendar events A are B same if _original do not match", function () {
+			const originalA = structuredClone(eventA)
+			originalA.uid = "differentUid"
+			const originalB = structuredClone(eventB)
+			eventA._original = originalA
+			eventB._original = originalB
+			o.check(eventHasSameFields(eventA, eventB)).equals(true)
+		})
+		o.test("calendar events A are B same if _errors do not match", function () {
+			eventA._errors = { someErrorKey: "someError" }
+			eventB._errors = { someErrorKey: "someError" }
+			o.check(eventHasSameFields(eventA, eventB)).equals(true)
+		})
 		o.test("calendar events A are B same if aggregatedIds do not match", function () {
 			eventA.organizer!._id = "newId"
 			eventB.attendees.map((attendee) => {
 				attendee._id = "newId"
 			})
 			o.check(eventHasSameFields(eventA, eventB)).equals(true)
+		})
+		o.test("calendar events A are B NOT same if attendees sorting is different", function () {
+			eventB.attendees = eventB.attendees.reverse()
+			o.check(eventHasSameFields(eventA, eventB)).equals(false)
 		})
 		o.test("calendar events A and B are NOT same if non technical field organizer name changes", function () {
 			eventA.organizer!.name = "newName"


### PR DESCRIPTION
With the refactoring in aa99cf98c70520d9c41b6401fbae27f41731a263 the comparison of two events using eventHasSameFields in ImportExportUtils.ts changed, which caused regular updates to all calendar events with organizers when doing an external calendar sync. Previous to this change, we were comparing fields on events within the eventHasSameFields function with custom functions for e.g. organizer, which was removing all identity ("_id", etc.), and all technical fields ("_errors", etc.) manually. With the change in aa99cf98c70520d9c41b6401fbae27f41731a263 we are using getStrippedClone, which did not remove the _original field. However, the _original values didn't match on the compared events, because the underlying aggregatedIds changed. For now, we are also removing the _original field in the removeTechnicalFields in EntityUtils.ts but in the future we should make sure that the actual aggregatedIds (and also all other identity and technical fields on the existing event are preserved when applying changes from an updated iCalCalenderEvent downloaded when doing an external calendar sync.