### PR TITLE
EditAll non-reschedule operations propagate to altered instances

### DIFF
--- a/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventModel.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventModel.ts
@@ -101,6 +101,7 @@ import { SimpleTextViewModel } from "../../../../common/misc/SimpleTextViewModel
 import { AlarmInfoTemplate } from "../../../../common/api/worker/facades/lazy/CalendarFacade.js"
 import { getEventType } from "../CalendarGuiUtils.js"
 import { getDefaultSender } from "../../../../common/mailFunctionality/SharedMailUtils.js"
+import { CalendarInviteHandler } from "../../view/CalendarInvites"
 
 /** the type of the event determines which edit operations are available to us. */
 export const enum EventType {
@@ -178,6 +179,7 @@ export async function makeCalendarEventModel(
 	notificationSender: CalendarNotificationSender,
 	entityClient: EntityClient,
 	responseTo: Mail | null,
+	calendarInviteHandler: CalendarInviteHandler,
 	zone: string = getTimeZone(),
 	showProgress: ShowProgressCallback = identity,
 	uiUpdateCallback: () => void = m.redraw,
@@ -234,7 +236,16 @@ export async function makeCalendarEventModel(
 	const recurrenceIds = async (uid?: string) =>
 		uid == null ? [] : ((await calendarModel.getEventsByUid(uid))?.alteredInstances.map((i) => i.recurrenceId) ?? [])
 	const notificationModel = new CalendarNotificationModel(notificationSender, logins)
-	const applyStrategies = new CalendarEventApplyStrategies(calendarModel, logins, notificationModel, makeEditModels, recurrenceIds, showProgress, zone)
+	const applyStrategies = new CalendarEventApplyStrategies(
+		calendarModel,
+		logins,
+		notificationModel,
+		makeEditModels,
+		recurrenceIds,
+		showProgress,
+		zone,
+		calendarInviteHandler,
+	)
 	const initialOrDefaultValues = Object.assign(makeEmptyCalendarEvent(), initialValues)
 	const cleanInitialValues = cleanupInitialValuesForEditing(initialOrDefaultValues)
 	const progenitor = () => calendarModel.resolveCalendarEventProgenitor(cleanInitialValues)

--- a/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventWhoModel.ts
+++ b/src/calendar-app/calendar/gui/eventeditor-model/CalendarEventWhoModel.ts
@@ -45,8 +45,8 @@ type AttendanceModelResult = {
  * tracks external passwords, attendance status, list of attendees, recipients to invite,
  * update, cancel and the calendar the event is in.
  */
+/** we need to resolve recipients to know if we need to show an external password field. */
 export class CalendarEventWhoModel {
-	/** we need to resolve recipients to know if we need to show an external password field. */
 	private readonly resolvedRecipients: Map<string, Recipient> = new Map()
 	private pendingRecipients: number = 0
 	private _recipientsSettled: DeferredObject<void> = defer()
@@ -432,8 +432,9 @@ export class CalendarEventWhoModel {
 	 * add a mail address to the list of invitees.
 	 *
 	 * @param address the EncryptedMailAddress to send the invite to
+	 * @param guestStatus
 	 */
-	public addAttendee(address: EncryptedMailAddress) {
+	public addAttendee(address: EncryptedMailAddress, guestStatus: CalendarAttendeeStatus = CalendarAttendeeStatus.ADDED) {
 		if (!this.canModifyGuests) {
 			throw new UserError(lang.makeTranslation("cannotAddAttendees_msg", "Cannot add attendees"))
 		}
@@ -463,7 +464,7 @@ export class CalendarEventWhoModel {
 				address.address,
 				createCalendarEventAttendee({
 					address,
-					status: CalendarAttendeeStatus.ADDED,
+					status: guestStatus,
 				}),
 			)
 		}

--- a/src/calendar-app/calendar/view/CalendarInvites.ts
+++ b/src/calendar-app/calendar/view/CalendarInvites.ts
@@ -8,7 +8,7 @@ import { Dialog } from "../../../common/gui/base/Dialog.js"
 import { UserError } from "../../../common/api/main/UserError.js"
 import { DataFile } from "../../../common/api/common/DataFile.js"
 import { findAttendeeInAddresses } from "../../../common/api/common/utils/CommonCalendarUtils.js"
-import { Recipient } from "../../../common/api/common/recipients/Recipient.js"
+import { Recipient, RecipientList } from "../../../common/api/common/recipients/Recipient.js"
 import { EventType } from "../gui/eventeditor-model/CalendarEventModel.js"
 import { CalendarNotificationModel } from "../gui/eventeditor-model/CalendarNotificationModel.js"
 import { getEventType } from "../gui/CalendarGuiUtils.js"
@@ -169,6 +169,20 @@ export class CalendarInviteHandler {
 		}
 
 		return ReplyResult.ReplySent
+	}
+
+	async getSendMailModelWithoutOwnRecipient(recipients: RecipientList) {
+		const mailboxDetails = await this.mailboxModel.getUserMailboxDetails()
+		const mailboxProperties = await this.mailboxModel.getMailboxProperties(mailboxDetails.mailboxGroupRoot)
+		const model = await this.sendMailModelFactory(mailboxDetails, mailboxProperties)
+
+		const filteredRecipients = recipients.filter((recipient) => {
+			return !mailboxProperties.mailAddressProperties.some((mailAddressProperty) => {
+				return mailAddressProperty.mailAddress === recipient.address
+			})
+		})
+
+		return await model.initWithTemplate(filteredRecipients, "", "")
 	}
 
 	private async getResponseModelForMail(

--- a/src/calendar-app/calendarLocator.ts
+++ b/src/calendar-app/calendarLocator.ts
@@ -370,8 +370,8 @@ class CalendarLocator implements CommonLocator {
 			calendarNotificationSender,
 			this.entityClient,
 			responseTo,
+			await this.calendarInviteHandler(),
 			getTimeZone(),
-			showProgress,
 		)
 	}
 

--- a/src/common/mailFunctionality/SendMailModel.ts
+++ b/src/common/mailFunctionality/SendMailModel.ts
@@ -747,10 +747,12 @@ export class SendMailModel {
 		return findRecipientWithAddress(this.getRecipientList(type), address)
 	}
 
-	removeRecipientByAddress(address: string, type: RecipientField, notify: boolean = true) {
-		const recipient = findRecipientWithAddress(this.getRecipientList(type), address)
-		if (recipient) {
-			this.removeRecipient(recipient, type, notify)
+	removeRecipientByAddress(address: string, recipientFields: RecipientField[], notify: boolean = true) {
+		for (const recipientField of recipientFields) {
+			const recipient = findRecipientWithAddress(this.getRecipientList(recipientField), address)
+			if (recipient) {
+				this.removeRecipient(recipient, recipientField, notify)
+			}
 		}
 	}
 

--- a/src/mail-app/mail/editor/MailEditor.ts
+++ b/src/mail-app/mail/editor/MailEditor.ts
@@ -1012,7 +1012,7 @@ export class MailEditor implements Component<MailEditorAttrs> {
 					}
 				}
 			},
-			onRecipientRemoved: (address) => this.sendMailModel.removeRecipientByAddress(address, field),
+			onRecipientRemoved: (address) => this.sendMailModel.removeRecipientByAddress(address, [field]),
 			getRecipientClickedDropdownAttrs: (address) => {
 				const recipient = this.sendMailModel.getRecipient(field, address)!
 				return this.getRecipientClickedContextButtons(recipient, field)

--- a/src/mail-app/mailLocator.ts
+++ b/src/mail-app/mailLocator.ts
@@ -501,6 +501,7 @@ class MailLocator implements CommonLocator {
 			calendarNotificationSender,
 			this.entityClient,
 			responseTo,
+			await this.calendarInviteHandler(),
 			getTimeZone(),
 			showProgress,
 		)

--- a/test/tests/calendar/eventeditor/CalendarEventModelTest.ts
+++ b/test/tests/calendar/eventeditor/CalendarEventModelTest.ts
@@ -39,6 +39,7 @@ import { createTestEntity } from "../../TestUtils.js"
 import { areExcludedDatesEqual, areRepeatRulesEqual } from "../../../../src/common/calendar/date/CalendarUtils.js"
 import { SendMailModel } from "../../../../src/common/mailFunctionality/SendMailModel.js"
 import { MailboxDetail } from "../../../../src/common/mailFunctionality/MailboxModel.js"
+import { CalendarInviteHandler } from "../../../../src/calendar-app/calendar/view/CalendarInvites"
 
 o.spec("CalendarEventModel", function () {
 	let distributor: CalendarNotificationSender
@@ -131,6 +132,7 @@ o.spec("CalendarEventModel", function () {
 			}
 			const mailboxProperties: MailboxProperties = createTestEntity(MailboxPropertiesTypeRef, {})
 			const sendModelFac: () => SendMailModel = func<() => SendMailModel>()
+			const mockCalendarInviteHandler: CalendarInviteHandler = object()
 
 			const model = await makeCalendarEventModel(
 				CalendarOperation.EditAll,
@@ -144,6 +146,7 @@ o.spec("CalendarEventModel", function () {
 				distributor,
 				entityClient,
 				null,
+				mockCalendarInviteHandler,
 				"Europe/Berlin",
 				identity,
 				noOp,


### PR DESCRIPTION
This commit improves handling changes to event series by propagating those changes to all altered instances.

EditAll reschedule operations will now send cancellations for altered instances.

Introduce guest management between event series and its altered instances. Adding, removing or keeping guests to the series will reflect on its occurrences and emails for invitation, update or cancellation will be sent.

Closes #10388


## Test notes

- [x] Create event series, invite guests and  create altered instance
- [x] Make change to event series using "Edit all".
     - [x] Simple edits are visible are also visible in the altered instance.
     - [x] Time change resets the whole series to new time (including altered instance)
     - [x] Adding or removing guest to event series, also adds/removes guest from altered instance.