### PR TITLE
Limit notification identifier list, refactor and test

### DIFF
--- a/src/mail-app/settings/NotificationSettingsViewerModel.ts
+++ b/src/mail-app/settings/NotificationSettingsViewerModel.ts
@@ -1,0 +1,83 @@
+import { PushIdentifier, PushIdentifierTypeRef, User } from "../../common/api/entities/sys/TypeRefs"
+import { AppType } from "../../common/misc/ClientConstants"
+import { assertMainOrNode } from "../../common/api/common/Env"
+import type { NativePushServiceApp } from "../../common/native/main/NativePushServiceApp"
+import { EntityClient } from "../../common/api/common/EntityClient"
+
+assertMainOrNode()
+
+// We clean up notifiers past a certain amount, but the list might not be cleaned up. To prevent showing an infinite
+// list, we limit the list to some pretty generous (but still fairly reasonable) amount.
+const MAX_DISPLAYED_PUSH_NOTIFIERS = 50
+
+/**
+ * Viewmodel that handles loading and sorting push identifiers remotely.
+ */
+export class NotificationSettingsViewerModel {
+	private currentIdentifier: string | null = null
+	private identifiers: readonly PushIdentifier[] = []
+
+	constructor(
+		private readonly pushService: NativePushServiceApp,
+		private readonly user: User,
+		private readonly entityClient: EntityClient,
+	) {}
+
+	/**
+	 * Get all loaded push identifiers.
+	 */
+	public getLoadedPushIdentifiers(): readonly PushIdentifier[] {
+		return this.identifiers
+	}
+
+	/**
+	 * Filter mail identifiers in an array of identifiers
+	 * @param identifiersAscending All identifiers in ascending order (i.e. oldest to newest order)
+	 * @param currentIdentifier Current identifier of the client
+	 */
+	private filterAndLimitMailIdentifiers(identifiersAscending: readonly PushIdentifier[], currentIdentifier: string | null): PushIdentifier[] {
+		// Filter out calendar targets
+		const validTargets = identifiersAscending.filter((identifier) => identifier.app === AppType.Mail || identifier.app === AppType.Integrated)
+
+		// The identifier may or may not be on the list depending on if the identifier was deleted
+		let currentIdentifierEntry: PushIdentifier | null = null
+		if (currentIdentifier != null) {
+			const currentIdentifierIndex = validTargets.findIndex((identifier) => identifier.identifier === currentIdentifier)
+			if (currentIdentifierIndex >= 0) {
+				currentIdentifierEntry = validTargets.splice(currentIdentifierIndex, 1)[0]
+			}
+		}
+
+		// The list is in ascending order, so older notifiers are at the beginning (take the last, at most, MAX_DISPLAYED_PUSH_NOTIFIERS)
+		const identifiersSlice = validTargets.slice(-MAX_DISPLAYED_PUSH_NOTIFIERS)
+
+		// We should take our push identifier and push it somewhere else!
+		if (currentIdentifierEntry != null) {
+			identifiersSlice.unshift(currentIdentifierEntry)
+		}
+
+		return identifiersSlice
+	}
+
+	/**
+	 * Get the current loaded push identifier for the client.
+	 */
+	public getCurrentIdentifier(): string | null {
+		return this.currentIdentifier
+	}
+
+	/**
+	 * (Re)load everything.
+	 */
+	public async reload() {
+		this.currentIdentifier = this.pushService.getLoadedPushIdentifier()?.identifier ?? null
+		const list = this.user.pushIdentifierList
+
+		if (list) {
+			const allIdentifiers = await this.entityClient.loadAll(PushIdentifierTypeRef, list.list)
+			this.identifiers = this.filterAndLimitMailIdentifiers(allIdentifiers, this.currentIdentifier)
+		} else {
+			this.identifiers = []
+		}
+	}
+}

--- a/test/tests/Suite.ts
+++ b/test/tests/Suite.ts
@@ -194,6 +194,7 @@ import "./misc/quickactions/QuickActionsModelTest.js"
 import "./calendar/CalendarTimeGridTest"
 import "./calendar/AllDaySectionTest"
 import "./mail/view/LabelsPopupViewModelTest.js"
+import "./settings/NotificationSettingsViewerModelTest.js"
 
 import * as td from "testdouble"
 import { random } from "@tutao/tutanota-crypto"

--- a/test/tests/settings/NotificationSettingsViewerModelTest.ts
+++ b/test/tests/settings/NotificationSettingsViewerModelTest.ts
@@ -1,0 +1,148 @@
+import o from "@tutao/otest"
+import { NotificationSettingsViewerModel } from "../../../src/mail-app/settings/NotificationSettingsViewerModel"
+import { NativePushServiceApp } from "../../../src/common/native/main/NativePushServiceApp"
+import { createPushIdentifierList, PushIdentifier, PushIdentifierTypeRef, User, UserTypeRef } from "../../../src/common/api/entities/sys/TypeRefs"
+import { EntityClient } from "../../../src/common/api/common/EntityClient"
+import { object, when } from "testdouble"
+import { createTestEntity } from "../TestUtils"
+import { AppType } from "../../../src/common/misc/ClientConstants"
+
+o.spec("NotificationSettingsViewerModel", () => {
+	let model: NotificationSettingsViewerModel
+	let pushService: NativePushServiceApp
+	let user: User
+	let entityClient: EntityClient
+
+	o.beforeEach(() => {
+		pushService = object()
+		user = createTestEntity(UserTypeRef, user)
+		entityClient = object()
+		model = new NotificationSettingsViewerModel(pushService, user, entityClient)
+	})
+
+	o.spec("reload push notifiers", () => {
+		o.test("not yet reloaded", () => {
+			o.check(model.getCurrentIdentifier()).equals(null)
+			o.check(model.getLoadedPushIdentifiers()).deepEquals([])
+		})
+
+		o.test("loaded with a few identifiers and no current identifier", async () => {
+			when(pushService.getLoadedPushIdentifier()).thenReturn(null)
+
+			user.pushIdentifierList = createPushIdentifierList({
+				list: "hi i'm a list",
+			})
+
+			const someList = [
+				createTestEntity(PushIdentifierTypeRef, { identifier: "a", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "b", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "c", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "d", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "e", app: AppType.Mail }),
+			]
+
+			when(entityClient.loadAll(PushIdentifierTypeRef, user.pushIdentifierList.list)).thenResolve(someList)
+
+			await model.reload()
+
+			o.check(model.getCurrentIdentifier()).equals(null)
+			o.check(model.getLoadedPushIdentifiers()).deepEquals(someList)
+		})
+
+		o.test("loaded with a few identifiers and a current identifier", async () => {
+			when(pushService.getLoadedPushIdentifier()).thenReturn({
+				identifier: "c",
+				disabled: false,
+			})
+
+			user.pushIdentifierList = createPushIdentifierList({
+				list: "hi i'm a list",
+			})
+
+			const someList = [
+				createTestEntity(PushIdentifierTypeRef, { identifier: "a", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "b", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "c", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "d", app: AppType.Mail }),
+				createTestEntity(PushIdentifierTypeRef, { identifier: "e", app: AppType.Mail }),
+			]
+
+			when(entityClient.loadAll(PushIdentifierTypeRef, user.pushIdentifierList.list)).thenResolve(someList)
+
+			await model.reload()
+
+			o.check(model.getCurrentIdentifier()).equals("c")
+			o.check(model.getLoadedPushIdentifiers()).deepEquals([someList[2], someList[0], someList[1], someList[3], someList[4]])
+		})
+
+		o.test("loaded with many identifiers and no current identifier", async () => {
+			when(pushService.getLoadedPushIdentifier()).thenReturn(null)
+
+			user.pushIdentifierList = createPushIdentifierList({
+				list: "hi i'm a list",
+			})
+
+			const someList: PushIdentifier[] = []
+
+			for (let i = 1; i <= 1000; i++) {
+				someList.push(createTestEntity(PushIdentifierTypeRef, { identifier: `${i}`, app: AppType.Mail }))
+			}
+			someList.splice(500, 0, createTestEntity(PushIdentifierTypeRef, { identifier: "this is my current identifier", app: AppType.Mail }))
+			when(entityClient.loadAll(PushIdentifierTypeRef, user.pushIdentifierList.list)).thenResolve(someList)
+
+			await model.reload()
+			o.check(model.getCurrentIdentifier()).equals(null)
+			const identifiers = model.getLoadedPushIdentifiers()
+			o.check(identifiers.length).equals(50)
+			o.check(identifiers[0].identifier).equals("951")
+			o.check(identifiers[49].identifier).equals("1000")
+		})
+
+		o.test("loaded with many identifiers and a current identifier", async () => {
+			when(pushService.getLoadedPushIdentifier()).thenReturn({
+				identifier: "this is my current identifier",
+				disabled: false,
+			})
+
+			user.pushIdentifierList = createPushIdentifierList({
+				list: "hi i'm a list",
+			})
+
+			const someList: PushIdentifier[] = []
+
+			for (let i = 1; i <= 1000; i++) {
+				someList.push(createTestEntity(PushIdentifierTypeRef, { identifier: `${i}`, app: AppType.Mail }))
+			}
+			someList.splice(500, 0, createTestEntity(PushIdentifierTypeRef, { identifier: "this is my current identifier", app: AppType.Mail }))
+			when(entityClient.loadAll(PushIdentifierTypeRef, user.pushIdentifierList.list)).thenResolve(someList)
+
+			await model.reload()
+			o.check(model.getCurrentIdentifier()).equals("this is my current identifier")
+			const identifiers = model.getLoadedPushIdentifiers()
+			o.check(identifiers.length).equals(51)
+			o.check(identifiers[0].identifier).equals("this is my current identifier")
+			o.check(identifiers[50].identifier).equals("1000")
+		})
+
+		o.test("calendar notifiers are ignored", async () => {
+			when(pushService.getLoadedPushIdentifier()).thenReturn(null)
+
+			user.pushIdentifierList = createPushIdentifierList({
+				list: "hi i'm a list",
+			})
+
+			const someList: PushIdentifier[] = []
+			someList.push(createTestEntity(PushIdentifierTypeRef, { identifier: `a mail identifier`, app: AppType.Mail }))
+			someList.push(createTestEntity(PushIdentifierTypeRef, { identifier: `a calendar identifier`, app: AppType.Calendar }))
+			someList.push(createTestEntity(PushIdentifierTypeRef, { identifier: `an integrated identifier`, app: AppType.Integrated }))
+
+			when(entityClient.loadAll(PushIdentifierTypeRef, user.pushIdentifierList.list)).thenResolve(someList)
+
+			await model.reload()
+			o.check(model.getCurrentIdentifier()).equals(null)
+			const identifiers = model.getLoadedPushIdentifiers()
+			o.check(identifiers.length).equals(2)
+			o.check(identifiers.every((identifier) => identifier.app !== AppType.Calendar)).equals(true)
+		})
+	})
+})


### PR DESCRIPTION
Limit to a large-but-still-reasonable number to avoid slowdown when drawing the list. Note that the server will also limit the number of stored push identifiers, although it might not have done so for the current user.

In any case, all of this logic should be tested. As such, the loading logic was also moved to a separate model, and unit tests were added.

Admittedly, more of the code in the viewer probably also belongs in here (and also in the unit tests), but this is such a minor and mostly already fixed issue that it didn't seem appropriate to hijack it into a major refactor.

Closes #4230