### PR TITLE
Improve blob decryption speed in browser

### DIFF
--- a/packages/tutanota-crypto/lib/encryption/Aes.ts
+++ b/packages/tutanota-crypto/lib/encryption/Aes.ts
@@ -51,6 +51,10 @@ export function aesDecrypt(key: AesKey, encryptedBytes: Uint8Array): Uint8Array 
 	return SYMMETRIC_CIPHER_FACADE.decryptBytes(key, encryptedBytes)
 }
 
+export function asyncDecryptBytes(key: AesKey, bytes: Uint8Array): Promise<Uint8Array> {
+	return SYMMETRIC_CIPHER_FACADE.asyncDecryptBytes(key, bytes)
+}
+
 /**
  * Decrypts the given words with AES-128/256 in CBC mode. Does not enforce a mac.
  * We always must enforce macs. This only exists for backward compatibility in some exceptional cases like search index entry encryption.

--- a/packages/tutanota-crypto/lib/encryption/Hmac.ts
+++ b/packages/tutanota-crypto/lib/encryption/Hmac.ts
@@ -1,6 +1,7 @@
 import sjcl from "../internal/sjcl.js"
 import { CryptoError } from "../misc/CryptoError.js"
 import { AesKey, bitArrayToUint8Array, uint8ArrayToBitArray } from "./symmetric/SymmetricCipherUtils.js"
+import { getAndVerifyAesKeyLength } from "./symmetric/AesKeyLength.js"
 
 export type MacTag = Uint8Array & { __brand: "macTag" }
 
@@ -18,6 +19,33 @@ export function hmacSha256(key: AesKey, data: Uint8Array): MacTag {
  */
 export function verifyHmacSha256(key: AesKey, data: Uint8Array, tag: MacTag) {
 	const computedTag = hmacSha256(key, data)
+	if (!sjcl.bitArray.equal(computedTag, tag)) {
+		throw new CryptoError("invalid mac")
+	}
+}
+
+/**
+ * Create an HMAC-SHA-256 tag over the given data using the given key.
+ */
+export async function hmacSha256Async(key: AesKey, data: Uint8Array): Promise<MacTag> {
+	const keyLength = getAndVerifyAesKeyLength(key)
+	const subtleAuthenticationKey = await crypto.subtle.importKey(
+		"raw",
+		bitArrayToUint8Array(key),
+		{ name: "HMAC", hash: "SHA-256", length: keyLength },
+		false,
+		["sign"],
+	)
+	return new Uint8Array(await crypto.subtle.sign("HMAC", subtleAuthenticationKey, data)) as MacTag
+}
+
+/**
+ * Import and verify an HMAC-SHA-256 tag for subtle crypto against the given data and key.
+ * @throws CryptoError if the tag does not match the data and key.
+ */
+export async function verifyHmacSha256Async(key: AesKey, data: Uint8Array, tag: MacTag) {
+	// technically re-implementing SubtleCrypto#verify() but doing it this way for easier testing and symmetry.
+	const computedTag = await hmacSha256Async(key, data)
 	if (!sjcl.bitArray.equal(computedTag, tag)) {
 		throw new CryptoError("invalid mac")
 	}

--- a/packages/tutanota-crypto/lib/encryption/symmetric/AesCbcFacade.ts
+++ b/packages/tutanota-crypto/lib/encryption/symmetric/AesCbcFacade.ts
@@ -11,7 +11,7 @@ import {
 import { CryptoError } from "../../misc/CryptoError.js"
 import { assertNotNull, concat } from "@tutao/tutanota-utils"
 import sjcl from "../../internal/sjcl.js"
-import { hmacSha256, MacTag, verifyHmacSha256 } from "../Hmac.js"
+import { hmacSha256, MacTag, verifyHmacSha256, verifyHmacSha256Async } from "../Hmac.js"
 import { SYMMETRIC_KEY_DERIVER, SymmetricKeyDeriver } from "./SymmetricKeyDeriver.js"
 import { AesKeyLength, getAndVerifyAesKeyLength } from "./AesKeyLength.js"
 
@@ -81,26 +81,15 @@ export class AesCbcFacade {
 				break
 			case SymmetricCipherVersion.AesCbcThenHmac: {
 				const authenticationKey = assertNotNull(subKeys.authenticationKey)
-				cipherTextWithoutMacAndVersionByte = cipherText.subarray(
-					SYMMETRIC_CIPHER_VERSION_PREFIX_LENGTH_BYTES,
-					cipherText.length - SYMMETRIC_AUTHENTICATION_TAG_LENGTH_BYTES,
-				)
-				const providedMacBytes = cipherText.subarray(cipherText.length - SYMMETRIC_AUTHENTICATION_TAG_LENGTH_BYTES, cipherText.length)
+				let providedMacBytes
+				;({ cipherTextWithoutMacAndVersionByte, providedMacBytes } = this.extractMacAndCipherText(cipherText))
 				verifyHmacSha256(authenticationKey, cipherTextWithoutMacAndVersionByte, providedMacBytes as MacTag)
 				break
 			}
 			default:
 				throw new Error("unexpected cipher version " + cipherVersion)
 		}
-		let iv: Uint8Array
-		let aesCbcCiphertext: Uint8Array
-		if (ivIsPrepended) {
-			iv = cipherTextWithoutMacAndVersionByte.subarray(0, IV_BYTE_LENGTH)
-			aesCbcCiphertext = cipherTextWithoutMacAndVersionByte.subarray(IV_BYTE_LENGTH, cipherTextWithoutMacAndVersionByte.length)
-		} else {
-			iv = FIXED_IV
-			aesCbcCiphertext = cipherTextWithoutMacAndVersionByte
-		}
+		let { iv, aesCbcCiphertext } = this.getIvAndCipherText(ivIsPrepended, cipherTextWithoutMacAndVersionByte)
 		try {
 			return bitArrayToUint8Array(
 				sjcl.mode.cbc.decrypt(
@@ -114,6 +103,63 @@ export class AesCbcFacade {
 		} catch (e) {
 			throw new CryptoError("aes decryption failed", e as Error)
 		}
+	}
+
+	async decryptAsync(
+		key: AesKey,
+		cipherText: Uint8Array,
+		ivIsPrepended: boolean,
+		cipherVersion: SymmetricCipherVersion,
+		skipAuthenticationEnforcement: boolean = false,
+	): Promise<Uint8Array> {
+		const subtle = crypto.subtle
+
+		this.tryToEnforceAuthentication(key, cipherVersion, skipAuthenticationEnforcement)
+		const subKeys = this.symmetricKeyDeriver.deriveSubKeys(key, cipherVersion)
+		let cipherTextWithoutMacAndVersionByte: Uint8Array
+		switch (cipherVersion) {
+			case SymmetricCipherVersion.UnusedReservedUnauthenticated:
+				cipherTextWithoutMacAndVersionByte = cipherText
+				break
+			case SymmetricCipherVersion.AesCbcThenHmac: {
+				const authenticationKey = assertNotNull(subKeys.authenticationKey)
+				let providedMacBytes
+				;({ cipherTextWithoutMacAndVersionByte, providedMacBytes } = this.extractMacAndCipherText(cipherText))
+				await verifyHmacSha256Async(authenticationKey, cipherTextWithoutMacAndVersionByte, providedMacBytes)
+				break
+			}
+			default:
+				throw new Error("unexpected cipher version " + cipherVersion)
+		}
+		let { iv, aesCbcCiphertext } = this.getIvAndCipherText(ivIsPrepended, cipherTextWithoutMacAndVersionByte)
+		try {
+			const encryptionKey = await subtle.importKey("raw", bitArrayToUint8Array(subKeys.encryptionKey), "AES-CBC", false, ["decrypt"])
+			return new Uint8Array(await subtle.decrypt({ name: "AES-CBC", iv }, encryptionKey, aesCbcCiphertext))
+		} catch (e) {
+			throw new CryptoError("aes decryption failed", e as Error)
+		}
+	}
+
+	private extractMacAndCipherText(cipherText: Uint8Array<ArrayBufferLike>): { cipherTextWithoutMacAndVersionByte: Uint8Array; providedMacBytes: MacTag } {
+		const cipherTextWithoutMacAndVersionByte = cipherText.subarray(
+			SYMMETRIC_CIPHER_VERSION_PREFIX_LENGTH_BYTES,
+			cipherText.length - SYMMETRIC_AUTHENTICATION_TAG_LENGTH_BYTES,
+		)
+		const providedMacBytes = cipherText.subarray(cipherText.length - SYMMETRIC_AUTHENTICATION_TAG_LENGTH_BYTES, cipherText.length) as MacTag
+		return { cipherTextWithoutMacAndVersionByte, providedMacBytes }
+	}
+
+	private getIvAndCipherText(ivIsPrepended: boolean, cipherTextWithoutMacAndVersionByte: Uint8Array<ArrayBufferLike>) {
+		let iv: Uint8Array
+		let aesCbcCiphertext: Uint8Array
+		if (ivIsPrepended) {
+			iv = cipherTextWithoutMacAndVersionByte.subarray(0, IV_BYTE_LENGTH)
+			aesCbcCiphertext = cipherTextWithoutMacAndVersionByte.subarray(IV_BYTE_LENGTH, cipherTextWithoutMacAndVersionByte.length)
+		} else {
+			iv = FIXED_IV
+			aesCbcCiphertext = cipherTextWithoutMacAndVersionByte
+		}
+		return { iv, aesCbcCiphertext }
 	}
 
 	private tryToEnforceAuthentication(key: AesKey, cipherVersion: SymmetricCipherVersion, skipAuthenticationEnforcement: boolean) {

--- a/packages/tutanota-crypto/lib/encryption/symmetric/SymmetricCipherFacade.ts
+++ b/packages/tutanota-crypto/lib/encryption/symmetric/SymmetricCipherFacade.ts
@@ -14,7 +14,14 @@ import { AesKeyLength, getAndVerifyAesKeyLength } from "./AesKeyLength.js"
  * In case of AEAD, there is additional associated data. Needed both for encryption and decryption, but it is not part of the created ciphertext.
  */
 export class SymmetricCipherFacade {
-	constructor(private readonly aesCbcFacade: AesCbcFacade) {}
+	/** whether we can use SubtleCrypto for big chunks of data (we use JS impl for most encryption) */
+	private readonly subtleCryptoAvailable: boolean
+	constructor(private readonly aesCbcFacade: AesCbcFacade) {
+		this.subtleCryptoAvailable = crypto.subtle != null
+		if (!this.subtleCryptoAvailable) {
+			console.log("SubtleCrypto is not available, falling back to JS AES impl of decryption")
+		}
+	}
 
 	/**
 	 * Encrypts a byte array with AES in CBC mode.
@@ -67,6 +74,14 @@ export class SymmetricCipherFacade {
 	 */
 	public decryptBytes(key: AesKey, bytes: Uint8Array): Uint8Array {
 		return this.decrypt(key, bytes, true)
+	}
+
+	public async asyncDecryptBytes(key: AesKey, bytes: Uint8Array): Promise<Uint8Array> {
+		if (this.subtleCryptoAvailable) {
+			return this.decryptAsync(key, bytes)
+		} else {
+			return this.decrypt(key, bytes, true)
+		}
 	}
 
 	/**
@@ -169,6 +184,25 @@ export class SymmetricCipherFacade {
 			case SymmetricCipherVersion.UnusedReservedUnauthenticated:
 			case SymmetricCipherVersion.AesCbcThenHmac: {
 				return this.aesCbcFacade.decrypt(key, cipherText, hasPrependedIv, padding, cipherVersion, skipAuthenticationEnforcement)
+			}
+			case SymmetricCipherVersion.Aead: {
+				// use this as soon as we define what to use as associated data
+				throw new Error("not yet enabled")
+			}
+		}
+	}
+
+	private decryptAsync(
+		key: AesKey,
+		cipherText: Uint8Array,
+		hasPrependedIv: boolean = true,
+		skipAuthenticationEnforcement: boolean = false,
+	): Promise<Uint8Array> {
+		const cipherVersion = getSymmetricCipherVersion(cipherText)
+		switch (cipherVersion) {
+			case SymmetricCipherVersion.UnusedReservedUnauthenticated:
+			case SymmetricCipherVersion.AesCbcThenHmac: {
+				return this.aesCbcFacade.decryptAsync(key, cipherText, hasPrependedIv, cipherVersion, skipAuthenticationEnforcement)
 			}
 			case SymmetricCipherVersion.Aead: {
 				// use this as soon as we define what to use as associated data

--- a/packages/tutanota-crypto/lib/index.ts
+++ b/packages/tutanota-crypto/lib/index.ts
@@ -2,6 +2,7 @@ export {
 	aesEncrypt,
 	aesEncryptConfigurationDatabaseItem,
 	aesDecrypt,
+	asyncDecryptBytes,
 	aes256EncryptSearchIndexEntry,
 	aesDecryptUnauthenticated,
 	aes256EncryptSearchIndexEntryWithIV,
@@ -115,7 +116,7 @@ export { TotpVerifier } from "./misc/TotpVerifier.js"
 export { TotpSecret } from "./misc/TotpVerifier.js"
 export { murmurHash } from "./hashes/MurmurHash.js"
 export { hkdf } from "./hashes/HKDF.js"
-export { hmacSha256, verifyHmacSha256, MacTag } from "./encryption/Hmac.js"
+export { hmacSha256, verifyHmacSha256, MacTag, verifyHmacSha256Async, hmacSha256Async } from "./encryption/Hmac.js"
 export {
 	aes256RandomKey,
 	keyToUint8Array,

--- a/src/common/api/worker/facades/lazy/BlobFacade.ts
+++ b/src/common/api/worker/facades/lazy/BlobFacade.ts
@@ -9,7 +9,6 @@ import {
 	getFirstOrThrow,
 	groupBy,
 	isEmpty,
-	mapMap,
 	neverNull,
 	noOp,
 	promiseMap,
@@ -23,7 +22,7 @@ import { HttpMethod, MediaType } from "../../../common/EntityFunctions.js"
 import { assertWorkerOrNode, isApp, isDesktop } from "../../../common/Env.js"
 import { isSuspensionResponse, SuspensionHandler } from "../../SuspensionHandler.js"
 import { BlobService } from "../../../entities/storage/Services.js"
-import { aesDecrypt, AesKey, sha256Hash } from "@tutao/tutanota-crypto"
+import { aesDecrypt, AesKey, asyncDecryptBytes, sha256Hash } from "@tutao/tutanota-crypto"
 import type { FileUri, NativeFileApp } from "../../../../native/common/FileApp.js"
 import type { AesApp } from "../../../../native/worker/AesApp.js"
 import { Blob, BlobReferenceTokenWrapper, createBlobReferenceTokenWrapper } from "../../../entities/sys/TypeRefs.js"
@@ -554,10 +553,11 @@ export class BlobFacade {
 				mapWithEncryptedBlobs.set(k, v)
 			}
 		}
-		return mapMap(mapWithEncryptedBlobs, (blob) => {
+		const processedBlobEntries = await promiseMap(Array.from(mapWithEncryptedBlobs.entries()), async ([blobId, blob]) => {
 			abortSignal?.throwIfAborted()
-			return aesDecrypt(sessionKey, blob)
+			return [blobId, await asyncDecryptBytes(sessionKey, blob)] as const
 		})
+		return new Map(processedBlobEntries)
 	}
 
 	/**

--- a/test/tests/api/worker/crypto/CompatibilityTest.ts
+++ b/test/tests/api/worker/crypto/CompatibilityTest.ts
@@ -4,6 +4,7 @@ import {
 	aesDecrypt,
 	aesEncrypt,
 	AsymmetricKeyPair,
+	asyncDecryptBytes,
 	bitArrayToUint8Array,
 	bytesToEd25519PrivateKey,
 	bytesToEd25519PublicKey,
@@ -24,13 +25,13 @@ import {
 	hexToRsaPublicKey,
 	hkdf,
 	hmacSha256,
+	hmacSha256Async,
 	IV_BYTE_LENGTH,
 	KeyLength,
 	KeyPairType,
 	keyToUint8Array,
 	kyberPrivateKeyToBytes,
 	kyberPublicKeyToBytes,
-	LibOQSExports,
 	MacTag,
 	PQKeyPairs,
 	PQPublicKeys,
@@ -41,6 +42,7 @@ import {
 	rsaEncrypt,
 	uint8ArrayToKey,
 	verifyHmacSha256,
+	verifyHmacSha256Async,
 	x25519Decapsulate,
 	x25519Encapsulate,
 } from "@tutao/tutanota-crypto"
@@ -134,6 +136,31 @@ o.spec("CompatibilityTest", function () {
 			o(uint8ArrayToBase64(encryptedKey256)).equals(td.encryptedKey256)
 			const decryptedKey256 = decryptKey(key, encryptedKey256)
 			o(uint8ArrayToHex(keyToUint8Array(decryptedKey256))).equals(td.keyToEncrypt256)
+		}
+	})
+
+	o.test("aes 256 async", async function () {
+		for (const td of testData.aes256Tests) {
+			let key = uint8ArrayToKey(hexToUint8Array(td.hexKey))
+
+			let decryptedBytes = uint8ArrayToBase64(await asyncDecryptBytes(key, base64ToUint8Array(td.cipherTextBase64)))
+			o.check(decryptedBytes).equals(td.plainTextBase64)
+		}
+	})
+	o.test("aes 128 async", async function () {
+		for (const td of testData.aes128Tests) {
+			let key = uint8ArrayToKey(hexToUint8Array(td.hexKey))
+
+			let decryptedBytes = uint8ArrayToBase64(await asyncDecryptBytes(key, base64ToUint8Array(td.cipherTextBase64)))
+			o.check(decryptedBytes).equals(td.plainTextBase64)
+		}
+	})
+	o.test("aes 128 async mac", async function () {
+		for (const td of testData.aes128MacTests) {
+			let key = uint8ArrayToKey(hexToUint8Array(td.hexKey))
+
+			let decryptedBytes = uint8ArrayToBase64(await asyncDecryptBytes(key, base64ToUint8Array(td.cipherTextBase64)))
+			o.check(decryptedBytes).equals(td.plainTextBase64)
 		}
 	})
 
@@ -270,6 +297,16 @@ o.spec("CompatibilityTest", function () {
 			const hmacSha256Tag = hexToUint8Array(td.hmacSha256TagHex) as MacTag
 			o(hmacSha256(key, data)).deepEquals(hmacSha256Tag)
 			verifyHmacSha256(key, data, hmacSha256Tag)
+		}
+	})
+
+	o.test("async-hmac-sha256", async function () {
+		for (const td of testData.hmacSha256Tests) {
+			const key = uint8ArrayToKey(hexToUint8Array(td.keyHex))
+			const data = hexToUint8Array(td.dataHex)
+			const hmacSha256Tag = hexToUint8Array(td.hmacSha256TagHex) as MacTag
+			o.check(await hmacSha256Async(key, data)).deepEquals(hmacSha256Tag)
+			await verifyHmacSha256Async(key, data, hmacSha256Tag)
 		}
 	})
 

--- a/test/tests/testInNode.ts
+++ b/test/tests/testInNode.ts
@@ -51,17 +51,6 @@ globalThis.performance = {
 	mark: noOp,
 	measure: noOp,
 }
-// modern node *does* have it set globally but it sometimes doesn't work
-const crypto = await import("node:crypto")
-Object.defineProperty(globalThis, "crypto", {
-	value: {
-		getRandomValues: function (bytes) {
-			let randomBytes = crypto.randomBytes(bytes.length)
-			bytes.set(randomBytes)
-			return bytes
-		},
-	},
-})
 
 globalThis.XMLHttpRequest = (await import("xhr2")).default
 process.on("unhandledRejection", function (e) {


### PR DESCRIPTION
We are using SubtleCrypto for AES decryption (including HMAC) as it is much faster than sjcl. For now, it is only used for blobs as they are big chunks of data and SubtleCrypto APIs are async which makes them poorly fitted for attribute encryption.

Close tuta#2854