### PR TITLE
Fix hidden elements that are not shown but navigable by screen readers

### DIFF
--- a/src/common/gui/base/TextField.ts
+++ b/src/common/gui/base/TextField.ts
@@ -218,6 +218,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 				a.autocompleteAs === Autocomplete.off
 					? [
 							m("input.abs", {
+								"aria-hidden": "true",
 								style: {
 									opacity: "0",
 									height: "0",
@@ -226,6 +227,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 								type: TextFieldType.Text,
 							}),
 							m("input.abs", {
+								"aria-hidden": "true",
 								style: {
 									opacity: "0",
 									height: "0",
@@ -234,6 +236,7 @@ export class TextField implements ClassComponent<TextFieldAttrs> {
 								type: TextFieldType.Password,
 							}),
 							m("input.abs", {
+								"aria-hidden": "true",
 								style: {
 									opacity: "0",
 									height: "0",


### PR DESCRIPTION
These are the invisible fields used to resist the autofill everything in smart browsers. Fixed by setting those elements hidden from the accessibility tree

close: #10396