### PR TITLE
Add aggregate refTypeId and instance typeId to computePatches error msg

### DIFF
--- a/src/common/api/common/utils/PatchGenerator.ts
+++ b/src/common/api/common/utils/PatchGenerator.ts
@@ -117,8 +117,9 @@ export async function computePatches(
 				(instance) => instance[assertNotNull(AttributeModel.getAttributeId(aggregateTypeModel, "_id"))] as Id,
 			)
 			if (!isDistinctAggregateIds(modifiedAggregateIds)) {
+				const modifiedInstanceId: IdTuple | Id = AttributeModel.getAttribute(modifiedInstance, "_id", typeModel)
 				throw new ProgrammingError(
-					"Duplicate aggregate ids in the modified instance: " + AttributeModel.getAttribute(modifiedInstance, "_id", typeModel),
+					`Duplicate aggregate ids of aggregate ${appName}/${typeId} in modified instance ${typeModel.app}/${typeModel.id} :  ${modifiedInstanceId}`,
 				)
 			}
 			const addedItems = modifiedAggregatedUntypedEntities.filter(


### PR DESCRIPTION
We received a couple of `Duplicate aggregate ids in the modified instance‥` error reports but it's not really clear for which aggregate on which instance.

For one report we can tell that the instance is `TutanotaProperties` because of a failed request prior to the error (this means the aggregate is likely `InboxRule`).