### PR TITLE
Add option to hide reader pane

### DIFF
--- a/src/common/gui/DesktopToolbars.ts
+++ b/src/common/gui/DesktopToolbars.ts
@@ -1,5 +1,5 @@
 import { pureComponent } from "./base/PureComponent.js"
-import m from "mithril"
+import m, { Children } from "mithril"
 import { component_size, px, size } from "./size.js"
 import { responsiveCardHMargin } from "./cards.js"
 
@@ -20,7 +20,8 @@ export const DesktopListToolbar = pureComponent((__, children) => {
 })
 
 /** Toolbar layout that is used in the third/viewer column. */
-export const DesktopViewerToolbar = pureComponent((__, children) => {
+type DesktopViewerToolbarAttrs = { leftContent?: Children }
+export const DesktopViewerToolbar = pureComponent(({ leftContent }: DesktopViewerToolbarAttrs, children) => {
 	// The viewer below will (or at least should) reserve some space for the scrollbar. To match that we put `scrollbar-gutter: stable` and for it to have
 	// effect we put `overflow-y: hidden`.
 	//
@@ -44,6 +45,7 @@ export const DesktopViewerToolbar = pureComponent((__, children) => {
 				},
 			},
 			[
+				leftContent,
 				// Height keeps the toolbar showing for consistency, even if there are no actions
 				m(".flex-grow", { style: { height: px(component_size.button_height) } }),
 				children,

--- a/src/common/gui/DesktopToolbars.ts
+++ b/src/common/gui/DesktopToolbars.ts
@@ -2,6 +2,7 @@ import { pureComponent } from "./base/PureComponent.js"
 import m, { Children } from "mithril"
 import { component_size, px, size } from "./size.js"
 import { responsiveCardHMargin } from "./cards.js"
+import { deviceConfig } from "../misc/DeviceConfig.js"
 
 /** Toolbar layout that is used in the second/list column. */
 export const DesktopListToolbar = pureComponent((__, children) => {
@@ -33,8 +34,9 @@ export const DesktopViewerToolbar = pureComponent(({ leftContent }: DesktopViewe
 		{
 			class: responsiveCardHMargin(),
 			style: {
-				marginLeft: 0,
+				marginLeft: deviceConfig.getMailNoPreviewMode() ? px(size.spacing_8) : 0,
 				marginBottom: px(size.spacing_24),
+				"border-radius": deviceConfig.getMailNoPreviewMode() ? `${size.radius_8}px 0 0 ${size.radius_8}px` : undefined,
 			},
 		},
 		m(

--- a/src/common/gui/base/ViewColumn.ts
+++ b/src/common/gui/base/ViewColumn.ts
@@ -37,6 +37,13 @@ export class ViewColumn implements Component<Attrs> {
 	isInForeground: boolean
 	isVisible: boolean
 	ariaRole: AriaLandmarks | null = null
+	/**
+	 * When true and this column is the focused column, the ViewSlider will not
+	 * render any other columns alongside it — it takes the full available width
+	 * Use this when a column should always occupy the entire screen when active,
+	 * regardless of how much space is available
+	 */
+	exclusive: boolean
 
 	/**
 	 * Create a view column.
@@ -87,6 +94,7 @@ export class ViewColumn implements Component<Attrs> {
 		this.isVisible = false
 		// fixup for old-style components
 		this.view = this.view.bind(this)
+		this.exclusive = false
 	}
 
 	view(vnode: Vnode<Attrs>): Children {

--- a/src/common/gui/nav/ViewSlider.ts
+++ b/src/common/gui/nav/ViewSlider.ts
@@ -251,6 +251,9 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	 * @param allColumns All columns*
 	 */
 	getNextVisibleColumn(visibleColumns: ViewColumn[], allColumns: ViewColumn[]): ViewColumn | null {
+		// if the column is exclusive we avoid rendering the other one
+		if (visibleColumns[0].exclusive) return null
+
 		// First: try to find a background column which is not visible
 		let nextColumn = allColumns.find((column) => {
 			return column.columnType === ColumnType.Background && visibleColumns.indexOf(column) < 0

--- a/src/common/gui/nav/ViewSlider.ts
+++ b/src/common/gui/nav/ViewSlider.ts
@@ -42,6 +42,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	focusedColumn: ViewColumn
 	private visibleBackgroundColumns: ViewColumn[]
 	private domSlidingPart!: HTMLElement
+	private totalWidth = 0
 	view: Component<ViewSliderAttrs>["view"]
 	private busy: Promise<unknown>
 	private isModalBackgroundVisible: boolean
@@ -163,7 +164,18 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	}
 
 	private getColumnsForMainSlider(): Array<ViewColumn> {
-		return this.viewColumns.filter((c) => c.columnType === ColumnType.Background || c.isVisible)
+		// In multi-column exclusive mode (no-preview), only one of the exclusive columns (list or
+		// mail) is active at a time. The inactive one is excluded from the DOM so that switching
+		// between them is an in-place mithril swap with no slide animation.
+		// In single-column mode (mobile) all columns stay in the DOM to allow slide animations.
+		const isMultiColumn = this.visibleBackgroundColumns.length > 1
+		const hasVisibleExclusive = this.viewColumns.some((column) => column.exclusive && column.isVisible)
+		return this.viewColumns.filter((column) => {
+			if (column.columnType === ColumnType.Background) {
+				return !(isMultiColumn && hasVisibleExclusive && column.exclusive && !column.isVisible)
+			}
+			return column.isVisible
+		})
 	}
 
 	private getColumnsForOverlay(): Array<ViewColumn> {
@@ -251,10 +263,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	 * @param allColumns All columns*
 	 */
 	getNextVisibleColumn(visibleColumns: ViewColumn[], allColumns: ViewColumn[]): ViewColumn | null {
-		// if the column is exclusive we avoid rendering the other one
-		if (visibleColumns[0].exclusive) return null
-
-		// First: try to find a background column which is not visible
+		// First: try to find a non-exclusive background column which is not yet visible
 		let nextColumn = allColumns.find((column) => {
 			return column.columnType === ColumnType.Background && !column.exclusive && visibleColumns.indexOf(column) < 0
 		})
@@ -347,6 +356,8 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 
 			await this.busy
 
+			// In exclusive mode, a multi-column layout switch doesn't trigger a slide
+			// animation, so we force a layout recalculation here to add/remove the active column.
 			if (viewColumn.exclusive || previousColumnWasExclusive) {
 				this.updateVisibleBackgroundColumns()
 			}
@@ -402,19 +413,28 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	}
 
 	updateOffsets() {
+		// In multi-column exclusive mode (no-preview), the inactive exclusive column (list or mail)
+		// is removed from the DOM entirely, so we must not allocate any offset space for it.
+		// We track the total width explicitly so getWidth() doesn't read a stale value from the
+		// last column, which may be the excluded one.
+		const isMultiColumn = this.viewColumns.filter((column) => column.isVisible).length > 1
+		const hasVisibleExclusive = this.viewColumns.some((column) => column.exclusive && column.isVisible)
 		let offset = 0
 
 		for (let column of this.viewColumns) {
 			if (column.columnType === ColumnType.Background || column.isVisible) {
-				column.offset = offset
-				offset += column.width
+				const excluded = isMultiColumn && hasVisibleExclusive && column.exclusive && !column.isVisible
+				if (!excluded) {
+					column.offset = offset
+					offset += column.width
+				}
 			}
 		}
+		this.totalWidth = offset
 	}
 
 	getWidth(): number {
-		let lastColumn = this.viewColumns[this.viewColumns.length - 1]
-		return lastColumn.offset + lastColumn.width
+		return this.totalWidth
 	}
 
 	getOffset(column: ViewColumn): number {
@@ -446,9 +466,13 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 	}
 
 	getPreviousColumn(): ViewColumn | null {
-		if (this.viewColumns.indexOf(this.visibleBackgroundColumns[0]) > 0 && !this.focusedColumn.isInForeground) {
-			let visibleColumnIndex = this.viewColumns.indexOf(this.visibleBackgroundColumns[0])
-			return this.viewColumns[visibleColumnIndex - 1]
+		// In exclusive mode the focused column replaces others at the same position, so we
+		// navigate relative to it rather than relative to the first visible background column
+		// (which would always be folderColumn, making "back" impossible from the reader).
+		const referenceColumn = this.focusedColumn.exclusive ? this.focusedColumn : this.visibleBackgroundColumns[0]
+		if (this.viewColumns.indexOf(referenceColumn) > 0 && !this.focusedColumn.isInForeground) {
+			let columnIndex = this.viewColumns.indexOf(referenceColumn)
+			return this.viewColumns[columnIndex - 1]
 		}
 
 		return null

--- a/src/common/gui/nav/ViewSlider.ts
+++ b/src/common/gui/nav/ViewSlider.ts
@@ -193,7 +193,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 		}
 	}
 
-	private updateVisibleBackgroundColumns() {
+	updateVisibleBackgroundColumns() {
 		// In case the first column (folder / sidebar / (calendar app settings categories) column should be rendered
 		// as a Background column instead of, as by default, as a Foreground column,
 		// we update the columnType on every redraw (orientation change, resize, etc.)
@@ -256,13 +256,13 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 
 		// First: try to find a background column which is not visible
 		let nextColumn = allColumns.find((column) => {
-			return column.columnType === ColumnType.Background && visibleColumns.indexOf(column) < 0
+			return column.columnType === ColumnType.Background && !column.exclusive && visibleColumns.indexOf(column) < 0
 		})
 
 		if (!nextColumn) {
 			// Second: if no more background columns are available add the foreground column to the visible columns
 			nextColumn = allColumns.find((column) => {
-				return column.columnType === ColumnType.Foreground && visibleColumns.indexOf(column) < 0
+				return column.columnType === ColumnType.Foreground && !column.exclusive && visibleColumns.indexOf(column) < 0
 			})
 		}
 
@@ -327,6 +327,7 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 			await this.busy
 			if (this.focusedColumn === viewColumn) return
 			// hide the foreground column if the column is in foreground
+			const previousColumnWasExclusive = this.focusedColumn.exclusive
 			if (this.focusedColumn.isInForeground) {
 				this.busy = this.slideForegroundColumn(this.focusedColumn, false)
 				await this.busy
@@ -345,6 +346,10 @@ export class ViewSlider implements Component<ViewSliderAttrs> {
 			}
 
 			await this.busy
+
+			if (viewColumn.exclusive || previousColumnWasExclusive) {
+				this.updateVisibleBackgroundColumns()
+			}
 		} finally {
 			// for updating header bar after animation
 			m.redraw()

--- a/src/common/misc/DeviceConfig.ts
+++ b/src/common/misc/DeviceConfig.ts
@@ -57,6 +57,8 @@ interface ConfigObject {
 	offlineTimeRangeDateByUser: Record<Id, number>
 	conversationViewShowOnlySelectedMail: boolean
 	mailListDisplayMode: MailListDisplayMode
+	/** Allow the user to hide the right pane */
+	hideReaderPane: boolean
 	/** Stores each users' definition about contact synchronization */
 	syncContactsWithPhonePreference: Record<Id, boolean>
 	/** Whether mobile calendar navigation is in the "per week" or "per month" mode */
@@ -146,6 +148,7 @@ export class DeviceConfig implements UsageTestStorage, NewsItemStorage {
 			offlineTimeRangeDateByUser: loadedConfig.offlineTimeRangeDateByUser ?? {},
 			conversationViewShowOnlySelectedMail: loadedConfig.conversationViewShowOnlySelectedMail ?? false,
 			mailListDisplayMode: loadedConfig.mailListDisplayMode ?? MailListDisplayMode.CONVERSATIONS,
+			hideReaderPane: loadedConfig.hideReaderPane ?? false,
 			syncContactsWithPhonePreference: loadedConfig.syncContactsWithPhonePreference ?? {},
 			isCalendarDaySelectorExpanded: loadedConfig.isCalendarDaySelectorExpanded ?? false,
 			mailAutoSelectBehavior: loadedConfig.mailAutoSelectBehavior ?? (isApp() ? ListAutoSelectBehavior.NONE : ListAutoSelectBehavior.OLDER),
@@ -432,6 +435,15 @@ export class DeviceConfig implements UsageTestStorage, NewsItemStorage {
 
 	setMailListDisplayMode(setting: MailListDisplayMode) {
 		this.config.mailListDisplayMode = setting
+		this.writeToStorage()
+	}
+
+	getHideReaderPane(): boolean {
+		return this.config.hideReaderPane
+	}
+
+	setHideReaderPane(setting: boolean) {
+		this.config.hideReaderPane = setting
 		this.writeToStorage()
 	}
 

--- a/src/common/misc/DeviceConfig.ts
+++ b/src/common/misc/DeviceConfig.ts
@@ -58,7 +58,7 @@ interface ConfigObject {
 	conversationViewShowOnlySelectedMail: boolean
 	mailListDisplayMode: MailListDisplayMode
 	/** Allow the user to hide the right pane */
-	hideReaderPane: boolean
+	mailNoPreviewMode: boolean
 	/** Stores each users' definition about contact synchronization */
 	syncContactsWithPhonePreference: Record<Id, boolean>
 	/** Whether mobile calendar navigation is in the "per week" or "per month" mode */
@@ -148,7 +148,7 @@ export class DeviceConfig implements UsageTestStorage, NewsItemStorage {
 			offlineTimeRangeDateByUser: loadedConfig.offlineTimeRangeDateByUser ?? {},
 			conversationViewShowOnlySelectedMail: loadedConfig.conversationViewShowOnlySelectedMail ?? false,
 			mailListDisplayMode: loadedConfig.mailListDisplayMode ?? MailListDisplayMode.CONVERSATIONS,
-			hideReaderPane: loadedConfig.hideReaderPane ?? false,
+			mailNoPreviewMode: loadedConfig.mailNoPreviewMode ?? false,
 			syncContactsWithPhonePreference: loadedConfig.syncContactsWithPhonePreference ?? {},
 			isCalendarDaySelectorExpanded: loadedConfig.isCalendarDaySelectorExpanded ?? false,
 			mailAutoSelectBehavior: loadedConfig.mailAutoSelectBehavior ?? (isApp() ? ListAutoSelectBehavior.NONE : ListAutoSelectBehavior.OLDER),
@@ -438,12 +438,12 @@ export class DeviceConfig implements UsageTestStorage, NewsItemStorage {
 		this.writeToStorage()
 	}
 
-	getHideReaderPane(): boolean {
-		return this.config.hideReaderPane
+	getMailNoPreviewMode(): boolean {
+		return this.config.mailNoPreviewMode
 	}
 
-	setHideReaderPane(setting: boolean) {
-		this.config.hideReaderPane = setting
+	setMailNoPreviewMode(setting: boolean) {
+		this.config.mailNoPreviewMode = setting
 		this.writeToStorage()
 	}
 

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -1,11 +1,5 @@
 // AUTO-GENERATED WITH tutanota-translation-sanitizer. DO NOT EDIT!
 export type TranslationKeyType =
-	// todo: remove me
-	| "mailNoPreviewMode_label"
-	| "mailNoPreviewModeWithReader_label"
-	| "mailNoPreviewModeWithoutReader_label"
-	| "mailNoPreviewModeHelp_msg"
-	// end todo
 	| "about_label"
 	| "accentColor_label"
 	| "accept_action"

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -1,5 +1,11 @@
 // AUTO-GENERATED WITH tutanota-translation-sanitizer. DO NOT EDIT!
 export type TranslationKeyType =
+	// todo: remove me
+	| "mailNoPreviewMode_label"
+	| "mailNoPreviewModeWithReader_label"
+	| "mailNoPreviewModeWithoutReader_label"
+	| "mailNoPreviewModeHelp_msg"
+	// end todo
 	| "about_label"
 	| "accentColor_label"
 	| "accept_action"

--- a/src/mail-app/mail/view/ConversationViewer.ts
+++ b/src/mail-app/mail/view/ConversationViewer.ts
@@ -11,6 +11,7 @@ import { component_size, px, size } from "../../../common/gui/size.js"
 import { Keys } from "../../../common/api/common/TutanotaConstants.js"
 import { keyManager, Shortcut } from "../../../common/misc/KeyManager.js"
 import { styles } from "../../../common/gui/styles.js"
+import { deviceConfig } from "../../../common/misc/DeviceConfig.js"
 import { responsiveCardHMargin } from "../../../common/gui/cards.js"
 import { MailTypeRef } from "../../../common/api/entities/tutanota/TypeRefs"
 import { assertNotNull, isSameTypeRef, ofClass } from "@tutao/tutanota-utils"
@@ -225,7 +226,7 @@ export class ConversationViewer implements Component<ConversationViewerAttrs> {
 						backgroundColor: theme.surface,
 						marginTop: px(position == null || position === 0 ? 0 : conversationCardMargin),
 						// column resize element takes some space, reduce margin to make the gap smaller
-						marginLeft: styles.isSingleColumnLayout() ? undefined : px(size.spacing_16),
+						marginLeft: deviceConfig.getMailNoPreviewMode() ? px(size.spacing_8) : styles.isSingleColumnLayout() ? undefined : px(size.spacing_16),
 					},
 				},
 				mailViewerViewModel.isCollapsed()

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -573,7 +573,11 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	}
 
 	view({ attrs }: Vnode<MailViewAttrs>): Children {
-		this.mailColumn.exclusive = deviceConfig.getMailNoPreviewMode()
+		const exclusive = deviceConfig.getMailNoPreviewMode()
+		if (this.mailColumn.exclusive !== exclusive) {
+			this.mailColumn.exclusive = exclusive
+			this.viewSlider.updateVisibleBackgroundColumns()
+		}
 		return m(
 			"#mail.main-view",
 			{

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -574,8 +574,12 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 
 	view({ attrs }: Vnode<MailViewAttrs>): Children {
 		const exclusive = deviceConfig.getMailNoPreviewMode()
+		// In no-preview mode, list and mail are mutually exclusive: only the focused one is shown
+		// alongside the folder sidebar. Marking both as exclusive prevents the layout algorithm
+		// from showing them side by side, and triggers an in-place DOM swap when switching.
 		if (this.mailColumn.exclusive !== exclusive) {
 			this.mailColumn.exclusive = exclusive
+			this.listColumn.exclusive = exclusive
 			this.viewSlider.updateVisibleBackgroundColumns()
 		}
 		return m(

--- a/src/mail-app/mail/view/MailView.ts
+++ b/src/mail-app/mail/view/MailView.ts
@@ -443,7 +443,20 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	private renderSingleMailViewer(header: AppHeaderAttrs, viewModel: ConversationViewModel) {
 		return m(BackgroundColumnLayout, {
 			backgroundColor: theme.surface_container,
-			desktopToolbar: () => m(DesktopViewerToolbar, this.mailViewerSingleActions(viewModel)),
+			desktopToolbar: () =>
+				m(
+					DesktopViewerToolbar,
+					{
+						leftContent: deviceConfig.getMailNoPreviewMode()
+							? m(IconButton, {
+									title: "back_action",
+									click: () => this.viewSlider.focusPreviousColumn(),
+									icon: Icons.ArrowBackward,
+								})
+							: null,
+					},
+					this.mailViewerSingleActions(viewModel),
+				),
 			mobileHeader: () =>
 				m(MobileHeader, {
 					...header,
@@ -560,6 +573,7 @@ export class MailView extends BaseTopLevelView implements TopLevelView<MailViewA
 	}
 
 	view({ attrs }: Vnode<MailViewAttrs>): Children {
+		this.mailColumn.exclusive = deviceConfig.getMailNoPreviewMode()
 		return m(
 			"#mail.main-view",
 			{

--- a/src/mail-app/settings/MailSettingsViewer.ts
+++ b/src/mail-app/settings/MailSettingsViewer.ts
@@ -335,6 +335,20 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 			},
 			dropdownWidth: 350,
 		}
+		const mailNoPreviewMode: DropDownSelectorAttrs<boolean> = {
+			label: "mailNoPreviewMode_label",
+			items: [
+				{ name: lang.getTranslationText("mailNoPreviewModeWithReader_label"), value: false },
+				{ name: lang.getTranslationText("mailNoPreviewModeWithoutReader_label"), value: true },
+			],
+			selectedValue: deviceConfig.getMailNoPreviewMode(),
+			helpLabel: () => lang.getTranslationText("mailNoPreviewModeHelp_msg"),
+			selectionChangedHandler: (arg: boolean) => {
+				deviceConfig.setMailNoPreviewMode(arg)
+				m.redraw()
+			},
+			dropdownWidth: 350,
+		}
 		return [
 			m(
 				"#user-settings.fill-absolute.scroll.plr-24.pb-48",
@@ -369,6 +383,7 @@ export class MailSettingsViewer implements UpdatableSettingsViewer {
 					m(".h4.mt-32#general", lang.get("general_label")),
 					m("#conversationthread", m(DropDownSelector, conversationViewDropdownAttrs)),
 					m("#maillistgrouping", m(DropDownSelector, mailListDisplayMode)),
+					m("#maillistissplit", m(DropDownSelector, mailNoPreviewMode)),
 					isBrowser() ? m("#mailindexing", m(DropDownSelector, enableMailIndexingAttrs)) : null,
 					m("#behavioraftermovingemail", m(DropDownSelector, behaviorAfterMoveEmailAction)),
 					m(".h4.mt-32#emailsending", lang.get("emailSending_label")),

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -3,12 +3,6 @@
 export default {
 	"code": "en",
 	"keys": {
-		// todo: remove me after the dev
-		"mailNoPreviewMode_label": "Show the reader",
-		"mailNoPreviewModeWithReader_label": "Yes",
-		"mailNoPreviewModeWithoutReader_label": "No",
-		"mailNoPreviewModeHelp_msg": "Set to no if you dosent want to get the email reader always next to the list of your email.",
-        // end of todo
 		"about_label": "About",
 		"accentColor_label": "Accent color",
 		"accept_action": "Accept",

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -3,6 +3,12 @@
 export default {
 	"code": "en",
 	"keys": {
+		// todo: remove me after the dev
+		"mailNoPreviewMode_label": "Show the reader",
+		"mailNoPreviewModeWithReader_label": "Yes",
+		"mailNoPreviewModeWithoutReader_label": "No",
+		"mailNoPreviewModeHelp_msg": "Set to no if you dosent want to get the email reader always next to the list of your email.",
+        // end of todo
 		"about_label": "About",
 		"accentColor_label": "Accent color",
 		"accept_action": "Accept",

--- a/test/tests/misc/DeviceConfigTest.ts
+++ b/test/tests/misc/DeviceConfigTest.ts
@@ -190,6 +190,7 @@ o.spec("DeviceConfig", function () {
 				retryRatingPromptAfter: null,
 				scrollTime: 8,
 				mailListDisplayMode: MailListDisplayMode.MAILS,
+				mailNoPreviewMode: false,
 				mailListSize: {},
 
 				_version: DeviceConfig.Version,


### PR DESCRIPTION
Hello, I have taken the liberty to open this PR to add a new option that I like in Gmail or Proton (for privacy and also because this is the way I like the UI to be displayed).

This PR add a user setting to hide the persistent reader pane in the mail view. When enabled, the layout switches from the classic 3-column design [folders | list | reader] to a 2-column design where the list and reader are mutually exclusive: [folders | list] ↔ [folders | reader].

I hope it respects your codding practice and architecture, I have done the best I can with your doc and considering that I don't know the project as well has you :slightly_smiling_face: 

I don't know either what is your `dev` branch, so I create the PR on master, I let you change it with the right one.

### What changes
New setting (Mail section): "Show the reader" — when set to No, the reader pane is hidden until the user opens an email.

### Layout behavior
  - The folder sidebar always stays visible.
  - Clicking an email replaces the list column with the reader column in-place (no horizontal slide on desktop).
  - A back button appears in the reader toolbar to return to the list.
  - On mobile the existing single-column slide navigation is unchanged.

<img width="2287" height="1308" alt="Screenshot_20260305_122831" src="https://github.com/user-attachments/assets/e9ef7e8c-5e71-4c4c-9384-8579aa141f0d" />
<img width="2282" height="1300" alt="Screenshot_20260305_122926" src="https://github.com/user-attachments/assets/9e1c4c11-df27-49ac-a0ce-c5b8ccded839" />

### Test 
- `cargo test --all` pass with one error that seem not related to my code.
- `npm test` is ok too.

### Translation
For local dev I have added these translations manually, there are removed in this PR:

In `TranslationKey.ts`
```
| "mailNoPreviewMode_label"
| "mailNoPreviewModeWithReader_label"
| "mailNoPreviewModeWithoutReader_label"
| "mailNoPreviewModeHelp_msg"
```

In `en.ts`
```
"mailNoPreviewMode_label": "Show the reader",
"mailNoPreviewModeWithReader_label": "Yes",
"mailNoPreviewModeWithoutReader_label": "No",
"mailNoPreviewModeHelp_msg": "Set to no if you dosent want to get the email reader always next to the list of your email.",
```