### PR TITLE
fix cache storage is not initialized

### DIFF
--- a/src/common/api/common/utils/spamClassificationUtils/PreprocessPatterns.ts
+++ b/src/common/api/common/utils/spamClassificationUtils/PreprocessPatterns.ts
@@ -11,18 +11,18 @@ export const ML_DATE_REGEX = [
 
 export const ML_DATE_TOKEN = " TDATE "
 
-export const ML_URL_REGEX = /(?:http|https|ftp|sftp):\/\/([\w.-]+)(?:\/[^\s]*)?/g
+export const ML_URL_REGEX = /(?:https?|ftp):\/\/([\w.-]+)(?:\/[^\s]*)?/g
 
 export const ML_URL_TOKEN = " TURL$1 "
 
-export const ML_EMAIL_ADDR_REGEX = /(?:mailto:)?[A-Za-z0-9_+\-.]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g
+export const ML_EMAIL_ADDR_REGEX = /(?:mailto:)?[A-Za-z0-9_+\-.]+@(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,}(?![\w.-])/g
 export const ML_EMAIL_ADDR_TOKEN = " TEMAIL "
 
 export const ML_BITCOIN_REGEX = /\b[13][a-km-zA-HJ-NP-Z1-9]{25,34}\b/g
 
 export const ML_BITCOIN_TOKEN = " TBITCOIN "
 
-export const ML_CREDIT_CARD_REGEX = /\b(\d{4}\s?){4}\b|\b[0-9]\d{13,16}\b/g
+export const ML_CREDIT_CARD_REGEX = /\b(?:\d{4}[\s-]?){3}\d{4}\b/g
 
 export const ML_CREDIT_CARD_TOKEN = " TCREDITCARD "
 

--- a/src/common/api/common/utils/spamClassificationUtils/SpamMailProcessor.ts
+++ b/src/common/api/common/utils/spamClassificationUtils/SpamMailProcessor.ts
@@ -97,51 +97,58 @@ export class SpamMailProcessor {
 
 		let preprocessedMail = mailText
 
-		// 1. Remove HTML code
-		if (this.preprocessConfiguration.isRemoveHTML) {
-			preprocessedMail = htmlToText(preprocessedMail)
-		}
-
-		// 2. Replace dates
-		if (this.preprocessConfiguration.isReplaceDates) {
-			for (const datePattern of ML_DATE_REGEX) {
-				preprocessedMail = preprocessedMail.replaceAll(datePattern, ML_DATE_TOKEN)
+		try {
+			// 1. Remove HTML code
+			if (this.preprocessConfiguration.isRemoveHTML) {
+				preprocessedMail = htmlToText(preprocessedMail)
 			}
-		}
 
-		// 3. Replace urls
-		if (this.preprocessConfiguration.isReplaceUrls) {
-			preprocessedMail = preprocessedMail.replaceAll(ML_URL_REGEX, ML_URL_TOKEN)
-		}
+			// 2. Replace dates
+			if (this.preprocessConfiguration.isReplaceDates) {
+				for (const datePattern of ML_DATE_REGEX) {
+					preprocessedMail = preprocessedMail.replaceAll(datePattern, ML_DATE_TOKEN)
+				}
+			}
 
-		// 4. Replace email addresses
-		if (this.preprocessConfiguration.isReplaceMailAddresses) {
-			preprocessedMail = preprocessedMail.replaceAll(ML_EMAIL_ADDR_REGEX, ML_EMAIL_ADDR_TOKEN)
-		}
+			// 3. Replace urls
+			if (this.preprocessConfiguration.isReplaceUrls) {
+				preprocessedMail = preprocessedMail.replaceAll(ML_URL_REGEX, ML_URL_TOKEN)
+			}
 
-		// 5. Replace Bitcoin addresses
-		if (this.preprocessConfiguration.isReplaceBitcoinAddress) {
-			preprocessedMail = preprocessedMail.replaceAll(ML_BITCOIN_REGEX, ML_BITCOIN_TOKEN)
-		}
+			// 4. Replace email addresses
+			if (this.preprocessConfiguration.isReplaceMailAddresses) {
+				preprocessedMail = preprocessedMail.replaceAll(ML_EMAIL_ADDR_REGEX, ML_EMAIL_ADDR_TOKEN)
+			}
 
-		// 6. Replace credit card numbers
-		if (this.preprocessConfiguration.isReplaceCreditCards) {
-			preprocessedMail = preprocessedMail.replaceAll(ML_CREDIT_CARD_REGEX, ML_CREDIT_CARD_TOKEN)
-		}
+			// 5. Replace Bitcoin addresses
+			if (this.preprocessConfiguration.isReplaceBitcoinAddress) {
+				preprocessedMail = preprocessedMail.replaceAll(ML_BITCOIN_REGEX, ML_BITCOIN_TOKEN)
+			}
 
-		// 7. Replace remaining numbers
-		if (this.preprocessConfiguration.isReplaceNumbers) {
-			preprocessedMail = preprocessedMail.replaceAll(ML_NUMBER_SEQUENCE_REGEX, ML_NUMBER_SEQUENCE_TOKEN)
-		}
+			// 6. Replace credit card numbers
+			if (this.preprocessConfiguration.isReplaceCreditCards) {
+				preprocessedMail = preprocessedMail.replaceAll(ML_CREDIT_CARD_REGEX, ML_CREDIT_CARD_TOKEN)
+			}
 
-		// 8. Remove special characters
-		if (this.preprocessConfiguration.isReplaceSpecialCharacters) {
-			preprocessedMail = preprocessedMail.replaceAll(ML_SPECIAL_CHARACTER_REGEX, ML_SPECIAL_CHARACTER_TOKEN)
-		}
+			// 7. Replace remaining numbers
+			if (this.preprocessConfiguration.isReplaceNumbers) {
+				preprocessedMail = preprocessedMail.replaceAll(ML_NUMBER_SEQUENCE_REGEX, ML_NUMBER_SEQUENCE_TOKEN)
+			}
 
-		// 9. Remove spaces at end of lines
-		if (this.preprocessConfiguration.isRemoveSpaceBeforeNewLine) {
-			preprocessedMail = preprocessedMail.replaceAll(ML_SPACE_BEFORE_NEW_LINE_REGEX, ML_SPACE_BEFORE_NEW_LINE_TOKEN)
+			// 8. Remove special characters
+			if (this.preprocessConfiguration.isReplaceSpecialCharacters) {
+				preprocessedMail = preprocessedMail.replaceAll(ML_SPECIAL_CHARACTER_REGEX, ML_SPECIAL_CHARACTER_TOKEN)
+			}
+
+			// 9. Remove spaces at end of lines
+			if (this.preprocessConfiguration.isRemoveSpaceBeforeNewLine) {
+				preprocessedMail = preprocessedMail.replaceAll(ML_SPACE_BEFORE_NEW_LINE_REGEX, ML_SPACE_BEFORE_NEW_LINE_TOKEN)
+			}
+		} catch (e) {
+			// Preprocessing for this mail fail failed, due to an REGEX error, most likely too much recursion,
+			// e.g. too complex html. We just continue in this case, and do not include the mail body
+			// in the training / prediction.
+			preprocessedMail = ""
 		}
 
 		preprocessedMail += this.getHeaderFeatures(mail)

--- a/src/common/api/worker/facades/LoginFacade.ts
+++ b/src/common/api/worker/facades/LoginFacade.ts
@@ -830,18 +830,24 @@ export class LoginFacade {
 	 */
 	private async initCache({ userId, databaseKey, timeRangeDate, forceNewDatabase }: InitCacheOptions): Promise<CacheInfo> {
 		if (databaseKey != null) {
-			return {
+			const { isPersistent, isNewOfflineDb } = await this.cacheInitializer.initialize({
+				type: "offline",
+				userId,
 				databaseKey,
-				...(await this.cacheInitializer.initialize({
-					type: "offline",
-					userId,
-					databaseKey,
-					timeRangeDate,
-					forceNewDatabase,
-				})),
+				timeRangeDate,
+				forceNewDatabase,
+			})
+			return {
+				isPersistent,
+				isNewOfflineDb,
+				databaseKey,
 			}
 		} else {
-			return { databaseKey: null, ...(await this.cacheInitializer.initialize({ type: "ephemeral", userId })) }
+			const { isPersistent, isNewOfflineDb } = await this.cacheInitializer.initialize({
+				type: "ephemeral",
+				userId,
+			})
+			return { isPersistent, isNewOfflineDb, databaseKey: null }
 		}
 	}
 

--- a/src/common/api/worker/offline/OfflineStorage.ts
+++ b/src/common/api/worker/offline/OfflineStorage.ts
@@ -208,6 +208,10 @@ export class OfflineStorage implements CacheStorage {
 		this.allTables = Object.freeze(Object.assign({}, additionalTables, TableDefinitions))
 	}
 
+	isInitialized(): boolean {
+		return this.userId != null
+	}
+
 	async getWholeListParsed(typeRef: TypeRef<unknown>, listId: string): Promise<ServerModelParsedInstance[]> {
 		const { query, params } = sql`SELECT entity
                                     FROM list_entities

--- a/src/common/api/worker/rest/CacheStorageProxy.ts
+++ b/src/common/api/worker/rest/CacheStorageProxy.ts
@@ -44,12 +44,15 @@ export type SomeStorage = OfflineStorage | EphemeralCacheStorage
  */
 export class LateInitializedCacheStorageImpl implements CacheStorageLateInitializer, CacheStorage {
 	private _inner: SomeStorage | null = null
-
 	constructor(
 		private readonly sendError: (error: Error) => Promise<void>,
 		private readonly ephemeralStorageProvider: () => Promise<EphemeralCacheStorage>,
 		private readonly offlineStorageProvider: () => Promise<null | OfflineStorage>,
 	) {}
+
+	isInitialized(): boolean {
+		return this._inner?.isInitialized() ?? false
+	}
 
 	async getParsed(typeRef: TypeRef<unknown>, listId: string | null, id: string): Promise<ServerModelParsedInstance | null> {
 		return await this.inner.getParsed(typeRef, listId, id)
@@ -83,7 +86,7 @@ export class LateInitializedCacheStorageImpl implements CacheStorageLateInitiali
 
 	async initialize(args: OfflineStorageArgs | EphemeralStorageArgs): Promise<CacheStorageInitReturn> {
 		// We might call this multiple times.
-		// This happens when persistent credentials login fails and we need to start with new cache for new login.
+		// This happens when persistent credentials login fails, and we need to start with new cache for new login.
 		const { storage, isPersistent, isNewOfflineDb } = await this.getStorage(args)
 		this._inner = storage
 		return {

--- a/src/common/api/worker/rest/DefaultEntityRestCache.ts
+++ b/src/common/api/worker/rest/DefaultEntityRestCache.ts
@@ -265,6 +265,8 @@ export interface CacheStorage extends ExposedCacheStorage {
 	getUserId(): Id
 
 	deleteAllOwnedBy(owner: Id): Promise<void>
+
+	isInitialized(): boolean
 }
 
 /**
@@ -947,6 +949,12 @@ export class DefaultEntityRestCache implements EntityRestCache {
 	 * @return true if the cache can be used, false if a direct network request should be performed
 	 */
 	private shouldUseCache(typeRef: TypeRef<any>, opts?: EntityRestClientLoadOptions): boolean {
+		// if the cacheStorage for some reason is not (yet) initialized we can not use the cache,
+		// but still want to be able to use the client and do a login, etc.
+		if (!this.storage.isInitialized()) {
+			return false
+		}
+
 		// some types won't be cached
 		if (isIgnoredType(typeRef)) {
 			return false

--- a/src/common/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/common/api/worker/rest/EphemeralCacheStorage.ts
@@ -48,12 +48,15 @@ export class EphemeralCacheStorage implements CacheStorage {
 	private lastTrainedFromScratchTime: number | null = null
 	private userId: Id | null = null
 	private lastBatchIdPerGroup = new Map<Id, Id>()
-
 	constructor(
 		private readonly modelMapper: ModelMapper,
 		private readonly typeModelResolver: ServerTypeModelResolver,
 		private readonly customCacheHandlerMap: CustomCacheHandlerMap,
 	) {}
+
+	isInitialized(): boolean {
+		return this.userId != null
+	}
 
 	init({ userId }: EphemeralStorageInitArgs) {
 		this.userId = userId

--- a/src/common/gui/base/Dialog.ts
+++ b/src/common/gui/base/Dialog.ts
@@ -29,7 +29,7 @@ import Stream from "mithril/stream"
 import { client } from "../../misc/ClientDetector"
 
 assertMainOrNode()
-export const INPUT = "input, textarea, div[contenteditable='true']"
+export const INPUT = "input.text, input.tutaui-text-field, textarea, div[contenteditable='true']"
 
 export const enum DialogType {
 	Progress = "Progress",
@@ -224,7 +224,8 @@ export class Dialog implements ModalComponent {
 	}
 
 	/**
-	 * By default the focus is set on the first text field after this dialog is fully visible. This behavior can be overwritten by calling this function.
+	 * By default, the focus is set on the first text field after this dialog is fully visible.
+	 * This behavior can be overwritten by calling this function.
 	 * If it has already been called, then calls it instantly
 	 */
 	setFocusOnLoadFunction(callback: Dialog["focusOnLoadFunction"]): void {

--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -2246,3 +2246,4 @@ export type TranslationKeyType =
 	| "emptyString_msg"
 	| "contactDeletionMoveToSpam_msg"
 	| "contactDeletionMoveToSpam_title"
+	| "userAlreadyAssignedToAllAvailableGroups_msg"

--- a/src/common/settings/UserViewer.ts
+++ b/src/common/settings/UserViewer.ts
@@ -43,12 +43,14 @@ export class UserViewer implements UpdatableSettingsDetailsViewer {
 	private usedStorage: number | null = null
 	private mailAddressTableModel: MailAddressTableModel | null = null
 	private mailAddressTableExpanded: boolean
+	private isPurchasingNewSharedMailbox: boolean
 
 	constructor(
 		public userGroupInfo: GroupInfo,
 		private isAdmin: boolean,
 	) {
 		this.userGroupInfo = userGroupInfo
+		this.isPurchasingNewSharedMailbox = false
 
 		this.mailAddressTableExpanded = false
 
@@ -339,6 +341,10 @@ export class UserViewer implements UpdatableSettingsDetailsViewer {
 						dialog.close()
 					},
 				})
+			} else {
+				showAddGroupDialog(() => {
+					this.isPurchasingNewSharedMailbox = true
+				})
 			}
 		}
 	}
@@ -411,6 +417,14 @@ export class UserViewer implements UpdatableSettingsDetailsViewer {
 				this.userGroupInfo = await locator.entityClient.load(GroupInfoTypeRef, this.userGroupInfo._id)
 				await this.updateUsedStorageAndAdminFlag()
 				m.redraw()
+			} else if (this.isPurchasingNewSharedMailbox && isUpdateForTypeRef(GroupInfoTypeRef, update) && operation === OperationType.CREATE) {
+				// When getting a create event, if user has just bought a new shared mailbox, add it to the selected user
+				const groupInfo = await locator.entityClient.load(GroupInfoTypeRef, [neverNull(instanceListId), instanceId])
+				await this.teamGroupInfos.reload()
+				this.isPurchasingNewSharedMailbox = false
+				const user = await this.user.getAsync()
+				showProgressDialog("pleaseWait_msg", locator.groupManagementFacade.addUserToGroup(user, groupInfo.group))
+				m.redraw()
 			} else if (
 				isUpdateForTypeRef(UserTypeRef, update) &&
 				operation === OperationType.UPDATE &&
@@ -461,4 +475,19 @@ export function showUserImportDialog(customDomains: string[]) {
 			}
 		},
 	})
+}
+
+export async function showAddGroupDialog(userConfirmedAddingGroup: () => void) {
+	const isCreateNewGroupSelected = await Dialog.choice("userAlreadyAssignedToAllAvailableGroups_msg", [
+		{ text: "close_alt", value: false },
+		{
+			text: "addGroup_label",
+			value: true,
+		},
+	])
+	if (isCreateNewGroupSelected) {
+		const { show } = await import("./../../mail-app/settings/groups/AddGroupDialog.js")
+		show()
+		userConfirmedAddingGroup()
+	}
 }

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -2248,5 +2248,6 @@ export default {
 		"zoomOut_action": "Herauszoomen",
 		"contactDeletionMoveToSpam_msg": "Du hast eine E-Mail von einem deiner Kontakte in den Spamordner verschoben.\nMails von Kontakte werden nie als Spam eingestuft.\nMöchtest du den/die ausgewählten Kontakt(e) löschen?",
 		"contactDeletionMoveToSpam_title": "Kontakt(e) löschen?",
+		"userAlreadyAssignedToAllAvailableGroups_msg": "Der Nutzer wurde bereits in alle verfügbaren Gruppen hinzugefügt.\nMöchtest du eine neue Geteilte Mailbox Gruppe erstellen und den Nutzer zu dieser neuen Gruppe hinzufügen?"
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -2248,5 +2248,6 @@ export default {
 		"zoomOut_action": "Herauszoomen",
 		"contactDeletionMoveToSpam_msg": "Sie haben eine E-Mail von einem Ihrer Kontakte in den Spamordner verschoben.\nMails von Kontakte werden nie als Spam eingestuft.\nMöchten Sie den/die ausgewählten Kontakt(e) löschen?",
 		"contactDeletionMoveToSpam_title": "Kontakt(e) löschen?",
+		"userAlreadyAssignedToAllAvailableGroups_msg": "Der Nutzer wurde bereits in alle verfügbaren Gruppen hinzugefügt.\nMöchten Sie eine neue Geteilte Mailbox Gruppe erstellen und den Nutzer zu dieser neuen Gruppe hinzufügen?"
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -2248,5 +2248,6 @@ export default {
 		"zoomOut_action": "Zoom Out",
 		"contactDeletionMoveToSpam_msg": "You have moved an email from a contact to the spam folder.\nMails sent by contacts are never classified as spam.\nWould you like to delete the selected contact(s)?",
 		"contactDeletionMoveToSpam_title": "Delete contact(s)?",
+		"userAlreadyAssignedToAllAvailableGroups_msg": "This user is already assigned to all available groups.\nWould you like to create a new shared mailbox group and add the user to this new group?"
 	}
 }

--- a/test/tests/api/worker/utils/spamClassification/SpamClassifierTest.ts
+++ b/test/tests/api/worker/utils/spamClassification/SpamClassifierTest.ts
@@ -373,7 +373,7 @@ Hello TSPECIALCHAR  these are my MAC Address
 \t\t\t\t§
 \t\t\t\tNumber Sequences TSPECIALCHAR
 \t\t\t\t TNUMBER
-\t\t\t\tIBAN TSPECIALCHAR  DE91  TCREDITCARD  TNUMBER
+\t\t\t\tIBAN TSPECIALCHAR  DE91  TCREDITCARD   TNUMBER
 \t\t\t\tNot Number Sequences
 \t\t\t\tSHLT116
 \t\t\t\tgb TSPECIALCHAR 67ca4b


### PR DESCRIPTION
When the cache storage is not initialized for some reason, e.g. due to weird concurrency, we should not try to write to it. In these cases it's still better to continue and load the instance from the server without writing it to the cache storage, instead of throwing an error. The cache storage is not initialized error is preventing users in some cases to do a login at all, which should always be possible.