### PR TITLE
 fix: unset repository url error during custom desktop release

### DIFF
--- a/buildSrc/electron-package-json-template.js
+++ b/buildSrc/electron-package-json-template.js
@@ -58,7 +58,7 @@ export default async function generateTemplate({ nameSuffix, version, updateUrl,
 					publishAutoUpdate: true,
 					useMultipleRangeRequest: false,
 				}
-			: undefined,
+			: null,
 		directories: {
 			output: "installers",
 		},

--- a/doc/BUILDING.md
+++ b/doc/BUILDING.md
@@ -94,8 +94,8 @@ Keep in mind that your own build of Tuta Mail Desktop will not update automatica
 1. Build packages: `npm run build-packages`
 2. Run `node desktop --custom-desktop-release`.
 
-The client for your platform will be in `build/desktop/`. Note that you can add `--unpacked` to the build command to
-skip the packaging of the installer. This will yield a directory containing the client that can be run without
+The client for your platform will be in `artifacts/desktop/`. Note that you can add `--unpacked` to the build command to
+skip the packaging of the installer. This will yield a directory in `build/desktop/` containing the client that can be run without
 installation.
 
 ### Extra Notes:


### PR DESCRIPTION
# Problem

Attempting to follow the build instructions in [BUILDING.md](https://github.com/tutao/tutanota/blob/master/doc/BUILDING.md#building-and-running-your-own-tuta-mail-desktop-client) for a custom desktop release fails with the following error:

```
Build error: Error: Cannot detect repository by .git/config. Please specify "repository" in the package.json (https://docs.npmjs.com/files/package.json#repository).
Please see https://electron.build/publish
    at getInfo (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/publish/PublishManager.ts:564:13)
    at getResolvedPublishConfig (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/publish/PublishManager.ts:573:18)
    at resolvePublishConfigurations (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/publish/PublishManager.ts:456:16)
    at getPublishConfigs (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/publish/PublishManager.ts:430:10)
    at getAppUpdatePublishConfiguration (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/publish/PublishManager.ts:255:73)
    at /home/patrick/code/tutanota/node_modules/app-builder-lib/src/publish/PublishManager.ts:125:29
    at emitInternal (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/util/asyncEventEmitter.ts:61:9)
    at AsyncEventEmitter.emit (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/util/asyncEventEmitter.ts:66:28)
    at Packager.emitAfterPack (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/packager.ts:334:5)
    at LinuxPackager.doPack (/home/patrick/code/tutanota/node_modules/app-builder-lib/src/platformPackager.ts:341:5)
```

# Reproducing

Follow the instructions in [BUILDING.md](https://github.com/tutao/tutanota/blob/master/doc/BUILDING.md#building-and-running-your-own-tuta-mail-desktop-client) for a custom desktop release.

# Changes

1. Set the `publish` value to `null` instead of `undefined` in the electron `package.json` when performing a custom desktop release.

This is doesn't seem well documented in the electron-builder documentation, but I found some mentions of it in various github issues [like this one](https://github.com/electron-userland/electron-builder/issues/1334). This resolves the issue for the workflow described for me.

2. Update the output directories mentioned for the desktop client

[It looks like a couple of years ago](https://github.com/tutao/tutanota/commit/487e4431a06d9897297f06711f8b71ba1c192e53), the output directory for the bundled client was updated. This results in artifacts (such as an AppImage) being located in `artifacts/desktop`, but the unbundled files are still in `build/desktop`.