### PR TITLE
Drive: fix pre-selection of basename not working in file rename dialog

### DIFF
--- a/src/common/gui/base/LoginTextField.ts
+++ b/src/common/gui/base/LoginTextField.ts
@@ -264,8 +264,8 @@ export class LoginTextField implements ClassComponent<LoginTextFieldAttrs> {
 						class: getOperatingClasses(a.disabled) + " text",
 						oncreate: (vnode) => {
 							this.domInput = vnode.dom as HTMLInputElement
-							a.onDomInputCreated?.(this.domInput)
 							this.domInput.value = a.value
+							a.onDomInputCreated?.(this.domInput)
 							if (a.type !== TextFieldType.Area) {
 								;(vnode.dom as HTMLElement).addEventListener("animationstart", (e: AnimationEvent) => {
 									if (e.animationName === "onAutoFillStart") {


### PR DESCRIPTION
When this dialog was switched from `TextField` to `LoginTextField`, this functionality had been broken. This is because the dialog expects `onDomInputCreated` to be called by the text field *after* its value has already been populated, and this was not the case in `LoginTextField`.

This makes its behaviour match `TextField`.

tuta#3250