### PR TITLE
Undo renaming IdTuple to IdTupleCustom

### DIFF
--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/Agenda.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/Agenda.kt
@@ -50,7 +50,7 @@ import de.tutao.calendar.widget.style.AppTheme
 import de.tutao.calendar.widget.style.Dimensions
 import de.tutao.tutasdk.Sdk
 import de.tutao.tutashared.AndroidNativeCryptoFacade
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.SdkFileClient
 import de.tutao.tutashared.SdkRestClient
 import de.tutao.tutashared.credentials.CredentialsEncryptionFactory
@@ -219,7 +219,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents[startOfToday] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"All day today",
 				"08:00",
@@ -236,7 +236,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents[startOfAfterTomorrow] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello Widget",
 				"08:00",
@@ -271,7 +271,7 @@ class Agenda : GlanceAppWidget() {
 		normalEventData[startOfToday] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello Widget wiith very long event title",
 				"08:00",
@@ -283,7 +283,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents[startOfToday] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"My all day which has a very very long title",
 				"00:00",
@@ -293,7 +293,7 @@ class Agenda : GlanceAppWidget() {
 			),
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Second all day event",
 				"00:00",
@@ -311,7 +311,7 @@ class Agenda : GlanceAppWidget() {
 			normalEventData[startOfTomorrow] = normalEventData[startOfTomorrow]!!.plus(
 				UIEvent(
 					"previewCalendar",
-					IdTupleCustom("", ""),
+					IdTuple("", ""),
 					"2196f3",
 					"Event #${i}",
 					"08:00",
@@ -325,7 +325,7 @@ class Agenda : GlanceAppWidget() {
 		allDayEvents[startOfTomorrow] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Something else",
 				"00:00",
@@ -335,7 +335,7 @@ class Agenda : GlanceAppWidget() {
 			),
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Vacations",
 				"00:00",
@@ -351,7 +351,7 @@ class Agenda : GlanceAppWidget() {
 		normalEventData[startOfAfterTomorrow] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello After Tomorrow Bit title",
 				"08:00",
@@ -361,7 +361,7 @@ class Agenda : GlanceAppWidget() {
 			),
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Meeting After Tomorrow",
 				"12:00",
@@ -394,7 +394,7 @@ class Agenda : GlanceAppWidget() {
 		normalEventData[startOfToday] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello Widget with very long name",
 				"08:00",
@@ -410,7 +410,7 @@ class Agenda : GlanceAppWidget() {
 		normalEventData[startOfTomorrow] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello Tomorrow",
 				"08:00",
@@ -420,7 +420,7 @@ class Agenda : GlanceAppWidget() {
 			),
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Meeting Tomorrow",
 				"12:00",
@@ -436,7 +436,7 @@ class Agenda : GlanceAppWidget() {
 		normalEventData[startOfAfterTomorrow] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello After Tomorrow Big Title",
 				"08:00",
@@ -446,7 +446,7 @@ class Agenda : GlanceAppWidget() {
 			),
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Meeting After Tomorrow",
 				"12:00",
@@ -485,7 +485,7 @@ class Agenda : GlanceAppWidget() {
 		normalEventData[startOfTomorrow] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello Tomorrow",
 				"08:00",
@@ -495,7 +495,7 @@ class Agenda : GlanceAppWidget() {
 			),
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Meeting Tomorrow",
 				"12:00",
@@ -511,7 +511,7 @@ class Agenda : GlanceAppWidget() {
 		normalEventData[startOfAfterTomorrow] = listOf(
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Hello After Tomorrow Big Title",
 				"08:00",
@@ -521,7 +521,7 @@ class Agenda : GlanceAppWidget() {
 			),
 			UIEvent(
 				"previewCalendar",
-				IdTupleCustom("", ""),
+				IdTuple("", ""),
 				"2196f3",
 				"Meeting After Tomorrow",
 				"12:00",

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/component/eventCard/EventRow.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/component/eventCard/EventRow.kt
@@ -25,7 +25,7 @@ import androidx.glance.text.TextStyle
 import de.tutao.calendar.R
 import de.tutao.calendar.widget.data.UIEvent
 import de.tutao.calendar.widget.style.Dimensions
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.midnightInDate
 import de.tutao.tutashared.parseColor
 import java.time.Instant
@@ -79,7 +79,7 @@ fun EventRowTodayPreview() {
 		modifier = GlanceModifier,
 		UIEvent(
 			"previewCalendar",
-			IdTupleCustom("", ""),
+			IdTuple("", ""),
 			"2196f3",
 			"Hello Widget",
 			"08:00",
@@ -101,7 +101,7 @@ fun EventRowTomorrowPreview() {
 		modifier = GlanceModifier,
 		UIEvent(
 			"previewCalendar",
-			IdTupleCustom("", ""),
+			IdTuple("", ""),
 			"2196f3",
 			"Hello Widget",
 			"08:00",

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/component/otherDayCard/AllDaySection.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/component/otherDayCard/AllDaySection.kt
@@ -14,7 +14,7 @@ import androidx.glance.preview.Preview
 import de.tutao.calendar.widget.component.allDayRow.AllDayRow
 import de.tutao.calendar.widget.data.UIEvent
 import de.tutao.calendar.widget.style.Dimensions
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 
 @Composable
 fun AllDaySection(allDayEvents: List<UIEvent>) {
@@ -36,7 +36,7 @@ fun AllDaySectionPreview() {
 	AllDaySection(
 		allDayEvents = listOf(
 			UIEvent(
-				"calendarId", IdTupleCustom("list", "elemnt"), "dd55ff", "My all day", "", "", true, 0L
+				"calendarId", IdTuple("list", "elemnt"), "dd55ff", "My all day", "", "", true, 0L
 			)
 		)
 	)
@@ -50,7 +50,7 @@ fun AllDaySectionBirthdayPreview() {
 	AllDaySection(
 		allDayEvents = listOf(
 			UIEvent(
-				"calendarId", IdTupleCustom("list", "elemnt"), "aa55ff", "Jane Birthday", "", "", true, 0L, true
+				"calendarId", IdTuple("list", "elemnt"), "aa55ff", "Jane Birthday", "", "", true, 0L, true
 			)
 		)
 	)

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventDao.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/CalendarEventDao.kt
@@ -1,11 +1,11 @@
 package de.tutao.calendar.widget.data
 
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class CalendarEventDao(
-	val id: IdTupleCustom?,
+	val id: IdTuple?,
 	val startTime: ULong,
 	val endTime: ULong,
 	val summary: String

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/UIEvent.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/UIEvent.kt
@@ -1,11 +1,11 @@
 package de.tutao.calendar.widget.data
 
 import de.tutao.tutasdk.GeneratedId
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 
 data class UIEvent(
 	val calendarId: GeneratedId,
-	val eventId: IdTupleCustom?,
+	val eventId: IdTuple?,
 	val calendarColor: String,
 	val summary: String,
 	val startTime: String,

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetDataRepository.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/data/WidgetDataRepository.kt
@@ -13,7 +13,7 @@ import de.tutao.tutasdk.CalendarEvent
 import de.tutao.tutasdk.GeneratedId
 import de.tutao.tutasdk.LoggedInSdk
 import de.tutao.tutashared.AndroidNativeCryptoFacade
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.base64ToBytes
 import de.tutao.tutashared.ipc.UnencryptedCredentials
 import de.tutao.tutashared.toBase64
@@ -208,7 +208,7 @@ class WidgetDataRepository private constructor() : WidgetRepository() {
 			val id = it.id ?: throw RuntimeException("Trying to convert an event without id to CalendarEventDao")
 
 			CalendarEventDao(
-				IdTupleCustom(id.listId, id.elementId),
+				IdTuple(id.listId, id.elementId),
 				it.startTime,
 				it.endTime,
 				it.summary
@@ -223,7 +223,7 @@ class WidgetDataRepository private constructor() : WidgetRepository() {
 			val age = it.contact.birthdayIso?.let { it1 -> calculateContactAge(it1) }
 
 			val event = CalendarEventDao(
-				IdTupleCustom(id.listId, id.elementId),
+				IdTuple(id.listId, id.elementId),
 				it.calendarEvent.startTime,
 				it.calendarEvent.endTime,
 				"" // The event title will be set later inside the composition

--- a/app-android/calendar/src/main/java/de/tutao/calendar/widget/model/WidgetUIViewModel.kt
+++ b/app-android/calendar/src/main/java/de/tutao/calendar/widget/model/WidgetUIViewModel.kt
@@ -23,7 +23,7 @@ import de.tutao.calendar.widget.widgetDataStore
 import de.tutao.tutasdk.LoginException
 import de.tutao.tutasdk.Sdk
 import de.tutao.tutashared.AndroidNativeCryptoFacade
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.base64ToBase64Url
 import de.tutao.tutashared.ipc.CalendarOpenAction
 import de.tutao.tutashared.ipc.NativeCredentialsFacade
@@ -353,7 +353,7 @@ fun openCalendarAgenda(
 	context: Context,
 	userId: String? = "",
 	date: LocalDateTime = LocalDateTime.now(),
-	eventId: IdTupleCustom? = null
+	eventId: IdTuple? = null
 ): Action {
 	val openCalendarAgenda = Intent(context, MainActivity::class.java)
 	openCalendarAgenda.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/app-android/calendar/src/test/java/de/tutao/calendar/WidgetRepositoryTest.kt
+++ b/app-android/calendar/src/test/java/de/tutao/calendar/WidgetRepositoryTest.kt
@@ -23,7 +23,7 @@ import de.tutao.tutasdk.LoggedInSdk
 import de.tutao.tutasdk.Sdk
 import de.tutao.tutashared.AndroidNativeCryptoFacade
 import de.tutao.tutashared.CredentialType
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.base64ToBytes
 import de.tutao.tutashared.ipc.CredentialsInfo
 import de.tutao.tutashared.ipc.DataWrapper
@@ -103,7 +103,7 @@ class WidgetRepositoryTest {
 		whenever(mockedCryptoFacade.aesEncryptData(any(), any(), any())).thenReturn(ByteArray(0))
 
 		workCalendarEvent = createTestCalendarEvent(
-			id = IdTupleCustom(
+			id = IdTuple(
 				"workCalendarList", "workCalendarEvent"
 			)
 		)
@@ -111,7 +111,7 @@ class WidgetRepositoryTest {
 		workCalendarEventsList.shortEvents = listOf(workCalendarEvent)
 
 		personalCalendarEvent = createTestCalendarEvent(
-			id = IdTupleCustom(
+			id = IdTuple(
 				"barList", "barEvent"
 			)
 		)
@@ -249,13 +249,13 @@ class WidgetRepositoryTest {
 
 		val workCalendarEventListDao = CalendarEventListDao(
 			workCalendarEventsList.shortEvents.map {
-				CalendarEventDao(IdTupleCustom(it.id!!.listId, it.id!!.elementId), it.startTime, it.endTime, it.summary)
+				CalendarEventDao(IdTuple(it.id!!.listId, it.id!!.elementId), it.startTime, it.endTime, it.summary)
 			},
 			listOf(),
 		)
 		val personalCalendarEventListDao = CalendarEventListDao(
 			personalCalendarEventsList.shortEvents.map {
-				CalendarEventDao(IdTupleCustom(it.id!!.listId, it.id!!.elementId), it.startTime, it.endTime, it.summary)
+				CalendarEventDao(IdTuple(it.id!!.listId, it.id!!.elementId), it.startTime, it.endTime, it.summary)
 			},
 			listOf(),
 		)
@@ -326,7 +326,7 @@ class WidgetRepositoryTest {
 
 		val workCalendarEventListDao = CalendarEventListDao(
 			workCalendarEventsList.shortEvents.map {
-				CalendarEventDao(IdTupleCustom(it.id!!.listId, it.id!!.elementId), it.startTime, it.endTime, it.summary)
+				CalendarEventDao(IdTuple(it.id!!.listId, it.id!!.elementId), it.startTime, it.endTime, it.summary)
 			},
 			listOf(),
 		)
@@ -363,7 +363,7 @@ class WidgetRepositoryTest {
 
 
 fun createTestCalendarEvent(
-	id: IdTupleCustom?,
+	id: IdTuple?,
 	summary: String = "",
 	description: String = "",
 	startTime: DateTime = Date().time.toULong(),

--- a/app-android/calendar/src/test/java/de/tutao/calendar/WidgetUIViewModelTest.kt
+++ b/app-android/calendar/src/test/java/de/tutao/calendar/WidgetUIViewModelTest.kt
@@ -13,7 +13,7 @@ import de.tutao.calendar.widget.model.WidgetUIViewModel
 import de.tutao.tutasdk.Sdk
 import de.tutao.tutashared.AndroidNativeCryptoFacade
 import de.tutao.tutashared.CredentialType
-import de.tutao.tutashared.IdTupleCustom
+import de.tutao.tutashared.IdTuple
 import de.tutao.tutashared.ipc.CredentialsInfo
 import de.tutao.tutashared.ipc.DataWrapper
 import de.tutao.tutashared.ipc.NativeCredentialsFacade
@@ -38,11 +38,11 @@ class WidgetUIViewModelTest {
 	private lateinit var mockWidgetCacheDataStore: DataStore<Preferences>
 	private lateinit var mockWidgetRepository: WidgetRepository
 
-	private val eventOne = CalendarEventDao(IdTupleCustom("list", "1"), 1758326400000UL, 1758330000000UL, "Event One")
-	private val eventTwo = CalendarEventDao(IdTupleCustom("list", "2"), 1758333600000UL, 1758337200000UL, "Event Two")
+	private val eventOne = CalendarEventDao(IdTuple("list", "1"), 1758326400000UL, 1758330000000UL, "Event One")
+	private val eventTwo = CalendarEventDao(IdTuple("list", "2"), 1758333600000UL, 1758337200000UL, "Event Two")
 	private val eventThree =
-		CalendarEventDao(IdTupleCustom("list", "3"), 1758330000000UL, 1758333600000UL, "Event Three")
-	private val eventFour = CalendarEventDao(IdTupleCustom("list", "4"), 1758319200000UL, 1758322800000UL, "Event Four")
+		CalendarEventDao(IdTuple("list", "3"), 1758330000000UL, 1758333600000UL, "Event Three")
+	private val eventFour = CalendarEventDao(IdTuple("list", "4"), 1758319200000UL, 1758322800000UL, "Event Four")
 
 	private val sdk: Sdk = mock<Sdk> { onBlocking { login(any()) } doReturn mock() }
 

--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/IdTupleWrapper.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/IdTupleWrapper.kt
@@ -23,4 +23,4 @@ fun IdTupleWrapper.toSdkIdTupleGenerated(): IdTupleGenerated {
 
 object IdTupleWrapperZeroOrOneAssociationSerializer : ZeroOrOneAssociationSerializer<IdTupleWrapper>(serializer())
 
-object IdTupleCustomOneAssociationSerializer : OneAssociationSerializer<IdTupleCustom>(serializer())
+object IdTupleOneAssociationSerializer : OneAssociationSerializer<IdTuple>(serializer())

--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/ModelTypes.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/ModelTypes.kt
@@ -26,8 +26,8 @@ enum class OperationType {
 	DELETE;
 }
 
-@Serializable(with = IdTupleCustom.IdTupleSerializer::class)
-class IdTupleCustom(
+@Serializable(with = IdTuple.IdTupleSerializer::class)
+class IdTuple(
 	val listId: String,
 	val elementId: String
 ) {
@@ -40,10 +40,10 @@ class IdTupleCustom(
 	}
 
 	@OptIn(ExperimentalSerializationApi::class)
-	companion object IdTupleSerializer : KSerializer<IdTupleCustom> {
+	companion object IdTupleSerializer : KSerializer<IdTuple> {
 		override val descriptor: SerialDescriptor = listSerialDescriptor<String>()
 
-		override fun serialize(encoder: Encoder, value: IdTupleCustom) {
+		override fun serialize(encoder: Encoder, value: IdTuple) {
 			val listEncoder = encoder.beginCollection(
 				ListSerializer(String.serializer()).descriptor,
 				2
@@ -53,7 +53,7 @@ class IdTupleCustom(
 			listEncoder.endStructure(descriptor)
 		}
 
-		override fun deserialize(decoder: Decoder): IdTupleCustom {
+		override fun deserialize(decoder: Decoder): IdTuple {
 			return decoder.decodeStructure(
 				ListSerializer(String.serializer()).descriptor
 			) {
@@ -67,7 +67,7 @@ class IdTupleCustom(
 						else -> error("Unknown index $index")
 					}
 				}
-				IdTupleCustom(listId, elementId)
+				IdTuple(listId, elementId)
 			}
 
 		}

--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/alarms/EncryptedAlarmNotificationEntity.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/alarms/EncryptedAlarmNotificationEntity.kt
@@ -6,8 +6,8 @@ import androidx.room.TypeConverter
 import androidx.room.TypeConverters
 import de.tutao.tutasdk.ByRule
 import de.tutao.tutashared.AndroidNativeCryptoFacade
-import de.tutao.tutashared.IdTupleCustom
-import de.tutao.tutashared.IdTupleCustomOneAssociationSerializer
+import de.tutao.tutashared.IdTuple
+import de.tutao.tutashared.IdTupleOneAssociationSerializer
 import de.tutao.tutashared.OneAssociationSerializer
 import de.tutao.tutashared.OperationType
 import de.tutao.tutashared.ZeroOrOneAssociationSerializer
@@ -114,8 +114,8 @@ class EncryptedAlarmNotificationEntity(
 	@Serializable
 	class NotificationSessionKey(
 		@SerialName("1555")
-		@Serializable(with = IdTupleCustomOneAssociationSerializer::class)
-		@field:Embedded val pushIdentifier: IdTupleCustom,
+		@Serializable(with = IdTupleOneAssociationSerializer::class)
+		@field:Embedded val pushIdentifier: IdTuple,
 		@SerialName("1556")
 		val pushIdentifierSessionEncSessionKey: String,
 	)

--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/LocalImportMailState.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/LocalImportMailState.kt
@@ -3,7 +3,8 @@
 
 package de.tutao.tutashared.ipc
 
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 
 
 /**
@@ -11,7 +12,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class LocalImportMailState(
-	val remoteStateId: de.tutao.tutashared.IdTupleCustom,
+	val remoteStateId: de.tutao.tutashared.IdTuple,
 	val status: Int,
 	val start_timestamp: Int,
 	val totalMails: Int,

--- a/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/ResumableImport.kt
+++ b/app-android/tutashared/src/main/java/de/tutao/tutashared/generated_ipc/ResumableImport.kt
@@ -4,6 +4,7 @@
 package de.tutao.tutashared.ipc
 
 import kotlinx.serialization.*
+import kotlinx.serialization.json.*
 
 
 /**
@@ -11,6 +12,6 @@ import kotlinx.serialization.*
  */
 @Serializable
 data class ResumableImport(
-	val remoteStateId: de.tutao.tutashared.IdTupleCustom,
+	val remoteStateId: de.tutao.tutashared.IdTuple,
 	val remainingEmlCount: Int,
 )


### PR DESCRIPTION
By accident we renamed the type IdTuple to IdTupleCustom in the android part of the application in commit fd4201f0ca6425759767a02dcfba9a8d01d58381.

This commit reverts the renaming as we do not distinguish between IdTupleCustom and IdTupleGeneratedId in the IPC definition.