### PR TITLE
header logo and nav bar adjustments

### DIFF
--- a/src/common/gui/base/DesktopBaseHeader.ts
+++ b/src/common/gui/base/DesktopBaseHeader.ts
@@ -1,6 +1,6 @@
 import m, { Children, ClassComponent, Vnode } from "mithril"
 import { AriaLandmarks, landmarkAttrs } from "../AriaUtils.js"
-import { layout_size, px, size, size as sizes } from "../size.js"
+import { layout_size, px, size } from "../size.js"
 import { theme } from "../theme.js"
 
 export interface DesktopBaseHeaderAttrs {
@@ -23,7 +23,7 @@ export class DesktopBaseHeader implements ClassComponent<DesktopBaseHeaderAttrs>
 
 	private renderLogo(width: number) {
 		return m(
-			".logo-height",
+			".logo-height.flex.items-center",
 			{
 				...landmarkAttrs(AriaLandmarks.Banner, "Tuta logo"),
 				style: {

--- a/src/common/gui/base/Logo.ts
+++ b/src/common/gui/base/Logo.ts
@@ -7,7 +7,7 @@ assertMainOrNodeBoot()
 
 export function getTutaLogo(): string {
 	if (isColorLight(theme.surface)) {
-		return getTutaLogoSvg()
+		return getTutaLogoSvg(theme.outline_variant)
 	}
 	return getTutaLogoSvg("#fff")
 }

--- a/src/common/gui/builtinThemes.ts
+++ b/src/common/gui/builtinThemes.ts
@@ -55,7 +55,7 @@ export const themes = (): Themes => {
 	const lightRed = Object.freeze<Theme>({
 		...semanticColorsLight,
 		themeId: isCalendarApp ? "light_secondary" : "light",
-		logo: getAppLogo(),
+		logo: getAppLogo("#d0c4c4"),
 		// Basic color tokens
 		primary: "#8F4A4E",
 		on_primary: "#FFFFFF",

--- a/src/common/gui/size.ts
+++ b/src/common/gui/size.ts
@@ -162,7 +162,7 @@ export const component_size = {
 	bottom_nav_bar: 50,
 	navbar_button_width: 80,
 	navbar_edge_width_mobile: 58,
-	header_logo_height: 38,
+	header_logo_height: 36,
 	list_row_height: 68,
 	dot_size: 7,
 	checkbox_size: 14,


### PR DESCRIPTION
This makes header logo 36px tall and dims it in lightRed theme. Dimming also applies to the bottom logo shown in the sign-up wizard.