### PR TITLE
fix: standardize FAQ link display in Settings

### DIFF
--- a/src/common/misc/news/MoreInfoLink.ts
+++ b/src/common/misc/news/MoreInfoLink.ts
@@ -37,7 +37,6 @@ export class MoreInfoLink implements Component<MoreInfoLinkAttrs> {
 			{
 				class: `${vnode.attrs.class} ${vnode.attrs.isSmall ? "small" : ""}`,
 			},
-			lang.get("moreInfo_msg") + " ",
 			m(
 				"span.text-break",
 				{
@@ -46,6 +45,7 @@ export class MoreInfoLink implements Component<MoreInfoLinkAttrs> {
 				[
 					m(ExternalLink, {
 						href: vnode.attrs.link,
+						text: lang.get("moreInfo_msg"),
 						isCompanySite: true,
 						specialType,
 					}),

--- a/src/common/settings/SettingsExpander.ts
+++ b/src/common/settings/SettingsExpander.ts
@@ -6,6 +6,7 @@ import { ifAllowedTutaLinks } from "../gui/base/GuiUtils.js"
 import type { lazy, Thunk } from "@tutao/tutanota-utils"
 import Stream from "mithril/stream"
 import { locator } from "../api/main/CommonLocator.js"
+import { MoreInfoLink } from "../misc/news/MoreInfoLink.js"
 
 export type SettingsExpanderAttrs = {
 	id?: string
@@ -45,7 +46,7 @@ export class SettingsExpander implements Component<SettingsExpanderAttrs> {
 				vnode.children,
 			),
 			infoMsg ? m("small", lang.getTranslationText(infoMsg)) : null,
-			infoLinkId ? ifAllowedTutaLinks(locator.logins, infoLinkId, (link) => m("small.text-break", [m(`a[href=${link}][target=_blank]`, link)])) : null,
+			infoLinkId ? ifAllowedTutaLinks(locator.logins, infoLinkId, (link) => m(MoreInfoLink, { link, isSmall: true })) : null,
 		])
 	}
 }

--- a/src/common/settings/whitelabel/WhitelabelSettingsViewer.ts
+++ b/src/common/settings/whitelabel/WhitelabelSettingsViewer.ts
@@ -21,6 +21,7 @@ import {
 	WhitelabelConfigTypeRef,
 } from "../../api/entities/sys/TypeRefs.js"
 import { InfoLink, lang } from "../../misc/LanguageViewModel.js"
+import { MoreInfoLink } from "../../misc/news/MoreInfoLink.js"
 import { FeatureType, OperationType } from "../../api/common/TutanotaConstants.js"
 import { progressIcon } from "../../gui/base/Icon.js"
 import { showProgressDialog } from "../../gui/dialogs/ProgressDialog.js"
@@ -94,7 +95,7 @@ export class WhitelabelSettingsViewer implements UpdatableSettingsViewer {
 				? [
 						m(".h4.mt-32", lang.get("whitelabel_label")),
 						m(".small", lang.get("whitelabelDomainLinkInfo_msg") + " "),
-						m("small.text-break", [m(`a[href=${InfoLink.Whitelabel}][target=_blank]`, InfoLink.Whitelabel)]),
+						m(MoreInfoLink, { link: InfoLink.Whitelabel, isSmall: true }),
 						this._renderWhitelabelStatusSettings(),
 						this._renderNotificationEmailSettings(),
 						m(".h4.mt-32", lang.get("whitelabelDomain_label")),


### PR DESCRIPTION
## Summary
Standardizes FAQ link rendering across Settings views for consistency.

## Changes
- **MoreInfoLink component**: Now passes descriptive `"More info"` text to `ExternalLink` instead of displaying the raw URL
- **SettingsExpander**: Replaced hand-rolled `<a>` tag (which showed raw URL) with the `MoreInfoLink` component
- **WhitelabelSettingsViewer**: Replaced inline raw URL anchor with `MoreInfoLink` component

### Before
FAQ links in Settings showed inconsistently — some as raw URLs like `https://tuta.com/faq#spam`, others with descriptive text.

### After
All FAQ/info links consistently display as a clickable "More info" link text, with the URL only visible on hover.

Fixes #3311

---
*Built autonomously by [islo.dev](https://islo.dev) Builder*