### PR TITLE
Drive/3318 fix ipad layout

### DIFF
--- a/src/common/gui/MobileHeader.ts
+++ b/src/common/gui/MobileHeader.ts
@@ -61,7 +61,11 @@ export class MobileHeader implements Component<MobileHeaderAttrs> {
 
 	private renderLeftAction(attrs: MobileHeaderAttrs) {
 		if (styles.isMobileDesktopLayout() && !client.isCalendarApp()) {
-			return m(".ml-8")
+			if (attrs.useBackButton) {
+				return m(MobileHeaderBackButton, { backAction: attrs.backAction })
+			} else {
+				return m(".ml-8")
+			}
 		} else if (attrs.columnType === "first" && !attrs.useBackButton) {
 			return m(MobileHeaderMenuButton, { newsModel: attrs.newsModel, backAction: attrs.backAction })
 		} else if (styles.isSingleColumnLayout() || attrs.useBackButton) {

--- a/src/drive-app/drive/view/DriveView.ts
+++ b/src/drive-app/drive/view/DriveView.ts
@@ -421,8 +421,8 @@ export class DriveView extends BaseTopLevelView implements TopLevelView<DriveVie
 			},
 			ColumnType.Background,
 			{
-				minWidth: layout_size.second_col_min_width,
-				maxWidth: layout_size.second_col_max_width,
+				minWidth: layout_size.second_col_min_width + layout_size.third_col_min_width,
+				maxWidth: layout_size.second_col_max_width + layout_size.third_col_max_width,
 			},
 		)
 	}


### PR DESCRIPTION
Ipad layout of the drive view had issues with the sidebar on landscape. It was not aligned with mail and calendar app and it was not possible to navigate back from a folder. Now the sidebar behaves in the same way as mail and calendar on various screen widths and is possible to navigate back from a folder