### PR TITLE
fix NotFound 404 error thrown when loading publicKey for disabled user

### DIFF
--- a/src/common/api/common/utils/ErrorUtils.ts
+++ b/src/common/api/common/utils/ErrorUtils.ts
@@ -210,7 +210,7 @@ export function objToError(o: Record<string, any>): Error {
 
 /**
  * Returns whether the error is expected for the cases where our local state might not be up-to-date with the server yet. E.g. we might be processing an update
- * for the instance that was already deleted. Normally this would be optimized away but it might still happen due to timing.
+ * for the instance that was already deleted. Normally this would be optimized away, but it might still happen due to timing.
  */
 export function isExpectedErrorForSynchronization(e: Error): boolean {
 	return e instanceof NotFoundError || e instanceof NotAuthorizedError

--- a/src/common/api/worker/crypto/CryptoFacade.ts
+++ b/src/common/api/worker/crypto/CryptoFacade.ts
@@ -537,6 +537,15 @@ export class CryptoFacade {
 				pqMessageSenderKeyVersion,
 			)
 		} catch (e) {
+			if (e instanceof NotFoundError) {
+				// In case there is a NotFound 404 error thrown, we do want to handle it gracefully
+				// because this happens when accounts have been disabled.
+				return {
+					authStatus: EncryptionAuthStatus.TUTACRYPT_AUTHENTICATION_FAILED,
+					verificationState: PresentableKeyVerificationState.ALERT,
+				}
+			}
+
 			console.error("Could not authenticate sender", e)
 
 			// we want an error that users can report


### PR DESCRIPTION
In case we load a publicKey for a disabled user, we should catch the NotFound 404 error, because there is nothing we can do and this is a expected error for synchronization.