### PR TITLE
Fix cannot set offline range more than 20 years from settings

### DIFF
--- a/src/app-env/TutanotaConstants.ts
+++ b/src/app-env/TutanotaConstants.ts
@@ -523,8 +523,11 @@ export enum FeatureType {
 	SolutionPartner = "23",
 }
 
-export const FULL_INDEXED_TIMESTAMP: number = 0
-export const NOTHING_INDEXED_TIMESTAMP: number = Math.pow(2, 42) - 1 // maximum Timestamp is 42 bit long (see GeneratedIdData.java)
+export const GENERATED_ID_MAX_TIMESTAMP: number = Math.pow(2, 42) - 1 // maximum Timestamp is 42 bit long (see GeneratedIdData.java)
+export const GENERATED_ID_MIN_TIMESTAMP: number = 0
+
+export const FULL_INDEXED_TIMESTAMP: number = GENERATED_ID_MIN_TIMESTAMP
+export const NOTHING_INDEXED_TIMESTAMP: number = GENERATED_ID_MAX_TIMESTAMP
 
 export const ENTITY_EVENT_BATCH_TTL_DAYS: number = 45 // 45 days (see InstanceDbMapperEventNotifier.java)
 

--- a/src/common/offline/OfflineStorageSettingsModel.ts
+++ b/src/common/offline/OfflineStorageSettingsModel.ts
@@ -2,7 +2,7 @@ import { assert, getDayShifted, getStartOfDay } from "@tutao/utils"
 import { UserController } from "../api/main/UserController"
 import { DeviceConfig } from "../misc/DeviceConfig"
 import { getStartOfTheWeekOffsetForUser } from "../misc/weekOffset"
-import { DAY_IN_MILLIS, isBrowser, Mode } from "@tutao/app-env"
+import { GENERATED_ID_MIN_TIMESTAMP, isBrowser, Mode } from "@tutao/app-env"
 import { getOfflineStorageDefaultTimeRangeDays } from "@tutao/typerefs"
 
 /**
@@ -50,11 +50,10 @@ export class OfflineStorageSettingsModel {
 	}
 
 	isValidDate(newDate: Date): boolean {
-		// The choice of 7500 days (a bit over 20 years) is a bit arbitrary.
-		// The theoretical maximum is the number of days between Epoch and May 15th 2109, exceeding that will
-		// lead to an overflow in our 42 bit timestamp in the id.
-		const now = new Date().getTime()
-		return newDate.getTime() < now && now - newDate.getTime() < 7500 * DAY_IN_MILLIS
+		//For a date to be valid, it must be between Epoch and May 15th 2109, exceeding that will lead to an overflow
+		// in our 42 bit timestamp in the id.
+		const now = Date.now()
+		return newDate.getTime() < now && newDate.getTime() > GENERATED_ID_MIN_TIMESTAMP
 	}
 
 	isFixedDays(): boolean {

--- a/src/mail-app/search/view/SearchViewModel.ts
+++ b/src/mail-app/search/view/SearchViewModel.ts
@@ -491,14 +491,18 @@ export class SearchViewModel {
 					const offlineRange = this.offlineStorageSettings.getTimeRange().getTime()
 					const isIndexingDoneOrCancelled = newState.progress === 0 && newState.error == null
 
-					// update offline storage range as index extends to not lose what's already indexed if the user logs out before indexing is done.
+					// update offline storage range as index extends to not lose what's already indexed if the user logs
+					// out before indexing is done.
 					// Update offline range when indexing is cancelled to not continue indexing on next login
 					if (offlineRange > newState.currentMailIndexTimestamp || isIndexingDoneOrCancelled) {
 						this.offlineStorageSettings.setTimeRange(
 							new Date(
-								newState.currentMailIndexTimestamp === FULL_INDEXED_TIMESTAMP
-									? newState.aimedMailIndexTimestamp
-									: newState.currentMailIndexTimestamp,
+								newState.currentMailIndexTimestamp !== FULL_INDEXED_TIMESTAMP
+									? newState.currentMailIndexTimestamp
+									: // aimedMailIndexTimestamp is set by the user and therefore might not be valid
+										this.offlineStorageSettings.isValidDate(new Date(newState.aimedMailIndexTimestamp))
+										? newState.aimedMailIndexTimestamp
+										: FULL_INDEXED_TIMESTAMP,
 							),
 						)
 					}


### PR DESCRIPTION
Fixed by setting the maximum extending range to Epoch instead of 20 years in both `mail settings` view and in `search list filter` view

Close #10673

Co-authored-by: hrb-hub <hrb-hub@users.noreply.github.com>