### PR TITLE
Add ability to set primary address name when setting GroupInfo.name

### DIFF
--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -2266,3 +2266,4 @@ export type TranslationKeyType =
 	| "indexingEmails_msg"
 	| "searchUntil_msg"
 	| "manualUpdateNeeded_msg"
+	| "setAsSenderNameForPrimaryAddress_label"

--- a/src/common/settings/login/LoginSettingsViewer.ts
+++ b/src/common/settings/login/LoginSettingsViewer.ts
@@ -1,7 +1,7 @@
 import m, { Children } from "mithril"
 import stream from "mithril/stream"
 import type { TextFieldAttrs } from "../../gui/base/TextField.js"
-import { TextField } from "../../gui/base/TextField.js"
+import { TextField, TextFieldType } from "../../gui/base/TextField.js"
 import { InfoLink, lang } from "../../misc/LanguageViewModel.js"
 import { Icons } from "../../gui/base/icons/Icons.js"
 import { CustomerPropertiesTypeRef, GroupInfo, Session, SessionTypeRef } from "../../api/entities/sys/TypeRefs.js"
@@ -35,6 +35,10 @@ import { AppLockMethod } from "../../native/common/generatedipc/AppLockMethod.js
 import { MobileSystemFacade } from "../../native/common/generatedipc/MobileSystemFacade.js"
 import { UpdatableSettingsViewer } from "../Interfaces.js"
 import { UserController } from "../../api/main/UserController"
+import { Checkbox } from "../../gui/base/Checkbox"
+import { isOfflineError } from "../../api/common/utils/ErrorUtils"
+import { LoginTextField } from "../../gui/base/LoginTextField"
+import { theme } from "../../gui/theme"
 
 assertMainOrNode()
 
@@ -225,17 +229,55 @@ export class LoginSettingsViewer implements UpdatableSettingsViewer {
 	}
 
 	private onChangeName(groupInfo: GroupInfo) {
-		Dialog.showProcessTextInputDialog(
-			{
-				title: "edit_action",
-				label: "name_label",
-				defaultValue: groupInfo.name,
-			},
-			async (newName) => {
-				groupInfo.name = newName
-				return locator.entityClient.update(groupInfo)
-			},
-		)
+		let name = groupInfo.name
+		let updatePrimaryAddressName = false
+		let dialog: Dialog
+
+		const wrappedOkAction = async () => {
+			try {
+				groupInfo.name = name
+				await locator.entityClient.update(groupInfo)
+
+				if (updatePrimaryAddressName) {
+					const model = await locator.mailAddressTableModelForOwnMailbox()
+					await model.setAliasName(assertNotNull(groupInfo.mailAddress), name)
+				}
+
+				dialog.close()
+			} catch (error) {
+				if (!isOfflineError(error)) {
+					dialog.close()
+				}
+				throw error
+			}
+		}
+
+		dialog = Dialog.showActionDialog({
+			title: "edit_action",
+			child: () => [
+				m(LoginTextField, {
+					label: "name_label",
+					value: name,
+					type: TextFieldType.Text,
+					leadingIcon: {
+						icon: Icons.PenFilled,
+						color: theme.on_surface_variant,
+					},
+					onReturnKeyPressed: wrappedOkAction,
+					oninput: (newName) => (name = newName),
+				}),
+				m(
+					".pt-16",
+					m(Checkbox, {
+						label: () => lang.getTranslationText("setAsSenderNameForPrimaryAddress_label"),
+						checked: updatePrimaryAddressName,
+						onChecked: (checked) => (updatePrimaryAddressName = checked),
+					}),
+				),
+			],
+			allowOkWithReturn: true,
+			okAction: wrappedOkAction,
+		})
 	}
 
 	private renderAppLockField(): Children {

--- a/src/mail-app/mail/view/MailViewerHeader.ts
+++ b/src/mail-app/mail/view/MailViewerHeader.ts
@@ -250,7 +250,7 @@ export class MailViewerHeader implements Component<MailViewerHeaderAttrs> {
 						: null,
 					this.tutaoBadge(viewModel),
 					m(
-						"span" + (displayAddressForSender ? ".invisible.overflow-hidden" : ".text-break") + (viewModel.isUnread() ? ".font-weight-600" : ""),
+						"span.text-break" + (viewModel.isUnread() ? ".font-weight-600" : ""),
 						displayAddressForSender ? (viewModel.getDisplayedSender()?.address ?? "") : senderName,
 					),
 				],

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -2267,6 +2267,7 @@ export default {
 		"yourMessage_label": "Deine Nachricht",
 		"zoomIn_action": "Hereinzoomen",
 		"zoomOut_action": "Herauszoomen",
-		"manualUpdateNeeded_msg": "Something is preventing the update.\n\nPlease download and update manually at {url}"
+		"manualUpdateNeeded_msg": "Something is preventing the update.\n\nPlease download and update manually at {url}",
+		"setAsSenderNameForPrimaryAddress_label": "Set as sender name for primary email address"
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -2267,6 +2267,7 @@ export default {
 		"yourMessage_label": "Ihre Nachricht",
 		"zoomIn_action": "Hereinzoomen",
 		"zoomOut_action": "Herauszoomen",
-		"manualUpdateNeeded_msg": "Something is preventing the update.\n\nPlease download and update manually at {url}"
+		"manualUpdateNeeded_msg": "Something is preventing the update.\n\nPlease download and update manually at {url}",
+		"setAsSenderNameForPrimaryAddress_label": "Set as sender name for primary email address"
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -2267,6 +2267,7 @@ export default {
 		"yourMessage_label": "Your message",
 		"zoomIn_action": "Zoom In",
 		"zoomOut_action": "Zoom Out",
-		"manualUpdateNeeded_msg": "Something is preventing the update.\n\nPlease download and update manually at {url}"
+		"manualUpdateNeeded_msg": "Something is preventing the update.\n\nPlease download and update manually at {url}",
+		"setAsSenderNameForPrimaryAddress_label": "Set as sender name for primary email address"
 	}
 }


### PR DESCRIPTION
Allow setting the sender name for the primary email address when setting the group info name from `Settings > Login > Name`.

Render the sender's email address in the mail viewer when sender name is empty.

Close #9547