### PR TITLE
Update URL on conversation change in search

### DIFF
--- a/src/mail-app/search/view/SearchViewModel.ts
+++ b/src/mail-app/search/view/SearchViewModel.ts
@@ -25,6 +25,7 @@ import {
 	deepEqual,
 	defer,
 	downcast,
+	first,
 	getEndOfDay,
 	getStartOfDay,
 	incrementMonth,
@@ -841,24 +842,29 @@ export class SearchViewModel {
 	}
 
 	private onListStateChange(newState: ListState<SearchResultListEntry>) {
+		let unsetConversationViewModel = this._conversationViewModel != null
+
 		if (isSameTypeRef(this.searchedType, tutanotaTypeRefs.MailTypeRef) && !newState.inMultiselect && newState.selectedItems.size === 1) {
-			const mail = this.getSelectedMails()[0]
+			const mail = first(this.getSelectedMails())
 
 			// Sometimes a stale state is passed through, resulting in no mail
-			if (mail) {
+			if (mail != null) {
 				// displayed conversation has changed
 				if (
 					!this._conversationViewModel ||
 					!isSameId(listIdPart(this._conversationViewModel.primaryMail._id), listIdPart(mail._id)) ||
 					!isSameId(elementIdPart(this._conversationViewModel.primaryMail._id), elementIdPart(mail._id))
 				) {
+					unsetConversationViewModel = false
 					this.updateDisplayedConversation(mail)
+					this.updateSearchUrl()
 				}
-			} else {
-				this._conversationViewModel = null
 			}
-		} else {
+		}
+
+		if (unsetConversationViewModel) {
 			this._conversationViewModel = null
+			this.updateSearchUrl()
 		}
 
 		this.updateUi()


### PR DESCRIPTION
We want to ensure the URL is changed when switching mails in the search list.

This also simplifies onListStateChange's logic slightly.

Closes #10674