### PR TITLE
Fix cannot see mails older than offline range with free account

### DIFF
--- a/src/common/api/common/EntityClient.ts
+++ b/src/common/api/common/EntityClient.ts
@@ -15,6 +15,7 @@ import {
 	GENERATED_MIN_ID,
 	getElementId,
 	getLetId,
+	getServerIdEncodingForType,
 	listIdPart,
 	RANGE_ITEM_LIMIT,
 	sysTypeRefs,
@@ -77,7 +78,7 @@ export class EntityClient {
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		if (typeModel.type !== Type.ListElement) throw new Error("only ListElement types are permitted")
 		const loadedEntities = await this._target.loadRange<T>(typeRef, listId, start, rangeItemLimit, true)
-		const filteredEntities = loadedEntities.filter((entity) => firstBiggerThanSecond(getElementId(entity), end, typeModel))
+		const filteredEntities = loadedEntities.filter((entity) => firstBiggerThanSecond(getElementId(entity), end, getServerIdEncodingForType(typeModel)))
 
 		if (filteredEntities.length === rangeItemLimit) {
 			const lastElementId = getElementId(filteredEntities[loadedEntities.length - 1])

--- a/src/common/api/common/utils/CommonCalendarUtils.ts
+++ b/src/common/api/common/utils/CommonCalendarUtils.ts
@@ -1,9 +1,8 @@
-import { tutanotaTypeRefs } from "@tutao/typerefs"
-import { stringToCustomId } from "@tutao/utils"
-import { StrippedEntity } from "@tutao/typerefs"
+import { StrippedEntity, tutanotaTypeRefs } from "@tutao/typerefs"
 import type { AlarmInterval } from "../../../calendar/date/CalendarUtils.js"
 import { IcsCalendarEvent, StrippedCalendarEventAttendee } from "../../../calendar/gui/ImportExportUtils"
 import { DAY_IN_MILLIS } from "@tutao/app-env"
+import { stringToBase64UrlCustomId } from "@tutao/utils"
 
 export type CalendarEventTimes = Pick<tutanotaTypeRefs.CalendarEvent, "startTime" | "endTime">
 
@@ -70,7 +69,7 @@ export function generateEventElementId(timestamp: number): string {
  */
 export function generateLocalEventElementId(timestamp: number, identifier: string): string {
 	// We don't have to shift the days because the event never leaves the client
-	return stringToCustomId(`${timestamp}${identifier}`)
+	return stringToBase64UrlCustomId(`${timestamp}${identifier}`)
 }
 
 /**
@@ -84,7 +83,7 @@ export function generateLocalEventElementId(timestamp: number, identifier: strin
  * @param shiftDays
  */
 export function createEventElementId(timestamp: number, shiftDays: number): string {
-	return stringToCustomId(String(timestamp + shiftDays))
+	return stringToBase64UrlCustomId(String(timestamp + shiftDays))
 }
 
 /**

--- a/src/common/api/common/utils/IndexUtils.ts
+++ b/src/common/api/common/utils/IndexUtils.ts
@@ -1,9 +1,8 @@
-import { isSameTypeRef, TypeRef } from "@tutao/utils"
+import { AppName, isSameTypeRef, TypeRef } from "@tutao/utils"
 import type { IndexUpdate, SearchIndexMetadataEntry, SearchRestriction } from "../../worker/search/SearchTypes"
-import { FULL_INDEXED_TIMESTAMP, NOTHING_INDEXED_TIMESTAMP } from "@tutao/app-env"
+import { FULL_INDEXED_TIMESTAMP, GroupType, isTest, NOTHING_INDEXED_TIMESTAMP } from "@tutao/app-env"
 import type { TypeModel } from "@tutao/typerefs"
 import { sysTypeRefs, tutanotaTypeModels, tutanotaTypeRefs } from "@tutao/typerefs"
-import { GroupType, isTest } from "@tutao/app-env"
 
 export type TypeInfo = {
 	appId: number
@@ -13,7 +12,7 @@ export type TypeInfo = {
 
 const MailTypeId = tutanotaTypeRefs.MailTypeRef.typeId
 const ContactTypeId = tutanotaTypeRefs.ContactTypeRef.typeId
-const typeInfos: Map<string, Map<number, any>> = new Map([
+const typeInfos: Map<AppName, Map<number, TypeInfo>> = new Map([
 	[
 		"tutanota",
 		new Map([
@@ -56,6 +55,14 @@ export function typeRefToTypeInfo(typeRef: TypeRef<any>): TypeInfo {
 	}
 
 	return typeInfo
+}
+
+export function typeInfoToTypeRef(typeInfo: TypeInfo, appName: AppName): TypeRef<unknown> | null {
+	if (typeInfos.get(appName)?.has(typeInfo.typeId)) {
+		return new TypeRef(appName, typeInfo.typeId)
+	} else {
+		return null
+	}
 }
 
 export function userIsGlobalAdmin(user: sysTypeRefs.User): boolean {

--- a/src/common/api/worker/facades/KeyLoaderFacade.ts
+++ b/src/common/api/worker/facades/KeyLoaderFacade.ts
@@ -11,7 +11,7 @@ import {
 	isRsaOrRsaX25519KeyPair,
 	VersionedKey,
 } from "@tutao/crypto"
-import { customIdToString, KeyVersion, lazyAsync, promiseMap, stringToCustomId, Versioned } from "@tutao/utils"
+import { base64UrlCustomIdToString, KeyVersion, lazyAsync, promiseMap, stringToBase64UrlCustomId, Versioned } from "@tutao/utils"
 import { UserFacade } from "./UserFacade.js"
 import * as restError from "@tutao/rest-client/error"
 import { getElementId, isSameId, sysTypeRefs, TypeId } from "@tutao/typerefs"
@@ -21,11 +21,11 @@ import { GroupType, ProgrammingError } from "@tutao/app-env"
 import { CryptoError } from "@tutao/crypto/error"
 
 function convertCustomIdToKeyVersion(customId: Id): KeyVersion {
-	return cryptoUtils.parseKeyVersion(customIdToString(customId))
+	return cryptoUtils.parseKeyVersion(base64UrlCustomIdToString(customId))
 }
 
 function convertKeyVersionToCustomId(version: KeyVersion): Id {
-	return stringToCustomId(String(version))
+	return stringToBase64UrlCustomId(String(version))
 }
 
 /**
@@ -299,7 +299,7 @@ export class KeyLoaderFacade {
 	}
 
 	private decodeGroupKeyVersion(id: Id): KeyVersion {
-		return cryptoUtils.parseKeyVersion(customIdToString(id))
+		return cryptoUtils.parseKeyVersion(base64UrlCustomIdToString(id))
 	}
 
 	private validateAndDecryptKeyPair(keyPair: sysTypeRefs.KeyPair | null, groupId: Id, groupKey: VersionedKey) {

--- a/src/common/api/worker/facades/lazy/CalendarFacade.ts
+++ b/src/common/api/worker/facades/lazy/CalendarFacade.ts
@@ -1,4 +1,4 @@
-import { assertWorkerOrNode, DAY_IN_MILLIS, GroupType, OperationType, TutanotaError } from "@tutao/app-env"
+import { assertWorkerOrNode, DAY_IN_MILLIS, GroupType, OperationType, ProgrammingError, TutanotaError } from "@tutao/app-env"
 import {
 	AttributeModel,
 	ClientModelUntypedInstance,
@@ -24,7 +24,7 @@ import {
 	promiseMap,
 	Require,
 	stringToUtf8Uint8Array,
-	uint8arrayToCustomId,
+	uint8arrayToBase64UrlCustomId,
 } from "@tutao/utils"
 import { CryptoFacade } from "../../crypto/CryptoFacade.js"
 import { DefaultEntityRestCache } from "../../rest/DefaultEntityRestCache.js"
@@ -39,7 +39,6 @@ import { UserFacade } from "../UserFacade.js"
 import { NativePushFacade } from "../../../../native/common/generatedipc/NativePushFacade.js"
 import { ExposedOperationProgressTracker, OperationId } from "../../../main/OperationProgressTracker.js"
 import { InfoMessageHandler } from "../../../../gui/InfoMessageHandler.js"
-import { ProgrammingError } from "@tutao/app-env"
 import {
 	addDaysForEventInstance,
 	addDaysForRecurringEvent,
@@ -502,7 +501,7 @@ export class CalendarFacade {
 
 				const indexEntry = await entityClient.load<tutanotaTypeRefs.CalendarEventUidIndex>(tutanotaTypeRefs.CalendarEventUidIndexTypeRef, [
 					groupRoot.index.list,
-					uint8arrayToCustomId(hashUid(uid)),
+					uint8arrayToBase64UrlCustomId(hashUid(uid)),
 				])
 
 				const progenitor: CalendarEventProgenitor | null = await loadProgenitorFromIndexEntry(entityClient, indexEntry)

--- a/src/common/api/worker/facades/lazy/GiftCardFacade.ts
+++ b/src/common/api/worker/facades/lazy/GiftCardFacade.ts
@@ -1,11 +1,11 @@
 import {
 	assertNotNull,
 	Base64,
-	base64ExtToBase64,
-	base64ToBase64Ext,
+	base64ExtToBase64Url,
 	base64ToBase64Url,
 	base64ToUint8Array,
 	base64UrlToBase64,
+	base64UrlToBase64Ext,
 	getFirstOrThrow,
 	isEmpty,
 	uint8ArrayToBase64,
@@ -99,7 +99,7 @@ export class GiftCardFacade {
 	}
 
 	async decodeGiftCardToken(token: string): Promise<{ id: Id; key: Base64 }> {
-		const id = base64ToBase64Ext(base64UrlToBase64(token.slice(0, ID_LENGTH)))
+		const id = base64UrlToBase64Ext(token.slice(0, ID_LENGTH))
 		const key = base64UrlToBase64(token.slice(ID_LENGTH, token.length))
 
 		if (id.length !== ID_LENGTH || (key.length !== KEY_LENGTH_128_BIT_B64 && key.length !== KEY_LENGTH_256_BIT_B64)) {
@@ -118,7 +118,7 @@ export class GiftCardFacade {
 			throw new Error("Invalid gift card key")
 		}
 
-		const idPart = base64ToBase64Url(base64ExtToBase64(id))
+		const idPart = base64ExtToBase64Url(id)
 		const keyPart = base64ToBase64Url(keyBase64)
 		return idPart + keyPart
 	}

--- a/src/common/api/worker/facades/lazy/MailFacade.ts
+++ b/src/common/api/worker/facades/lazy/MailFacade.ts
@@ -79,7 +79,7 @@ import {
 	promiseFilter,
 	promiseMap,
 	splitInChunks,
-	stringToCustomId,
+	stringToBase64UrlCustomId,
 } from "@tutao/utils"
 import { BlobFacade } from "./BlobFacade.js"
 import { EntityClient } from "../../../common/EntityClient.js"
@@ -852,7 +852,7 @@ export class MailFacade {
 	): Promise<{ currentExternalUserGroupKey: VersionedKey; currentExternalMailGroupKey: VersionedKey }> {
 		const groupRoot = await this.entityClient.loadRoot(sysTypeRefs.GroupRootTypeRef, this.userFacade.getUserGroupId())
 		const cleanedMailAddress = recipientMailAddress.trim().toLocaleLowerCase()
-		const mailAddressId = stringToCustomId(cleanedMailAddress)
+		const mailAddressId = stringToBase64UrlCustomId(cleanedMailAddress)
 
 		let externalUserReference: sysTypeRefs.ExternalUserReference
 		try {

--- a/src/common/api/worker/offline/OfflineStorage.ts
+++ b/src/common/api/worker/offline/OfflineStorage.ts
@@ -998,7 +998,7 @@ export class OfflineStorage implements CacheStorage {
 			// !!however ids for entities with a customId used to QUERY the offline database
 			// MUST always be base64Ext encoded
 			// Therefore, we need to compare against the rawCutoffId here!
-			const rangeWontBeModified = id != null && (firstBiggerThanSecond(id, rawCutoffId) || id === rawCutoffId)
+			const rangeWontBeModified = id != null && (firstBiggerThanSecond(id, rawCutoffId, typeModel) || id === rawCutoffId)
 			if (rangeWontBeModified) {
 				return
 			}

--- a/src/common/api/worker/offline/OfflineStorage.ts
+++ b/src/common/api/worker/offline/OfflineStorage.ts
@@ -2,10 +2,8 @@ import {
 	AttributeModel,
 	BlobElementEntity,
 	CUSTOM_MIN_ID,
-	customIdToBase64Url,
 	ElementEntity,
 	elementIdPart,
-	ensureBase64Ext,
 	Entity,
 	firstBiggerThanSecond,
 	firstBiggerThanSecondBase64Ext,
@@ -15,7 +13,9 @@ import {
 	isCustomIdType,
 	ListElementEntity,
 	listIdPart,
+	localToServerIdEncoding,
 	ServerModelParsedInstance,
+	serverToLocalIdEncoding,
 	SomeEntity,
 	Type as TypeId,
 	TypeModel,
@@ -332,7 +332,7 @@ export class OfflineStorage implements CacheStorage {
 		}
 		const taggedRows = await this.sqlCipherFacade.all(formattedQuery.query, formattedQuery.params)
 		const rows = taggedRows.map(untagSqlObject) as { listId?: Id; elementId: Id }[]
-		const ids = rows.map((row) => collapseId(row.listId ?? null, customIdToBase64Url(typeModel, row.elementId)))
+		const ids = rows.map((row) => collapseId(row.listId ?? null, localToServerIdEncoding(typeModel, row.elementId)))
 		await this.deleteByIds(typeRef, ids)
 	}
 
@@ -355,7 +355,7 @@ export class OfflineStorage implements CacheStorage {
 		const tm = syncMetrics?.beginMeasurement(Category.GetDb)
 		const type = getTypeString(typeRef)
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
-		const encodedElementId = ensureBase64Ext(typeModel, id)
+		const encodedElementId = serverToLocalIdEncoding(typeModel, id)
 		let formattedQuery
 		switch (typeModel.type) {
 			case TypeId.Element:
@@ -392,7 +392,7 @@ export class OfflineStorage implements CacheStorage {
 
 		if (elementIds.length === 0) return []
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
-		const encodedElementIds = elementIds.map((elementId) => ensureBase64Ext(typeModel, elementId))
+		const encodedElementIds = elementIds.map((elementId) => serverToLocalIdEncoding(typeModel, elementId))
 
 		const type = getTypeString(typeRef)
 		const serializedList: ReadonlyArray<Record<string, TaggedSqlValue>> = await this.allChunked(1000, encodedElementIds, (c) => {
@@ -438,7 +438,7 @@ export class OfflineStorage implements CacheStorage {
 										  OR ${firstIdBigger("elementId", range.lower)})
 										AND NOT (${firstIdBigger("elementId", range.upper)})`
 		const rows = await this.sqlCipherFacade.all(query, params)
-		return rows.map((row) => customIdToBase64Url(typeModel, row.elementId.value as string))
+		return rows.map((row) => localToServerIdEncoding(typeModel, row.elementId.value as string))
 	}
 
 	/** don't use this internally in this class, use OfflineStorage::getRange instead. OfflineStorage is
@@ -449,14 +449,14 @@ export class OfflineStorage implements CacheStorage {
 		if (range == null) return range
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		return {
-			lower: customIdToBase64Url(typeModel, range.lower),
-			upper: customIdToBase64Url(typeModel, range.upper),
+			lower: localToServerIdEncoding(typeModel, range.lower),
+			upper: localToServerIdEncoding(typeModel, range.upper),
 		}
 	}
 
 	async isElementIdInCacheRange<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, elementId: Id): Promise<boolean> {
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
-		const encodedElementId = ensureBase64Ext(typeModel, elementId)
+		const encodedElementId = serverToLocalIdEncoding(typeModel, elementId)
 
 		const range = await this.getRange(typeRef, listId)
 		return range != null && !firstBiggerThanSecondBase64Ext(encodedElementId, range.upper) && !firstBiggerThanSecondBase64Ext(range.lower, encodedElementId)
@@ -471,7 +471,7 @@ export class OfflineStorage implements CacheStorage {
 	): Promise<ServerModelParsedInstance[]> {
 		const tm = syncMetrics?.beginMeasurement(Category.ProvideRangeDb)
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
-		const encodedStartId = ensureBase64Ext(typeModel, start)
+		const encodedStartId = serverToLocalIdEncoding(typeModel, start)
 		const type = getTypeString(typeRef)
 		let formattedQuery
 		if (reverse) {
@@ -609,7 +609,7 @@ export class OfflineStorage implements CacheStorage {
 					rowId: null,
 					listId,
 					elementId,
-					encodedElementId: ensureBase64Ext(typeModel, elementId),
+					encodedElementId: serverToLocalIdEncoding(typeModel, elementId),
 					ownerGroup,
 					serializedInstance,
 					instance,
@@ -666,7 +666,7 @@ export class OfflineStorage implements CacheStorage {
 
 	async setLowerRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lowerId: Id): Promise<void> {
 		let typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
-		lowerId = ensureBase64Ext(typeModel, lowerId)
+		lowerId = serverToLocalIdEncoding(typeModel, lowerId)
 		const type = getTypeString(typeRef)
 		const { query, params } = sql`UPDATE ranges
 									  SET lower = ${lowerId}
@@ -676,7 +676,7 @@ export class OfflineStorage implements CacheStorage {
 	}
 
 	async setUpperRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, upperId: Id): Promise<void> {
-		upperId = ensureBase64Ext(await this.typeModelResolver.resolveClientTypeReference(typeRef), upperId)
+		upperId = serverToLocalIdEncoding(await this.typeModelResolver.resolveClientTypeReference(typeRef), upperId)
 		const type = getTypeString(typeRef)
 		const { query, params } = sql`UPDATE ranges
 									  SET upper = ${upperId}
@@ -687,8 +687,8 @@ export class OfflineStorage implements CacheStorage {
 
 	async setNewRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lower: Id, upper: Id): Promise<void> {
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
-		lower = ensureBase64Ext(typeModel, lower)
-		upper = ensureBase64Ext(typeModel, upper)
+		lower = serverToLocalIdEncoding(typeModel, lower)
+		upper = serverToLocalIdEncoding(typeModel, upper)
 
 		const type = getTypeString(typeRef)
 		const { query, params } = sql`INSERT
@@ -922,7 +922,7 @@ export class OfflineStorage implements CacheStorage {
 			case TypeId.Element:
 				await this.runChunked(
 					MAX_SAFE_SQL_VARS - 1,
-					(ids as Id[]).map((id) => ensureBase64Ext(typeModel, id)),
+					(ids as Id[]).map((id) => serverToLocalIdEncoding(typeModel, id)),
 					(c) => sql`DELETE
 							   FROM element_entities
 							   WHERE type = ${type}
@@ -931,7 +931,7 @@ export class OfflineStorage implements CacheStorage {
 				break
 			case TypeId.ListElement:
 				{
-					const byListId = groupByAndMap(ids as IdTuple[], listIdPart, (id) => ensureBase64Ext(typeModel, elementIdPart(id)))
+					const byListId = groupByAndMap(ids as IdTuple[], listIdPart, (id) => serverToLocalIdEncoding(typeModel, elementIdPart(id)))
 					for (const [listId, elementIds] of byListId) {
 						await this.runChunked(
 							MAX_SAFE_SQL_VARS - 2,
@@ -947,7 +947,7 @@ export class OfflineStorage implements CacheStorage {
 				break
 			case TypeId.BlobElement:
 				{
-					const byListId = groupByAndMap(ids as IdTuple[], listIdPart, (id) => ensureBase64Ext(typeModel, elementIdPart(id)))
+					const byListId = groupByAndMap(ids as IdTuple[], listIdPart, (id) => serverToLocalIdEncoding(typeModel, elementIdPart(id)))
 					for (const [listId, elementIds] of byListId) {
 						await this.runChunked(
 							MAX_SAFE_SQL_VARS - 2,
@@ -980,7 +980,7 @@ export class OfflineStorage implements CacheStorage {
 	async updateRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, rawCutoffId: Id): Promise<void> {
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const isCustomId = isCustomIdType(typeModel)
-		const encodedCutoffId = ensureBase64Ext(typeModel, rawCutoffId)
+		const encodedCutoffId = serverToLocalIdEncoding(typeModel, rawCutoffId)
 
 		const range = await this.getRange(typeRef, listId)
 		if (range == null) {

--- a/src/common/api/worker/offline/OfflineStorage.ts
+++ b/src/common/api/worker/offline/OfflineStorage.ts
@@ -8,8 +8,10 @@ import {
 	ensureBase64Ext,
 	Entity,
 	firstBiggerThanSecond,
+	firstBiggerThanSecondBase64Ext,
 	GENERATED_MIN_ID,
 	getElementId,
+	getServerIdEncodingForType,
 	isCustomIdType,
 	ListElementEntity,
 	listIdPart,
@@ -457,7 +459,7 @@ export class OfflineStorage implements CacheStorage {
 		const encodedElementId = ensureBase64Ext(typeModel, elementId)
 
 		const range = await this.getRange(typeRef, listId)
-		return range != null && !firstBiggerThanSecond(encodedElementId, range.upper) && !firstBiggerThanSecond(range.lower, encodedElementId)
+		return range != null && !firstBiggerThanSecondBase64Ext(encodedElementId, range.upper) && !firstBiggerThanSecondBase64Ext(range.lower, encodedElementId)
 	}
 
 	async provideFromRangeParsed<T extends ListElementEntity>(
@@ -998,17 +1000,17 @@ export class OfflineStorage implements CacheStorage {
 			// !!however ids for entities with a customId used to QUERY the offline database
 			// MUST always be base64Ext encoded
 			// Therefore, we need to compare against the rawCutoffId here!
-			const rangeWontBeModified = id != null && (firstBiggerThanSecond(id, rawCutoffId, typeModel) || id === rawCutoffId)
+			const rangeWontBeModified = id != null && (id === rawCutoffId || firstBiggerThanSecond(id, rawCutoffId, getServerIdEncodingForType(typeModel)))
 			if (rangeWontBeModified) {
 				return
 			}
 		}
 
-		if (firstBiggerThanSecond(encodedCutoffId, range.lower)) {
+		if (firstBiggerThanSecondBase64Ext(encodedCutoffId, range.lower)) {
 			// If the upper id of the range is below the cutoff, then the entire range will be deleted from the storage
 			// so we just delete the range as well
 			// Otherwise, we only want to modify
-			if (firstBiggerThanSecond(encodedCutoffId, range.upper)) {
+			if (firstBiggerThanSecondBase64Ext(encodedCutoffId, range.upper)) {
 				await this.deleteRange(typeRef, listId)
 			} else {
 				await this.setLowerRangeForList(typeRef, listId, rawCutoffId)

--- a/src/common/api/worker/rest/DefaultEntityRestCache.ts
+++ b/src/common/api/worker/rest/DefaultEntityRestCache.ts
@@ -19,6 +19,7 @@ import {
 	GENERATED_MAX_ID,
 	GENERATED_MIN_ID,
 	get_IdValue,
+	getServerIdEncodingForType,
 	hasError,
 	isCustomIdType,
 	ListElementEntity,
@@ -31,8 +32,7 @@ import {
 	TypeModelResolver,
 	ValueType,
 } from "@tutao/typerefs"
-import { ProgrammingError } from "@tutao/app-env"
-import { assertWorkerOrNode, Mode, OperationType } from "@tutao/app-env"
+import { assertWorkerOrNode, Mode, OperationType, ProgrammingError } from "@tutao/app-env"
 import { ENTITY_EVENT_BATCH_EXPIRE_MS } from "../EventBusClient"
 import { CustomCacheHandlerMap } from "./cacheHandler/CustomCacheHandler.js"
 import { collapseId, expandId } from "./RestClientIdUtils"
@@ -705,6 +705,7 @@ export class DefaultEntityRestCache implements EntityRestCache {
 
 		const typeModel = await this.typeModelResolver.resolveClientTypeReference(typeRef)
 		const isCustomId = isCustomIdType(typeModel)
+		const idEncoding = getServerIdEncodingForType(typeModel)
 		if (
 			(!reverse && (isCustomId ? upper === CUSTOM_MAX_ID : upper === GENERATED_MAX_ID)) ||
 			(reverse && (isCustomId ? lower === CUSTOM_MIN_ID : lower === GENERATED_MIN_ID))
@@ -723,7 +724,7 @@ export class DefaultEntityRestCache implements EntityRestCache {
 				elementsToRead = count - (allRangeList.length - 1 - indexOfStart)
 				startElementId = allRangeList[allRangeList.length - 1] // use the  highest id in allRange as start element
 			}
-		} else if (lower === start || (firstBiggerThanSecond(start, lower, typeModel) && firstBiggerThanSecond(allRangeList[0], start, typeModel))) {
+		} else if (lower === start || (firstBiggerThanSecond(start, lower, idEncoding) && firstBiggerThanSecond(allRangeList[0], start, idEncoding))) {
 			// Start element is not in allRange but has been used has start element for a range request, eg. EntityRestInterface.GENERATED_MIN_ID, or start is between lower range id and lowest element in range
 			if (!reverse) {
 				// if not reverse read only elements that are not in allRange
@@ -733,7 +734,7 @@ export class DefaultEntityRestCache implements EntityRestCache {
 			// if reverse read all elements
 		} else if (
 			upper === start ||
-			(firstBiggerThanSecond(start, allRangeList[allRangeList.length - 1], typeModel) && firstBiggerThanSecond(upper, start, typeModel))
+			(firstBiggerThanSecond(start, allRangeList[allRangeList.length - 1], idEncoding) && firstBiggerThanSecond(upper, start, idEncoding))
 		) {
 			// Start element is not in allRange but has been used has start element for a range request, eg. EntityRestInterface.GENERATED_MAX_ID, or start is between upper range id and highest element in range
 			if (reverse) {
@@ -967,7 +968,8 @@ export class DefaultEntityRestCache implements EntityRestCache {
  * Check if a range request begins inside an existing range
  */
 function isStartIdWithinRange(range: Range, startId: Id, typeModel: TypeModel): boolean {
-	return !firstBiggerThanSecond(startId, range.upper, typeModel) && !firstBiggerThanSecond(range.lower, startId, typeModel)
+	const idEncoding = getServerIdEncodingForType(typeModel)
+	return !firstBiggerThanSecond(startId, range.upper, idEncoding) && !firstBiggerThanSecond(range.lower, startId, idEncoding)
 }
 
 /**
@@ -975,7 +977,8 @@ function isStartIdWithinRange(range: Range, startId: Id, typeModel: TypeModel): 
  * Assumes that the range request doesn't start inside the range
  */
 function isRangeRequestAwayFromExistingRange(range: Range, reverse: boolean, start: string, typeModel: TypeModel) {
-	return reverse ? firstBiggerThanSecond(range.lower, start, typeModel) : firstBiggerThanSecond(start, range.upper, typeModel)
+	const idEncoding = getServerIdEncodingForType(typeModel)
+	return reverse ? firstBiggerThanSecond(range.lower, start, idEncoding) : firstBiggerThanSecond(start, range.upper, idEncoding)
 }
 
 /**

--- a/src/common/api/worker/rest/DefaultEntityRestCache.ts
+++ b/src/common/api/worker/rest/DefaultEntityRestCache.ts
@@ -71,10 +71,10 @@ const IGNORED_TYPES = [
 
 /**
  * List of types containing a customId that we want to explicitly enable caching for.
- * CustomId types are not cached by default because their id is using base64UrlEncoding while GeneratedUId types are using base64Ext encoding.
+ * CustomId types are not cached by default because their id is using base64Url encoding while GeneratedUId types are using base64Ext encoding.
  * base64Url encoding results in a different sort order of elements that we have on the server, this is problematic for caching LET and their ranges.
  * When enabling caching for customId types we convert the id that we store in cache from base64Url to base64Ext so we have the same sort order. (see function
- * OfflineStorage.ensureBase64Ext). In theory, we can try to enable caching for all types but as of now we enable it for a limited amount of types because there
+ * EntityUtils.serverToLocalIdEncoding). In theory, we can try to enable caching for all types but as of now we enable it for a limited amount of types because there
  * are other ways to cache customId types (see implementation of CustomCacheHandler)
  */
 const CACHEABLE_CUSTOMID_TYPES = [tutanotaTypeRefs.MailSetEntryTypeRef, sysTypeRefs.GroupKeyTypeRef] as const

--- a/src/common/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/common/api/worker/rest/EphemeralCacheStorage.ts
@@ -1,14 +1,14 @@
 import {
 	AttributeModel,
 	BlobElementEntity,
-	customIdToBase64Url,
-	ensureBase64Ext,
 	Entity,
 	firstBiggerThanSecondBase64Ext,
 	GENERATED_MIN_ID,
 	hasError,
 	ListElementEntity,
+	localToServerIdEncoding,
 	ServerModelParsedInstance,
+	serverToLocalIdEncoding,
 	ServerTypeModelResolver,
 	SomeEntity,
 	Type as TypeId,
@@ -88,7 +88,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 		// We downcast because we can't prove that map has correct entity on the type level
 		const type = getTypeString(typeRef)
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
-		id = ensureBase64Ext(typeModel, id)
+		id = serverToLocalIdEncoding(typeModel, id)
 		switch (typeModel.type) {
 			case TypeId.Element:
 				return clone(this.entities.get(type)?.get(id) ?? null)
@@ -109,7 +109,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 		reverse: boolean,
 	): Promise<ServerModelParsedInstance[]> {
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
-		startElementId = ensureBase64Ext(typeModel, startElementId)
+		startElementId = serverToLocalIdEncoding(typeModel, startElementId)
 
 		const listCache = this.lists.get(getTypeString(typeRef))?.get(listId)
 
@@ -186,7 +186,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	): Promise<void> {
 		const type = getTypeString(typeRef)
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
-		elementId = ensureBase64Ext(typeModel, elementId)
+		elementId = serverToLocalIdEncoding(typeModel, elementId)
 
 		const handler = this.customCacheHandlerMap.get(typeRef)
 		const id: T["_id"] = listId == null ? elementId : [listId, elementId]
@@ -229,7 +229,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 
 	async isElementIdInCacheRange(typeRef: TypeRef<unknown>, listId: Id, elementId: Id): Promise<boolean> {
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
-		elementId = ensureBase64Ext(typeModel, elementId)
+		elementId = serverToLocalIdEncoding(typeModel, elementId)
 
 		const cache = this.lists.get(getTypeString(typeRef))?.get(listId)
 		return cache != null && !firstBiggerThanSecondBase64Ext(elementId, cache.upperRangeId) && !firstBiggerThanSecondBase64Ext(cache.lowerRangeId, elementId)
@@ -246,7 +246,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 			)
 			return
 		}
-		elementId = ensureBase64Ext(typeModel, elementId)
+		elementId = serverToLocalIdEncoding(typeModel, elementId)
 
 		const handler = this.customCacheHandlerMap.get(typeRef as TypeRef<SomeEntity>)
 		if (handler?.onBeforeCacheUpdate) {
@@ -357,14 +357,14 @@ export class EphemeralCacheStorage implements CacheStorage {
 
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
 		return {
-			lower: customIdToBase64Url(typeModel, listCache.lowerRangeId),
-			upper: customIdToBase64Url(typeModel, listCache.upperRangeId),
+			lower: localToServerIdEncoding(typeModel, listCache.lowerRangeId),
+			upper: localToServerIdEncoding(typeModel, listCache.upperRangeId),
 		}
 	}
 
 	async setUpperRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, upperId: Id): Promise<void> {
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
-		upperId = ensureBase64Ext(typeModel, upperId)
+		upperId = serverToLocalIdEncoding(typeModel, upperId)
 		const listCache = this.lists.get(getTypeString(typeRef))?.get(listId)
 		if (listCache == null) {
 			throw new Error("list does not exist")
@@ -374,7 +374,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 
 	async setLowerRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lowerId: Id): Promise<void> {
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
-		lowerId = ensureBase64Ext(typeModel, lowerId)
+		lowerId = serverToLocalIdEncoding(typeModel, lowerId)
 		const listCache = this.lists.get(getTypeString(typeRef))?.get(listId)
 		if (listCache == null) {
 			throw new Error("list does not exist")
@@ -391,8 +391,8 @@ export class EphemeralCacheStorage implements CacheStorage {
 	 */
 	async setNewRangeForList<T extends ListElementEntity>(typeRef: TypeRef<T>, listId: Id, lower: Id, upper: Id): Promise<void> {
 		const typeModel = await this.typeModelResolver.resolveServerTypeReference(typeRef)
-		lower = ensureBase64Ext(typeModel, lower)
-		upper = ensureBase64Ext(typeModel, upper)
+		lower = serverToLocalIdEncoding(typeModel, lower)
+		upper = serverToLocalIdEncoding(typeModel, upper)
 
 		const typeId = getTypeString(typeRef)
 		const listCache = this.lists.get(typeId)?.get(listId)
@@ -417,7 +417,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 				.get(getTypeString(typeRef))
 				?.get(listId)
 				?.allRange.map((elementId) => {
-					return customIdToBase64Url(typeModel, elementId)
+					return localToServerIdEncoding(typeModel, elementId)
 				}) ?? []
 		)
 	}

--- a/src/common/api/worker/rest/EphemeralCacheStorage.ts
+++ b/src/common/api/worker/rest/EphemeralCacheStorage.ts
@@ -1,13 +1,24 @@
-import { BlobElementEntity, Entity, ListElementEntity, ServerModelParsedInstance, SomeEntity, TypeModel } from "@tutao/typerefs"
-import { customIdToBase64Url, ensureBase64Ext, firstBiggerThanSecond, GENERATED_MIN_ID } from "@tutao/typerefs"
+import {
+	AttributeModel,
+	BlobElementEntity,
+	customIdToBase64Url,
+	ensureBase64Ext,
+	Entity,
+	firstBiggerThanSecondBase64Ext,
+	GENERATED_MIN_ID,
+	hasError,
+	ListElementEntity,
+	ServerModelParsedInstance,
+	ServerTypeModelResolver,
+	SomeEntity,
+	Type as TypeId,
+	TypeModel,
+} from "@tutao/typerefs"
 import { CacheStorage, LastUpdateTime } from "./DefaultEntityRestCache.js"
-import { assertNotNull, clone, filterNull, getFromMap, getTypeString, newPromise, Nullable, parseTypeString, remove, TypeRef } from "@tutao/utils"
+import { assertNotNull, clone, filterNull, getFromMap, getTypeString, Nullable, parseTypeString, remove, TypeRef } from "@tutao/utils"
 import { CustomCacheHandlerMap } from "./cacheHandler/CustomCacheHandler.js"
-import { Type as TypeId, hasError } from "@tutao/typerefs"
 import { ProgrammingError } from "@tutao/app-env"
-import { AttributeModel } from "@tutao/typerefs"
 import { ModelMapper } from "@tutao/instance-pipeline"
-import { ServerTypeModelResolver } from "@tutao/typerefs"
 import { expandId } from "./RestClientIdUtils"
 import type { SpamClassificationModel } from "../../../../mail-app/workerUtils/spamClassification/SpamClassifier"
 
@@ -111,7 +122,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 		if (reverse) {
 			let i
 			for (i = range.length - 1; i >= 0; i--) {
-				if (firstBiggerThanSecond(startElementId, range[i])) {
+				if (firstBiggerThanSecondBase64Ext(startElementId, range[i])) {
 					break
 				}
 			}
@@ -127,7 +138,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 				ids = []
 			}
 		} else {
-			const i = range.findIndex((id) => firstBiggerThanSecond(id, startElementId))
+			const i = range.findIndex((id) => firstBiggerThanSecondBase64Ext(id, startElementId))
 			ids = range.slice(i, i + count)
 		}
 		let result: ServerModelParsedInstance[] = []
@@ -221,7 +232,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 		elementId = ensureBase64Ext(typeModel, elementId)
 
 		const cache = this.lists.get(getTypeString(typeRef))?.get(listId)
-		return cache != null && !firstBiggerThanSecond(elementId, cache.upperRangeId) && !firstBiggerThanSecond(cache.lowerRangeId, elementId)
+		return cache != null && !firstBiggerThanSecondBase64Ext(elementId, cache.upperRangeId) && !firstBiggerThanSecondBase64Ext(cache.lowerRangeId, elementId)
 	}
 
 	async put(typeRef: TypeRef<unknown>, instance: ServerModelParsedInstance): Promise<void> {
@@ -310,7 +321,7 @@ export class EphemeralCacheStorage implements CacheStorage {
 	private insertIntoAllRange(allRange: Array<Id>, elementId: Id) {
 		for (let i = 0; i < allRange.length; i++) {
 			const rangeElement = allRange[i]
-			if (firstBiggerThanSecond(rangeElement, elementId)) {
+			if (firstBiggerThanSecondBase64Ext(rangeElement, elementId)) {
 				allRange.splice(i, 0, elementId)
 				return
 			}

--- a/src/common/api/worker/rest/cacheHandler/CustomCalendarEventCacheHandler.ts
+++ b/src/common/api/worker/rest/cacheHandler/CustomCalendarEventCacheHandler.ts
@@ -1,12 +1,21 @@
 import { CustomCacheHandler } from "./CustomCacheHandler"
-import { tutanotaTypeRefs } from "@tutao/typerefs"
+import {
+	AttributeModel,
+	CUSTOM_MAX_ID,
+	CUSTOM_MIN_ID,
+	elementIdPart,
+	firstBiggerThanSecond,
+	getElementId,
+	getServerIdEncodingForType,
+	LOAD_MULTIPLE_LIMIT,
+	ServerModelParsedInstance,
+	tutanotaTypeRefs,
+	TypeModel,
+	TypeModelResolver,
+} from "@tutao/typerefs"
 import { CacheStorage, Range } from "../DefaultEntityRestCache"
-import { TypeModelResolver } from "@tutao/typerefs"
-import { ServerModelParsedInstance, TypeModel } from "@tutao/typerefs"
 import { EntityRestClient } from "../EntityRestClient"
-import { CUSTOM_MAX_ID, CUSTOM_MIN_ID, elementIdPart, firstBiggerThanSecond, getElementId, LOAD_MULTIPLE_LIMIT } from "@tutao/typerefs"
 import { ProgrammingError } from "@tutao/app-env"
-import { AttributeModel } from "@tutao/typerefs"
 
 /**
  * implements range loading in JS because the custom Ids of calendar events prevent us from doing
@@ -51,13 +60,14 @@ export class CustomCalendarEventCacheHandler implements CustomCacheHandler<tutan
 		}
 		const unsortedList = await this.entityRestClient.mapInstancesToEntity(tutanotaTypeRefs.CalendarEventTypeRef, rawList)
 
+		const idEncoding = getServerIdEncodingForType(typeModel)
 		const sortedList = reverse
 			? unsortedList
-					.filter((calendarEvent) => firstBiggerThanSecond(start, getElementId(calendarEvent), typeModel))
-					.sort((a, b) => (firstBiggerThanSecond(getElementId(b), getElementId(a), typeModel) ? 1 : -1))
+					.filter((calendarEvent) => firstBiggerThanSecond(start, getElementId(calendarEvent), idEncoding))
+					.sort((a, b) => (firstBiggerThanSecond(getElementId(b), getElementId(a), idEncoding) ? 1 : -1))
 			: unsortedList
-					.filter((calendarEvent) => firstBiggerThanSecond(getElementId(calendarEvent), start, typeModel))
-					.sort((a, b) => (firstBiggerThanSecond(getElementId(a), getElementId(b), typeModel) ? 1 : -1))
+					.filter((calendarEvent) => firstBiggerThanSecond(getElementId(calendarEvent), start, idEncoding))
+					.sort((a, b) => (firstBiggerThanSecond(getElementId(a), getElementId(b), idEncoding) ? 1 : -1))
 		return sortedList.slice(0, count)
 	}
 

--- a/src/common/contactsFunctionality/ContactModel.ts
+++ b/src/common/contactsFunctionality/ContactModel.ts
@@ -1,5 +1,5 @@
 import { assertMainOrNode, ShareCapability } from "@tutao/app-env"
-import { elementIdPart, entityUpdateUtils, getEtId, listIdPart, sortCompareById, sysTypeRefs, tutanotaTypeRefs } from "@tutao/typerefs"
+import { elementIdPart, entityUpdateUtils, getEtId, EntityIdEncoding, listIdPart, sortCompareById, sysTypeRefs, tutanotaTypeRefs } from "@tutao/typerefs"
 import { assertNotNull, first, getFirstOrThrow, isNotNull, LazyLoaded, ofClass, promiseMap } from "@tutao/utils"
 import Stream from "mithril/stream"
 import stream from "mithril/stream"
@@ -98,7 +98,7 @@ export class ContactModel {
 			(await this.findContactsUsingFacade(cleanedMailAddress, listId)) ?? (await this.entityClient.loadAll(tutanotaTypeRefs.ContactTypeRef, listId))
 
 		// the result is sorted from newest to oldest, but we want to return the oldest first like before
-		result.sort(sortCompareById)
+		result.sort((a, b) => sortCompareById(a, b, EntityIdEncoding.Base64Ext))
 
 		// searchFacade is not guaranteed to return an exact match, but we are looking for an exact match for the given
 		// mail address

--- a/src/common/mailFunctionality/SendMailModel.ts
+++ b/src/common/mailFunctionality/SendMailModel.ts
@@ -30,7 +30,7 @@ import {
 	ofClass,
 	promiseMap,
 	remove,
-	stringToCustomId,
+	stringToBase64UrlCustomId,
 	typedValues,
 } from "@tutao/utils"
 import Stream from "mithril/stream"
@@ -1241,7 +1241,7 @@ export class SendMailModel {
 	private sendApprovalMail(body: string): Promise<unknown> {
 		const listId = "---------c--"
 		const m = monitorTypeRefs.createApprovalMail({
-			_id: [listId, stringToCustomId(this.senderAddress)],
+			_id: [listId, stringToBase64UrlCustomId(this.senderAddress)],
 			_ownerGroup: this.user().user.userGroup.group,
 			text: `Subject: ${this.getSubject()}<br>${body}`,
 			date: null,

--- a/src/crypto/CryptoUtils.ts
+++ b/src/crypto/CryptoUtils.ts
@@ -1,6 +1,5 @@
-import { isKeyVersion, KeyVersion, stringToCustomId } from "@tutao/utils"
+import { isKeyVersion, KeyVersion } from "@tutao/utils"
 import { CryptoError } from "@tutao/crypto/error"
-import { customIdToString } from "@tutao/utils"
 
 export function parseKeyVersion(version: NumberString): KeyVersion {
 	const versionAsNumber = Number(version)

--- a/src/mail-app/contacts/view/ContactGuiUtils.ts
+++ b/src/mail-app/contacts/view/ContactGuiUtils.ts
@@ -1,6 +1,6 @@
 import type { MaybeTranslation, TranslationKey } from "../../../common/misc/LanguageViewModel"
 import { lang } from "../../../common/misc/LanguageViewModel"
-import { sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
+import { EntityIdEncoding, sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
 import {
 	ContactAddressType,
 	ContactCustomDateType,
@@ -194,13 +194,13 @@ export function compareContacts(contact1: tutanotaTypeRefs.Contact, contact2: tu
 				return 1
 			} else if (c1MailLength === 0 && c2MailLength === 0) {
 				// see Multiselect with shift and up arrow not working properly #152 at github
-				return sortCompareByReverseId(contact1, contact2)
+				return sortCompareByReverseId(contact1, contact2, EntityIdEncoding.Base64Ext)
 			} else {
 				result = contact1.mailAddresses[0].address.trim().localeCompare(contact2.mailAddresses[0].address.trim())
 
 				if (result === 0) {
 					// see Multiselect with shift and up arrow not working properly #152 at github
-					return sortCompareByReverseId(contact1, contact2)
+					return sortCompareByReverseId(contact1, contact2, EntityIdEncoding.Base64Ext)
 				} else {
 					return result
 				}

--- a/src/mail-app/contacts/view/ContactSelectionDialog.ts
+++ b/src/mail-app/contacts/view/ContactSelectionDialog.ts
@@ -1,6 +1,6 @@
 import { Dialog, DialogType } from "../../../common/gui/base/Dialog.js"
 import { lang, TranslationKey } from "../../../common/misc/LanguageViewModel.js"
-import { tutanotaTypeRefs } from "@tutao/typerefs"
+import { elementIdPart, EntityIdEncoding, isSameId, sortCompareById, tutanotaTypeRefs } from "@tutao/typerefs"
 import m from "mithril"
 import { List, ListAttrs, ListState, MultiselectMode, RenderConfig } from "../../../common/gui/base/List.js"
 import { component_size, px } from "../../../common/gui/size.js"
@@ -12,7 +12,6 @@ import { theme } from "../../../common/gui/theme"
 import { Card } from "../../../common/gui/base/Card"
 import { ContentWithOptionsDialog } from "../../../common/gui/dialogs/ContentWithOptionsDialog"
 import { ListModel, selectionAttrsForList } from "../../../common/misc/ListModel"
-import { elementIdPart, isSameId, sortCompareById } from "@tutao/typerefs"
 import { noOp } from "@tutao/utils"
 import { ListAutoSelectBehavior } from "../../../common/misc/DeviceConfig"
 import Stream from "mithril/stream"
@@ -170,7 +169,7 @@ class ContactSelectionDialogViewModel {
 			},
 
 			sortCompare: (item1, item2) => {
-				return sortCompareById(item1, item2)
+				return sortCompareById(item1, item2, EntityIdEncoding.Base64Ext)
 			},
 
 			getItemId: (item) => elementIdPart(item._id),

--- a/src/mail-app/mail/model/ConversationListModel.ts
+++ b/src/mail-app/mail/model/ConversationListModel.ts
@@ -1,12 +1,13 @@
 import { applyInboxRulesAndSpamPrediction, LoadedMail, MailSetListModel, resolveMailSetEntries } from "./MailSetListModel"
 import { ListLoadingState, ListState } from "../../../common/gui/base/List"
 import {
+	compareNewestFirst,
 	CUSTOM_MAX_ID,
-	customIdToUint8array,
 	deconstructMailSetEntryId,
 	elementIdPart,
 	entityUpdateUtils,
 	getElementId,
+	EntityIdEncoding,
 	isSameId,
 	listIdPart,
 	tutanotaTypeRefs,
@@ -19,7 +20,6 @@ import { MailModel } from "./MailModel"
 import { ExposedCacheStorage } from "../../../common/api/worker/rest/DefaultEntityRestCache"
 import {
 	assertNotNull,
-	compare,
 	findAllAndRemove,
 	first,
 	insertIntoSortedArray,
@@ -580,7 +580,7 @@ export class ConversationListModel implements MailSetListModel {
 			return -1
 		}
 
-		return reverseCompareMailSetId(elementIdPart(item1Id), elementIdPart(item2Id))
+		return reverseCompareMailSetEntryId(elementIdPart(item1Id), elementIdPart(item2Id))
 	}
 
 	/**
@@ -692,9 +692,9 @@ export class ConversationListModel implements MailSetListModel {
 	}
 }
 
-function reverseCompareMailSetId(id1: Id, id2: Id): number {
+function reverseCompareMailSetEntryId(id1: Id, id2: Id): number {
 	// Sort in reverse order to ensure newer mails are first
-	return compare(customIdToUint8array(id2), customIdToUint8array(id1))
+	return compareNewestFirst(id1, id2, EntityIdEncoding.Base64URL)
 }
 
 /**
@@ -718,7 +718,7 @@ export class LoadedConversation {
 		insertIntoSortedArray(
 			mail,
 			this.conversationMails,
-			(a, b) => reverseCompareMailSetId(elementIdPart(a.mailSetEntryId), elementIdPart(b.mailSetEntryId)),
+			(a, b) => reverseCompareMailSetEntryId(elementIdPart(a.mailSetEntryId), elementIdPart(b.mailSetEntryId)),
 			() => true,
 		)
 	}

--- a/src/mail-app/mail/model/MailListModel.ts
+++ b/src/mail-app/mail/model/MailListModel.ts
@@ -1,11 +1,12 @@
 import { ListFilter, ListModel } from "../../../common/misc/ListModel"
 import {
+	compareNewestFirst,
 	CUSTOM_MAX_ID,
-	customIdToUint8array,
 	deconstructMailSetEntryId,
 	elementIdPart,
 	entityUpdateUtils,
 	getElementId,
+	EntityIdEncoding,
 	isSameId,
 	listIdPart,
 	tutanotaTypeRefs,
@@ -13,7 +14,7 @@ import {
 import { EntityClient } from "../../../common/api/common/EntityClient"
 import { ConversationPrefProvider } from "../view/ConversationViewModel"
 import { assertMainOrNode, OperationType } from "@tutao/app-env"
-import { assertNotNull, compare, first, last, memoizedWithHiddenArgument } from "@tutao/utils"
+import { assertNotNull, first, last, memoizedWithHiddenArgument } from "@tutao/utils"
 import { ListLoadingState, ListState } from "../../../common/gui/base/List"
 import Stream from "mithril/stream"
 import { MailModel } from "./MailModel"
@@ -59,7 +60,7 @@ export class MailListModel implements MailSetListModel {
 				const item2Id = elementIdPart(item2.mailSetEntryId)
 
 				// Sort in reverse order to ensure newer mails are first
-				return compare(customIdToUint8array(item2Id), customIdToUint8array(item1Id))
+				return compareNewestFirst(item1Id, item2Id, EntityIdEncoding.Base64URL)
 			},
 
 			getItemId: (item) => elementIdPart(item.mailSetEntryId),

--- a/src/mail-app/mail/model/MailUtils.ts
+++ b/src/mail-app/mail/model/MailUtils.ts
@@ -1,5 +1,5 @@
 import { FolderSystem, IndentedFolder } from "../../../common/api/common/mail/FolderSystem.js"
-import { isFolderReadOnly, isSameId, MOVE_SYSTEM_FOLDERS, sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
+import { EntityIdEncoding, isFolderReadOnly, isSameId, MOVE_SYSTEM_FOLDERS, sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
 import { assertNotNull, first } from "@tutao/utils"
 import { MailModel } from "./MailModel.js"
 import { lang } from "../../../common/misc/LanguageViewModel.js"
@@ -186,7 +186,7 @@ export function mailInFolder(mail: tutanotaTypeRefs.Mail, folderId: IdTuple): bo
 export function compareMails(mail1: tutanotaTypeRefs.Mail, mail2: tutanotaTypeRefs.Mail): number {
 	const dateDifference = mail2.receivedDate.getTime() - mail1.receivedDate.getTime()
 	if (dateDifference === 0) {
-		return sortCompareByReverseId(mail1, mail2)
+		return sortCompareByReverseId(mail1, mail2, EntityIdEncoding.Base64Ext)
 	} else {
 		return dateDifference
 	}

--- a/src/mail-app/mail/view/ConversationViewModel.ts
+++ b/src/mail-app/mail/view/ConversationViewModel.ts
@@ -1,4 +1,13 @@
-import { elementIdPart, entityUpdateUtils, firstBiggerThanSecond, getElementId, haveSameId, isSameId, listIdPart, tutanotaTypeRefs } from "@tutao/typerefs"
+import {
+	elementIdPart,
+	entityUpdateUtils,
+	firstBiggerThanSecondBase64Ext,
+	getElementId,
+	haveSameId,
+	isSameId,
+	listIdPart,
+	tutanotaTypeRefs,
+} from "@tutao/typerefs"
 import { MailViewerViewModel } from "./MailViewerViewModel.js"
 import { CreateMailViewerOptions } from "./MailViewer.js"
 import {
@@ -124,7 +133,7 @@ export class ConversationViewModel {
 					return
 				}
 				const mail = await this.entityClient.load(tutanotaTypeRefs.MailTypeRef, entry.mail)
-				let index = findLastIndex(conversation, (i) => firstBiggerThanSecond(getElementId(entry), elementIdPart(i.entryId)))
+				let index = findLastIndex(conversation, (i) => firstBiggerThanSecondBase64Ext(getElementId(entry), elementIdPart(i.entryId)))
 				if (index < 0) {
 					index = conversation.length
 				} else {

--- a/src/mail-app/search/view/SearchViewModel.ts
+++ b/src/mail-app/search/view/SearchViewModel.ts
@@ -9,6 +9,7 @@ import {
 	entityUpdateUtils,
 	GENERATED_MAX_ID,
 	getElementId,
+	EntityIdEncoding,
 	isPermanentDeleteAllowedForFolder,
 	isSameId,
 	ListElement,
@@ -17,7 +18,7 @@ import {
 	sortCompareByReverseId,
 	tutanotaTypeRefs,
 } from "@tutao/typerefs"
-import { FULL_INDEXED_TIMESTAMP, isBrowser, MailSetKind, Mode, NOTHING_INDEXED_TIMESTAMP, OperationType } from "@tutao/app-env"
+import { FULL_INDEXED_TIMESTAMP, isBrowser, MailSetKind, Mode, NOTHING_INDEXED_TIMESTAMP, OperationType, ProgrammingError } from "@tutao/app-env"
 import { ListLoadingState, ListState } from "../../../common/gui/base/List.js"
 import {
 	assertNotNull,
@@ -67,7 +68,6 @@ import { MailOpenedListener } from "../../mail/view/MailViewModel.js"
 
 import { CalendarInfoBase, CalendarModel, isBirthdayCalendarInfo, isCalendarInfo } from "../../../calendar-app/calendar/model/CalendarModel.js"
 import { CalendarFacade } from "../../../common/api/worker/facades/lazy/CalendarFacade.js"
-import { ProgrammingError } from "@tutao/app-env"
 import { ProgressTracker } from "../../../common/api/main/ProgressTracker.js"
 import { ListAutoSelectBehavior } from "../../../common/misc/DeviceConfig.js"
 import { generateCalendarInstancesInRange, isBirthdayCalendar, retrieveBirthdayEventsForUser } from "../../../common/calendar/date/CalendarUtils.js"
@@ -949,17 +949,17 @@ export class SearchViewModel {
 						const resultB = this.searchResultIdToIndex.get(getElementId(o2.entry))
 
 						if (resultA == null || resultB == null) {
-							return sortCompareByReverseId(o1.entry, o2.entry)
+							return sortCompareByReverseId(o1.entry, o2.entry, EntityIdEncoding.Base64Ext)
 						}
 
 						return resultA - resultB
 					} else {
 						// IndexedDb only loads a small amount of results at once, expanding the results as we scroll
 						// through the list, and since it's loaded by ID range, results can jump around mid-scroll.
-						return sortCompareByReverseId(o1.entry, o2.entry)
+						return sortCompareByReverseId(o1.entry, o2.entry, EntityIdEncoding.Base64Ext)
 					}
 				} else {
-					return sortCompareByReverseId(o1.entry, o2.entry)
+					throw new ProgrammingError(`cannot sort entries for type: ${o1.entry._type.app}/${o1.entry._type.typeId}`)
 				}
 			},
 			autoSelectBehavior: () => (isSameTypeRef(this.searchedType, tutanotaTypeRefs.MailTypeRef) ? this.selectionBehavior : ListAutoSelectBehavior.OLDER),

--- a/src/mail-app/settings/DesktopMailImportSettingsViewer.ts
+++ b/src/mail-app/settings/DesktopMailImportSettingsViewer.ts
@@ -8,7 +8,7 @@ import { ImportStatus, UpgradePromptType } from "@tutao/app-env"
 import { IndentedFolder } from "../../common/api/common/mail/FolderSystem"
 import { lang, TranslationKey } from "../../common/misc/LanguageViewModel"
 import { MailImporter, UiImportStatus } from "../mail/import/MailImporter.js"
-import { elementIdPart, entityUpdateUtils, generatedIdToTimestamp, isSameId, sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
+import { elementIdPart, entityUpdateUtils, generatedIdToTimestamp, EntityIdEncoding, isSameId, sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
 import { Icons } from "../../common/gui/base/icons/Icons.js"
 import { DropDownSelector, type DropDownSelectorAttrs, SelectorItemList } from "../../common/gui/base/DropDownSelector.js"
 import { showUpgradeWizardOrSwitchSubscriptionDialog } from "../../common/misc/SubscriptionDialogs.js"
@@ -280,7 +280,7 @@ export class DesktopMailImportSettingsViewer implements UpdatableSettingsViewer 
 		if (folders) {
 			return this.mailImporter()
 				.getFinalisedImports(mailboxId)
-				.sort(sortCompareByReverseId)
+				.sort((a, b) => sortCompareByReverseId(a, b, EntityIdEncoding.Base64Ext))
 				.map((im) => {
 					const targetFolderId = im.targetFolder
 					const displayTargetFolder = folders!.find((f) => isSameId(f.folder._id, targetFolderId))

--- a/src/mail-app/settings/GlobalSettingsViewer.ts
+++ b/src/mail-app/settings/GlobalSettingsViewer.ts
@@ -9,6 +9,7 @@ import {
 	generatedIdToTimestamp,
 	getElementId,
 	getSpamRuleField,
+	EntityIdEncoding,
 	sortCompareByReverseId,
 	sysTypeRefs,
 	timestampToGeneratedId,
@@ -215,7 +216,7 @@ export class GlobalSettingsViewer implements UpdatableSettingsViewer {
 						)
 					} else {
 						// ensure that rejected senders are sorted in descending order
-						return rejectedSenders.sort(sortCompareByReverseId)
+						return rejectedSenders.sort((a, b) => sortCompareByReverseId(a, b, EntityIdEncoding.Base64Ext))
 					}
 				})
 				.then((rejectedSenders) => {

--- a/src/mail-app/workerUtils/index/IndexedDbSearchFacade.ts
+++ b/src/mail-app/workerUtils/index/IndexedDbSearchFacade.ts
@@ -1,13 +1,15 @@
-import type { TypeModel } from "@tutao/typerefs"
 import {
 	AssociationType,
 	Cardinality,
 	ClientTypeModelResolver,
 	compareNewestFirst,
 	elementIdPart,
-	firstBiggerThanSecond,
+	EntityIdEncoding,
+	firstBiggerThanSecondBase64Ext,
+	getServerIdEncodingForType,
 	timestampToGeneratedId,
 	tutanotaTypeRefs,
+	TypeModel,
 	ValueType,
 } from "@tutao/typerefs"
 import { DbTransaction } from "../../../common/api/worker/search/DbFacade.js"
@@ -15,6 +17,7 @@ import {
 	arrayHashSigned,
 	assertNotNull,
 	asyncFind,
+	base64UrlToBase64Ext,
 	contains,
 	downcast,
 	isEmpty,
@@ -114,6 +117,8 @@ export class IndexedDbSearchFacade implements SearchFacade {
 			let isFirstWordSearch = searchTokens.length === 1
 			let before = getPerformanceTimestamp()
 
+			const typeModel = await this.typeModelResolver.resolveClientTypeReference(restriction.type)
+			const idEncoding = getServerIdEncodingForType(typeModel)
 			let searchPromise
 
 			if (minSuggestionCount > 0 && isFirstWordSearch && isSameTypeRef(tutanotaTypeRefs.ContactTypeRef, restriction.type)) {
@@ -136,7 +141,7 @@ export class IndexedDbSearchFacade implements SearchFacade {
 				searchPromise = this.startOrContinueSearch(result).then(() => {
 					// we now filter for the suggestion token manually because searching for suggestions for the last word and reducing the initial search result with them can lead to
 					// dozens of searches without any effect when the seach token is found in too many contacts, e.g. in the email address with the ending "de"
-					result.results.sort(compareNewestFirst)
+					result.results.sort((a, b) => compareNewestFirst(a, b, idEncoding))
 					return this.loadAndReduce(restriction, result, suggestionToken, minSuggestionCount)
 				})
 			} else {
@@ -144,7 +149,7 @@ export class IndexedDbSearchFacade implements SearchFacade {
 			}
 
 			return searchPromise.then(() => {
-				result.results.sort(compareNewestFirst)
+				result.results.sort((a, b) => compareNewestFirst(a, b, idEncoding))
 				return result
 			})
 		} else {
@@ -152,20 +157,22 @@ export class IndexedDbSearchFacade implements SearchFacade {
 		}
 	}
 
-	extendSearchResult(result: SearchResult, extensionEnd: number): Promise<SearchResult> {
+	async extendSearchResult(result: SearchResult, extensionEnd: number): Promise<SearchResult> {
 		const restrictionEnd = assertNotNull(result.restriction.end, "null end restriction when extending search")
 		result.restriction = {
 			...result.restriction,
 			end: extensionEnd,
 		}
 
-		return this.startOrContinueSearch(result).then(() => {
-			result.restriction.end = Math.min(restrictionEnd, extensionEnd)
-			result.currentIndexTimestamp = getMailIndexTimestampForSearch(this.mailIndexer.currentIndexTimestamp)
-			result.results.sort(compareNewestFirst)
+		await this.startOrContinueSearch(result)
 
-			return result
-		})
+		result.restriction.end = Math.min(restrictionEnd, extensionEnd)
+		result.currentIndexTimestamp = getMailIndexTimestampForSearch(this.mailIndexer.currentIndexTimestamp)
+
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(result.restriction.type)
+		result.results.sort((a, b) => compareNewestFirst(a, b, getServerIdEncodingForType(typeModel)))
+
+		return result
 	}
 
 	private async loadAndReduce(restriction: SearchRestriction, result: SearchResult, suggestionToken: string, minSuggestionCount: number): Promise<void> {
@@ -246,9 +253,10 @@ export class IndexedDbSearchFacade implements SearchFacade {
 		}).then((found) => found != null)
 	}
 
-	private startOrContinueSearch(searchResult: SearchResult, maxResults?: number): Promise<void> {
+	private async startOrContinueSearch(searchResult: SearchResult, maxResults?: number): Promise<void> {
 		markStart("findIndexEntries")
 
+		const typeModel = await this.typeModelResolver.resolveClientTypeReference(searchResult.restriction.type)
 		let moreResultsEntries: Promise<Array<MoreResultsIndexEntry>>
 
 		if (maxResults && searchResult.moreResults.length >= maxResults) {
@@ -268,7 +276,7 @@ export class IndexedDbSearchFacade implements SearchFacade {
 				.then((keyToIndexEntries) => {
 					markEnd("_decryptSearchResult")
 					markStart("_filterByTypeAndAttributeAndTime")
-					return this.filterByTypeAndAttributeAndTime(keyToIndexEntries, searchResult.restriction)
+					return this.filterByTypeAndAttributeAndTime(keyToIndexEntries, searchResult.restriction, typeModel)
 				})
 				.then((keyToIndexEntries) => {
 					markEnd("_filterByTypeAndAttributeAndTime")
@@ -289,7 +297,7 @@ export class IndexedDbSearchFacade implements SearchFacade {
 		return moreResultsEntries
 			.then((searchIndexEntries: MoreResultsIndexEntry[]) => {
 				markStart("_filterByListIdAndGroupSearchResults")
-				return this.filterByListIdAndGroupSearchResults(searchIndexEntries, searchResult, maxResults)
+				return this.filterByListIdAndGroupSearchResults(searchIndexEntries, searchResult, maxResults, typeModel)
 			})
 			.then(() => {
 				markEnd("_filterByListIdAndGroupSearchResults")
@@ -525,15 +533,16 @@ export class IndexedDbSearchFacade implements SearchFacade {
 		})
 	}
 
-	private filterByTypeAndAttributeAndTime(results: KeyToIndexEntries[], restriction: SearchRestriction): KeyToIndexEntries[] {
+	private filterByTypeAndAttributeAndTime(results: KeyToIndexEntries[], restriction: SearchRestriction, typeModel: TypeModel): KeyToIndexEntries[] {
 		// first filter each index entry by itself
 		let endTimestamp = getSearchEndTimestamp(this.mailIndexer.currentIndexTimestamp, restriction)
 
+		const idEncoding = getServerIdEncodingForType(typeModel)
 		const minIncludedId = timestampToGeneratedId(endTimestamp)
 		const maxExcludedId = restriction.start ? timestampToGeneratedId(restriction.start + 1) : null
 		for (const result of results) {
 			result.indexEntries = result.indexEntries.filter((entry) => {
-				return this.isValidAttributeAndTime(restriction, entry, minIncludedId, maxExcludedId)
+				return this.isValidAttributeAndTime(restriction, entry, minIncludedId, maxExcludedId, idEncoding)
 			})
 		}
 		// now filter all ids that are in all of the search words
@@ -559,22 +568,29 @@ export class IndexedDbSearchFacade implements SearchFacade {
 		})
 	}
 
-	private isValidAttributeAndTime(restriction: SearchRestriction, entry: SearchIndexEntry, minIncludedId: Id, maxExcludedId: Id | null): boolean {
+	private isValidAttributeAndTime(
+		restriction: SearchRestriction,
+		entry: SearchIndexEntry,
+		minIncludedId: Id,
+		maxExcludedId: Id | null,
+		entryIdEncoding: EntityIdEncoding,
+	): boolean {
 		if (restriction.attributeIds) {
 			if (!contains(restriction.attributeIds, entry.attribute)) {
 				return false
 			}
 		}
 
+		const base64ExtEntryId = entryIdEncoding === EntityIdEncoding.Base64URL ? base64UrlToBase64Ext(entry.id) : entry.id
 		if (maxExcludedId) {
 			// timestampToGeneratedId provides the lowest id with the given timestamp (server id and counter set to 0),
 			// so we add one millisecond to make sure all ids of the timestamp are covered
-			if (!firstBiggerThanSecond(maxExcludedId, entry.id)) {
+			if (!firstBiggerThanSecondBase64Ext(maxExcludedId, base64ExtEntryId)) {
 				return false
 			}
 		}
 
-		return !firstBiggerThanSecond(minIncludedId, entry.id)
+		return !firstBiggerThanSecondBase64Ext(minIncludedId, base64ExtEntryId)
 	}
 
 	private reduceWords(results: KeyToIndexEntries[], matchWordOrder: boolean): ReadonlyArray<DecryptedSearchIndexEntry> {
@@ -623,9 +639,11 @@ export class IndexedDbSearchFacade implements SearchFacade {
 	private filterByListIdAndGroupSearchResults(
 		indexEntries: Array<MoreResultsIndexEntry>,
 		searchResult: SearchResult,
-		maxResults: number | null | undefined,
+		maxResults: number | undefined,
+		typeModel: TypeModel,
 	): Promise<void> {
-		indexEntries.sort((l, r) => compareNewestFirst(l.id, r.id))
+		const idEncoding = getServerIdEncodingForType(typeModel)
+		indexEntries.sort((l, r) => compareNewestFirst(l.id, r.id, idEncoding))
 		// We filter out everything we've processed from moreEntries, even if we didn't include it
 		// downcast: Array of optional elements in not subtype of non-optional elements
 		const entriesCopy: Array<MoreResultsIndexEntry | null> = downcast(indexEntries.slice())

--- a/src/mail-app/workerUtils/offline/MailOfflineCleaner.ts
+++ b/src/mail-app/workerUtils/offline/MailOfflineCleaner.ts
@@ -2,7 +2,7 @@ import { assertNotNull, groupByAndMap } from "@tutao/utils"
 import {
 	constructMailSetEntryId,
 	elementIdPart,
-	firstBiggerThanSecondCustomId,
+	firstBiggerThanSecondBase64Url,
 	GENERATED_MAX_ID,
 	getElementId,
 	getOfflineStorageDefaultTimeRangeDays,
@@ -64,7 +64,7 @@ export class MailOfflineCleaner implements OfflineStorageCleaner {
 			const mailSetEntriesToDelete: IdTuple[] = []
 			const mailSetEntries = await offlineStorage.getWholeList(tutanotaTypeRefs.MailSetEntryTypeRef, entriesListId)
 			for (let mailSetEntry of mailSetEntries) {
-				if (firstBiggerThanSecondCustomId(cutoffId, getElementId(mailSetEntry))) {
+				if (firstBiggerThanSecondBase64Url(cutoffId, getElementId(mailSetEntry))) {
 					mailSetEntriesToDelete.push(mailSetEntry._id)
 					mailIdsToDelete.push(mailSetEntry.mail)
 				}

--- a/src/mail-app/workerUtils/spamClassification/SpamClassifierDataDealer.ts
+++ b/src/mail-app/workerUtils/spamClassification/SpamClassifierDataDealer.ts
@@ -6,17 +6,17 @@ import {
 	getElementId,
 	getMailSetKind,
 	hasError,
+	EntityIdEncoding,
 	isFolder,
 	isSameId,
 	StrippedEntity,
 	timestampToGeneratedId,
 	tutanotaTypeRefs,
 } from "@tutao/typerefs"
-import { SpamDecision } from "@tutao/app-env"
+import { isAppleDevice, isDesktop, MailSetKind, MAX_NBR_OF_MAILS_SYNC_OPERATION, SpamDecision } from "@tutao/app-env"
 import { BulkMailLoader, MailWithMailDetails } from "../index/BulkMailLoader"
 import { MailFacade } from "../../../common/api/worker/facades/lazy/MailFacade"
 import { getSpamConfidence } from "../../../common/api/common/utils/spamClassificationUtils/SpamMailProcessor"
-import { isAppleDevice, isDesktop, MailSetKind, MAX_NBR_OF_MAILS_SYNC_OPERATION } from "@tutao/app-env"
 
 // visible for testing
 export const SINGLE_TRAIN_INTERVAL_TRAINING_DATA_LIMIT = 1000
@@ -160,7 +160,7 @@ export class SpamClassifierDataDealer {
 		// we always want to include more recently received mails before including older mails
 		const HIGH_CONFIDENCE_THRESHOLD = 4
 
-		const dateSortedClientSpamTrainingData = clientSpamTrainingData.sort((l, r) => compareNewestFirst(l._id, r._id))
+		const dateSortedClientSpamTrainingData = clientSpamTrainingData.sort((l, r) => compareNewestFirst(l._id, r._id, EntityIdEncoding.Base64Ext))
 
 		const hamDataHighConfidence = dateSortedClientSpamTrainingData.filter(
 			(d) => Number(d.confidence) >= HIGH_CONFIDENCE_THRESHOLD && d.spamDecision === SpamDecision.WHITELIST,

--- a/src/typerefs/EntityUtils.ts
+++ b/src/typerefs/EntityUtils.ts
@@ -16,7 +16,7 @@ import {
 	repeat,
 	TypeRef,
 	uint8ArrayToBase64,
-	uint8arrayToCustomId,
+	uint8arrayToBase64UrlCustomId,
 } from "@tutao/utils"
 import { ElementEntity, Entity, ModelValue, ParsedInstance, SomeEntity, TypeModel } from "./EntityTypes.js"
 import { Cardinality, ValueType } from "./EntityConstants.js"
@@ -125,7 +125,7 @@ export const enum EntityIdEncoding {
  */
 export function firstBiggerThanSecond(firstId: Id, secondId: Id, encoding: EntityIdEncoding): boolean {
 	if (encoding === EntityIdEncoding.Base64URL) {
-		return firstBiggerThanSecondCustomId(firstId, secondId)
+		return firstBiggerThanSecondBase64Url(firstId, secondId)
 	} else if (encoding === EntityIdEncoding.Base64Ext) {
 		return firstBiggerThanSecondBase64Ext(firstId, secondId)
 	} else {
@@ -133,8 +133,8 @@ export function firstBiggerThanSecond(firstId: Id, secondId: Id, encoding: Entit
 	}
 }
 
-export function firstBiggerThanSecondCustomId(firstId: Id, secondId: Id): boolean {
-	return compare(customIdToUint8array(firstId), customIdToUint8array(secondId)) === 1
+export function firstBiggerThanSecondBase64Url(firstId: Id, secondId: Id): boolean {
+	return compare(base64UrlIdToUint8array(firstId), base64UrlIdToUint8array(secondId)) === 1
 }
 
 export function firstBiggerThanSecondBase64Ext(firstId: Id, secondId: Id): boolean {
@@ -154,7 +154,7 @@ export function get_IdValue(typeModel?: TypeModel): ModelValue | undefined {
 	}
 }
 
-export function customIdToUint8array(id: Id): Uint8Array {
+export function base64UrlIdToUint8array(id: Id): Uint8Array {
 	if (id === "") {
 		return new Uint8Array()
 	}
@@ -484,11 +484,11 @@ export function constructMailSetEntryId(receiveDate: Date, mailId: Id): Id {
 		buffer.setUint8(i + 4, mailIdBytes[i])
 	}
 
-	return uint8arrayToCustomId(new Uint8Array(buffer.buffer))
+	return uint8arrayToBase64UrlCustomId(new Uint8Array(buffer.buffer))
 }
 
 export function deconstructMailSetEntryId(id: Id): { receiveDate: Date; mailId: Id } {
-	const buffer = customIdToUint8array(id)
+	const buffer = base64UrlIdToUint8array(id)
 	const timestampBytes = buffer.slice(0, 4)
 	const generatedIdBytes = buffer.slice(4)
 
@@ -542,7 +542,7 @@ export function getServerIdEncodingForType(typeModel: TypeModel): EntityIdEncodi
  * @param elementId The element id as it is stored on the server (base64ext for generatedIds, base64url for customIds).
  * @return base64ext encoded id
  */
-export function ensureBase64Ext(typeModel: TypeModel, elementId: Id): Id {
+export function serverToLocalIdEncoding(typeModel: TypeModel, elementId: Id): Id {
 	if (isCustomIdType(typeModel)) {
 		return base64UrlToBase64Ext(elementId)
 	}
@@ -557,7 +557,7 @@ export function ensureBase64Ext(typeModel: TypeModel, elementId: Id): Id {
  * @param elementId The element id as it is stored locally (must be encoded as base64ext).
  * @return base64url encoded id for element with customId, base64ext encoded id otherwise.
  */
-export function customIdToBase64Url(typeModel: TypeModel, elementId: Id): Id {
+export function localToServerIdEncoding(typeModel: TypeModel, elementId: Id): Id {
 	if (isCustomIdType(typeModel)) {
 		return base64ExtToBase64Url(elementId)
 	}

--- a/src/typerefs/EntityUtils.ts
+++ b/src/typerefs/EntityUtils.ts
@@ -1,9 +1,11 @@
 import {
+	assertNotNull,
 	base64ExtToBase64,
+	base64ExtToBase64Url,
 	base64ToBase64Ext,
-	base64ToBase64Url,
 	base64ToUint8Array,
 	base64UrlToBase64,
+	base64UrlToBase64Ext,
 	clone,
 	compare,
 	downcast,
@@ -18,6 +20,7 @@ import {
 } from "@tutao/utils"
 import { ElementEntity, Entity, ModelValue, ParsedInstance, SomeEntity, TypeModel } from "./EntityTypes.js"
 import { Cardinality, ValueType } from "./EntityConstants.js"
+import { ProgrammingError } from "@tutao/app-env"
 
 /**
  * the maximum ID for elements stored on the server (number with the length of 10 bytes) => 2^80 - 1
@@ -104,30 +107,44 @@ export type StrippedEntity<T extends Entity> =
 	  >
 	| OptionalEntity<T>
 
+export const enum EntityIdEncoding {
+	Base64Ext,
+	Base64URL,
+}
+
 /**
  * Tests if one id is bigger than another.
- * For generated IDs we use base64ext which is sortable.
- * For custom IDs we use base64url which is not sortable, so we convert them to string before comparing.
- * Important: using this for custom IDs works only with custom IDs which are derived from strings.
+ * base64ext is sortable, and it's how generated IDs are stored on the server.
+ * base64url is not sortable, and it's how custom IDs are stored on the server.
+ * Important: using this for base64url encoded custom IDs works only with custom IDs which are derived from strings.
  *
  * @param firstId The element id that is tested if it is bigger.
  * @param secondId The element id that is tested against.
- * @param typeModel optional - the type the Ids belong to. this can be used to compare custom IDs.
+ * @param encoding The encoding of the elements ids to be tested
  * @return True if firstId is bigger than secondId, false otherwise.
  */
-export function firstBiggerThanSecond(firstId: Id, secondId: Id, typeModel?: TypeModel): boolean {
-	const _idValue = get_IdValue(typeModel)
-	if (_idValue && _idValue.type === ValueType.CustomId) {
+export function firstBiggerThanSecond(firstId: Id, secondId: Id, encoding: EntityIdEncoding): boolean {
+	if (encoding === EntityIdEncoding.Base64URL) {
 		return firstBiggerThanSecondCustomId(firstId, secondId)
+	} else if (encoding === EntityIdEncoding.Base64Ext) {
+		return firstBiggerThanSecondBase64Ext(firstId, secondId)
 	} else {
-		// if the number of digits is bigger, then the id is bigger, otherwise we can use the lexicographical comparison
-		if (firstId.length > secondId.length) {
-			return true
-		} else if (secondId.length > firstId.length) {
-			return false
-		} else {
-			return firstId > secondId
-		}
+		throw new ProgrammingError(`unknown id type: ${encoding}`)
+	}
+}
+
+export function firstBiggerThanSecondCustomId(firstId: Id, secondId: Id): boolean {
+	return compare(customIdToUint8array(firstId), customIdToUint8array(secondId)) === 1
+}
+
+export function firstBiggerThanSecondBase64Ext(firstId: Id, secondId: Id): boolean {
+	// if the number of digits is bigger, then the id is bigger, otherwise we can use the lexicographical comparison
+	if (firstId.length > secondId.length) {
+		return true
+	} else if (secondId.length > firstId.length) {
+		return false
+	} else {
+		return firstId > secondId
 	}
 }
 
@@ -137,10 +154,6 @@ export function get_IdValue(typeModel?: TypeModel): ModelValue | undefined {
 	}
 }
 
-export function firstBiggerThanSecondCustomId(firstId: Id, secondId: Id): boolean {
-	return compare(customIdToUint8array(firstId), customIdToUint8array(secondId)) === 1
-}
-
 export function customIdToUint8array(id: Id): Uint8Array {
 	if (id === "") {
 		return new Uint8Array()
@@ -148,34 +161,34 @@ export function customIdToUint8array(id: Id): Uint8Array {
 	return base64ToUint8Array(base64UrlToBase64(id))
 }
 
-export function compareNewestFirst(id1: Id | IdTuple, id2: Id | IdTuple): number {
+export function compareNewestFirst(id1: Id | IdTuple, id2: Id | IdTuple, encoding: EntityIdEncoding): number {
 	let firstId = id1 instanceof Array ? id1[1] : id1
 	let secondId = id2 instanceof Array ? id2[1] : id2
 
 	if (firstId === secondId) {
 		return 0
 	} else {
-		return firstBiggerThanSecond(firstId, secondId) ? -1 : 1
+		return firstBiggerThanSecond(firstId, secondId, encoding) ? -1 : 1
 	}
 }
 
-export function compareOldestFirst(id1: Id | IdTuple, id2: Id | IdTuple): number {
+export function compareOldestFirst(id1: Id | IdTuple, id2: Id | IdTuple, encoding: EntityIdEncoding): number {
 	let firstId = id1 instanceof Array ? id1[1] : id1
 	let secondId = id2 instanceof Array ? id2[1] : id2
 
 	if (firstId === secondId) {
 		return 0
 	} else {
-		return firstBiggerThanSecond(firstId, secondId) ? 1 : -1
+		return firstBiggerThanSecond(firstId, secondId, encoding) ? 1 : -1
 	}
 }
 
-export function sortCompareByReverseId<T extends ListElement>(entity1: T, entity2: T): number {
-	return compareNewestFirst(getElementId(entity1), getElementId(entity2))
+export function sortCompareByReverseId<T extends ListElement>(entity1: T, entity2: T, encoding: EntityIdEncoding): number {
+	return compareNewestFirst(getElementId(entity1), getElementId(entity2), encoding)
 }
 
-export function sortCompareById<T extends ListElement>(entity1: T, entity2: T): number {
-	return compareOldestFirst(getElementId(entity1), getElementId(entity2))
+export function sortCompareById<T extends ListElement>(entity1: T, entity2: T, encoding: EntityIdEncoding): number {
+	return compareOldestFirst(getElementId(entity1), getElementId(entity2), encoding)
 }
 
 /**
@@ -505,18 +518,48 @@ export function isCustomIdType(typeModel: TypeModel): boolean {
 }
 
 /**
- * We store customIds as base64ext in the db to make them sortable, but we get them as base64url from the server.
+ * customIds are stored as base64url on the server and that's how we get them, but we store them locally as base64ext to make them sortable.
+ * generatedIds are stored as base64ext both on the server and locally.
+ */
+export function getServerIdEncodingForType(typeModel: TypeModel): EntityIdEncoding {
+	const _idValueType = assertNotNull(get_IdValue(typeModel), `no _id found for typeModel: ${typeModel.app}/${typeModel.id} `).type
+	if (_idValueType === ValueType.CustomId) {
+		return EntityIdEncoding.Base64URL
+	} else if (_idValueType === ValueType.GeneratedId) {
+		return EntityIdEncoding.Base64Ext
+	} else {
+		throw new ProgrammingError(`unknown _id type for entity: ${typeModel.app}/${typeModel.id}`)
+	}
+}
+
+/**
+ * customIds are stored as base64url on the server and that's how we get them, but we store them locally as base64ext to make them sortable.
+ * generatedIds are stored as base64ext both on the server and locally.
+ *
+ * BEWARE: Calling this with a customId typeModel and a base64ext encoded customId will return a different base64ext.
+ *
+ * @param typeModel The type model for the element.
+ * @param elementId The element id as it is stored on the server (base64ext for generatedIds, base64url for customIds).
+ * @return base64ext encoded id
  */
 export function ensureBase64Ext(typeModel: TypeModel, elementId: Id): Id {
 	if (isCustomIdType(typeModel)) {
-		return base64ToBase64Ext(base64UrlToBase64(elementId))
+		return base64UrlToBase64Ext(elementId)
 	}
 	return elementId
 }
 
+/**
+ * customIds are stored as base64url on the server and that's how we get them, but we store them locally as base64ext to make them sortable.
+ * generatedIds are stored as base64ext both on the server and locally.
+ *
+ * @param typeModel The type model for the element.
+ * @param elementId The element id as it is stored locally (must be encoded as base64ext).
+ * @return base64url encoded id for element with customId, base64ext encoded id otherwise.
+ */
 export function customIdToBase64Url(typeModel: TypeModel, elementId: Id): Id {
 	if (isCustomIdType(typeModel)) {
-		return base64ToBase64Url(base64ExtToBase64(elementId))
+		return base64ExtToBase64Url(elementId)
 	}
 	return elementId
 }

--- a/src/utils/Encoding.ts
+++ b/src/utils/Encoding.ts
@@ -129,6 +129,20 @@ export function base64UrlToBase64(base64url: Base64Url): Base64 {
 	throw new Error("Illegal base64 string.")
 }
 
+/**
+ * Convert a base64url encoded string to base64ext
+ */
+export function base64UrlToBase64Ext(base64Url: string): string {
+	return base64ToBase64Ext(base64UrlToBase64(base64Url))
+}
+
+/**
+ * Convert a base64ext encoded string to base64url
+ */
+export function base64ExtToBase64Url(base64Ext: string): string {
+	return base64ToBase64Url(base64ExtToBase64(base64Ext))
+}
+
 // just for edge, as it does not support TextEncoder yet
 export function _stringToUtf8Uint8ArrayLegacy(string: string): Uint8Array {
 	let fixedString
@@ -437,7 +451,7 @@ function readShort(array: Uint8Array, index: number): number {
 }
 
 /**
- * Converts a string to a custom id. Attention: the custom id must be intended to be derived from a string.
+ * Converts a string to a base64url encoded custom id. Attention: the custom id must be intended to be derived from a string.
  */
 export function stringToCustomId(string: string): string {
 	return uint8arrayToCustomId(stringToUtf8Uint8Array(string))
@@ -448,7 +462,7 @@ export function uint8arrayToCustomId(array: Uint8Array): string {
 }
 
 /**
- * Converts a custom id to a string. Attention: the custom id must be intended to be derived from a string.
+ * Converts a base64url encoded custom id to a string. Attention: the custom id must be intended to be derived from a string.
  */
 export function customIdToString(customId: string): string {
 	return utf8Uint8ArrayToString(base64ToUint8Array(base64UrlToBase64(customId)))

--- a/src/utils/Encoding.ts
+++ b/src/utils/Encoding.ts
@@ -453,17 +453,17 @@ function readShort(array: Uint8Array, index: number): number {
 /**
  * Converts a string to a base64url encoded custom id. Attention: the custom id must be intended to be derived from a string.
  */
-export function stringToCustomId(string: string): string {
-	return uint8arrayToCustomId(stringToUtf8Uint8Array(string))
+export function stringToBase64UrlCustomId(string: string): string {
+	return uint8arrayToBase64UrlCustomId(stringToUtf8Uint8Array(string))
 }
 
-export function uint8arrayToCustomId(array: Uint8Array): string {
+export function uint8arrayToBase64UrlCustomId(array: Uint8Array): string {
 	return base64ToBase64Url(uint8ArrayToBase64(array))
 }
 
 /**
  * Converts a base64url encoded custom id to a string. Attention: the custom id must be intended to be derived from a string.
  */
-export function customIdToString(customId: string): string {
+export function base64UrlCustomIdToString(customId: string): string {
 	return utf8Uint8ArrayToString(base64ToUint8Array(base64UrlToBase64(customId)))
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -94,6 +94,8 @@ export {
 	base64ToBase64Ext,
 	base64ExtToBase64,
 	base64UrlToBase64,
+	base64UrlToBase64Ext,
+	base64ExtToBase64Url,
 	stringToUtf8Uint8Array,
 	utf8Uint8ArrayToString,
 	hexToUint8Array,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -112,9 +112,9 @@ export {
 	_replaceLoneSurrogates,
 	_stringToUtf8Uint8ArrayLegacy,
 	_utf8Uint8ArrayToStringLegacy,
-	stringToCustomId,
-	customIdToString,
-	uint8arrayToCustomId,
+	stringToBase64UrlCustomId,
+	base64UrlCustomIdToString,
+	uint8arrayToBase64UrlCustomId,
 } from "./Encoding.js"
 export type { Base64, Base64Ext, Base64Url, Hex } from "./Encoding.js"
 export { LazyLoaded } from "./LazyLoaded.js"

--- a/test/tests/api/worker/facades/KeyLoaderFacadeTest.ts
+++ b/test/tests/api/worker/facades/KeyLoaderFacadeTest.ts
@@ -18,7 +18,7 @@ import {
 	rsaPublicKeyToHex,
 	VersionedKey,
 } from "@tutao/crypto"
-import { freshVersioned, hexToUint8Array, KeyVersion, stringToCustomId } from "@tutao/utils"
+import { freshVersioned, hexToUint8Array, KeyVersion, stringToBase64UrlCustomId } from "@tutao/utils"
 import { createTestEntity } from "../../../TestUtils.js"
 import { EntityClient } from "../../../../../src/common/api/common/EntityClient.js"
 import { matchers, object, reset, verify, when } from "testdouble"
@@ -76,7 +76,7 @@ o.spec("KeyLoaderFacadeTest", function () {
 
 		for (let i = formerKeysDecrypted.length - 1; i >= 0; i--) {
 			const key: sysTypeRefs.GroupKey = createTestEntity(sysTypeRefs.GroupKeyTypeRef)
-			key._id = ["list", stringToCustomId(i.toString())]
+			key._id = ["list", stringToBase64UrlCustomId(i.toString())]
 			key.ownerEncGKey = encryptKey(lastKey, formerKeysDecrypted[i])
 			const pqKeyPair = formerKeyPairsDecrypted[i]
 
@@ -128,7 +128,7 @@ o.spec("KeyLoaderFacadeTest", function () {
 				entityClient.loadRange(
 					sysTypeRefs.GroupKeyTypeRef,
 					group.formerGroupKeys!.list,
-					stringToCustomId(String(currentGroupKeyVersion)),
+					stringToBase64UrlCustomId(String(currentGroupKeyVersion)),
 					FORMER_KEYS_LENGTH - i,
 					true,
 				),
@@ -205,7 +205,7 @@ o.spec("KeyLoaderFacadeTest", function () {
 
 		o("load key pair when group is updated in cache but key cache still has the old sym key", async function () {
 			const requestedVersion = cryptoUtils.checkKeyVersionConstraints(currentGroupKeyVersion - 1)
-			when(entityClient.load(sysTypeRefs.GroupKeyTypeRef, [group.formerGroupKeys.list, stringToCustomId(String(requestedVersion))])).thenResolve(
+			when(entityClient.load(sysTypeRefs.GroupKeyTypeRef, [group.formerGroupKeys.list, stringToBase64UrlCustomId(String(requestedVersion))])).thenResolve(
 				formerKeys[requestedVersion],
 			)
 			await keyCache.getCurrentGroupKey(group._id, () =>
@@ -322,7 +322,7 @@ o.spec("KeyLoaderFacadeTest", function () {
 				entityClient.loadRange(
 					sysTypeRefs.GroupKeyTypeRef,
 					group.formerGroupKeys.list,
-					stringToCustomId(groupKey.version.toString()),
+					stringToBase64UrlCustomId(groupKey.version.toString()),
 					groupKey.version - requestedVersion,
 					true,
 				),
@@ -331,7 +331,7 @@ o.spec("KeyLoaderFacadeTest", function () {
 			const result = await keyLoaderFacade.loadSymGroupKey(group._id, requestedVersion, groupKey)
 
 			o(result).deepEquals(formerKeysDecrypted[0])
-			verify(entityClient.loadMultiple(sysTypeRefs.GroupKeyTypeRef, group.formerGroupKeys.list, [stringToCustomId(requestedVersion.toString())]))
+			verify(entityClient.loadMultiple(sysTypeRefs.GroupKeyTypeRef, group.formerGroupKeys.list, [stringToBase64UrlCustomId(requestedVersion.toString())]))
 		})
 	})
 

--- a/test/tests/api/worker/offline/OfflineStorageTest.ts
+++ b/test/tests/api/worker/offline/OfflineStorageTest.ts
@@ -7,13 +7,13 @@ import {
 	CUSTOM_MIN_ID,
 	deconstructMailSetEntryId,
 	elementIdPart,
-	ensureBase64Ext,
 	Entity,
 	GENERATED_MAX_ID,
 	GENERATED_MIN_ID,
 	getElementId,
 	listIdPart,
 	ServerModelParsedInstance,
+	serverToLocalIdEncoding,
 	SomeEntity,
 	storageTypeRefs,
 	sysTypeRefs,
@@ -27,7 +27,7 @@ import { DateProvider } from "../../../../../src/common/api/common/DateProvider.
 import { OfflineStorageMigrator } from "../../../../../src/common/api/worker/offline/OfflineStorageMigrator.js"
 import { InterWindowEventFacadeSendDispatcher } from "../../../../../src/common/native/common/generatedipc/InterWindowEventFacadeSendDispatcher.js"
 import { SqlType, untagSqlObject } from "../../../../../src/common/api/worker/offline/SqlValue.js"
-import { FREE_OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS } from "../../../../../src/app-env"
+import { AccountType, FREE_OFFLINE_STORAGE_DEFAULT_TIME_RANGE_DAYS, MailSetKind } from "../../../../../src/app-env"
 import { DesktopSqlCipher } from "../../../../../src/common/desktop/db/DesktopSqlCipher.js"
 import { clientInitializedTypeModelResolver, createTestEntity, IdGenerator, modelMapperFromTypeModelResolver, removeOriginals } from "../../../TestUtils.js"
 import { sql } from "../../../../../src/common/api/worker/offline/Sql.js"
@@ -38,7 +38,6 @@ import { SqlCipherFacade } from "../../../../../src/common/native/common/generat
 import { expandId } from "../../../../../src/common/api/worker/rest/RestClientIdUtils"
 import { ApplicationTypesFacade } from "../../../../../src/common/api/worker/facades/ApplicationTypesFacade"
 import { OfflineStorageLastProcessedEventBatchStorageFacade } from "../../../../../src/common/api/worker/LastProcessedEventBatchStorageFacade"
-import { AccountType, MailSetKind } from "../../../../../src/app-env"
 
 function incrementMailSetEntryId(mailSetEntryId, mailId, ms: number) {
 	const { receiveDate } = deconstructMailSetEntryId(mailSetEntryId)
@@ -1208,7 +1207,7 @@ o.spec("OfflineStorageDb", function () {
 				const allMails = await getAllIdsForType(tutanotaTypeRefs.MailTypeRef)
 				o.check(allMails).deepEquals([elementIdPart(mailId1)])
 				const allMailSetEntries = await getAllIdsForType(tutanotaTypeRefs.MailSetEntryTypeRef)
-				o.check(allMailSetEntries).deepEquals([ensureBase64Ext(mailSetEntryTypeModel, mailSetEntryElementId1)])
+				o.check(allMailSetEntries).deepEquals([serverToLocalIdEncoding(mailSetEntryTypeModel, mailSetEntryElementId1)])
 				const allBlobDetails = await getAllIdsForType(tutanotaTypeRefs.MailDetailsBlobTypeRef)
 				o.check(allBlobDetails).deepEquals([elementIdPart(mailDetailsBlobId1)])
 			})
@@ -1253,8 +1252,8 @@ o.spec("OfflineStorageDb", function () {
 					type: mailSetEntryType,
 					listId: entriesListId,
 					// we need to encode with base64Ext, as we read raw data from the database, which stores custom elementIds in base64Ext not base64Url
-					lower: ensureBase64Ext(mailSetEntryTypeModel, cutoffMailSetEntryId),
-					upper: ensureBase64Ext(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
+					lower: serverToLocalIdEncoding(mailSetEntryTypeModel, cutoffMailSetEntryId),
+					upper: serverToLocalIdEncoding(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
 				})
 			})
 			o.test("unmodified ranges will not be deleted or shrunk", async function () {
@@ -1298,8 +1297,8 @@ o.spec("OfflineStorageDb", function () {
 					type: mailSetEntryType,
 					listId: entriesListId,
 					// we need to encode with base64Ext, as we read raw data from the database, which stores custom elementIds in base64Ext not base64Url
-					lower: ensureBase64Ext(mailSetEntryTypeModel, lowerMailSetEntryIdForRange),
-					upper: ensureBase64Ext(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
+					lower: serverToLocalIdEncoding(mailSetEntryTypeModel, lowerMailSetEntryIdForRange),
+					upper: serverToLocalIdEncoding(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
 				})
 			})
 			o.test("complete ranges won't be lost if entities are all newer than cutoff", async function () {
@@ -1391,8 +1390,8 @@ o.spec("OfflineStorageDb", function () {
 					type: mailSetEntryType,
 					listId: listIdPart(mailSetEntryId),
 					// we need to encode with base64Ext, as we read raw data from the database, which stores custom elementIds in base64Ext not base64Url
-					lower: ensureBase64Ext(mailSetEntryTypeModel, lowerMailSetEntryIdForRange),
-					upper: ensureBase64Ext(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
+					lower: serverToLocalIdEncoding(mailSetEntryTypeModel, lowerMailSetEntryIdForRange),
+					upper: serverToLocalIdEncoding(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
 				})
 
 				const allFolderIds = await getAllIdsForType(tutanotaTypeRefs.MailSetTypeRef)
@@ -1401,7 +1400,7 @@ o.spec("OfflineStorageDb", function () {
 				o.check(allMailIds).deepEquals([elementIdPart(mailId)])
 				const allMailSetEntries = await getAllIdsForType(tutanotaTypeRefs.MailSetEntryTypeRef)
 				// we need to encode with base64Ext, as we read raw data from the database, which stores custom elementIds in base64Ext not base64Url
-				o.check(allMailSetEntries).deepEquals([ensureBase64Ext(mailSetEntryTypeModel, mailSetEntryElementId)])
+				o.check(allMailSetEntries).deepEquals([serverToLocalIdEncoding(mailSetEntryTypeModel, mailSetEntryElementId)])
 				const allBlobDetails = await getAllIdsForType(tutanotaTypeRefs.MailDetailsBlobTypeRef)
 				o.check(allBlobDetails).deepEquals([elementIdPart(mailDetailsBlobId)])
 			})
@@ -1492,8 +1491,8 @@ o.spec("OfflineStorageDb", function () {
 					type: mailSetEntryType,
 					listId: listIdPart(mailSetEntryId),
 					// we need to encode with base64Ext, as we read raw data from the database, which stores custom elementIds in base64Ext not base64Url
-					lower: ensureBase64Ext(mailSetEntryTypeModel, cutoffMailSetEntryId),
-					upper: ensureBase64Ext(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
+					lower: serverToLocalIdEncoding(mailSetEntryTypeModel, cutoffMailSetEntryId),
+					upper: serverToLocalIdEncoding(mailSetEntryTypeModel, upperMailSetEntryIdForRange),
 				})
 
 				const allFolderIds = await getAllIdsForType(tutanotaTypeRefs.MailSetTypeRef)
@@ -1700,14 +1699,14 @@ o.spec("OfflineStorageDb", function () {
 				// Ensure only data older than cutoff is cleared
 				o.check(await getAllIdsForType(tutanotaTypeRefs.MailTypeRef)).deepEquals([spamMailId, trashMailId, trashSubfolderMailId])
 				o.check(await getAllIdsForType(tutanotaTypeRefs.MailSetEntryTypeRef)).deepEquals([
-					ensureBase64Ext(mailSetEntryTypeModel, spamMailSetEntryElementId),
-					ensureBase64Ext(mailSetEntryTypeModel, trashMailSetEntryElementId),
-					ensureBase64Ext(mailSetEntryTypeModel, trashSubfolderMailSetEntryElementId),
+					serverToLocalIdEncoding(mailSetEntryTypeModel, spamMailSetEntryElementId),
+					serverToLocalIdEncoding(mailSetEntryTypeModel, trashMailSetEntryElementId),
+					serverToLocalIdEncoding(mailSetEntryTypeModel, trashSubfolderMailSetEntryElementId),
 				])
 				o.check(await getAllIdsForType(tutanotaTypeRefs.MailDetailsBlobTypeRef)).deepEquals([
-					ensureBase64Ext(detailsBlobTypeModel, elementIdPart(spamDetailsId)),
-					ensureBase64Ext(detailsBlobTypeModel, elementIdPart(trashDetailsId)),
-					ensureBase64Ext(detailsBlobTypeModel, elementIdPart(trashSubfolderDetailsId)),
+					serverToLocalIdEncoding(detailsBlobTypeModel, elementIdPart(spamDetailsId)),
+					serverToLocalIdEncoding(detailsBlobTypeModel, elementIdPart(trashDetailsId)),
+					serverToLocalIdEncoding(detailsBlobTypeModel, elementIdPart(trashSubfolderDetailsId)),
 				])
 
 				o.check(await getAllIdsForType(tutanotaTypeRefs.MailSetTypeRef)).deepEquals([spamFolderId, trashFolderId, trashSubfolderId])
@@ -1818,7 +1817,7 @@ o.spec("OfflineStorageDb", function () {
 
 				o.check(await getAllIdsForType(tutanotaTypeRefs.MailSetTypeRef)).deepEquals([inboxFolderId, spamFolderId, trashFolderId])
 				const allMailSetEntryIds = await getAllIdsForType(tutanotaTypeRefs.MailSetEntryTypeRef)
-				o.check(allMailSetEntryIds).deepEquals([ensureBase64Ext(mailSetEntryTypeModel, twoDaysAfterMailSetEntryElementId)])
+				o.check(allMailSetEntryIds).deepEquals([serverToLocalIdEncoding(mailSetEntryTypeModel, twoDaysAfterMailSetEntryElementId)])
 				o.check(await getAllIdsForType(tutanotaTypeRefs.MailTypeRef)).deepEquals([twoDaysAfterMailId])
 				o.check(await getAllIdsForType(tutanotaTypeRefs.MailDetailsBlobTypeRef)).deepEquals([afterMailDetailsId].map(elementIdPart))
 			})

--- a/test/tests/api/worker/rest/EntityRestCacheTest.ts
+++ b/test/tests/api/worker/rest/EntityRestCacheTest.ts
@@ -8,7 +8,7 @@ import {
 	elementIdPart,
 	Entity,
 	entityUpdateUtils,
-	firstBiggerThanSecond,
+	firstBiggerThanSecondBase64Ext,
 	GENERATED_MAX_ID,
 	GENERATED_MIN_ID,
 	getElementId,
@@ -37,7 +37,7 @@ import { CustomCacheHandler, CustomCacheHandlerMap } from "../../../../../src/co
 import { ModelMapper, PatchMerger } from "@tutao/instance-pipeline"
 import { collapseId } from "../../../../../src/common/api/worker/rest/RestClientIdUtils"
 import { LastProcessedEventBatchStorageFacade } from "../../../../../src/common/api/worker/LastProcessedEventBatchStorageFacade"
-import { OperationType } from "../../../../../src/app-env"
+import { OperationType } from "@tutao/app-env"
 
 const { anything } = matchers
 
@@ -1715,7 +1715,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id, custo
 
 			const loadParsedInstancesRange = spy(async (typeRef, listIdToLoad: string, startId: Id, count: number, reverse: boolean) => {
 				if (listId !== listIdToLoad) throw new restError.NotFoundError("unknown list id")
-				const startOfList = serverMails.filter((mail) => firstBiggerThanSecond(getElementId(mail), startId)).slice(0, count)
+				const startOfList = serverMails.filter((mail) => firstBiggerThanSecondBase64Ext(getElementId(mail), startId)).slice(0, count)
 				return Promise.all(startOfList.map(toStorableInstance))
 			})
 

--- a/test/tests/api/worker/rest/EntityRestCacheTest.ts
+++ b/test/tests/api/worker/rest/EntityRestCacheTest.ts
@@ -21,7 +21,7 @@ import {
 	tutanotaTypeRefs,
 	TypeModelResolver,
 } from "@tutao/typerefs"
-import { arrayOf, assertNotNull, clone, deepEqual, downcast, isSameTypeRef, last, Nullable, promiseMap, stringToCustomId, TypeRef } from "@tutao/utils"
+import { arrayOf, assertNotNull, clone, deepEqual, downcast, isSameTypeRef, last, Nullable, promiseMap, stringToBase64UrlCustomId, TypeRef } from "@tutao/utils"
 import { CacheStorage, DefaultEntityRestCache, EXTEND_RANGE_MIN_CHUNK_SIZE } from "../../../../../src/common/api/worker/rest/DefaultEntityRestCache.js"
 import { OfflineStorage, OfflineStorageCleaner } from "../../../../../src/common/api/worker/offline/OfflineStorage.js"
 import { NoZoneDateProvider } from "../../../../../src/common/api/common/utils/NoZoneDateProvider.js"
@@ -1297,7 +1297,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id, custo
 
 		o("custom id range is not stored", async function () {
 			let ref = clone(createTestEntity(sysTypeRefs.ExternalUserReferenceTypeRef))
-			ref._id = ["listId1", stringToCustomId("custom")]
+			ref._id = ["listId1", stringToBase64UrlCustomId("custom")]
 			const loadRange = spy(async function (typeRef, listId, start, count, reverse) {
 				o(isSameTypeRef(typeRef, sysTypeRefs.ExternalUserReferenceTypeRef)).equals(true)
 				o(listId).equals("listId1")
@@ -1326,7 +1326,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id, custo
 					_ownerGroup: "owner-group",
 				}),
 			)
-			ref._id = ["listId1", stringToCustomId("1")]
+			ref._id = ["listId1", stringToBase64UrlCustomId("1")]
 			const loadRange = spy(async function (typeRef, listId, start, count, reverse) {
 				o(isSameTypeRef(typeRef, sysTypeRefs.GroupKeyTypeRef)).equals(true)
 				o(listId).equals("listId1")
@@ -1849,7 +1849,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id, custo
 		})
 
 		o.test("when loading single ET custom id entity it is cached", async function () {
-			const id = stringToCustomId("1")
+			const id = stringToBase64UrlCustomId("1")
 			const client: EntityRestClient = mockRestClient()
 			const entity = createTestEntity(sysTypeRefs.MailAddressToGroupTypeRef, {
 				_id: id,
@@ -1870,7 +1870,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id, custo
 		})
 
 		o.test("when loading single LET custom id entity it is cached", async function () {
-			const id: IdTuple = [createId("0"), stringToCustomId("1")]
+			const id: IdTuple = [createId("0"), stringToBase64UrlCustomId("1")]
 			const client: EntityRestClient = mockRestClient()
 			const entity = createTestEntity(sysTypeRefs.RootInstanceTypeRef, {
 				_id: id,
@@ -1892,7 +1892,7 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id, custo
 		})
 
 		o.test("when loading multiple ET custom id entities are cached", async function () {
-			const ids = [stringToCustomId("1"), stringToCustomId("2")]
+			const ids = [stringToBase64UrlCustomId("1"), stringToBase64UrlCustomId("2")]
 			const client: EntityRestClient = mockRestClient()
 			const firstEntity = createTestEntity(sysTypeRefs.MailAddressToGroupTypeRef, {
 				_id: ids[0],
@@ -1927,8 +1927,8 @@ export function testEntityRestCache(name: string, getStorage: (userId: Id, custo
 		o.test("when loading multiple LET custom id entities are cached", async function () {
 			const listId = createId("0")
 			const ids: IdTuple[] = [
-				[listId, stringToCustomId("1")],
-				[listId, stringToCustomId("2")],
+				[listId, stringToBase64UrlCustomId("1")],
+				[listId, stringToBase64UrlCustomId("2")],
 			]
 			const client: EntityRestClient = mockRestClient()
 			const firstEntity = createTestEntity(sysTypeRefs.RootInstanceTypeRef, {

--- a/test/tests/api/worker/rest/EntityRestClientMock.ts
+++ b/test/tests/api/worker/rest/EntityRestClientMock.ts
@@ -8,6 +8,7 @@ import {
 	firstBiggerThanSecond,
 	getElementId,
 	getListId,
+	getServerIdEncodingForType,
 	isSameId,
 	listIdPart,
 	timestampToGeneratedId,
@@ -138,14 +139,17 @@ export class EntityRestClientMock extends EntityRestClient {
 		if (!entriesForListId) return []
 		let filteredIds
 
+		const typeModel = await this._typeModelResolver.resolveClientTypeReference(typeRef)
+		const idEncoding = getServerIdEncodingForType(typeModel)
+
 		if (reverse) {
 			filteredIds = Object.keys(entriesForListId)
-				.sort(compareNewestFirst)
-				.filter((id) => firstBiggerThanSecond(start, id))
+				.sort((a, b) => compareNewestFirst(a, b, idEncoding))
+				.filter((id) => firstBiggerThanSecond(start, id, idEncoding))
 		} else {
 			filteredIds = Object.keys(entriesForListId)
-				.sort(compareOldestFirst)
-				.filter((id) => firstBiggerThanSecond(id, start))
+				.sort((a, b) => compareOldestFirst(a, b, idEncoding))
+				.filter((id) => firstBiggerThanSecond(id, start, idEncoding))
 		}
 
 		return filteredIds.map((id) => this._handleMockElement(entriesForListId[id], id))
@@ -155,8 +159,8 @@ export class EntityRestClientMock extends EntityRestClient {
 		const lid = listId
 
 		if (lid) {
-			const typeModule = await this._typeModelResolver.resolveClientTypeReference(typeRef)
-			if (typeModule.type === Type.ListElement.valueOf()) {
+			const typeModel = await this._typeModelResolver.resolveClientTypeReference(typeRef)
+			if (typeModel.type === Type.ListElement.valueOf()) {
 				return elementIds
 					.map((id) => {
 						return downcast(this._getListEntry(lid, id))

--- a/test/tests/api/worker/search/IndexedDbSearchFacadeTest.ts
+++ b/test/tests/api/worker/search/IndexedDbSearchFacadeTest.ts
@@ -5,12 +5,13 @@ import {
 	elementIdPart,
 	firstBiggerThanSecond,
 	generatedIdToTimestamp,
+	getServerIdEncodingForType,
 	listIdPart,
+	sysTypeRefs,
 	timestampToGeneratedId,
 	tutanotaTypeRefs,
 } from "@tutao/typerefs"
-import type { TypeInfo } from "../../../../../src/common/api/common/utils/IndexUtils.js"
-import { typeRefToTypeInfo } from "../../../../../src/common/api/common/utils/IndexUtils.js"
+import { TypeInfo, typeInfoToTypeRef, typeRefToTypeInfo } from "../../../../../src/common/api/common/utils/IndexUtils.js"
 import {
 	ElementDataDbRow,
 	SearchIndexEntry,
@@ -18,11 +19,11 @@ import {
 	SearchRestriction,
 	SearchResult,
 } from "../../../../../src/common/api/worker/search/SearchTypes.js"
-import { Base64, groupBy, numberRange, splitInChunks } from "@tutao/utils"
+import { AppNameEnum, Base64, groupBy, numberRange, splitInChunks } from "@tutao/utils"
 import { appendBinaryBlocks } from "../../../../../src/common/api/worker/search/SearchIndexEncoding.js"
 import { createSearchIndexDbStub, DbStub, DbStubTransaction } from "./DbStub.js"
 import type { BrowserData } from "../../../../../src/common/misc/ClientConstants.js"
-import { browserDataStub, createTestEntity } from "../../../TestUtils.js"
+import { browserDataStub, clientInitializedTypeModelResolver, createTestEntity } from "../../../TestUtils.js"
 import { aes256RandomKey, FIXED_IV } from "@tutao/crypto"
 import { ElementDataOS, SearchIndexMetaDataOS, SearchIndexOS } from "../../../../../src/common/api/worker/search/IndexTables.js"
 import { object, when } from "testdouble"
@@ -36,7 +37,7 @@ import {
 	encryptMetaData,
 	encryptSearchIndexEntry,
 } from "../../../../../src/common/api/worker/search/IndexEncryptionUtils"
-import { sysTypeRefs } from "@tutao/typerefs"
+import { ProgrammingError } from "@tutao/app-env"
 
 type SearchIndexEntryWithType = SearchIndexEntry & {
 	typeInfo: TypeInfo
@@ -50,6 +51,7 @@ const contactTypeInfo = typeRefToTypeInfo(tutanotaTypeRefs.ContactTypeRef)
 const mailTypeInfo = typeRefToTypeInfo(tutanotaTypeRefs.MailTypeRef)
 const browserData: BrowserData = browserDataStub
 const entityClient: EntityClient = object()
+const typeModelResolver = clientInitializedTypeModelResolver()
 o.spec("IndexedDbSearchFacade", () => {
 	let mail = createTestEntity(tutanotaTypeRefs.MailTypeRef)
 	let user = createTestEntity(sysTypeRefs.UserTypeRef)
@@ -79,10 +81,9 @@ o.spec("IndexedDbSearchFacade", () => {
 		)
 	}
 
-	function createDbContent(transaction: DbStubTransaction, dbData: KeyToIndexEntriesWithType[], fullIds: IdTuple[]) {
+	async function createDbContent(transaction: DbStubTransaction, dbData: KeyToIndexEntriesWithType[], fullIds: IdTuple[]) {
 		let counter = 0
 		for (const [index, keyToIndexEntries] of dbData.entries()) {
-			keyToIndexEntries.indexEntries.sort((a, b) => compareOldestFirst(a.id, b.id))
 			const indexEntriesByType = groupBy(keyToIndexEntries.indexEntries, (e) => e.typeInfo)
 			const metaDataRow: SearchIndexMetaDataRow = {
 				id: index + 1,
@@ -90,6 +91,14 @@ o.spec("IndexedDbSearchFacade", () => {
 				rows: [],
 			}
 			for (const [typeInfo, entries] of indexEntriesByType.entries()) {
+				const typeRef = typeInfoToTypeRef(typeInfo, AppNameEnum.Tutanota)
+				if (typeRef == null) {
+					throw new ProgrammingError(`No TypeRef for TypeInfo ${typeInfo.appId}/${typeInfo.typeId}`)
+				}
+
+				const typeModel = await typeModelResolver.resolveClientTypeReference(typeRef)
+				entries.sort((a, b) => compareOldestFirst(a.id, b.id, getServerIdEncodingForType(typeModel)))
+
 				const chunks = splitInChunks(2, entries)
 				for (const chunk of chunks) {
 					counter++
@@ -153,7 +162,7 @@ o.spec("IndexedDbSearchFacade", () => {
 		}
 	}
 
-	let testSearch = (
+	let testSearch = async (
 		dbData: KeyToIndexEntriesWithType[],
 		dbListIds: IdTuple[],
 		query: string,
@@ -163,13 +172,16 @@ o.spec("IndexedDbSearchFacade", () => {
 		minSuggestionCount: number = 0,
 		maxResults?: number,
 	): Promise<void> => {
-		createDbContent(transaction, dbData, dbListIds)
-		let s = createSearchFacade(transaction, currentIndexTimestamp)
-		return s.search(query, restriction, minSuggestionCount, maxResults).then((result) => {
-			o.check(result.query).equals(query)
-			o.check(result.restriction).deepEquals(restriction)
-			o.check(result.results).deepEquals(expectedResult.sort((idTuple1, idTuple2) => (firstBiggerThanSecond(idTuple1[1], idTuple2[1]) ? -1 : 1)))
-		})
+		await createDbContent(transaction, dbData, dbListIds)
+		const s = createSearchFacade(transaction, currentIndexTimestamp)
+		const typeModel = await typeModelResolver.resolveClientTypeReference(restriction.type)
+
+		const result = await s.search(query, restriction, minSuggestionCount, maxResults)
+		o.check(result.query).equals(query)
+		o.check(result.restriction).deepEquals(restriction)
+		o.check(result.results).deepEquals(
+			expectedResult.sort((idTuple1, idTuple2) => (firstBiggerThanSecond(idTuple1[1], idTuple2[1], getServerIdEncodingForType(typeModel)) ? -1 : 1)),
+		)
 	}
 
 	let dbStub: DbStub
@@ -430,7 +442,7 @@ o.spec("IndexedDbSearchFacade", () => {
 		let id3 = timestampToGeneratedId(new Date(2017, 5, 12).getTime())
 		let id4 = timestampToGeneratedId(new Date(2017, 5, 14).getTime())
 
-		createDbContent(
+		await createDbContent(
 			transaction,
 			[
 				createKeyToIndexEntries("test", [
@@ -492,7 +504,7 @@ o.spec("IndexedDbSearchFacade", () => {
 		let id3 = timestampToGeneratedId(new Date(2017, 5, 12).getTime())
 		let id4 = timestampToGeneratedId(new Date(2017, 5, 14).getTime())
 
-		createDbContent(
+		await createDbContent(
 			transaction,
 			[
 				createKeyToIndexEntries("test", [
@@ -554,7 +566,7 @@ o.spec("IndexedDbSearchFacade", () => {
 		let id3 = timestampToGeneratedId(new Date(2017, 5, 12).getTime())
 		let id4 = timestampToGeneratedId(new Date(2017, 5, 14).getTime())
 
-		createDbContent(
+		await createDbContent(
 			transaction,
 			[
 				createKeyToIndexEntries("test", [
@@ -613,7 +625,7 @@ o.spec("IndexedDbSearchFacade", () => {
 		let id3 = timestampToGeneratedId(new Date(2017, 5, 12).getTime())
 		let id4 = timestampToGeneratedId(new Date(2017, 5, 14).getTime())
 
-		createDbContent(
+		await createDbContent(
 			transaction,
 			[
 				createKeyToIndexEntries("test", [
@@ -675,7 +687,7 @@ o.spec("IndexedDbSearchFacade", () => {
 		let id3 = timestampToGeneratedId(new Date(2017, 5, 12).getTime())
 		let id4 = timestampToGeneratedId(new Date(2017, 5, 14).getTime())
 
-		createDbContent(
+		await createDbContent(
 			transaction,
 			[
 				createKeyToIndexEntries("test", [

--- a/test/tests/api/worker/search/OfflineStoragePersistenceTest.ts
+++ b/test/tests/api/worker/search/OfflineStoragePersistenceTest.ts
@@ -5,7 +5,7 @@ import { DesktopSqlCipher } from "../../../../../src/common/desktop/db/DesktopSq
 import { assertNotNull, getTypeString, typedValues } from "@tutao/utils"
 import { untagSqlObject, untagSqlValue } from "../../../../../src/common/api/worker/offline/SqlValue"
 import { sql } from "../../../../../src/common/api/worker/offline/Sql"
-import { ClientModelInfo, ensureBase64Ext, getElementId, getListId, ListElementEntity, tutanotaTypeRefs } from "@tutao/typerefs"
+import { ClientModelInfo, getElementId, getListId, ListElementEntity, serverToLocalIdEncoding, tutanotaTypeRefs } from "@tutao/typerefs"
 import { createTestEntity } from "../../../TestUtils"
 import { object } from "testdouble"
 import { CacheStorage } from "../../../../../src/common/api/worker/rest/DefaultEntityRestCache"
@@ -418,7 +418,7 @@ async function fakeStoreListElementEntityInOfflineDb(sqlCipherFacade: SqlCipherF
 
 async function getElementIdB64ExtEnsured(l: ListElementEntity) {
 	const typeModel = await ClientModelInfo.getNewInstanceForTestsOnly().resolveClientTypeReference(l._type)
-	return ensureBase64Ext(typeModel, getElementId(l))
+	return serverToLocalIdEncoding(typeModel, getElementId(l))
 }
 
 async function prepareIndexedGroups(sqlCipherFacade: SqlCipherFacade) {

--- a/test/tests/api/worker/utils/spamClassification/SpamClassifierDataDealerTest.ts
+++ b/test/tests/api/worker/utils/spamClassification/SpamClassifierDataDealerTest.ts
@@ -4,8 +4,8 @@ import {
 	SpamClassifierDataDealer,
 	UnencryptedPopulateClientSpamTrainingDatum,
 } from "../../../../../../src/mail-app/workerUtils/spamClassification/SpamClassifierDataDealer"
-import { compareNewestFirst, GENERATED_MIN_ID, getElementId, isSameId, tutanotaTypeRefs } from "@tutao/typerefs"
-import { SpamDecision } from "../../../../../../src/app-env"
+import { compareNewestFirst, GENERATED_MIN_ID, getElementId, EntityIdEncoding, isSameId, tutanotaTypeRefs } from "@tutao/typerefs"
+import { MailSetKind, MAX_NBR_OF_MAILS_SYNC_OPERATION, SpamDecision } from "../../../../../../src/app-env"
 import { matchers, object, verify, when } from "testdouble"
 import { EntityClient } from "../../../../../../src/common/api/common/EntityClient"
 import { BulkMailLoader } from "../../../../../../src/mail-app/workerUtils/index/BulkMailLoader"
@@ -13,7 +13,6 @@ import { MailFacade } from "../../../../../../src/common/api/worker/facades/lazy
 import { createTestEntity } from "../../../../TestUtils"
 import { DEFAULT_IS_SPAM_CONFIDENCE } from "../../../../../../src/common/api/common/utils/spamClassificationUtils/SpamMailProcessor"
 import { last } from "@tutao/utils"
-import { MailSetKind, MAX_NBR_OF_MAILS_SYNC_OPERATION } from "../../../../../../src/app-env"
 
 const { anything } = matchers
 
@@ -489,7 +488,7 @@ o.spec("SpamClassifierDataDealer", () => {
 			verify(mailFacadeMock.populateClientSpamTrainingData("owner", secondUnencryptedPayload), { times: 1 })
 
 			o(trainingDataset).deepEquals({
-				trainingData: updatedSpamTrainingData.sort((l, r) => compareNewestFirst(l._id, r._id)),
+				trainingData: updatedSpamTrainingData.sort((l, r) => compareNewestFirst(l._id, r._id, EntityIdEncoding.Base64Ext)),
 				lastTrainingDataIndexId: getElementId(last(modifiedIndicesSinceStart)!),
 				hamCount: 80,
 				spamCount: 80,

--- a/test/tests/misc/ListElementListModelTest.ts
+++ b/test/tests/misc/ListElementListModelTest.ts
@@ -1,20 +1,21 @@
 import o from "@tutao/otest"
-import { getElementId, getListId, sortCompareById, tutanotaTypeRefs } from "@tutao/typerefs"
+import { getElementId, getListId, EntityIdEncoding, sortCompareById, tutanotaTypeRefs } from "@tutao/typerefs"
 import { defer, DeferredObject } from "@tutao/utils"
 import { ListFetchResult } from "../../../src/common/gui/base/ListUtils.js"
 import { createTestEntity } from "../TestUtils.js"
 import { ListAutoSelectBehavior } from "../../../src/common/misc/DeviceConfig.js"
 import { ListElementListModel, ListElementListModelConfig } from "../../../src/common/misc/ListElementListModel"
 import * as restError from "@tutao/rest-client/error"
-import { OperationType } from "../../../src/app-env"
+import { OperationType } from "@tutao/app-env"
 
 o.spec("ListElementListModel", function () {
 	const listId = "listId"
+	const entityIdEncoding = EntityIdEncoding.Base64Ext
 	let fetchDefer: DeferredObject<ListFetchResult<tutanotaTypeRefs.KnowledgeBaseEntry>>
 	let listModel: ListElementListModel<tutanotaTypeRefs.KnowledgeBaseEntry>
 	const defaultListConfig: ListElementListModelConfig<tutanotaTypeRefs.KnowledgeBaseEntry> = {
 		fetch: () => fetchDefer.promise,
-		sortCompare: sortCompareById,
+		sortCompare: (a, b) => sortCompareById(a, b, entityIdEncoding),
 		loadSingle: () => {
 			throw new Error("noop")
 		},
@@ -51,7 +52,7 @@ o.spec("ListElementListModel", function () {
 	})
 
 	function getSortedSelection() {
-		return listModel.getSelectedAsArray().sort(sortCompareById)
+		return listModel.getSelectedAsArray().sort((a, b) => sortCompareById(a, b, entityIdEncoding))
 	}
 
 	o.spec("selection controls", function () {

--- a/test/tests/misc/ListModelTest.ts
+++ b/test/tests/misc/ListModelTest.ts
@@ -1,6 +1,6 @@
 import o from "@tutao/otest"
 import { ListModel, ListModelConfig } from "../../../src/common/misc/ListModel.js"
-import { getElementId, sortCompareById, timestampToGeneratedId, tutanotaTypeRefs } from "@tutao/typerefs"
+import { getElementId, EntityIdEncoding, sortCompareById, timestampToGeneratedId, tutanotaTypeRefs } from "@tutao/typerefs"
 import { defer, DeferredObject, getFirstOrThrow, lastThrow } from "@tutao/utils"
 import { ListFetchResult } from "../../../src/common/gui/base/ListUtils.js"
 import { ListLoadingState } from "../../../src/common/gui/base/List.js"
@@ -10,6 +10,7 @@ import { ListAutoSelectBehavior } from "../../../src/common/misc/DeviceConfig.js
 
 o.spec("ListModel", function () {
 	const listId = "listId"
+	const entityIdEncoding = EntityIdEncoding.Base64Ext
 	let fetchDefer: DeferredObject<ListFetchResult<tutanotaTypeRefs.KnowledgeBaseEntry>>
 	let listModel: ListModel<tutanotaTypeRefs.KnowledgeBaseEntry, Id>
 	let currentSelectBehavior = ListAutoSelectBehavior.OLDER
@@ -185,7 +186,7 @@ o.spec("ListModel", function () {
 	})
 
 	function getSortedSelection() {
-		return listModel.getSelectedAsArray().sort(sortCompareById)
+		return listModel.getSelectedAsArray().sort((a, b) => sortCompareById(a, b, entityIdEncoding))
 	}
 
 	o.spec("selection controls selectPrevious/selectNext", function () {


### PR DESCRIPTION
Offline cleaner was not updating range for the entries list correctly, caused by wrongly comparing the oldest entry's id against the cutoff id as if they were GeneratedId instead of CustomId.

When an element's list is fully loaded, we set the list's lower range to MIN_ID (this is different for GeneratedId and CustomId).
When MailOfflineCleaner runs, it deletes mails and entries older than the offline range cutoff, and sets the list's lower range to the cutoffId.
However, if a list is fully loaded and the oldest entry in the list is within the offline range, then the list's lower range is not set to the cutoffId but rather kept as is (MIN_ID).

Because of the incorrect comparison, MailOfflineCleaner was deleting entities older than offline range cutoff, but keeping the list's lower range set to MIN_ID, resulting in a broken state where the list is incomplete but fully loaded.

Close #10694

Co-authored-by: wrd <wrd@tutao.de>
Co-authored-by: abp <abp@tutao.de>
Co-authored-by: das <das@tutao.de>
Co-authored-by: ivk <ivk@tutao.de>
Co-authored-by: paw <paw-hub@users.noreply.github.com>