### PR TITLE
implement encryptAndUploadMultiple in BlobFacade

### DIFF
--- a/src/common/api/worker/facades/lazy/BlobFacade.ts
+++ b/src/common/api/worker/facades/lazy/BlobFacade.ts
@@ -19,7 +19,7 @@ import {
 } from "@tutao/utils"
 import { ArchiveDataType, assertWorkerOrNode, CANCEL_UPLOAD_EVENT, isApp, isDesktop, ProgrammingError } from "@tutao/app-env"
 import { AttributeModel, ServerModelUntypedInstance, SomeEntity, storageServices, storageTypeModels, storageTypeRefs, sysTypeRefs } from "@tutao/typerefs"
-import { _encryptBytes, aesDecrypt, AesKey, asyncDecryptBytes, sha256Hash } from "@tutao/crypto"
+import { _encryptBytes, aesDecrypt, aesEncrypt, AesKey, asyncDecryptBytes, sha256Hash } from "@tutao/crypto"
 import type { FileUri, NativeFileApp } from "../../../../native/common/FileApp.js"
 import type { AesApp } from "../../../../native/worker/AesApp.js"
 import { FileReference, splitFileIntoChunks } from "../../../common/utils/FileUtils.js"
@@ -35,6 +35,26 @@ import { TransferProgressDispatcher } from "../../../main/TransferProgressDispat
 assertWorkerOrNode()
 export const BLOB_SERVICE_REST_PATH = `/rest/${storageServices.BlobService.app}/${storageServices.BlobService.name.toLowerCase()}`
 export const TAG = "BlobFacade"
+
+export type FileData = {
+	data: Uint8Array
+	sessionKey: AesKey
+}
+type NewBlobWrapper = {
+	hash: Uint8Array
+	data: Uint8Array
+}
+export type KeyedNewBlobWrapper = {
+	sessionKey: AesKey
+	newBlobWrapper: NewBlobWrapper
+}
+type SerializedBinaryWrapper = {
+	sessionKeys: AesKey[]
+	binary: Uint8Array
+}
+export const MAX_NUMBER_OF_BLOBS_IN_BINARY = 200
+const MAX_UNENCRYPTED_BLOB_SIZE_BYTES = 10 * 1024 * 1024
+const NEW_BLOB_OVERHEAD_BYTES = 4 + 6
 
 export interface BlobLoadOptions {
 	extraHeaders?: Dict
@@ -250,6 +270,79 @@ export class BlobFacade {
 				this.nativeUploadProgressState.delete(chunkId)
 			}
 		}
+	}
+
+	async encryptAndUploadMultiple(
+		archiveDataType: ArchiveDataType,
+		ownerGroupId: Id,
+		fileData: FileData[],
+		transferId: TransferId,
+		onChunkUploaded?: (info: UploadProgressInfo) => void,
+	): Promise<sysTypeRefs.BlobReferenceTokenWrapper[][]> {
+		const sessionKeyToReferenceTokens = new Map<AesKey, sysTypeRefs.BlobReferenceTokenWrapper[]>(fileData.map((f) => [f.sessionKey, []]))
+		const keyedNewBlobWrappers = encryptMultipleFileData(fileData)
+		const serializedBinaries = serializeNewBlobsInBinaryChunks(keyedNewBlobWrappers)
+		const doBlobRequest: () => Promise<sysTypeRefs.BlobReferenceTokenWrapper[][]> = async () => {
+			const blobServerAccessInfo = await this.blobAccessTokenFacade.requestWriteToken(archiveDataType, ownerGroupId)
+
+			for (const serializedBinary of serializedBinaries) {
+				const tokens = await this.uploadMultipleBlobs(serializedBinary.binary, blobServerAccessInfo)
+				if (tokens.length !== serializedBinary.sessionKeys.length) {
+					throw new ProgrammingError("Mismatch between session keys and returned tokens")
+				}
+				for (let idx = 0; idx < serializedBinary.sessionKeys.length; idx++) {
+					const sessionKey = serializedBinary.sessionKeys[idx]
+					const token = tokens[idx]
+
+					if (!token) {
+						throw new ProgrammingError("Missing token for session key")
+					}
+
+					const list = assertNotNull(sessionKeyToReferenceTokens.get(sessionKey))
+					list.push(token)
+				}
+
+				onChunkUploaded?.({
+					transferId,
+					totalBytes: serializedBinaries.map((serializedBinary) => serializedBinary.binary.length).reduce((a, b) => a + b, 0),
+					uploadedBytes: serializedBinary.binary.length,
+				})
+			}
+			const referenceTokensPerFileData: sysTypeRefs.BlobReferenceTokenWrapper[][] = []
+
+			for (const fileDatum of fileData) {
+				const tokens = assertNotNull(sessionKeyToReferenceTokens.get(fileDatum.sessionKey))
+				referenceTokensPerFileData.push(tokens)
+			}
+
+			return referenceTokensPerFileData
+		}
+
+		const doEvictToken = () => this.blobAccessTokenFacade.evictWriteToken(archiveDataType, ownerGroupId)
+
+		return doBlobRequestWithRetry(doBlobRequest, doEvictToken)
+	}
+
+	private async uploadMultipleBlobs(
+		encryptedData: Uint8Array,
+		blobServerAccessInfo: storageTypeRefs.BlobServerAccessInfo,
+	): Promise<sysTypeRefs.BlobReferenceTokenWrapper[]> {
+		const queryParams = await this.blobAccessTokenFacade.createQueryParams(blobServerAccessInfo, {}, storageTypeRefs.BlobGetInTypeRef)
+
+		return tryServers(
+			blobServerAccessInfo.servers,
+			async (serverUrl) => {
+				const response = await this.restClient.request(BLOB_SERVICE_REST_PATH, HttpMethod.POST, {
+					queryParams,
+					body: encryptedData,
+					responseType: MediaType.Json,
+					baseUrl: serverUrl,
+				})
+
+				return await this.parseBlobPostOutResponseMultiple(response)
+			},
+			`can't upload multiple blobs`,
+		)
 	}
 
 	/**
@@ -603,6 +696,15 @@ export class BlobFacade {
 		return sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken })
 	}
 
+	public async parseBlobPostOutResponseMultiple(jsonData: string): Promise<sysTypeRefs.BlobReferenceTokenWrapper[]> {
+		const instance = AttributeModel.removeNetworkDebuggingInfoIfNeeded<ServerModelUntypedInstance>(JSON.parse(jsonData))
+		const { blobReferenceTokens } = await this.instancePipeline.decryptAndMap(storageTypeRefs.BlobPostOutTypeRef, instance, null)
+		if (isEmpty(blobReferenceTokens)) {
+			throw new ProgrammingError("empty blobReferenceTokens not allowed for post multiple blob")
+		}
+		return blobReferenceTokens
+	}
+
 	private async downloadAndDecryptMultipleBlobsOfArchives(
 		blobs: readonly sysTypeRefs.Blob[],
 		blobServerAccessInfos: Map<Id, storageTypeRefs.BlobServerAccessInfo>,
@@ -848,4 +950,107 @@ export function parseMultipleBlobsResponse(concatBinaryData: Uint8Array): Map<Id
 
 function generateFileChunkId(): string {
 	return uint8ArrayToBase64(crypto.getRandomValues(new Uint8Array(6)))
+}
+
+export function serializeNewBlobsInBinaryChunks(
+	blobs: KeyedNewBlobWrapper[],
+	maxBinaryChunkSize: number = MAX_BLOB_SIZE_BYTES,
+	maxBlobsPerChunk: number = MAX_NUMBER_OF_BLOBS_IN_BINARY,
+): SerializedBinaryWrapper[] {
+	const chunks: KeyedNewBlobWrapper[][] = []
+
+	let current: KeyedNewBlobWrapper[] = []
+	let currentSize = 0
+
+	for (const blob of blobs) {
+		const blobSize = NEW_BLOB_OVERHEAD_BYTES + blob.newBlobWrapper.data.length
+
+		const wouldOverflow = currentSize + blobSize > maxBinaryChunkSize || current.length >= maxBlobsPerChunk
+
+		if (wouldOverflow && current.length > 0) {
+			chunks.push(current)
+			current = []
+			currentSize = 0
+		}
+
+		current.push(blob)
+		currentSize += blobSize
+	}
+
+	if (current.length > 0) chunks.push(current)
+
+	return chunks.map((chunk) => ({
+		sessionKeys: chunk.map((c) => c.sessionKey),
+		binary: serializeNewBlobs(chunk.map((c) => c.newBlobWrapper)),
+	}))
+}
+
+function encryptMultipleFileData(fileData: FileData[]): KeyedNewBlobWrapper[] {
+	const result: KeyedNewBlobWrapper[] = []
+
+	for (const file of fileData) {
+		for (const chunk of chunkData(file.data, MAX_UNENCRYPTED_BLOB_SIZE_BYTES)) {
+			const encrypted = aesEncrypt(file.sessionKey, chunk)
+
+			const hashFull = sha256Hash(encrypted)
+			const shortHash = hashFull.slice(0, 6)
+
+			result.push({
+				sessionKey: file.sessionKey,
+				newBlobWrapper: {
+					hash: shortHash,
+					data: encrypted,
+				},
+			})
+		}
+	}
+
+	return result
+}
+
+function chunkData(data: Uint8Array, size: number): Uint8Array[] {
+	if (data.length === 0) return [new Uint8Array(0)]
+
+	const out: Uint8Array[] = []
+	for (let i = 0; i < data.length; i += size) {
+		out.push(data.subarray(i, i + size))
+	}
+	return out
+}
+
+// see comment for parseMultipleBlobsResponse above and BinaryBlobSerializer in tutadb
+function serializeNewBlobs(blobs: NewBlobWrapper[]): Uint8Array {
+	let totalSize = 4 // bytes for the number of blobs
+
+	for (const blob of blobs) {
+		if (blob.hash.length !== 6) {
+			throw new Error("Invalid hash length, expected 6 bytes")
+		}
+		totalSize += 6 + 4 + blob.data.length
+	}
+
+	const buffer = new Uint8Array(totalSize)
+	const view = new DataView(buffer.buffer)
+
+	let offset = 0
+
+	// write blob count
+	view.setUint32(offset, blobs.length, false)
+	offset += 4
+
+	for (const blob of blobs) {
+		// hash (6 bytes)
+		buffer.set(blob.hash, offset)
+		offset += 6
+
+		// size (4 bytes)
+		view.setUint32(offset, blob.data.length, false)
+		offset += 4
+
+		// data
+		buffer.set(blob.data, offset)
+		offset += blob.data.length
+	}
+
+	return buffer
 }

--- a/test/tests/api/worker/facades/BlobFacadeTest.ts
+++ b/test/tests/api/worker/facades/BlobFacadeTest.ts
@@ -1,5 +1,13 @@
 import o, { assertThrows } from "@tutao/otest"
-import { BLOB_SERVICE_REST_PATH, BlobFacade, parseMultipleBlobsResponse } from "../../../../../src/common/api/worker/facades/lazy/BlobFacade.js"
+import {
+	BLOB_SERVICE_REST_PATH,
+	BlobFacade,
+	FileData,
+	KeyedNewBlobWrapper,
+	MAX_NUMBER_OF_BLOBS_IN_BINARY,
+	parseMultipleBlobsResponse,
+	serializeNewBlobsInBinaryChunks,
+} from "../../../../../src/common/api/worker/facades/lazy/BlobFacade.js"
 import { HttpMethod, MAX_BLOB_SIZE_BYTES, RestClient, RestClientOptions, restSuspension } from "@tutao/rest-client"
 import { NativeFileApp } from "../../../../../src/common/native/common/FileApp.js"
 import { AesApp } from "../../../../../src/common/native/worker/AesApp.js"
@@ -127,6 +135,157 @@ o.spec("BlobFacade", function () {
 			const decryptedData = aesDecrypt(sessionKey, encryptedData)
 			o(arrayEquals(decryptedData, blobData)).equals(true)
 			o(optionsCaptor.value.baseUrl).equals("w1")
+		})
+
+		o.spec("encryptAndUploadMultiple tests", function () {
+			o("encryptAndUploadMultiple - multiple small attachments in single request", async function () {
+				const ownerGroup = "ownerGroupId"
+				const transferId = "t1" as TransferId
+
+				const fileData: FileData[] = [
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(2048) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(2 * 1024 * 1024) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(2048) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(2048) },
+				]
+
+				const expectedTokens = [
+					sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "first_attachment_token" }),
+					sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "second_attachment_token" }),
+					sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "third_attachment_token" }),
+					sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "fourth_attachment_token" }),
+				]
+
+				const blobAccessInfo = createTestEntity(storageTypeRefs.BlobServerAccessInfoTypeRef, {
+					blobAccessToken: "123",
+					servers: [createTestEntity(storageTypeRefs.BlobServerUrlTypeRef, { url: "w1.api.tuta.com" })],
+				})
+
+				when(blobAccessTokenFacade.requestWriteToken(anything(), anything())).thenResolve(blobAccessInfo)
+
+				when(restClientMock.request(BLOB_SERVICE_REST_PATH, HttpMethod.POST, anything())).thenResolve(JSON.stringify({}))
+
+				when(instancePipelineMock.decryptAndMap(anything(), anything(), anything())).thenResolve(
+					createTestEntity(storageTypeRefs.BlobPostOutTypeRef, {
+						blobReferenceTokens: expectedTokens,
+					}),
+				)
+
+				const result = await blobFacade.encryptAndUploadMultiple(archiveDataType, ownerGroup, fileData, transferId)
+				o(result).deepEquals([[expectedTokens[0]], [expectedTokens[1]], [expectedTokens[2]], [expectedTokens[3]]])
+				verify(restClientMock.request(BLOB_SERVICE_REST_PATH, HttpMethod.POST, anything()), { times: 1 })
+				verify(instancePipelineMock.decryptAndMap(anything(), anything(), anything()), { times: 1 })
+				verify(blobAccessTokenFacade.requestWriteToken(anything(), anything()), { times: 1 })
+			})
+			o("encryptAndUploadMultiple - multiple attachments including one large", async function () {
+				const ownerGroup = "ownerGroupId"
+				const transferId = "t2" as TransferId
+
+				const fileData: FileData[] = [
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(12 * 1024 * 1024) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(2 * 1024 * 1024) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(2 * 1024 * 1024) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(1024 * 1024) },
+				]
+
+				const firstPartToken = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "first_attachment_token1" })
+				const secondPartToken = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "first_attachment_token2" })
+				const secondAttachmentToken = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "second_attachment_token" })
+				const thirdAttachmentToken = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "third_attachment_token" })
+				const fourthAttachmentToken = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "fourth_attachment_token" })
+
+				const blobAccessInfo = createTestEntity(storageTypeRefs.BlobServerAccessInfoTypeRef, {
+					blobAccessToken: "123",
+					servers: [createTestEntity(storageTypeRefs.BlobServerUrlTypeRef, { url: "w1.api.tuta.com" })],
+				})
+
+				when(blobAccessTokenFacade.requestWriteToken(anything(), anything())).thenResolve(blobAccessInfo)
+
+				when(restClientMock.request(BLOB_SERVICE_REST_PATH, HttpMethod.POST, anything())).thenResolve(JSON.stringify({}))
+
+				let decryptCall = 0
+				when(instancePipelineMock.decryptAndMap(anything(), anything(), anything())).thenDo(() => {
+					decryptCall++
+					if (decryptCall === 1) {
+						return Promise.resolve(
+							createTestEntity(storageTypeRefs.BlobPostOutTypeRef, {
+								blobReferenceTokens: [firstPartToken],
+							}),
+						)
+					} else if (decryptCall === 2) {
+						return Promise.resolve(
+							createTestEntity(storageTypeRefs.BlobPostOutTypeRef, {
+								blobReferenceTokens: [secondPartToken, secondAttachmentToken, thirdAttachmentToken, fourthAttachmentToken],
+							}),
+						)
+					} else {
+						// dummy mock necessary for verify calls
+						// if this was called, it would throw in BlobFacade#parseBlobPostOutResponseMultiple
+						return Promise.resolve(
+							createTestEntity(storageTypeRefs.BlobPostOutTypeRef, {
+								blobReferenceTokens: [],
+							}),
+						)
+					}
+				})
+
+				const result = await blobFacade.encryptAndUploadMultiple(archiveDataType, ownerGroup, fileData, transferId)
+				o(result).deepEquals([[firstPartToken, secondPartToken], [secondAttachmentToken], [thirdAttachmentToken], [fourthAttachmentToken]])
+				verify(restClientMock.request(BLOB_SERVICE_REST_PATH, HttpMethod.POST, anything()), { times: 2 })
+				verify(instancePipelineMock.decryptAndMap(anything(), anything(), anything()), { times: 2 })
+			})
+			o("encryptAndUploadMultiple - worst case", async function () {
+				const ownerGroup = "ownerGroupId"
+				const transferId = "t3" as TransferId
+
+				const fileData: FileData[] = [
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(14 * 1024 * 1024) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(9 * 1024 * 1024) },
+					{ sessionKey: aes256RandomKey(), data: new Uint8Array(2 * 1024 * 1024) },
+				]
+
+				const t1 = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "first_attachment_token1" })
+				const t2 = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "first_attachment_token2" })
+				const t3 = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "second_attachment_token" })
+				const t4 = sysTypeRefs.createBlobReferenceTokenWrapper({ blobReferenceToken: "third_attachment_token" })
+
+				const blobAccessInfo = createTestEntity(storageTypeRefs.BlobServerAccessInfoTypeRef, {
+					blobAccessToken: "123",
+					servers: [createTestEntity(storageTypeRefs.BlobServerUrlTypeRef, { url: "w1.api.tuta.com" })],
+				})
+
+				when(blobAccessTokenFacade.requestWriteToken(anything(), anything())).thenResolve(blobAccessInfo)
+
+				when(restClientMock.request(BLOB_SERVICE_REST_PATH, HttpMethod.POST, anything())).thenResolve(JSON.stringify({}))
+
+				let decryptCall = 0
+				when(instancePipelineMock.decryptAndMap(anything(), anything(), anything())).thenDo(() => {
+					decryptCall++
+					switch (decryptCall) {
+						case 1:
+							return Promise.resolve(createTestEntity(storageTypeRefs.BlobPostOutTypeRef, { blobReferenceTokens: [t1] }))
+						case 2:
+							return Promise.resolve(createTestEntity(storageTypeRefs.BlobPostOutTypeRef, { blobReferenceTokens: [t2] }))
+						case 3:
+							return Promise.resolve(createTestEntity(storageTypeRefs.BlobPostOutTypeRef, { blobReferenceTokens: [t3] }))
+						case 4:
+							return Promise.resolve(createTestEntity(storageTypeRefs.BlobPostOutTypeRef, { blobReferenceTokens: [t4] }))
+						default:
+							// dummy mock necessary for verify calls
+							// if this was called, it would throw in BlobFacade#parseBlobPostOutResponseMultiple
+							return Promise.resolve(
+								createTestEntity(storageTypeRefs.BlobPostOutTypeRef, {
+									blobReferenceTokens: [],
+								}),
+							)
+					}
+				})
+				const result = await blobFacade.encryptAndUploadMultiple(archiveDataType, ownerGroup, fileData, transferId)
+
+				o(result).deepEquals([[t1, t2], [t3], [t4]])
+				verify(restClientMock.request(BLOB_SERVICE_REST_PATH, HttpMethod.POST, anything()), { times: 4 })
+				verify(instancePipelineMock.decryptAndMap(anything(), anything(), anything()), { times: 4 })
+			})
 		})
 
 		o("encryptAndUploadNative", async function () {
@@ -979,6 +1138,71 @@ o.spec("BlobFacade", function () {
 
 			const result = parseMultipleBlobsResponse(new Uint8Array(binaryData))
 			o(result).deepEquals(new Map<Id, Uint8Array>())
+		})
+	})
+	o.spec("serializeNewBlobsInChunks", function () {
+		o.test("serializeNewBlobsInBinaryChunks splits blobs by max size", function () {
+			const sessionKey1 = aes256RandomKey()
+			const firstBlob: KeyedNewBlobWrapper = {
+				sessionKey: sessionKey1,
+				newBlobWrapper: {
+					hash: new Uint8Array([1, 2, 3, 4, 5, 6]),
+					data: new Uint8Array([1, 2, 3]),
+				},
+			}
+
+			const sessionKey2 = aes256RandomKey()
+			const secondBlob: KeyedNewBlobWrapper = {
+				sessionKey: sessionKey2,
+				newBlobWrapper: {
+					hash: new Uint8Array([4, 5, 6, 2, 3, 5]),
+					data: new Uint8Array([1, 2, 3, 4, 5, 6]),
+				},
+			}
+
+			const result = serializeNewBlobsInBinaryChunks(
+				[firstBlob, secondBlob],
+				13, // force chunk size to 13 bytes
+				MAX_NUMBER_OF_BLOBS_IN_BINARY,
+			)
+
+			o(result.length).deepEquals(2)
+
+			o(result[0].sessionKeys).deepEquals([sessionKey1])
+			o(result[1].sessionKeys).deepEquals([sessionKey2])
+
+			o(result[0].binary.length > 0).equals(true)
+			o(result[1].binary.length > 0).equals(true)
+		})
+		o.test("serializeNewBlobsInBinaryChunks does not exceed max blobs per chunk", function () {
+			const sessionKey1 = aes256RandomKey()
+			const firstBlob: KeyedNewBlobWrapper = {
+				sessionKey: sessionKey1,
+				newBlobWrapper: {
+					hash: new Uint8Array([1, 2, 3, 4, 5, 6]),
+					data: new Uint8Array([1, 2, 3]),
+				},
+			}
+
+			const sessionKey2 = aes256RandomKey()
+			const secondBlob: KeyedNewBlobWrapper = {
+				sessionKey: sessionKey2,
+				newBlobWrapper: {
+					hash: new Uint8Array([4, 5, 6, 2, 3, 5]),
+					data: new Uint8Array([1, 2, 3, 4, 5, 6]),
+				},
+			}
+
+			const result = serializeNewBlobsInBinaryChunks(
+				[firstBlob, secondBlob],
+				MAX_BLOB_SIZE_BYTES,
+				1, // force single blob per chunk
+			)
+
+			o(result.length).deepEquals(2)
+
+			o(result[0].sessionKeys).deepEquals([sessionKey1])
+			o(result[1].sessionKeys).deepEquals([sessionKey2])
 		})
 	})
 })


### PR DESCRIPTION
With this commit we carry over the encrypt_and_upload_multiple implementation done in Rust for the file email import to TypeScript, since it is useful for uploading multiple small files at once with fewer BlobService requests as possible.