### PR TITLE
Put UrlSession in iosNotification handeling to background

### DIFF
--- a/app-ios/TutanotaNotificationExtension/NotificationService.swift
+++ b/app-ios/TutanotaNotificationExtension/NotificationService.swift
@@ -10,8 +10,16 @@ class NotificationService: UNNotificationServiceExtension {
 
 	private var contentHandler: ((UNNotificationContent) -> Void)?
 	private var bestAttemptContent: UNMutableNotificationContent?
-	private let urlSession: URLSession = makeUrlSession()
+	private let urlSession: URLSession
 	private let logger = Logger(subsystem: "TutaNotifications", category: "Notifications")
+	override init() {
+		do { self.urlSession = try makeBackgroundUrlSession() } catch {
+			self.logger.error("[Error] Cannot create background url Session due to: \(String(describing: error))")
+			self.logger.info("Fallingback to urlSession as backgroundUrlSession can not be constructed")
+			self.urlSession = makeUrlSession()
+		}
+		super.init()
+	}
 
 	override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
 		self.contentHandler = contentHandler

--- a/app-ios/TutanotaSharedFramework/Utils/Utils.swift
+++ b/app-ios/TutanotaSharedFramework/Utils/Utils.swift
@@ -65,6 +65,18 @@ public func makeUrlSession() -> URLSession {
 
 	return urlSession
 }
+	
+public func makeBackgroundUrlSession() throws -> URLSession {
+	let backgroundSessionId =
+		if let bundleId = Bundle.main.bundleIdentifier { "\(bundleId).TutaNotificationAction" } else {
+			throw GenericTutanotaError(message: "No bundleId found")
+		}
+	let config = URLSessionConfiguration.background(withIdentifier: backgroundSessionId)
+	config.timeoutIntervalForRequest = 20
+	config.requestCachePolicy = .reloadIgnoringCacheData
+	config.httpAdditionalHeaders = ["cv": appVersion()]
+	return URLSession(configuration: config)
+}
 
 func appVersion() -> String { Bundle.main.infoDictionary?["CFBundleShortVersionString"] as! String }
 


### PR DESCRIPTION
Notification action in ios is not 100% relaible. Sometimes, the action is only applied when the app is in foreground.
We suspect it might be because the request we make is not in background tho we could not reproduce it locally.
We intend to test in testflight with these changes