### PR TITLE
Enable outline for most elements when using keyboard navigation

### DIFF
--- a/src/common/gui/main-styles.ts
+++ b/src/common/gui/main-styles.ts
@@ -1613,8 +1613,6 @@ styles.registerStyle("main", () => {
 		":where(.keyboard-nav) .state-bg:focus": {
 			background: theme.state_bg_focus,
 			"transition-duration": ".3s",
-			// disable default focus indicator because we have our own for this element
-			outline: "none",
 		},
 		".state-bg:active, .state-bg[pressed=true]": {
 			background: theme.state_bg_active,
@@ -1625,8 +1623,6 @@ styles.registerStyle("main", () => {
 		".state-bg-2": {
 			// We have to position pseudoelement
 			position: "relative",
-			// disable default focus indicator because we have our own for this element
-			outline: "none",
 		},
 		".state-bg-2::before": {
 			"background-color": `var(--state-bg-color, ${theme.on_surface})`,
@@ -1873,9 +1869,6 @@ styles.registerStyle("main", () => {
 			outline: "none",
 		},
 		".nofocus:focus": {
-			outline: "none",
-		},
-		".input": {
 			outline: "none",
 		},
 		".input::placeholder": {


### PR DESCRIPTION
The outline was disabled in the past to not interfere with our own interactive element indication. Since then there was added a dynamic system that enables/disables outline based on the last used input method (see `RootView`).

To improve accessibility and make it more clear which elements are currently selected we have enabled outline for elements with state-bg class again. Ther are still a few cases where noninteractive elements have their outline hidden.