### PR TITLE
[desktop] Harden DesktopFileFacade

### DIFF
--- a/src/common/desktop/files/DesktopFileFacade.ts
+++ b/src/common/desktop/files/DesktopFileFacade.ts
@@ -30,6 +30,7 @@ import { FetchImpl } from "../net/NetAgent"
 import { OpenDialogOptions } from "electron"
 import { CommandExecutor } from "../CommandExecutor"
 import { CommonNativeFacade } from "../../native/common/generatedipc/CommonNativeFacade"
+import { ProgrammingError } from "@tutao/app-env"
 
 const TAG = "[DesktopFileFacade]"
 
@@ -59,8 +60,9 @@ export class DesktopFileFacade implements FileFacade {
 		return Promise.resolve()
 	}
 
-	async deleteFile(filename: string): Promise<void> {
-		return await this.fs.promises.unlink(filename)
+	async deleteFile(filePath: string): Promise<void> {
+		this.tfs.assertInTmpDir(filePath)
+		return await this.fs.promises.unlink(filePath)
 	}
 
 	async download(sourceUrl: string, fileName: string, headers: Record<string, string>, fileId: string): Promise<DownloadTaskResponse> {
@@ -124,21 +126,25 @@ export class DesktopFileFacade implements FileFacade {
 		}
 	}
 
-	async getMimeType(file: string): Promise<string> {
-		return await getMimeTypeForFile(file)
+	/** can be used with arbitrary paths, is run on the selected file locations before the files are read */
+	async getMimeType(filePath: string): Promise<string> {
+		return await getMimeTypeForFile(filePath)
 	}
 
-	async getName(file: string): Promise<string> {
-		return path.basename(file)
+	/** can be used with arbitrary paths, is run on the selected file locations before the files are read */
+	async getName(filePath: string): Promise<string> {
+		return path.basename(filePath)
 	}
 
-	async getSize(fileUri: string): Promise<number> {
-		const stats = await this.fs.promises.stat(fileUri)
+	/** can be used with arbitrary paths, is run on the selected file locations before the files are read */
+	async getSize(filePath: string): Promise<number> {
+		const stats = await this.fs.promises.stat(filePath)
 		return stats.size
 	}
 
-	async hashFile(fileUri: string): Promise<string> {
-		const data = await this.fs.promises.readFile(fileUri)
+	async hashFile(filePath: string): Promise<string> {
+		this.tfs.assertInTmpDir(filePath)
+		const data = await this.fs.promises.readFile(filePath)
 		const checksum = sha256Hash(data).slice(0, 6)
 		return uint8ArrayToBase64(checksum)
 	}
@@ -148,23 +154,37 @@ export class DesktopFileFacade implements FileFacade {
 
 		const filesInDirectory = await this.fs.promises.readdir(downloadDirectory)
 		const newFilename = nonClobberingFilename(filesInDirectory, filename)
-		const fileUri = path.join(downloadDirectory, newFilename)
-		const outStream = this.fs.createWriteStream(fileUri, { autoClose: false })
+		const filePath = path.join(downloadDirectory, newFilename)
+		const outStream = this.fs.createWriteStream(filePath, { autoClose: false })
 
-		for (const infile of files) {
-			await newPromise<void>((resolve, reject) => {
+		try {
+			for (const infile of files) {
+				this.tfs.assertInTmpDir(infile)
 				const readStream = this.fs.createReadStream(infile)
-				readStream.on("end", resolve)
-				readStream.on("error", reject)
-				readStream.pipe(outStream, { end: false })
-			})
-			await this.deleteFile(infile)
+				try {
+					await newPromise<void>((resolve, reject) => {
+						readStream.on("end", resolve)
+						readStream.on("error", reject)
+						readStream.pipe(outStream, { end: false })
+					})
+				} finally {
+					readStream.close()
+				}
+				await this.fs.promises.unlink(infile)
+			}
+
+			await closeFileStream(outStream)
+		} catch (e) {
+			// clean up if we couldn't finish writing
+			await closeFileStream(outStream)
+			await this.fs.promises.unlink(filePath)
 		}
-		await closeFileStream(outStream)
-		return fileUri
+
+		return filePath
 	}
 
 	async open(location: string /* , mimeType: string omitted */): Promise<void> {
+		this.tfs.assertInTmpDir(location)
 		const openWithElectronShell = () =>
 			this.electron.shell
 				.openPath(location) // may resolve with "" or an error message
@@ -240,6 +260,7 @@ export class DesktopFileFacade implements FileFacade {
 	}
 
 	async putFileIntoDownloadsFolder(localFileUri: string, fileNameToUse: string): Promise<string> {
+		this.tfs.assertInTmpDir(localFileUri)
 		const savePath = await this.pickSavePath(fileNameToUse)
 		await this.fs.promises.mkdir(path.dirname(savePath), {
 			recursive: true,
@@ -249,6 +270,7 @@ export class DesktopFileFacade implements FileFacade {
 		return savePath
 	}
 
+	/** can be used with arbitrary paths, is run on the selected file locations */
 	async splitFile(fileUri: string, maxChunkSizeBytes: number): Promise<Array<string>> {
 		const tempDir = await this.tfs.ensureUnencrytpedDir()
 		const fullBytes = await this.fs.promises.readFile(fileUri)
@@ -269,6 +291,8 @@ export class DesktopFileFacade implements FileFacade {
 	}
 
 	async upload(fileUri: string, targetUrl: string, method: HttpMethod, headers: Record<string, string>, fileId: string): Promise<UploadTaskResponse> {
+		// we only upload encrypted blobs so it should be safe
+		this.tfs.assertInTmpDir(fileUri)
 		const fileStream = this.fs.createReadStream(fileUri)
 		const stat = await this.fs.promises.stat(fileUri)
 		headers["Content-Length"] = `${stat.size}`
@@ -318,22 +342,21 @@ export class DesktopFileFacade implements FileFacade {
 	// This write data to app dir and return full path
 	async writeToAppDir(fileConent: Uint8Array, fileName: string): Promise<void> {
 		const fullPath = this.path.join(this.electron.app.getPath("userData"), fileName)
+		this.assertPathWithinUserData(fullPath)
 		this.fs.writeFileSync(fullPath, fileConent)
 	}
 
-	async readFromAppDir(fileName: string): Promise<Buffer> {
+	async readFromAppDir(fileName: string): Promise<Uint8Array> {
 		const fullPath = this.path.join(this.electron.app.getPath("userData"), fileName)
+		this.assertPathWithinUserData(fullPath)
 		return this.fs.readFileSync(fullPath)
 	}
 
 	async deleteFromAppDir(fileName: string): Promise<void> {
 		const userDataDir = this.electron.app.getPath("userData")
 
-		const resolvedBase = this.path.resolve(userDataDir)
 		const resolvedTarget = this.path.resolve(userDataDir, fileName)
-		if (!resolvedTarget.startsWith(resolvedBase + this.path.sep)) {
-			return
-		}
+		this.assertPathWithinUserData(resolvedTarget)
 
 		try {
 			await this.fs.promises.unlink(resolvedTarget)
@@ -342,7 +365,7 @@ export class DesktopFileFacade implements FileFacade {
 		}
 	}
 
-	// this is used to read unencrypted data from arbitrary locations
+	/** this is used to read unencrypted data from arbitrary locations */
 	async readDataFile(uriOrPath: FileUri): Promise<DataFile | null> {
 		try {
 			uriOrPath = url.fileURLToPath(uriOrPath)
@@ -351,7 +374,11 @@ export class DesktopFileFacade implements FileFacade {
 		}
 		const name = path.basename(uriOrPath)
 		try {
-			const [data, mimeType] = await Promise.all([this.fs.promises.readFile(uriOrPath), this.getMimeType(uriOrPath)])
+			const [data, mimeType] = await Promise.all([
+				this.fs.promises.readFile(uriOrPath),
+				// freestanding function doesn't have the checks
+				getMimeTypeForFile(uriOrPath),
+			])
 			if (data == null) return null
 			return {
 				_type: "DataFile",
@@ -366,8 +393,10 @@ export class DesktopFileFacade implements FileFacade {
 		}
 	}
 
-	/** select a non-colliding name in the configured downloadPath, preferably with the given file name
-	 * public for testing */
+	/**
+	 * Select a non-colliding name in the configured downloadPath, preferably with the given file name
+	 * public for testing
+	 */
 	async pickSavePath(filename: string): Promise<string> {
 		const defaultDownloadPath = await this.conf.getVar(DesktopConfigKey.defaultDownloadPath)
 
@@ -396,6 +425,14 @@ export class DesktopFileFacade implements FileFacade {
 		if (lastOpenedFileManagerAt == null || this.dateProvider.now() - lastOpenedFileManagerAt > fileManagerTimeout) {
 			this.lastOpenedFileManagerAt = this.dateProvider.now()
 			this.electron.shell.showItemInFolder(savePath)
+		}
+	}
+	/** can be used with arbitrary paths, is run on the selected file locations before the files are read */
+	private assertPathWithinUserData(unresolvedPath: string): void {
+		const resolvedBase = this.electron.app.getPath("userData")
+		const resolvedTarget = path.resolve(unresolvedPath)
+		if (!resolvedTarget.startsWith(resolvedBase + this.path.sep)) {
+			throw new ProgrammingError("Invalid file path: " + unresolvedPath)
 		}
 	}
 }

--- a/src/common/desktop/files/TempFs.ts
+++ b/src/common/desktop/files/TempFs.ts
@@ -2,6 +2,7 @@ import path from "node:path"
 import { ElectronExports, FsExports } from "../ElectronExportTypes.js"
 import { CryptoFunctions } from "../CryptoFns.js"
 import { base64ToBase64Url, uint8ArrayToBase64, uint8ArrayToHex } from "@tutao/utils"
+import { ProgrammingError } from "@tutao/app-env"
 
 type TmpSub = "reg" | "encrypted" | "decrypted"
 
@@ -141,6 +142,13 @@ export class TempFs {
 		const downloadDirectory = this.getUnencryptedTempDir()
 		await this.fs.promises.mkdir(downloadDirectory, { recursive: true })
 		return downloadDirectory
+	}
+
+	assertInTmpDir(unresolvedPath: string) {
+		const resolvedTarget = path.resolve(unresolvedPath)
+		if (!resolvedTarget.startsWith(this.getTutanotaTempPath() + path.sep)) {
+			throw new ProgrammingError("Invalid file path: " + unresolvedPath)
+		}
 	}
 
 	private getEncryptedTempDir() {

--- a/test/tests/desktop/files/DesktopFileFacadeTest.ts
+++ b/test/tests/desktop/files/DesktopFileFacadeTest.ts
@@ -8,29 +8,32 @@ import { HttpMethod, restError } from "@tutao/rest-client"
 import type fs from "node:fs"
 import { stringToUtf8Uint8Array } from "@tutao/utils"
 import { DesktopConfig } from "../../../../src/common/desktop/config/DesktopConfig.js"
-import { DesktopUtils } from "../../../../src/common/desktop/DesktopUtils.js"
 import { DateProvider } from "../../../../src/common/api/common/DateProvider.js"
 import { TempFs } from "../../../../src/common/desktop/files/TempFs.js"
 import { BuildConfigKey, DesktopConfigKey } from "../../../../src/common/desktop/config/ConfigKeys.js"
 import { FetchImpl, FetchResult } from "../../../../src/common/desktop/net/NetAgent"
 import { CommandExecutor } from "../../../../src/common/desktop/CommandExecutor"
-import { BufferEncoding } from "rollup"
 import stream from "node:stream"
-import { WriteStream } from "fs-extra"
+import nodePath from "node:path"
+import { ProgrammingError } from "@tutao/app-env"
 
 const DEFAULT_DOWNLOAD_PATH = "/a/download/path/"
+const USER_DATA_PATH = "/path/to/user/data"
+
+type Writable<T> = {
+	-readonly [P in keyof T]: T[P]
+}
 
 o.spec("DesktopFileFacade", function () {
 	let win: ApplicationWindow
 	let conf: DesktopConfig
-	let du: DesktopUtils
 	let dp: DateProvider
 	let fetch: FetchImpl
-	let electron: ElectronExports
+	let electron: Writable<ElectronExports>
 	let fs: FsExports
 	let tfs: TempFs
 	let ff: DesktopFileFacade
-	let path: PathExports
+	let path: Writable<PathExports>
 	let executor: CommandExecutor
 	let process: Writeable<Partial<NodeJS.Process>>
 
@@ -46,14 +49,16 @@ o.spec("DesktopFileFacade", function () {
 		}
 		when(fs.promises.stat(matchers.anything())).thenResolve({ size: 42 })
 		electron = object()
-		// @ts-ignore read-only prop
 		electron["shell"] = object()
-		// @ts-ignore read-only prop
 		electron["dialog"] = object()
+		electron.app = object()
+		when(electron.app.getPath("userData")).thenReturn(USER_DATA_PATH)
 		process.platform = "linux"
+		path.sep = "/"
+		when(path.resolve(), { ignoreExtraArgs: true }).thenDo((...args) => nodePath.resolve(...args))
+		when(path.join(), { ignoreExtraArgs: true }).thenDo((...args) => args.join("/"))
 
 		conf = object()
-		du = object()
 		dp = object()
 		executor = object()
 
@@ -211,7 +216,7 @@ o.spec("DesktopFileFacade", function () {
 			when(fetch(matchers.anything(), matchers.anything())).thenResolve(response)
 			const error = new Error("Test! I/O error")
 			const ws = mockWriteStream({ error })
-			when(fs.createWriteStream(matchers.anything(), matchers.anything())).thenReturn(ws as unknown as WriteStream)
+			when(fs.createWriteStream(matchers.anything(), matchers.anything())).thenReturn(ws as unknown as fs.WriteStream)
 			when(tfs.ensureEncryptedDir()).thenResolve("/tutanota/tmp/path/encrypted")
 
 			const e = await assertThrows(Error, () => ff.download("some://url/file", "nativelyDownloadedFile", headers, "fileId"))
@@ -247,6 +252,7 @@ o.spec("DesktopFileFacade", function () {
 			o(uploadResult.precondition).equals(null)
 			o(uploadResult.suspensionTime).equals(null)
 			o(Array.from(uploadResult.responseBody)).deepEquals(Array.from(body))
+			verify(tfs.assertInTmpDir(fileToUploadPath))
 		})
 
 		o("when 404 is returned it returns correct result", async function () {
@@ -349,6 +355,7 @@ o.spec("DesktopFileFacade", function () {
 						},
 					}),
 				)
+				verify(tfs.assertInTmpDir("/some/folder/file"))
 			})
 			o.test("open on non ubuntu", async function () {
 				when(electron.shell.openPath("/some/folder/file")).thenReject(new Error("wrong function"))
@@ -390,6 +397,7 @@ o.spec("DesktopFileFacade", function () {
 			when(tfs.ensureUnencrytpedDir()).thenResolve("/tutanota/tmp/path/unencrypted")
 			const joinedFilePath = await ff.joinFiles("fileName.pdf", ["/file1"])
 			o(joinedFilePath).equals("/tutanota/tmp/path/unencrypted/fileName.pdf")
+			verify(tfs.assertInTmpDir("/file1"))
 		})
 	})
 
@@ -456,6 +464,7 @@ o.spec("DesktopFileFacade", function () {
 			const copiedFileUri = await ff.putFileIntoDownloadsFolder(src, filename)
 			verify(fs.promises.copyFile(src, DEFAULT_DOWNLOAD_PATH + "fileName.pdf"))
 			o(copiedFileUri).equals(DEFAULT_DOWNLOAD_PATH + "fileName.pdf")
+			verify(tfs.assertInTmpDir(src))
 		})
 	})
 
@@ -470,6 +479,7 @@ o.spec("DesktopFileFacade", function () {
 		o("hash", async function () {
 			when(fs.promises.readFile("/file1")).thenResolve(new Uint8Array([0, 1, 2, 3]) as Buffer)
 			o(await ff.hashFile("/file1")).equals("BU7ewdAh")
+			verify(tfs.assertInTmpDir("/file1"))
 		})
 	})
 
@@ -484,6 +494,42 @@ o.spec("DesktopFileFacade", function () {
 
 		o.test("given nonexisting extension it returns default fallback", async function () {
 			o.check(await getMimeTypeForFile("/tmp/picture.nonsense")).equals("application/octet-stream")
+		})
+	})
+
+	o.spec("writeToAppDir", function () {
+		o.test("writes to a correct file normally", async function () {
+			const data = new Uint8Array([1, 2, 3])
+			await ff.writeToAppDir(data, "name.dat")
+			verify(fs.writeFileSync(`${USER_DATA_PATH}/name.dat`, data))
+		})
+
+		o.test("fails if outside the app dir", async function () {
+			const data = new Uint8Array([1, 2, 3])
+			await o.check(() => ff.writeToAppDir(data, "../name.dat")).asyncThrows(ProgrammingError)
+		})
+	})
+
+	o.spec("readFromAppDir", function () {
+		o.test("reads a correct file normally", async function () {
+			const data = new Uint8Array([1, 2, 3])
+			when(fs.readFileSync(`${USER_DATA_PATH}/name.dat`)).thenReturn(Buffer.from(data))
+			o.check(await ff.readFromAppDir("name.dat")).deepEquals(data)
+		})
+
+		o.test("fails if outside the app dir", async function () {
+			await o.check(() => ff.readFromAppDir("../name.dat")).asyncThrows(ProgrammingError)
+		})
+	})
+
+	o.spec("deleteFromAppDir", function () {
+		o.test("deletes correct file normally", async function () {
+			await ff.deleteFromAppDir("name.dat")
+			o.check(fs.promises.unlink(`${USER_DATA_PATH}/name.dat`))
+		})
+
+		o.test("fails if outside the app dir", async function () {
+			await o.check(() => ff.deleteFromAppDir("../name.dat")).asyncThrows(ProgrammingError)
 		})
 	})
 })


### PR DESCRIPTION
Try to restrict available operations to guard against a compromised renderer process. Unfortunately, a lot of the methods cannot be restricted more than arbitrary paths at the moment, but all of them should be readonly.

Hopefully in the future we can make bigger use of xdg-portals and similar technologies to restrict the access even more.