### PR TITLE
Revert "Update URL on conversation change in search"

### DIFF
--- a/src/mail-app/search/view/SearchViewModel.ts
+++ b/src/mail-app/search/view/SearchViewModel.ts
@@ -6,10 +6,10 @@ import {
 	assertIsEntity,
 	assertIsEntity2,
 	elementIdPart,
+	EntityIdEncoding,
 	entityUpdateUtils,
 	GENERATED_MAX_ID,
 	getElementId,
-	EntityIdEncoding,
 	isPermanentDeleteAllowedForFolder,
 	isSameId,
 	ListElement,
@@ -26,7 +26,6 @@ import {
 	deepEqual,
 	defer,
 	downcast,
-	first,
 	getEndOfDay,
 	getStartOfDay,
 	incrementMonth,
@@ -846,29 +845,24 @@ export class SearchViewModel {
 	}
 
 	private onListStateChange(newState: ListState<SearchResultListEntry>) {
-		let unsetConversationViewModel = this._conversationViewModel != null
-
 		if (isSameTypeRef(this.searchedType, tutanotaTypeRefs.MailTypeRef) && !newState.inMultiselect && newState.selectedItems.size === 1) {
-			const mail = first(this.getSelectedMails())
+			const mail = this.getSelectedMails()[0]
 
 			// Sometimes a stale state is passed through, resulting in no mail
-			if (mail != null) {
+			if (mail) {
 				// displayed conversation has changed
 				if (
 					!this._conversationViewModel ||
 					!isSameId(listIdPart(this._conversationViewModel.primaryMail._id), listIdPart(mail._id)) ||
 					!isSameId(elementIdPart(this._conversationViewModel.primaryMail._id), elementIdPart(mail._id))
 				) {
-					unsetConversationViewModel = false
 					this.updateDisplayedConversation(mail)
-					this.updateSearchUrl()
 				}
+			} else {
+				this._conversationViewModel = null
 			}
-		}
-
-		if (unsetConversationViewModel) {
+		} else {
 			this._conversationViewModel = null
-			this.updateSearchUrl()
 		}
 
 		this.updateUi()


### PR DESCRIPTION
This reverts commit 65e17f6a1cd188a5327cd48a0310fa0309ffdae9.

Properly fixing issue caused by 65e17f6 requires more effort, and we are going to anyway rework SearchViewModel soon, so reverting the change for now.

Close #10766

Co-authored-by: wrd <wrd@tutao.de>