### PR TITLE
bring back eventQueue in entity event processing in EventBusClient

### DIFF
--- a/src/common/api/worker/EventBusClient.ts
+++ b/src/common/api/worker/EventBusClient.ts
@@ -13,9 +13,8 @@ import {
 	tutanotaModelInfo,
 	tutanotaTypeRefs,
 	TypeModelResolver,
-	GENERATED_MIN_ID,
 } from "@tutao/typerefs"
-import { AppName, delay, identity, isSameTypeRef, lazyAsync, Nullable, ofClass, promiseMap, randomIntFromInterval, TypeRef } from "@tutao/utils"
+import { AppName, assertNotNull, delay, identity, isSameTypeRef, lazyAsync, Nullable, ofClass, promiseMap, randomIntFromInterval, TypeRef } from "@tutao/utils"
 import { OutOfSyncError } from "../common/error/OutOfSyncError"
 import { CancelledError } from "../common/error/CancelledError"
 import { WsConnectionState } from "../main/WorkerClient"
@@ -33,6 +32,7 @@ import { DateProvider } from "../common/DateProvider"
 import { ExposedProgressTracker } from "../main/ProgressTracker"
 import { ProgressMonitorDelegate } from "./ProgressMonitorDelegate"
 import { filterIndexMemberships } from "../common/utils/IndexUtils"
+import { EventQueue, QueuedBatch } from "./EventQueue"
 
 assertWorkerOrNode()
 
@@ -107,6 +107,8 @@ export class EventBusClient {
 
 	private lastAntiphishingMarkersId: Id | null = null
 
+	/** Queue to process all events. */
+	private readonly eventQueue: EventQueue
 	private reconnectTimer: TimeoutID | null
 	private connectTimer: TimeoutID | null
 
@@ -127,11 +129,9 @@ export class EventBusClient {
 	private readonly initialWorkDone = 25
 
 	/**
-	 * Represents multiple retried executions due to a ServiceUnavailableError
-	 * We store the retry promise of connection as GENERATED_MIN_ID and for other retries of batch processing as BatchId
+	 * Represents a currently retried execution due to a ServiceUnavailableError
 	 */
-	private batchIdToServiceUnavailableRetryMap: Map<Id, Promise<void>> = new Map()
-
+	private serviceUnavailableRetry: Promise<void> | null = null
 	/**
 	 * The message queue is used to ensure that messages are processed in the correct order.
 	 * The messages are sent from the server in a correct order, but if they are not awaited,
@@ -160,13 +160,17 @@ export class EventBusClient {
 		this.socket = null
 		this.reconnectTimer = null
 		this.connectTimer = null
+		this.eventQueue = new EventQueue("ws", (modification) => this.eventQueueCallback(modification))
 		this.reset()
 	}
 
 	private reset() {
 		this.immediateReconnect = false
 
-		this.batchIdToServiceUnavailableRetryMap = new Map()
+		this.eventQueue.pause()
+		this.eventQueue.clear()
+
+		this.serviceUnavailableRetry = null
 	}
 
 	/**
@@ -176,7 +180,7 @@ export class EventBusClient {
 	async connect(connectMode: ConnectMode) {
 		console.log("ws connect reconnect:", connectMode === ConnectMode.Reconnect, "state:", this.state)
 		// make sure a retry will be cancelled by setting _serviceUnavailableRetry to null
-		this.batchIdToServiceUnavailableRetryMap = new Map()
+		this.serviceUnavailableRetry = null
 
 		this.connectivityListener.updateWebSocketState(WsConnectionState.connecting)
 
@@ -329,7 +333,13 @@ export class EventBusClient {
 					// such as two entity updates per mail after the ProcessInboxService call. We complete this added work in the EventController
 					await this.progressMonitor?.updateTotalWork(this.progressMonitor.totalWork + 1)
 				}
-				await this.processEventBatch(updates, batchId, groupId, this.isInitialSyncDone)
+				// if the updates were not added to the queue, since the array is empty because it was optimized away,
+				// we need to complete the work for the batch here, since the processEventBatch function
+				// (and therefore the EventController) will not be called for this particular batch.
+				const wasAdded = this.eventQueue.add(batchId, groupId, updates, this.isInitialSyncDone)
+				if (!wasAdded && !this.progressMonitor?.isDone()) {
+					await this.progressMonitor?.workDone(1)
+				}
 				break
 			}
 			case MessageType.UnreadCounterUpdate: {
@@ -507,6 +517,7 @@ export class EventBusClient {
 
 	private async initEntityEvents(connectMode: ConnectMode): Promise<void> {
 		return this.initConnection()
+			.then(() => this.eventQueue.resume())
 			.catch(
 				ofClass(restError.ConnectionError, (e) => {
 					console.log("ws not connected in connect(), close websocket", e)
@@ -525,16 +536,14 @@ export class EventBusClient {
 					console.log("ws retry init entity events in ", RETRY_AFTER_SERVICE_UNAVAILABLE_ERROR_MS, e)
 					let promise = delay(RETRY_AFTER_SERVICE_UNAVAILABLE_ERROR_MS).then(() => {
 						// if we have a websocket reconnect we have to stop retrying
-						if (this.batchIdToServiceUnavailableRetryMap.has(GENERATED_MIN_ID)) {
+						if (this.serviceUnavailableRetry === promise) {
 							console.log("ws retry initializing entity events")
 							return this.initEntityEvents(connectMode)
 						} else {
 							console.log("ws cancel initializing entity events")
 						}
 					})
-					// Since this is the initial connect, overriding a previous connect in case of failure may not
-					// cause any problems, thus GENERATED_MIN_ID is used as a placeholder for initial connection.
-					this.batchIdToServiceUnavailableRetryMap.set(GENERATED_MIN_ID, promise)
+					this.serviceUnavailableRetry = promise
 					return promise
 				}),
 			)
@@ -548,6 +557,7 @@ export class EventBusClient {
 				}),
 			)
 			.catch((e) => {
+				this.eventQueue.resume()
 				this.listener.onError(e)
 			})
 	}
@@ -594,6 +604,16 @@ export class EventBusClient {
 		if (await this.cache.isOutOfSync()) {
 			// We handle it where we initialize the connection and purge the cache there.
 			throw new OutOfSyncError("some missed EntityEventBatches cannot be loaded any more")
+		}
+	}
+
+	private async eventQueueCallback(modification: QueuedBatch): Promise<void> {
+		try {
+			await this.processEventBatch(modification)
+		} catch (e) {
+			console.log("ws error while processing event batches", e)
+			this.listener.onError(e)
+			throw e
 		}
 	}
 
@@ -648,13 +668,19 @@ export class EventBusClient {
 		}
 	}
 
-	private async processEventBatch(entityUpdates: entityUpdateUtils.EntityUpdateData[], batchId: Id, groupId: Id, isInitialSyncDone: boolean): Promise<void> {
+	private async processEventBatch(batch: QueuedBatch): Promise<void> {
 		try {
 			if (this.isTerminated()) return
-			const filteredEvents = await this.cache.entityEventsReceived(entityUpdates, batchId, groupId)
+			const filteredEvents = await this.cache.entityEventsReceived(batch.events, batch.batchId, batch.groupId)
 			if (!this.isTerminated()) {
 				const progressMonitorId = (await this.progressMonitor?.progressMonitorId) ?? null
-				await this.listener.onEntityEventsReceived(filteredEvents, batchId, groupId, progressMonitorId, isInitialSyncDone)
+				await this.listener.onEntityEventsReceived(
+					filteredEvents,
+					batch.batchId,
+					batch.groupId,
+					progressMonitorId,
+					assertNotNull(batch.isInitialSyncDone),
+				)
 			}
 		} catch (e) {
 			if (e instanceof restError.ServiceUnavailableError) {
@@ -662,13 +688,13 @@ export class EventBusClient {
 				console.log("ws retry processing event in 30s", e)
 				const retryPromise = delay(RETRY_AFTER_SERVICE_UNAVAILABLE_ERROR_MS).then(() => {
 					// if we have a websocket reconnect we have to stop retrying
-					if (this.batchIdToServiceUnavailableRetryMap.has(batchId)) {
-						return this.processEventBatch(entityUpdates, batchId, groupId, isInitialSyncDone)
+					if (this.serviceUnavailableRetry === retryPromise) {
+						return this.processEventBatch(batch)
 					} else {
 						throw new CancelledError("stop retry processing after service unavailable due to reconnect")
 					}
 				})
-				this.batchIdToServiceUnavailableRetryMap.set(batchId, retryPromise)
+				this.serviceUnavailableRetry = retryPromise
 				return retryPromise
 			} else {
 				if (!isExpectedErrorForSynchronization(e)) {

--- a/src/common/api/worker/EventBusEventCoordinator.ts
+++ b/src/common/api/worker/EventBusEventCoordinator.ts
@@ -27,7 +27,12 @@ export class EventBusEventCoordinator implements EventBusListener {
 		private readonly keyRotationFacade: KeyRotationFacade,
 		private readonly cacheManagementFacade: lazyAsync<CacheManagementFacade>,
 		private readonly sendError: (error: Error) => Promise<void>,
-		private readonly appSpecificBatchHandling: (events: readonly entityUpdateUtils.EntityUpdateData[], batchId: Id, groupId: Id) => void,
+		private readonly appSpecificBatchHandling: (
+			events: readonly entityUpdateUtils.EntityUpdateData[],
+			batchId: Id,
+			groupId: Id,
+			isInitialSyncDone: boolean,
+		) => void,
 		private readonly rolloutFacade: RolloutFacade,
 		private readonly groupManagementFacade: lazyAsync<GroupManagementFacade>,
 		private readonly identityKeyCreator: lazyAsync<IdentityKeyCreator>,
@@ -49,7 +54,7 @@ export class EventBusEventCoordinator implements EventBusListener {
 		if (!(env.mode === Mode.Test) && !(env.mode === Mode.Admin)) {
 			const configurationDatabase = await this.configurationDatabase()
 			await configurationDatabase.onEntityEventsReceived(events, batchId, groupId)
-			this.appSpecificBatchHandling(events, batchId, groupId)
+			this.appSpecificBatchHandling(events, batchId, groupId, isInitialSyncDone)
 		}
 	}
 

--- a/src/common/api/worker/EventQueue.ts
+++ b/src/common/api/worker/EventQueue.ts
@@ -7,6 +7,7 @@ export type QueuedBatch = {
 	events: readonly entityUpdateUtils.EntityUpdateData[]
 	groupId: Id
 	batchId: Id
+	isInitialSyncDone: boolean
 }
 
 type WritableQueuedBatch = QueuedBatch & { events: entityUpdateUtils.EntityUpdateData[] }
@@ -38,7 +39,7 @@ export class EventQueue {
 
 	addBatches(batches: ReadonlyArray<QueuedBatch>) {
 		for (const batch of batches) {
-			this.add(batch.batchId, batch.groupId, batch.events)
+			this.add(batch.batchId, batch.groupId, batch.events, batch.isInitialSyncDone)
 		}
 	}
 
@@ -50,11 +51,12 @@ export class EventQueue {
 	/**
 	 * @return whether the batch was added (not optimized away)
 	 */
-	add(batchId: Id, groupId: Id, newEvents: ReadonlyArray<entityUpdateUtils.EntityUpdateData>): boolean {
+	add(batchId: Id, groupId: Id, newEvents: ReadonlyArray<entityUpdateUtils.EntityUpdateData>, isInitialSyncDone: boolean): boolean {
 		const newBatch: WritableQueuedBatch = {
 			events: [],
 			groupId,
 			batchId,
+			isInitialSyncDone,
 		}
 
 		newBatch.events.push(...newEvents)

--- a/src/mail-app/workerUtils/index/IndexedDbIndexer.ts
+++ b/src/mail-app/workerUtils/index/IndexedDbIndexer.ts
@@ -294,7 +294,7 @@ export class IndexedDbIndexer implements Indexer {
 		this.eventQueue.resume()
 	}
 
-	async processEntityEvents(updates: readonly entityUpdateUtils.EntityUpdateData[], batchId: Id, groupId: Id): Promise<void> {
+	async processEntityEvents(updates: readonly entityUpdateUtils.EntityUpdateData[], batchId: Id, groupId: Id, isInitialSyncDone: boolean): Promise<void> {
 		try {
 			await this.throwIfOutOfDate()
 			await this.writeServerTimestamp()
@@ -303,7 +303,7 @@ export class IndexedDbIndexer implements Indexer {
 				await this.disableMailIndexing()
 			}
 		}
-		this.eventQueue.addBatches([{ events: updates, batchId, groupId }])
+		this.eventQueue.addBatches([{ events: updates, batchId, groupId, isInitialSyncDone }])
 		// Trigger event queue processing in case it was stopped due to an error
 		// Realtime queue won't be automatically paused and doesn't need a trigger here. It will be resumed when
 		// we loaded all events.

--- a/src/mail-app/workerUtils/index/Indexer.ts
+++ b/src/mail-app/workerUtils/index/Indexer.ts
@@ -16,7 +16,7 @@ export interface Indexer {
 
 	disableMailIndexing(): Promise<void>
 
-	processEntityEvents(updates: readonly entityUpdateUtils.EntityUpdateData[], batchId: Id, groupId: Id): Promise<void>
+	processEntityEvents(updates: readonly entityUpdateUtils.EntityUpdateData[], batchId: Id, groupId: Id, isInitialSyncDone: boolean): Promise<void>
 
 	/**
 	 * Extends the mail index to the given timestamp.

--- a/src/mail-app/workerUtils/worker/WorkerLocator.ts
+++ b/src/mail-app/workerUtils/worker/WorkerLocator.ts
@@ -873,9 +873,9 @@ export async function initLocator(worker: WorkerImpl, browserData: BrowserData) 
 		async (error: Error) => {
 			await worker.sendError(error)
 		},
-		async (events, batchId, groupId) => {
+		async (events, batchId, groupId, isInitialSyncDone) => {
 			const indexer = await locator.indexer()
-			await indexer.processEntityEvents(events, batchId, groupId)
+			await indexer.processEntityEvents(events, batchId, groupId, isInitialSyncDone)
 		},
 		locator.rolloutFacade,
 		locator.groupManagement,

--- a/test/tests/api/worker/search/EventQueueTest.ts
+++ b/test/tests/api/worker/search/EventQueueTest.ts
@@ -3,7 +3,7 @@ import { EventQueue, QueuedBatch } from "../../../../../src/common/api/worker/Ev
 import { defer, delay } from "@tutao/utils"
 import * as restError from "@tutao/rest-client/error"
 import { entityUpdateUtils, tutanotaTypeRefs } from "@tutao/typerefs"
-import { OperationType } from "../../../../../src/app-env"
+import { OperationType } from "@tutao/app-env"
 
 o.spec("EventQueueTest", function () {
 	let queue: EventQueue
@@ -43,6 +43,7 @@ o.spec("EventQueueTest", function () {
 			events: [newUpdate(OperationType.DELETE, "1")],
 			groupId,
 			batchId: "1",
+			isInitialSyncDone: true,
 		}
 		queue.addBatches([batchWithOnlyDelete])
 
@@ -61,6 +62,7 @@ o.spec("EventQueueTest", function () {
 			events: [newUpdate(OperationType.DELETE, "1")],
 			groupId,
 			batchId: "1",
+			isInitialSyncDone: true,
 		}
 		queue.addBatches([batchWithOnlyDelete])
 
@@ -75,11 +77,13 @@ o.spec("EventQueueTest", function () {
 			events: [newUpdate(OperationType.CREATE, "2"), newUpdate(OperationType.DELETE, "2")],
 			groupId,
 			batchId: "2",
+			isInitialSyncDone: true,
 		}
 		const batchWithOnlyCreate: QueuedBatch = {
 			events: [newUpdate(OperationType.CREATE, "3")],
 			groupId,
 			batchId: "3",
+			isInitialSyncDone: true,
 		}
 
 		lastProcess = defer()

--- a/test/tests/api/worker/search/IndexedDbIndexerTest.ts
+++ b/test/tests/api/worker/search/IndexedDbIndexerTest.ts
@@ -577,6 +577,7 @@ o.spec("IndexedDbIndexer", () => {
 				events,
 				groupId,
 				batchId,
+				isInitialSyncDone: true,
 			}
 			await indexer._processEntityEvents(batch)
 			verify(core.putLastBatchIdForGroup(groupId, batchId))
@@ -606,7 +607,7 @@ o.spec("IndexedDbIndexer", () => {
 			indexer._processEntityEvents = func<IndexedDbIndexer["_processEntityEvents"]>()
 			const queue = indexer.eventQueue
 			queue.addBatches = func<EventQueue["addBatches"]>()
-			await indexer.processEntityEvents(entityUpdateData, newestBatchId, groupId)
+			await indexer.processEntityEvents(entityUpdateData, newestBatchId, groupId, true)
 			verify(queue.addBatches(matchers.anything()), { times: 1 })
 			verify(
 				queue.addBatches([
@@ -614,6 +615,7 @@ o.spec("IndexedDbIndexer", () => {
 						groupId,
 						batchId: newestBatchId,
 						events: entityUpdateData,
+						isInitialSyncDone: true,
 					},
 				]),
 			)
@@ -679,6 +681,7 @@ o.spec("IndexedDbIndexer", () => {
 				events: events1,
 				groupId: groupId,
 				batchId: batchId1,
+				isInitialSyncDone: true,
 			}
 
 			const events2: entityUpdateUtils.EntityUpdateData[] = [
@@ -695,9 +698,10 @@ o.spec("IndexedDbIndexer", () => {
 				events: events2,
 				groupId: groupId,
 				batchId: batchId2,
+				isInitialSyncDone: true,
 			}
-			await indexer.processEntityEvents(batch1.events, batch1.batchId, batch1.groupId)
-			await indexer.processEntityEvents(batch2.events, batch2.batchId, batch2.groupId)
+			await indexer.processEntityEvents(batch1.events, batch1.batchId, batch1.groupId, true)
+			await indexer.processEntityEvents(batch2.events, batch2.batchId, batch2.groupId, true)
 
 			indexer.eventQueue.resume()
 
@@ -716,7 +720,7 @@ o.spec("IndexedDbIndexer", () => {
 		o.spec("handles mail updates", () => {
 			let indexer: IndexedDbIndexer
 
-			const testBatch: { batchId: Id; groupId: Id; events: readonly entityUpdateUtils.EntityUpdateData[] } = {
+			const testBatch: QueuedBatch = {
 				events: [
 					{
 						typeRef: tutanotaTypeRefs.MailTypeRef,
@@ -786,6 +790,7 @@ o.spec("IndexedDbIndexer", () => {
 				],
 				groupId: "blah",
 				batchId: "asdf",
+				isInitialSyncDone: true,
 			}
 
 			o.beforeEach(() => {
@@ -989,7 +994,7 @@ o.spec("IndexedDbIndexer", () => {
 
 				await initialIndexingCalled.promise
 				// dispatch an event while initial indexing is running and see that it is not immediately processed
-				await indexer.processEntityEvents(updates, "batchId", userGroupId)
+				await indexer.processEntityEvents(updates, "batchId", userGroupId, true)
 				// not processed yet
 				verify(mailIndexer.processEntityEvents(matchers.anything(), matchers.anything(), matchers.anything()), { times: 0 })
 
@@ -1028,7 +1033,7 @@ o.spec("IndexedDbIndexer", () => {
 				indexer.extendMailIndex(time.getTime())
 
 				await extendingMailIndexingCalled.promise
-				await indexer.processEntityEvents(updates, "batchId", userGroupId)
+				await indexer.processEntityEvents(updates, "batchId", userGroupId, true)
 				// not processed yet
 				verify(mailIndexer.processEntityEvents(matchers.anything(), matchers.anything(), matchers.anything()), { times: 0 })
 


### PR DESCRIPTION
Since f679bca9cbdc18b6a390b2ac797736abfb17c205 we are processing events in order, but it could still cause data inconsistencies in case of errors. We now use EventQueue again while processing entity events to make use of the existing error handling in EventQueue.