### PR TITLE
fix zip file download containing sanitized file names

### DIFF
--- a/src/common/file/FileController.ts
+++ b/src/common/file/FileController.ts
@@ -267,8 +267,8 @@ export async function zipDataFiles(dataFiles: Array<DataFile>, name: string): Pr
 	const zip = jsZip.default()
 	const deduplicatedMap = deduplicateFilenames(dataFiles.map((df) => sanitizeFilename(df.name)))
 	for (let file of dataFiles) {
-		const filename = assertNotNull(deduplicatedMap[file.name].shift())
-		zip.file(sanitizeFilename(filename), file.data, { binary: true })
+		const filename = assertNotNull(deduplicatedMap[sanitizeFilename(file.name)].shift())
+		zip.file(filename, file.data, { binary: true })
 	}
 	const zipData = await zip.generateAsync({ type: "uint8array" })
 	return createDataFile(name, "application/zip", zipData)


### PR DESCRIPTION
`deduplicatedMap` contains only sanitized filenames, but entries were located using unsanitized filenames only. This hasn't been noticed for a long time, as most common filenames are the same before and after sanitization, and it only happens when downloading multiple attachments at once.

However, for weird filenames like `<script>null;</script>`, this would fail which is why we're also sanitizing filenames before lookup now.

tuta#3396