### PR TITLE
Add Archive action to mail push notifications (Android + iOS)

### DIFF
--- a/app-android/app/src/main/java/de/tutao/tutanota/push/LocalNotificationsFacade.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/LocalNotificationsFacade.kt
@@ -115,6 +115,16 @@ class LocalNotificationsFacade(private val context: Context, private val sseStor
 					PendingIntent.FLAG_IMMUTABLE
 				)
 
+			val intentArchiveMailAction: Intent =
+				MailNotificationActionReceiver.makeArchiveIntent(context, notificationId, notificationInfo)
+			val pendingArchiveAction: PendingIntent =
+				PendingIntent.getBroadcast(
+					context,
+					generateNotificationId(),
+					intentArchiveMailAction,
+					PendingIntent.FLAG_IMMUTABLE
+				)
+
 			@ColorInt val redColor = context.resources.getColor(R.color.red, context.theme)
 			val notificationBuilder = NotificationCompat.Builder(context, EMAIL_NOTIFICATION_CHANNEL_ID)
 				.setLights(redColor, 1000, 1000)
@@ -162,6 +172,7 @@ class LocalNotificationsFacade(private val context: Context, private val sseStor
 				})
 				.addAction(R.drawable.ic_sync, context.getString(R.string.delete_action), pendingDeleteAction)
 				.addAction(R.drawable.ic_sync, context.getString(R.string.markRead_action), pendingReadAction)
+				.addAction(R.drawable.ic_sync, context.getString(R.string.archive_action), pendingArchiveAction)
 
 			notificationManager.notify(notificationId, notificationBuilder.build())
 			sendSummaryNotification(notificationInfo)

--- a/app-android/app/src/main/java/de/tutao/tutanota/push/MailNotificationActionReceiver.kt
+++ b/app-android/app/src/main/java/de/tutao/tutanota/push/MailNotificationActionReceiver.kt
@@ -50,10 +50,11 @@ class MailNotificationActionReceiver : BroadcastReceiver() {
 				when (action) {
 					TRASH_ACTION -> sendMailToTrash(sdk, notificationInfo)
 					READ_ACTION -> markMailAsRead(sdk, notificationInfo)
+					ARCHIVE_ACTION -> sendMailToArchive(sdk, notificationInfo)
 					else -> {
 						Log.e(
 							TAG,
-							"Invalid notification action received: $action (valid actions are $TRASH_ACTION and $READ_ACTION)"
+							"Invalid notification action received: $action (valid actions are $TRASH_ACTION, $READ_ACTION, and $ARCHIVE_ACTION)"
 						)
 					}
 				}
@@ -76,6 +77,10 @@ class MailNotificationActionReceiver : BroadcastReceiver() {
 		sdk.mailFacade().setUnreadStatusForMails(listOf(notificationInfo.mailId!!.toSdkIdTupleGenerated()), false)
 	}
 
+	private suspend fun sendMailToArchive(sdk: LoggedInSdk, notificationInfo: NotificationInfo) {
+		sdk.mailFacade().archiveMails(listOf(notificationInfo.mailId!!.toSdkIdTupleGenerated()))
+	}
+
 	private fun dismissNotification(notificationManager: NotificationManager, notificationIdToDismiss: Int) {
 		notificationManager.cancel(notificationIdToDismiss)
 		// Filter manually because cancel might not be quick enough
@@ -93,6 +98,7 @@ class MailNotificationActionReceiver : BroadcastReceiver() {
 		private const val TAG = "NotifAction"
 		private const val TRASH_ACTION = "trash"
 		private const val READ_ACTION = "read"
+		private const val ARCHIVE_ACTION = "archive"
 		private const val NOTIFICATION_INFO_EXTRA = "NotifInfo"
 
 		fun makeTrashIntent(context: Context, notificationId: Int, notificationInfo: NotificationInfo): Intent {
@@ -102,6 +108,10 @@ class MailNotificationActionReceiver : BroadcastReceiver() {
 
 		fun makeReadIntent(context: Context, notificationId: Int, notificationInfo: NotificationInfo): Intent {
 			return makeIntent(READ_ACTION, context, notificationId, notificationInfo)
+		}
+
+		fun makeArchiveIntent(context: Context, notificationId: Int, notificationInfo: NotificationInfo): Intent {
+			return makeIntent(ARCHIVE_ACTION, context, notificationId, notificationInfo)
 		}
 
 		private fun makeIntent(

--- a/app-android/app/src/main/res/values/strings.xml
+++ b/app-android/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="unlockCredentials_action">Unlock credentials</string>
     <string name="delete_action">Delete</string>
     <string name="markRead_action">Mark read</string>
+    <string name="archive_action">Archive</string>
     <string name="sendLogs_action">Send Logs</string>
     <string name="account_label">User</string>
     <string name="calendars_label">Calendars</string>

--- a/app-ios/TutanotaSharedFramework/Notifications/NotificationActions.swift
+++ b/app-ios/TutanotaSharedFramework/Notifications/NotificationActions.swift
@@ -1,3 +1,4 @@
 public let MAIL_ACTIONS_CATEGORY = "mailActionsCategory"
 public let MAIL_READ_ACTION = "mail.readAction"
 public let MAIL_TRASH_ACTION = "mail.trashAction"
+public let MAIL_ARCHIVE_ACTION = "mail.archiveAction"

--- a/app-ios/translations/en.lproj/InfoPlist.strings
+++ b/app-ios/translations/en.lproj/InfoPlist.strings
@@ -15,6 +15,7 @@ TutaoUnlockCredentialsAction = "Unlock credentials";
 TutaoPushNewMail = "New email received.";
 TutaoDeleteAction = "Delete";
 TutaoMarkReadAction = "Mark read";
+TutaoArchiveAction = "Archive";
 TutaoWidgetOpenAppAction = "Open the app";
 TutaoWidgetUnexpectedErrorMsg = "Oops! Something went wrong.";
 TutaoWidgetSendLogsAction = "Send Logs";

--- a/app-ios/tutanota/Sources/AppDelegate.swift
+++ b/app-ios/tutanota/Sources/AppDelegate.swift
@@ -186,6 +186,7 @@ public let MAILTO_SCHEME = "mailto"
 		switch response.actionIdentifier {
 		case MAIL_READ_ACTION: Task { try await handleWithSdk(mailId: mailId, userId: userId, actionIdentifier: MAIL_READ_ACTION) }
 		case MAIL_TRASH_ACTION: Task { try await handleWithSdk(mailId: mailId, userId: userId, actionIdentifier: MAIL_TRASH_ACTION) }
+		case MAIL_ARCHIVE_ACTION: Task { try await handleWithSdk(mailId: mailId, userId: userId, actionIdentifier: MAIL_ARCHIVE_ACTION) }
 		case UNNotificationDefaultActionIdentifier:
 			let mailIdTuple = (mailId[0], mailId[1])
 			let address = userInfo["firstRecipient"] as? String ?? ""
@@ -221,6 +222,7 @@ public let MAILTO_SCHEME = "mailto"
 		switch actionIdentifier {
 		case MAIL_TRASH_ACTION: try await sdk.mailFacade().trashMails(mails: [mail])
 		case MAIL_READ_ACTION: try await sdk.mailFacade().setUnreadStatusForMails(mails: [mail], unread: false)
+		case MAIL_ARCHIVE_ACTION: try await sdk.mailFacade().archiveMails(mails: [mail])
 		default: TUTSLog("Invalid Notification Action")
 		}
 	}
@@ -235,9 +237,10 @@ public let MAILTO_SCHEME = "mailto"
 	private func registerNotificationCategories() {
 		let readAction = UNNotificationAction(identifier: MAIL_READ_ACTION, title: translate("TutaoMarkReadAction", default: "Mark Read"), options: [])
 		let trashAction = UNNotificationAction(identifier: MAIL_TRASH_ACTION, title: translate("TutaoDeleteAction", default: "Delete"), options: [.destructive])
+		let archiveAction = UNNotificationAction(identifier: MAIL_ARCHIVE_ACTION, title: translate("TutaoArchiveAction", default: "Archive"), options: [])
 		let mailActionsCategory = UNNotificationCategory(
 			identifier: MAIL_ACTIONS_CATEGORY,
-			actions: [readAction, trashAction],
+			actions: [readAction, trashAction, archiveAction],
 			intentIdentifiers: [],
 			options: .customDismissAction
 		)

--- a/tuta-sdk/rust/sdk/src/mail_facade.rs
+++ b/tuta-sdk/rust/sdk/src/mail_facade.rs
@@ -49,7 +49,8 @@ const MAX_MAIL_UPDATE_LIMIT: usize = 50;
 /// All allowed targets for the SimpleMoveMailService.
 ///
 /// This should be kept up-to-date with the server if any more targets are desired.
-const ALLOWED_SIMPLE_MOVE_MAIL_TARGETS: &[MailSetKind] = &[MailSetKind::Trash];
+const ALLOWED_SIMPLE_MOVE_MAIL_TARGETS: &[MailSetKind] =
+	&[MailSetKind::Trash, MailSetKind::Archive];
 
 impl MailFacade {
 	pub async fn load_user_mailbox(&self) -> Result<MailBox, ApiCallError> {
@@ -217,6 +218,11 @@ impl MailFacade {
 	/// Trash mailSets.
 	pub async fn trash_mails(&self, mails: Vec<IdTupleGenerated>) -> Result<(), ApiCallError> {
 		self.simple_move_mail(mails, MailSetKind::Trash).await
+	}
+
+	/// Move the given mails to the archive folder of their respective mailboxes.
+	pub async fn archive_mails(&self, mails: Vec<IdTupleGenerated>) -> Result<(), ApiCallError> {
+		self.simple_move_mail(mails, MailSetKind::Archive).await
 	}
 }
 
@@ -449,6 +455,106 @@ mod tests {
 			Arc::new(executor),
 		);
 		facade.trash_mails(mails).await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn archive_mail_split() {
+		let mut executor = MockResolvingServiceExecutor::default();
+		let mails = generate_id_tuples(100);
+		let first_invocation = SimpleMoveMailPostIn {
+			_format: 0,
+			mails: mails[..50].to_vec(),
+			destinationSetType: MailSetKind::Archive as i64,
+			moveReason: None,
+		};
+		let second_invocation = SimpleMoveMailPostIn {
+			_format: 0,
+			mails: mails[50..].to_vec(),
+			destinationSetType: MailSetKind::Archive as i64,
+			moveReason: None,
+		};
+
+		executor
+			.expect_post::<SimpleMoveMailService>()
+			.with(eq(first_invocation), always())
+			.returning(|_, _| {
+				Ok(MoveMailPostOut {
+					..create_test_entity()
+				})
+			});
+
+		executor
+			.expect_post::<SimpleMoveMailService>()
+			.with(eq(second_invocation), always())
+			.returning(|_, _| {
+				Ok(MoveMailPostOut {
+					..create_test_entity()
+				})
+			});
+
+		let facade = MailFacade::new(
+			Arc::new(MockCryptoEntityClient::default()),
+			Arc::new(MockUserFacade::default()),
+			Arc::new(executor),
+		);
+		facade.archive_mails(mails).await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn archive_mail_dedupe() {
+		let mut executor = MockResolvingServiceExecutor::default();
+		let mails: Vec<IdTupleGenerated> = std::iter::repeat(IdTupleGenerated::new(
+			GeneratedId::test_random(),
+			GeneratedId::test_random(),
+		))
+		.take(100)
+		.collect();
+		let invocation = SimpleMoveMailPostIn {
+			_format: 0,
+			mails: vec![mails[0].clone()],
+			destinationSetType: MailSetKind::Archive as i64,
+			moveReason: None,
+		};
+		executor
+			.expect_post::<SimpleMoveMailService>()
+			.with(eq(invocation), always())
+			.returning(|_, _| {
+				Ok(MoveMailPostOut {
+					..create_test_entity()
+				})
+			});
+		let facade = MailFacade::new(
+			Arc::new(MockCryptoEntityClient::default()),
+			Arc::new(MockUserFacade::default()),
+			Arc::new(executor),
+		);
+		facade.archive_mails(mails).await.unwrap();
+	}
+
+	#[tokio::test]
+	async fn archive_mail_one() {
+		let mut executor = MockResolvingServiceExecutor::default();
+		let mails = generate_id_tuples(1);
+		let invocation = SimpleMoveMailPostIn {
+			_format: 0,
+			mails: mails.clone(),
+			destinationSetType: MailSetKind::Archive as i64,
+			moveReason: None,
+		};
+		executor
+			.expect_post::<SimpleMoveMailService>()
+			.with(eq(invocation), always())
+			.returning(|_, _| {
+				Ok(MoveMailPostOut {
+					..create_test_entity()
+				})
+			});
+		let facade = MailFacade::new(
+			Arc::new(MockCryptoEntityClient::default()),
+			Arc::new(MockUserFacade::default()),
+			Arc::new(executor),
+		);
+		facade.archive_mails(mails).await.unwrap();
 	}
 
 	fn generate_id_tuples(amt: usize) -> Vec<IdTupleGenerated> {


### PR DESCRIPTION
Hi, I created this PR to add an Archive button to the notifications for both Android and iOS. I've been using this build as my daily driver on my phone and it's been stable. In my repo the workflows all passed, though I do not have any way to build the iOS app or test it beyond those workflows. 

Let me know if there's anything else I can do to help progress this change. Thanks! 

## Screenshot

<img width="1080" height="663" alt="Screenshot_20260514_104519_IronFox" src="https://github.com/user-attachments/assets/ff604506-b716-4cfe-aeb2-18e1d830ea74" />

## Summary

Adds an **Archive** notification action button to push notifications on Android and iOS, alongside the existing Delete and Mark Read actions. Tapping it moves the mail to the Archive folder without opening the app.

## Changes

- **Rust SDK** (`tuta-sdk/rust/sdk/src/mail_facade.rs`): expose `archive_mails()` via `MailSetKind::Archive` in `simple_move_mail`; add tests mirroring `trash_mail_*`
- **Android** (`LocalNotificationsFacade.kt`, `MailNotificationActionReceiver.kt`, `strings.xml`): new `ARCHIVE_ACTION` constant, PendingIntent, and `.addAction()` call
- **iOS** (`NotificationActions.swift`, `AppDelegate.swift`): new `MAIL_ARCHIVE_ACTION` constant, registered in `UNNotificationCategory`, handled in `userNotificationCenter` and `handleWithSdk`
- **Localization**: English string added (`TutaoArchiveAction`); other languages can follow through the normal translation process

### Testing

- Rust: `cargo test -p tuta-sdk` — `archive_mail_split`, `archive_mail_dedupe`, `archive_mail_one` pass
- Android: built and manually tested on device (archive button appears, tapping moves mail to Archive folder)
- iOS: Swift changes compile via CI; manual device test requires signed build