### PR TITLE
make IProgressMonitor.isDone async to handle returned promise correctly

### DIFF
--- a/src/common/api/common/utils/EstimatingProgressMonitor.ts
+++ b/src/common/api/common/utils/EstimatingProgressMonitor.ts
@@ -109,7 +109,7 @@ export class EstimatingProgressMonitor implements IProgressMonitor {
 		this.updater(WORK_MAX_PERCENTAGE)
 	}
 
-	public isDone(): boolean {
-		return this.workCompleted >= this.totalWork
+	public isDone(): Promise<boolean> {
+		return Promise.resolve(this.workCompleted >= this.totalWork)
 	}
 }

--- a/src/common/api/common/utils/ProgressMonitor.ts
+++ b/src/common/api/common/utils/ProgressMonitor.ts
@@ -18,7 +18,7 @@ export interface IProgressMonitor {
 
 	completed(): void
 
-	isDone(): boolean
+	isDone(): Promise<boolean>
 }
 
 /**
@@ -63,8 +63,8 @@ export class ProgressMonitor implements IProgressMonitor {
 		this.updater(100)
 	}
 
-	isDone(): boolean {
-		return this.workCompleted >= this.totalWork
+	isDone(): Promise<boolean> {
+		return Promise.resolve(this.workCompleted >= this.totalWork)
 	}
 }
 
@@ -79,8 +79,8 @@ export class NoopProgressMonitor implements IProgressMonitor {
 
 	completed() {}
 
-	isDone(): boolean {
-		return true
+	isDone(): Promise<boolean> {
+		return Promise.resolve(true)
 	}
 }
 

--- a/src/common/api/main/EventController.ts
+++ b/src/common/api/main/EventController.ts
@@ -71,7 +71,7 @@ export class EventController {
 				await listener.onEntityUpdatesReceived(entityUpdates, eventOwnerGroupId, isInitialSyncDone)
 			}
 
-			if (progressMonitorId !== null && !this.progressTracker.getMonitor(progressMonitorId)?.isDone()) {
+			if (progressMonitorId !== null && !(await this.progressTracker.getMonitor(progressMonitorId)?.isDone())) {
 				await this.progressTracker.workDoneForMonitor(progressMonitorId, 1)
 			}
 		}

--- a/src/common/api/worker/EventBusClient.ts
+++ b/src/common/api/worker/EventBusClient.ts
@@ -328,7 +328,7 @@ export class EventBusClient {
 				const groupId = entityUpdateData.eventBatchOwner
 				const batchId = entityUpdateData.eventBatchId
 
-				if (this.isInitialSyncDone && !this.progressMonitor?.isDone()) {
+				if (this.isInitialSyncDone && !(await this.progressMonitor?.isDone())) {
 					// the initial sync is done; this is to add work for entity updates we receive right after the initial sync is done,
 					// such as two entity updates per mail after the ProcessInboxService call. We complete this added work in the EventController
 					await this.progressMonitor?.updateTotalWork(this.progressMonitor.totalWork + 1)
@@ -337,7 +337,7 @@ export class EventBusClient {
 				// we need to complete the work for the batch here, since the processEventBatch function
 				// (and therefore the EventController) will not be called for this particular batch.
 				const wasAdded = this.eventQueue.add(batchId, groupId, updates, this.isInitialSyncDone)
-				if (!wasAdded && !this.progressMonitor?.isDone()) {
+				if (!wasAdded && !(await this.progressMonitor?.isDone())) {
 					await this.progressMonitor?.workDone(1)
 				}
 				break

--- a/src/common/api/worker/ProgressMonitorDelegate.ts
+++ b/src/common/api/worker/ProgressMonitorDelegate.ts
@@ -31,7 +31,7 @@ export class ProgressMonitorDelegate implements IProgressMonitor {
 		await this.progressTracker.workDoneForMonitor(await this.progressMonitorId, this.totalWork)
 	}
 
-	isDone(): boolean {
-		return this.progressTracker.isDone()
+	async isDone(): Promise<boolean> {
+		return await this.progressTracker.isDoneForMonitor(await this.progressMonitorId)
 	}
 }


### PR DESCRIPTION
ProgressMonitor.isDone in EventBusClient was returning a promise even though the function signature implied it is non-async, due to message communication between the main and the worker threads. This was causing us to evaluate if conditions incorrectly and preventing the progress bar from completing when syncing. This commit changes the function signature and makes the implementations return a promise instead.