### PR TITLE
Fix LegacyPrivatePlans typo

### DIFF
--- a/src/common/gui/editor/Editor.ts
+++ b/src/common/gui/editor/Editor.ts
@@ -1,6 +1,6 @@
 import m, { Children, Component } from "mithril"
 import SquireEditor from "squire-rte"
-import { defer } from "@tutao/utils"
+import { defer, first, isNotNull } from "@tutao/utils"
 import { px } from "../size"
 import { Dialog } from "../base/Dialog"
 import { isMailAddress } from "../../misc/FormatValidator"
@@ -21,6 +21,8 @@ type Styles = {
 	alignment: Alignment
 	listing: Listing | null
 }
+
+const ALIGN_CLASS_SELECTOR_PREFIX = ".align-"
 
 export class Editor implements ImageHandler, Component {
 	squire: SquireEditor | null = null
@@ -243,28 +245,29 @@ export class Editor implements ImageHandler, Component {
 
 		//links
 		this.styles.a = pathSegments.includes("A")
+
 		// alignment
-		let alignment = pathSegments.find((f) => f.includes("align"))
+		const alignment = pathSegments
+			.map((f) => {
+				const alignClassLocation = f.indexOf(ALIGN_CLASS_SELECTOR_PREFIX)
+				if (alignClassLocation >= 0) {
+					return first(f.substring(alignClassLocation + ALIGN_CLASS_SELECTOR_PREFIX.length).split(/[^a-z]/))
+				} else {
+					return null
+				}
+			})
+			.find(isNotNull)
+		switch (alignment) {
+			case "right":
+			case "justify":
+			case "center":
+			case "left":
+				this.styles.alignment = alignment
+				break
 
-		if (alignment !== undefined) {
-			switch (alignment.split(".")[1].substring(6)) {
-				case "left":
-					this.styles.alignment = "left"
-					break
-
-				case "right":
-					this.styles.alignment = "right"
-					break
-
-				case "center":
-					this.styles.alignment = "center"
-					break
-
-				default:
-					this.styles.alignment = "justify"
-			}
-		} else {
-			this.styles.alignment = "left"
+			default:
+				// null (or otherwise invalid)
+				this.styles.alignment = "left"
 		}
 
 		// font

--- a/src/common/subscription/SubscriptionSelector.ts
+++ b/src/common/subscription/SubscriptionSelector.ts
@@ -14,7 +14,17 @@ import {
 	SelectedSubscriptionOptions,
 	UpgradePriceType,
 } from "./FeatureListProvider"
-import { ProgrammingError } from "@tutao/app-env"
+import {
+	AvailablePlanType,
+	HighlightedPlans,
+	isIOSApp,
+	LegacyPlans,
+	NewBusinessPlans,
+	NewPersonalPlans,
+	PaymentMethodType,
+	PlanType,
+	ProgrammingError,
+} from "@tutao/app-env"
 import { Button, ButtonType } from "../gui/base/Button.js"
 import { assertNotNull, downcast, lazy, NBSP } from "@tutao/utils"
 import { px, size } from "../gui/size.js"
@@ -29,7 +39,6 @@ import {
 	UpgradeType,
 } from "./utils/SubscriptionUtils.js"
 import { PlanTypeToName, sysTypeRefs } from "@tutao/typerefs"
-import { AvailablePlanType, isIOSApp, LegacyPlans, LegacyPrivatePlans, NewBusinessPlans, NewPersonalPlans, PaymentMethodType, PlanType } from "@tutao/app-env"
 import { PrimaryButton, PrimaryButtonAttrs } from "../gui/base/buttons/VariantButtons.js"
 
 const BusinessUseItems: SegmentControlItem<boolean>[] = [
@@ -358,7 +367,7 @@ export class SubscriptionSelector implements Component<SubscriptionSelectorAttr>
 		// If we are on a campaign, we want to let the user know the discount is just for the first year.
 		const isYearly = interval === PaymentInterval.Yearly
 		const paymentMethod = selectorAttrs.accountingInfo?.paymentMethod ?? null
-		const isHighlighted = hasFirstYearDiscount || (upgradingToPaidAccount && LegacyPrivatePlans.includes(targetSubscription))
+		const isHighlighted = hasFirstYearDiscount || (upgradingToPaidAccount && HighlightedPlans.includes(targetSubscription))
 
 		const multiuser = NewBusinessPlans.includes(targetSubscription) || LegacyPlans.includes(targetSubscription) || selectorAttrs.multipleUsersAllowed
 

--- a/src/common/subscription/utils/SubscriptionUtils.ts
+++ b/src/common/subscription/utils/SubscriptionUtils.ts
@@ -2,26 +2,26 @@ import type { TranslationKey } from "../../misc/LanguageViewModel"
 import { downcast, isEmpty, LazyLoaded } from "@tutao/utils"
 import { locator } from "../../api/main/CommonLocator"
 import { entityUpdateUtils, getClientType, getPaymentMethodType, PlanTypeToName, sysServices, sysTypeRefs } from "@tutao/typerefs"
-import { ProgrammingError } from "@tutao/app-env"
-import { IServiceExecutor } from "../../api/common/ServiceRequest.js"
-import { MobilePaymentSubscriptionOwnership } from "../../native/common/generatedipc/MobilePaymentSubscriptionOwnership.js"
-import { client } from "../../misc/ClientDetector"
-import { formatMonthlyPrice, PaymentInterval, PriceAndConfigProvider } from "./PriceUtils.js"
-import { ReplacementKey, UpgradePriceType } from "../FeatureListProvider.js"
 import {
 	AccountType,
 	AvailablePlans,
 	AvailablePlanType,
 	BookingItemFeatureType,
 	CustomDomainType,
+	CustomDomainTypeCount,
 	isIOSApp,
-	LegacyPrivatePlans,
+	LegacyBusinessPlans,
 	NewBusinessPlans,
 	NewPaidPlans,
 	PaymentMethodType,
 	PlanType,
-	CustomDomainTypeCount,
+	ProgrammingError,
 } from "@tutao/app-env"
+import { IServiceExecutor } from "../../api/common/ServiceRequest.js"
+import { MobilePaymentSubscriptionOwnership } from "../../native/common/generatedipc/MobilePaymentSubscriptionOwnership.js"
+import { client } from "../../misc/ClientDetector"
+import { formatMonthlyPrice, PaymentInterval, PriceAndConfigProvider } from "./PriceUtils.js"
+import { ReplacementKey, UpgradePriceType } from "../FeatureListProvider.js"
 import { CacheMode } from "../../api/worker/rest/EntityRestClient"
 
 export const enum UpgradeType {
@@ -518,7 +518,7 @@ export function getFeaturePlaceholderReplacement(
  * @return true if the given plan is a business plan
  */
 export function isBusinessPlan(plan: AvailablePlanType): boolean {
-	return NewBusinessPlans.includes(plan) || LegacyPrivatePlans.includes(plan)
+	return NewBusinessPlans.includes(plan) || LegacyBusinessPlans.includes(plan)
 }
 
 /**

--- a/src/mail-app/settings/DesktopMailImportSettingsViewer.ts
+++ b/src/mail-app/settings/DesktopMailImportSettingsViewer.ts
@@ -4,11 +4,11 @@ import { IconButton, IconButtonAttrs } from "../../common/gui/base/IconButton"
 import { ButtonSize } from "../../common/gui/base/ButtonSize"
 import { assertNotNull, lazy } from "@tutao/utils"
 import { getFolderName, getIndentedFolderNameForDropdown, getPathToFolderString } from "../mail/model/MailUtils"
-import { ImportStatus, UpgradePromptType } from "@tutao/app-env"
+import { AvailablePlanType, HighestTierPlans, ImportStatus, isHighestTierPlan, MailSetKind, UpgradePromptType } from "@tutao/app-env"
 import { IndentedFolder } from "../../common/api/common/mail/FolderSystem"
 import { lang, TranslationKey } from "../../common/misc/LanguageViewModel"
 import { MailImporter, UiImportStatus } from "../mail/import/MailImporter.js"
-import { elementIdPart, entityUpdateUtils, generatedIdToTimestamp, EntityIdEncoding, isSameId, sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
+import { elementIdPart, EntityIdEncoding, entityUpdateUtils, generatedIdToTimestamp, isSameId, sortCompareByReverseId, tutanotaTypeRefs } from "@tutao/typerefs"
 import { Icons } from "../../common/gui/base/icons/Icons.js"
 import { DropDownSelector, type DropDownSelectorAttrs, SelectorItemList } from "../../common/gui/base/DropDownSelector.js"
 import { showUpgradeWizardOrSwitchSubscriptionDialog } from "../../common/misc/SubscriptionDialogs.js"
@@ -21,7 +21,6 @@ import { PrimaryButton } from "../../common/gui/base/buttons/VariantButtons.js"
 import { client } from "../../common/misc/ClientDetector"
 import { getMailboxName } from "../../common/mailFunctionality/SharedMailUtils"
 import { MailboxDetail } from "../../common/mailFunctionality/MailboxModel"
-import { AvailablePlanType, isHighestTierPlan, LegacyPrivatePlans, MailSetKind } from "@tutao/app-env"
 
 /**
  * Settings viewer for mail import rendered only in the Desktop client.
@@ -64,7 +63,7 @@ export class DesktopMailImportSettingsViewer implements UpdatableSettingsViewer 
 		const userController = mailLocator.logins.getUserController()
 		const currentPlanType = await userController.getPlanType()
 		if (!isHighestTierPlan(currentPlanType)) {
-			await showUpgradeWizardOrSwitchSubscriptionDialog(UpgradePromptType.IMPORT, userController, LegacyPrivatePlans as readonly AvailablePlanType[])
+			await showUpgradeWizardOrSwitchSubscriptionDialog(UpgradePromptType.IMPORT, userController, HighestTierPlans as readonly AvailablePlanType[])
 			return
 		}
 


### PR DESCRIPTION
LegacyPrivatePlans was mistakenly used in a few locations.

- The upgrade dialog for import (was HighestTierPlans)
- The recommended/highlighted plans (was HighlightedPlans)
- isBusinessPlan (was LegacyBusinessPlans)

These have been fixed.

Closes #10818