### PR TITLE
Drive: use Ctrl-A and ESC to select/deselect files

### DIFF
--- a/src/common/misc/TranslationKey.ts
+++ b/src/common/misc/TranslationKey.ts
@@ -2283,3 +2283,5 @@ export type TranslationKeyType =
 	| "confirmCancelTransfers_msg"
 	| "confirmCancelTransfers_action"
 	| "nativeFileUploadTooLarge_msg"
+	| "selectAllFiles_action"
+	| "clearFileSelection_action"

--- a/src/drive-app/drive/view/DriveView.ts
+++ b/src/drive-app/drive/view/DriveView.ts
@@ -161,6 +161,24 @@ export class DriveView extends BaseTopLevelView implements TopLevelView<DriveVie
 		this.shortcuts = [
 			...listSelectionKeyboardShortcuts(MultiselectMode.Enabled, () => this.driveViewModel),
 			{
+				key: Keys.ESC,
+				enabled: () => true,
+				help: "clearFileSelection_action",
+				ctrlOrCmd: false,
+				exec: () => {
+					this.driveViewModel.selectNone()
+				},
+			},
+			{
+				key: Keys.A,
+				enabled: () => true,
+				help: "selectAllFiles_action",
+				ctrlOrCmd: true,
+				exec: () => {
+					this.driveViewModel.selectAll()
+				},
+			},
+			{
 				key: Keys.C,
 				enabled: () => true,
 				help: "copy_action",
@@ -490,7 +508,7 @@ export class DriveView extends BaseTopLevelView implements TopLevelView<DriveVie
 			return m(MultiselectMobileHeader, {
 				message: lang.getTranslation("itemsSelected_label", { "{number}": listState.selectedItems.size }),
 				selected: listState.selectedItems.size === listState.items.length,
-				selectAll: () => this.driveViewModel.selectAll(),
+				selectAll: () => this.driveViewModel.toggleSelectAll(),
 				selectNone: () => this.driveViewModel.selectNone(),
 			})
 		} else {
@@ -558,7 +576,7 @@ export class DriveView extends BaseTopLevelView implements TopLevelView<DriveVie
 			listState: listState,
 			selectionEvents: {
 				onSelectAll: () => {
-					this.driveViewModel.selectAll()
+					this.driveViewModel.toggleSelectAll()
 				},
 				onSelectNone: () => {
 					this.driveViewModel.selectNone()

--- a/src/drive-app/drive/view/DriveViewModel.ts
+++ b/src/drive-app/drive/view/DriveViewModel.ts
@@ -650,12 +650,16 @@ export class DriveViewModel {
 		return this.listModel.areAllSelected()
 	}
 
-	selectAll() {
+	toggleSelectAll() {
 		if (this.listModel.isSelectionEmpty()) {
 			this.listModel.selectAll()
 		} else {
 			this.listModel.selectNone()
 		}
+	}
+
+	selectAll() {
+		this.listModel.selectAll()
 	}
 
 	selectNone() {

--- a/src/mail-app/translations/de.ts
+++ b/src/mail-app/translations/de.ts
@@ -2285,5 +2285,7 @@ export default {
 		"confirmCancelTransfers_msg": "Are you sure you want to cancel {count} transfers?",
 		"confirmCancelTransfers_action": "Cancel transfers",
 		"nativeFileUploadTooLarge_msg": "Diese Datei ist zu groß, um aus der App hochgeladen zu werden. Bitte versuche es in der Web-App erneut.",
+		"selectAllFiles_action": "Alle Dateien und Ordner auswählen",
+		"clearFileSelection_action": "Datei- und Ordnerauswahl leeren",
 	}
 }

--- a/src/mail-app/translations/de_sie.ts
+++ b/src/mail-app/translations/de_sie.ts
@@ -2285,5 +2285,7 @@ export default {
 		"confirmCancelTransfers_msg": "Are you sure you want to cancel {count} transfers?",
 		"confirmCancelTransfers_action": "Cancel transfers",
 		"nativeFileUploadTooLarge_msg": "Diese Datei ist zu groß, um aus der App hochgeladen zu werden. Bitte versuchen Sie es in der Web-App erneut.",
+		"selectAllFiles_action": "Alle Dateien und Ordner auswählen",
+		"clearFileSelection_action": "Datei- und Ordnerauswahl leeren",
 	}
 }

--- a/src/mail-app/translations/en.ts
+++ b/src/mail-app/translations/en.ts
@@ -2285,5 +2285,7 @@ export default {
 		"confirmCancelTransfers_msg": "Are you sure you want to cancel {count} transfers?",
 		"confirmCancelTransfers_action": "Cancel transfers",
 		"nativeFileUploadTooLarge_msg": "This file is too large to be uploaded - try uploading it from the web app for now.",
+		"selectAllFiles_action": "Select all files and folders",
+		"clearFileSelection_action": "Clear selected files and folders"
 	}
 }


### PR DESCRIPTION
This makes Ctrl-A (or Cmd-A on Mac) select all currently listed files. Repeatedly pressing Ctrl-A keeps these files selected.

This also makes ESC deselect all currently selected files.

If only a subset of files was selected, clicking the checkbox in the header bar will now also select all files immediately instead of first clearing the selection.

tuta#3487