### PR TITLE
Fix creating inbox rule by clicking mail address doesn't autofill value

### DIFF
--- a/src/applications/mail-app/mail/view/MailViewer.ts
+++ b/src/applications/mail-app/mail/view/MailViewer.ts
@@ -659,7 +659,7 @@ export class MailViewer implements Component<MailViewerAttrs> {
 								return
 							}
 							const { show, createInboxRuleTemplate } = await import("../../settings/AddInboxRuleDialog")
-							const newRule = rule ?? createInboxRuleTemplate(defaultInboxRuleField, mailAddress.address.trim().toLowerCase())
+							const newRule = rule ?? createInboxRuleTemplate(defaultInboxRuleField, mailAddress.address)
 
 							show(mailboxDetails, newRule)
 						},

--- a/src/applications/mail-app/settings/AddInboxRuleDialog.ts
+++ b/src/applications/mail-app/settings/AddInboxRuleDialog.ts
@@ -9,7 +9,6 @@ import type { MailboxDetail } from "../../common/mailFunctionality/MailboxModel.
 import stream from "mithril/stream"
 import { DropDownSelector } from "../../../ui/base/DropDownSelector.js"
 import { Autocapitalize, LegacyTextField } from "../../../ui/base/LegacyTextField.js"
-import { neverNull } from "../../../platform-kit/utils"
 import { isOfflineError, LockedError } from "../../../platform-kit/rest-client/error"
 import { showNotAvailableForFreeDialog } from "../../common/misc/SubscriptionDialogs"
 import { locator } from "../../common/api/main/CommonLocator"
@@ -140,10 +139,11 @@ export async function show(mailBoxDetail: MailboxDetail, ruleOrTemplate: InboxRu
 	}
 }
 
-export function createInboxRuleTemplate(ruleType: string | null, value: string | null): InboxRuleTemplate {
+export function createInboxRuleTemplate(ruleType: string | null, value: string): InboxRuleTemplate {
+	const type = ruleType ?? InboxRuleType.FROM_EQUALS
 	return {
-		type: ruleType ?? InboxRuleType.FROM_EQUALS,
-		value: getCleanedValue(neverNull(ruleType), value || ""),
+		type,
+		value: getCleanedValue(type, value),
 	}
 }
 


### PR DESCRIPTION
This issue is caused by the `createInboxRuleTemplate` function being transpiled and minified incorrectly to:
`function Ns(e,t){return{type:e,value:Us(e,"")}}`
resulting in `getCleanedValue` always being called with a value of "" (empty string).

A better solution would be to find the root cause and fix it, but for now, changing createInboxRuleTemplate's signature to always take string value is acceptable as a fix.

Close #10605