### PR TITLE
add blob element reading to Rust SDK

### DIFF
--- a/tuta-sdk/rust/sdk/src/blobs/blob_access_token_cache.rs
+++ b/tuta-sdk/rust/sdk/src/blobs/blob_access_token_cache.rs
@@ -6,10 +6,6 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::sync::{Arc, RwLock};
 
-/// still missing ReadArchive(archive_id) and ReadBlob(archive_id, blob_id)
-/// (see TS impl of the cache)
-/// once we have those, it should be made even more type safe by restricting the input to
-/// reading/writing functions on blob facade to the right kind of token.
 #[derive(Clone, Hash, PartialEq, Eq)]
 #[cfg_attr(test, derive(Debug))]
 pub(crate) struct BlobWriteTokenKey(String, ArchiveDataType);
@@ -20,20 +16,32 @@ impl BlobWriteTokenKey {
 	}
 }
 
+#[derive(Clone, Hash, PartialEq, Eq)]
+#[cfg_attr(test, derive(Debug))]
+pub(crate) struct BlobReadArchiveTokenKey(String);
+
+impl BlobReadArchiveTokenKey {
+	pub fn new(archive_id: &GeneratedId) -> Self {
+		Self(archive_id.to_string())
+	}
+}
+
 pub(super) struct BlobAccessTokenCache {
-	cache: RwLock<HashMap<BlobWriteTokenKey, BlobServerAccessInfo>>,
+	write_cache: RwLock<HashMap<BlobWriteTokenKey, BlobServerAccessInfo>>,
+	read_cache: RwLock<HashMap<BlobReadArchiveTokenKey, BlobServerAccessInfo>>,
 	date_provider: Arc<dyn DateProvider>,
 }
 
 impl BlobAccessTokenCache {
 	pub fn new(date_provider: Arc<dyn DateProvider>) -> Self {
 		Self {
-			cache: RwLock::default(),
+			write_cache: RwLock::default(),
+			read_cache: RwLock::default(),
 			date_provider,
 		}
 	}
 
-	pub async fn try_get_token<F, E, Loader>(
+	pub async fn try_get_write_token<F, E, Loader>(
 		&self,
 		key: &BlobWriteTokenKey,
 		loader: Loader,
@@ -43,28 +51,57 @@ impl BlobAccessTokenCache {
 		Loader: FnOnce() -> F + Send,
 	{
 		{
-			let cache = self.cache.read().expect("poisoned lock");
-			let maybe_value = cache.get(key);
-			if let Some(value) = maybe_value {
+			let cache = self.write_cache.read().expect("poisoned lock");
+			if let Some(value) = cache.get(key) {
 				if can_be_used_for_another_request(value, self.date_provider.as_ref()) {
 					return Ok(value.clone());
 				}
 			}
 		}
 		let loaded = loader().await?;
-		self.insert(key.to_owned(), loaded.clone());
+		self.insert_write(key.to_owned(), loaded.clone());
 		Ok(loaded)
 	}
 
-	fn insert(&self, key: BlobWriteTokenKey, value: BlobServerAccessInfo) {
-		let mut cache = self.cache.write().expect("poisoned lock");
-		// someone else might have inserted something while we were loading.
-		// we're just replacing + dropping that value.
+	pub async fn try_get_read_token<F, E, Loader>(
+		&self,
+		key: &BlobReadArchiveTokenKey,
+		loader: Loader,
+	) -> Result<BlobServerAccessInfo, E>
+	where
+		F: Future<Output = Result<BlobServerAccessInfo, E>> + Sized + Send,
+		Loader: FnOnce() -> F + Send,
+	{
+		{
+			let cache = self.read_cache.read().expect("poisoned lock");
+			if let Some(value) = cache.get(key) {
+				if can_be_used_for_another_request(value, self.date_provider.as_ref()) {
+					return Ok(value.clone());
+				}
+			}
+		}
+		let loaded = loader().await?;
+		self.insert_read(key.to_owned(), loaded.clone());
+		Ok(loaded)
+	}
+
+	fn insert_write(&self, key: BlobWriteTokenKey, value: BlobServerAccessInfo) {
+		let mut cache = self.write_cache.write().expect("poisoned lock");
 		let _previous = cache.insert(key, value);
 	}
 
-	pub fn evict(&self, key: &BlobWriteTokenKey) {
-		let mut cache = self.cache.write().expect("poisoned lock");
+	fn insert_read(&self, key: BlobReadArchiveTokenKey, value: BlobServerAccessInfo) {
+		let mut cache = self.read_cache.write().expect("poisoned lock");
+		let _previous = cache.insert(key, value);
+	}
+
+	pub fn evict_write(&self, key: &BlobWriteTokenKey) {
+		let mut cache = self.write_cache.write().expect("poisoned lock");
+		cache.remove(key);
+	}
+
+	pub fn evict_read(&self, key: &BlobReadArchiveTokenKey) {
+		let mut cache = self.read_cache.write().expect("poisoned lock");
 		cache.remove(key);
 	}
 }
@@ -81,7 +118,8 @@ fn can_be_used_for_another_request(
 #[cfg(test)]
 mod tests {
 	use crate::blobs::blob_access_token_cache::{
-		can_be_used_for_another_request, BlobAccessTokenCache, BlobWriteTokenKey,
+		can_be_used_for_another_request, BlobAccessTokenCache, BlobReadArchiveTokenKey,
+		BlobWriteTokenKey,
 	};
 	use crate::date::date_provider::stub::DateProviderStub;
 	use crate::date::DateTime;
@@ -102,8 +140,8 @@ mod tests {
 			expires: DateTime::from_millis(10),
 			..create_test_entity()
 		};
-		cache.insert(key.clone(), test_token.clone());
-		let loaded = cache.try_get_token(&key, || async {
+		cache.insert_write(key.clone(), test_token.clone());
+		let loaded = cache.try_get_write_token(&key, || async {
 			// helps type inference
 			if true {
 				panic!("should be in cache");
@@ -124,7 +162,7 @@ mod tests {
 			..create_test_entity()
 		};
 		let test_clone = test_token.clone();
-		let loaded = cache.try_get_token(&key, || async move {
+		let loaded = cache.try_get_write_token(&key, || async move {
 			Ok(test_clone) as Result<BlobServerAccessInfo, ()>
 		});
 		assert_eq!(test_token, loaded.await.unwrap())
@@ -141,13 +179,13 @@ mod tests {
 			expires: DateTime::from_millis(10),
 			..create_test_entity()
 		};
-		cache.insert(key.clone(), expired_token.clone());
+		cache.insert_write(key.clone(), expired_token.clone());
 		let new_token = BlobServerAccessInfo {
 			expires: DateTime::from_millis(30),
 			..create_test_entity()
 		};
 		let expected_token = new_token.clone();
-		let loaded = cache.try_get_token(&key, || async move {
+		let loaded = cache.try_get_write_token(&key, || async move {
 			Ok(new_token) as Result<BlobServerAccessInfo, ()>
 		});
 		assert_eq!(expected_token, loaded.await.unwrap())
@@ -183,9 +221,41 @@ mod tests {
 			expires: DateTime::from_millis(10),
 			..create_test_entity()
 		};
-		cache.insert(key.clone(), expired_token.clone());
+		cache.insert_write(key.clone(), expired_token.clone());
 
-		cache.evict(&key);
-		assert!(!cache.cache.read().unwrap().contains_key(&key));
+		cache.evict_write(&key);
+		assert!(!cache.write_cache.read().unwrap().contains_key(&key));
+	}
+
+	#[tokio::test]
+	async fn get_read_cached() {
+		let cache = BlobAccessTokenCache::new(Arc::new(DateProviderStub::new(0)));
+		let key = BlobReadArchiveTokenKey::new(&GeneratedId("archive1".to_owned()));
+		let test_token = BlobServerAccessInfo {
+			expires: DateTime::from_millis(10),
+			..create_test_entity()
+		};
+		cache.insert_read(key.clone(), test_token.clone());
+		let loaded = cache.try_get_read_token(&key, || async {
+			if true {
+				panic!("should be in cache");
+			}
+			Err(())
+		});
+		assert_eq!(test_token, loaded.await.unwrap())
+	}
+
+	#[test]
+	fn evict_read() {
+		let cache = BlobAccessTokenCache::new(Arc::new(DateProviderStub::new(20)));
+		let key = BlobReadArchiveTokenKey::new(&GeneratedId("archive1".to_owned()));
+		let token = BlobServerAccessInfo {
+			expires: DateTime::from_millis(10),
+			..create_test_entity()
+		};
+		cache.insert_read(key.clone(), token);
+
+		cache.evict_read(&key);
+		assert!(!cache.read_cache.read().unwrap().contains_key(&key));
 	}
 }

--- a/tuta-sdk/rust/sdk/src/blobs/blob_access_token_facade.rs
+++ b/tuta-sdk/rust/sdk/src/blobs/blob_access_token_facade.rs
@@ -1,7 +1,9 @@
-use crate::blobs::blob_access_token_cache::{BlobAccessTokenCache, BlobWriteTokenKey};
+use crate::blobs::blob_access_token_cache::{
+	BlobAccessTokenCache, BlobReadArchiveTokenKey, BlobWriteTokenKey,
+};
 use crate::date::DateProvider;
 use crate::entities::generated::storage::{
-	BlobAccessTokenPostIn, BlobServerAccessInfo, BlobWriteData,
+	BlobAccessTokenPostIn, BlobReadData, BlobServerAccessInfo, BlobWriteData,
 };
 use crate::services::generated::storage::BlobAccessTokenService;
 #[cfg_attr(test, mockall_double::double)]
@@ -67,8 +69,44 @@ impl BlobAccessTokenFacade {
 		};
 
 		self.cache
-			.try_get_token(
+			.try_get_write_token(
 				&BlobWriteTokenKey::new(owner_group_id, archive_data_type),
+				loader,
+			)
+			.await
+	}
+
+	/// Requests an archive-level token for reading blob elements.
+	/// Mirrors TS `BlobAccessTokenFacade.requestReadTokenArchive()`.
+	pub async fn request_read_token_archive(
+		&self,
+		archive_id: &GeneratedId,
+	) -> Result<BlobServerAccessInfo, ApiCallError> {
+		let archive_id_clone = archive_id.clone();
+		let loader = move || async move {
+			let post_in = BlobAccessTokenPostIn {
+				_format: 0,
+				archiveDataType: None,
+				write: None,
+				read: Some(BlobReadData {
+					_id: Some(CustomId(
+						BASE64_URL_SAFE_NO_PAD
+							.encode(self.randomizer_facade.generate_random_array::<4>()),
+					)),
+					archiveId: archive_id_clone,
+					instanceListId: None,
+					instanceIds: vec![],
+				}),
+			};
+			self.service_executor
+				.post::<BlobAccessTokenService>(post_in, ExtraServiceParams::default())
+				.await
+				.map(|r| r.blobAccessInfo)
+		};
+
+		self.cache
+			.try_get_read_token(
+				&BlobReadArchiveTokenKey::new(archive_id),
 				loader,
 			)
 			.await
@@ -77,7 +115,13 @@ impl BlobAccessTokenFacade {
 	/// Remove a given write token from the cache.
 	#[allow(unused)]
 	pub fn evict_access_token(&self, key: &BlobWriteTokenKey) {
-		self.cache.evict(key);
+		self.cache.evict_write(key);
+	}
+
+	/// Remove a read archive token from the cache.
+	pub fn evict_archive_token(&self, archive_id: &GeneratedId) {
+		self.cache
+			.evict_read(&BlobReadArchiveTokenKey::new(archive_id));
 	}
 }
 #[cfg(test)]

--- a/tuta-sdk/rust/sdk/src/blobs/blob_facade.rs
+++ b/tuta-sdk/rust/sdk/src/blobs/blob_facade.rs
@@ -1,5 +1,5 @@
 use crate::bindings::rest_client;
-use crate::bindings::rest_client::HttpMethod::POST;
+use crate::bindings::rest_client::HttpMethod::{GET, POST};
 use crate::bindings::rest_client::RestClient;
 use crate::bindings::rest_client::{RestClientOptions, RestResponse};
 use crate::bindings::suspendable_rest_client::SuspensionBehavior;
@@ -22,7 +22,7 @@ use crate::tutanota_constants::{
 };
 use crate::type_model_provider::TypeModelProvider;
 use crate::GeneratedId;
-use crate::{crypto, ApiCallError, HeadersProvider};
+use crate::{crypto, ApiCallError, HeadersProvider, TypeRef};
 use base64::Engine;
 use crypto::sha256;
 use crypto_primitives::aes::Iv;
@@ -69,6 +69,132 @@ impl BlobFacade {
 			json_serializer,
 			type_model_provider,
 		}
+	}
+
+	/// Load a blob element from a blob server, trying each server URL in order.
+	/// On `NotAuthorizedError` (HTTP 403), the token is evicted and the request
+	/// is retried once with a fresh token.
+	/// Mirrors TS `EntityRestClient.loadMultipleBlobElements()` +
+	/// `doBlobRequestWithRetry()` + `tryServers()`.
+	pub async fn load_blob_element(
+		&self,
+		type_ref: &TypeRef,
+		archive_id: &GeneratedId,
+		element_id: &GeneratedId,
+		instance_list_id: &GeneratedId,
+	) -> Result<Vec<u8>, ApiCallError> {
+		let type_model = self
+			.type_model_provider
+			.resolve_client_type_ref(type_ref)
+			.ok_or_else(|| {
+				ApiCallError::internal(format!("type model not found for {}", type_ref))
+			})?;
+		let path = format!(
+			"/rest/{app}/{name}/{list_id}",
+			app = type_ref.app,
+			name = type_model.name.to_lowercase(),
+			list_id = instance_list_id,
+		);
+
+		let mut attempt = 0u8;
+		loop {
+			let access_info = self
+				.blob_access_token_facade
+				.request_read_token_archive(archive_id)
+				.await?;
+
+			let query_params = self.create_read_query_params(
+				&access_info.blobAccessToken,
+				element_id,
+				type_model.version,
+			);
+			let encoded_query_params = rest_client::encode_query_params(query_params);
+
+			let mut last_retriable_error: Option<ApiCallError> = None;
+			let mut got_unauthorized = false;
+
+			for server in &access_info.servers {
+				let url = format!("{}{}{}", server.url, path, encoded_query_params);
+				let maybe_response = self
+					.rest_client
+					.request_binary(
+						url,
+						GET,
+						RestClientOptions {
+							body: None,
+							headers: Default::default(),
+							suspension_behavior: None,
+						},
+					)
+					.await;
+
+				match maybe_response {
+					Ok(RestResponse {
+						status: 200 | 201,
+						body,
+						..
+					}) => {
+						return body.ok_or_else(|| {
+							ApiCallError::internal("Empty response from blob server".to_owned())
+						});
+					},
+					Ok(RestResponse { status, .. }) => {
+						match HttpError::from_http_response(status, &Default::default()) {
+							Ok(HttpError::NotAuthorizedError) => {
+								got_unauthorized = true;
+								break;
+							},
+							Ok(
+								error @ (HttpError::ConnectionError
+								| HttpError::InternalServerError
+								| HttpError::NotFoundError),
+							) => {
+								last_retriable_error = Some(error.into());
+								continue;
+							},
+							Ok(error) => return Err(error.into()),
+							Err(error) => return Err(error),
+						}
+					},
+					Err(error) => {
+						last_retriable_error = Some(error.into());
+						continue;
+					},
+				}
+			}
+
+			if got_unauthorized && attempt == 0 {
+				self.blob_access_token_facade
+					.evict_archive_token(archive_id);
+				attempt += 1;
+				continue;
+			}
+
+			return Err(last_retriable_error.unwrap_or_else(|| {
+				if got_unauthorized {
+					HttpError::NotAuthorizedError.into()
+				} else {
+					ApiCallError::InternalSdkError {
+						error_message: "no blob servers available".to_owned(),
+					}
+				}
+			}));
+		}
+	}
+
+	fn create_read_query_params(
+		&self,
+		blob_access_token: &str,
+		element_id: &GeneratedId,
+		entity_version: u64,
+	) -> Vec<(String, String)> {
+		let mut query_params: Vec<(String, String)> = vec![
+			("ids".into(), element_id.to_string()),
+			("blobAccessToken".into(), blob_access_token.to_owned()),
+		];
+		let auth_headers = self.auth_headers_provider.provide_headers(entity_version);
+		query_params.extend(auth_headers);
+		query_params
 	}
 
 	/// Encrypt and upload multiple file_data (i.e. files) in minimum amount of requests to
@@ -1134,6 +1260,235 @@ mod tests {
 				.collect::<Vec<_>>(),
 			reference_tokens
 		);
+	}
+
+	fn make_read_token_mock(archive_id: GeneratedId, token: &str) -> MockBlobAccessTokenFacade {
+		let blob_access_info = BlobServerAccessInfo {
+			blobAccessToken: token.to_string(),
+			servers: vec![BlobServerUrl {
+				url: "https://w1.api.tuta.com".to_string(),
+				..create_test_entity()
+			}],
+			..create_test_entity()
+		};
+		let mut facade = MockBlobAccessTokenFacade::default();
+		facade
+			.expect_request_read_token_archive()
+			.with(predicate::eq(archive_id))
+			.return_once(move |_| Ok(blob_access_info));
+		facade
+	}
+
+	#[tokio::test]
+	async fn load_blob_element_success() {
+		let archive_id = GeneratedId("archId".to_owned());
+		let element_id = GeneratedId("elemId".to_owned());
+		let expected_body = b"decrypted blob data".to_vec();
+
+		let mut mock_token = make_read_token_mock(archive_id.clone(), "accessToken123");
+		mock_token.expect_evict_archive_token().never();
+
+		let expected_body_clone = expected_body.clone();
+		let list_id_check = archive_id.clone();
+		let element_id_check = element_id.clone();
+		let mut rest_client = MockRestClient::default();
+		rest_client
+			.expect_request_binary()
+			.times(1)
+			.withf(move |url, method, _opts| {
+				let uri = url.parse::<Uri>().unwrap();
+				assert_eq!("w1.api.tuta.com", uri.host().unwrap());
+				assert!(
+					uri.path().contains(&format!("/maildetailsblob/{list_id_check}")),
+					"path should contain list_id, got: {}",
+					uri.path()
+				);
+				let query = uri.query().unwrap_or("");
+				assert!(
+					query.contains(&format!("ids={element_id_check}")),
+					"query should contain ids param, got: {query}"
+				);
+				assert!(
+					query.contains("blobAccessToken=accessToken123"),
+					"query should contain blobAccessToken, got: {query}"
+				);
+				assert_eq!(&GET, method);
+				true
+			})
+			.return_once(move |_, _, _| {
+				Ok(RestResponse {
+					status: 200,
+					headers: HashMap::new(),
+					body: Some(expected_body_clone),
+				})
+			});
+
+		let type_model_provider = Arc::new(TypeModelProvider::new_test(
+			Arc::new(MockRestClient::new()),
+			Arc::new(MockFileClient::new()),
+			"http://localhost:9000".to_string(),
+		));
+		let blob_facade = BlobFacade {
+			blob_access_token_facade: mock_token,
+			rest_client: Arc::new(rest_client),
+			randomizer_facade: RandomizerFacade::from_core(DeterministicRng(42)),
+			auth_headers_provider: Arc::new(HeadersProvider { access_token: None }),
+			instance_mapper: Arc::new(InstanceMapper::new(type_model_provider.clone())),
+			json_serializer: Arc::new(JsonSerializer::new(type_model_provider.clone())),
+			type_model_provider,
+		};
+
+		use crate::entities::generated::tutanota::MailDetailsBlob;
+		let result = blob_facade
+			.load_blob_element(&MailDetailsBlob::type_ref(), &archive_id, &element_id, &archive_id)
+			.await
+			.expect("should succeed");
+		assert_eq!(expected_body, result);
+	}
+
+	#[tokio::test]
+	async fn load_blob_element_retries_on_403() {
+		let archive_id = GeneratedId("archId".to_owned());
+		let element_id = GeneratedId("elemId".to_owned());
+		let expected_body = b"retry succeeded".to_vec();
+
+		// first token returns 403, second succeeds
+		let access_info_first = BlobServerAccessInfo {
+			blobAccessToken: "expiredToken".to_string(),
+			servers: vec![BlobServerUrl {
+				url: "https://w1.api.tuta.com".to_string(),
+				..create_test_entity()
+			}],
+			..create_test_entity()
+		};
+		let access_info_second = BlobServerAccessInfo {
+			blobAccessToken: "freshToken".to_string(),
+			servers: vec![BlobServerUrl {
+				url: "https://w1.api.tuta.com".to_string(),
+				..create_test_entity()
+			}],
+			..create_test_entity()
+		};
+
+		let mut mock_token = MockBlobAccessTokenFacade::default();
+		mock_token
+			.expect_request_read_token_archive()
+			.times(1)
+			.with(predicate::eq(archive_id.clone()))
+			.return_once(move |_| Ok(access_info_first));
+		mock_token
+			.expect_request_read_token_archive()
+			.times(1)
+			.with(predicate::eq(archive_id.clone()))
+			.return_once(move |_| Ok(access_info_second));
+		mock_token
+			.expect_evict_archive_token()
+			.times(1)
+			.with(predicate::eq(archive_id.clone()))
+			.return_const(());
+
+		let expected_body_clone = expected_body.clone();
+		let mut rest_client = MockRestClient::default();
+		// First request: 403 (NotAuthorizedError)
+		rest_client
+			.expect_request_binary()
+			.times(1)
+			.withf(|url, _, _| url.contains("expiredToken"))
+			.return_once(|_, _, _| {
+				Ok(RestResponse {
+					status: 403,
+					headers: HashMap::new(),
+					body: None,
+				})
+			});
+		// Second request (after retry): 200
+		rest_client
+			.expect_request_binary()
+			.times(1)
+			.withf(|url, _, _| url.contains("freshToken"))
+			.return_once(move |_, _, _| {
+				Ok(RestResponse {
+					status: 200,
+					headers: HashMap::new(),
+					body: Some(expected_body_clone),
+				})
+			});
+
+		let type_model_provider = Arc::new(TypeModelProvider::new_test(
+			Arc::new(MockRestClient::new()),
+			Arc::new(MockFileClient::new()),
+			"http://localhost:9000".to_string(),
+		));
+		let blob_facade = BlobFacade {
+			blob_access_token_facade: mock_token,
+			rest_client: Arc::new(rest_client),
+			randomizer_facade: RandomizerFacade::from_core(DeterministicRng(42)),
+			auth_headers_provider: Arc::new(HeadersProvider { access_token: None }),
+			instance_mapper: Arc::new(InstanceMapper::new(type_model_provider.clone())),
+			json_serializer: Arc::new(JsonSerializer::new(type_model_provider.clone())),
+			type_model_provider,
+		};
+
+		use crate::entities::generated::tutanota::MailDetailsBlob;
+		let result = blob_facade
+			.load_blob_element(&MailDetailsBlob::type_ref(), &archive_id, &element_id, &archive_id)
+			.await
+			.expect("should succeed after retry");
+		assert_eq!(expected_body, result);
+	}
+
+	#[tokio::test]
+	async fn load_blob_element_returns_server_error_without_retry() {
+		// When all servers return retriable errors (Connection/InternalServer/NotFound)
+		// without a 403, the original error is returned without retrying — matching TS
+		// `tryServers` which throws the last error, and `doBlobRequestWithRetry` which
+		// only retries on `NotAuthorizedError`.
+		let archive_id = GeneratedId("archId".to_owned());
+		let element_id = GeneratedId("elemId".to_owned());
+
+		let mut mock_token = make_read_token_mock(archive_id.clone(), "token");
+		// Critical: token must NOT be evicted, retry must NOT happen.
+		mock_token.expect_evict_archive_token().never();
+
+		let mut rest_client = MockRestClient::default();
+		rest_client
+			.expect_request_binary()
+			.times(1)
+			.return_once(|_, _, _| {
+				Ok(RestResponse {
+					status: 500,
+					headers: HashMap::new(),
+					body: None,
+				})
+			});
+
+		let type_model_provider = Arc::new(TypeModelProvider::new_test(
+			Arc::new(MockRestClient::new()),
+			Arc::new(MockFileClient::new()),
+			"http://localhost:9000".to_string(),
+		));
+		let blob_facade = BlobFacade {
+			blob_access_token_facade: mock_token,
+			rest_client: Arc::new(rest_client),
+			randomizer_facade: RandomizerFacade::from_core(DeterministicRng(42)),
+			auth_headers_provider: Arc::new(HeadersProvider { access_token: None }),
+			instance_mapper: Arc::new(InstanceMapper::new(type_model_provider.clone())),
+			json_serializer: Arc::new(JsonSerializer::new(type_model_provider.clone())),
+			type_model_provider,
+		};
+
+		use crate::entities::generated::tutanota::MailDetailsBlob;
+		let err = blob_facade
+			.load_blob_element(&MailDetailsBlob::type_ref(), &archive_id, &element_id, &archive_id)
+			.await
+			.expect_err("should return error");
+
+		match err {
+			ApiCallError::ServerResponseError {
+				source: HttpError::InternalServerError,
+			} => {},
+			other => panic!("expected InternalServerError, got: {other:?}"),
+		}
 	}
 
 	#[test]

--- a/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
+++ b/tuta-sdk/rust/sdk/src/crypto_entity_client.rs
@@ -6,6 +6,7 @@ use crate::crypto::asymmetric_crypto_facade::AsymmetricCryptoError;
 use crate::crypto::asymmetric_crypto_facade::AsymmetricCryptoFacade;
 #[cfg_attr(test, mockall_double::double)]
 use crate::crypto::crypto_facade::CryptoFacade;
+use crate::crypto::crypto_facade::ResolvedSessionKey;
 use crate::crypto::key::AsymmetricKeyPair;
 use crate::crypto::public_key_provider::{PublicKeyIdentifier, PublicKeyLoadingError};
 use crate::crypto::X25519PublicKey;
@@ -113,6 +114,28 @@ impl CryptoEntityClient {
 			.await?;
 
 		self.process_server_response(parsed_entities).await
+	}
+
+	pub fn decrypt_with_owner_key<T: Entity + DeserializeOwned>(
+		&self,
+		parsed_entity: ParsedEntity,
+		session_key: &GenericAesKey,
+		owner_enc_session_key: Vec<u8>,
+		owner_key_version: u64,
+	) -> Result<T, ApiCallError> {
+		let type_model = self.entity_client.resolve_server_type_ref(&T::type_ref())?;
+		let resolved = ResolvedSessionKey {
+			session_key: session_key.clone(),
+			owner_enc_session_key,
+			owner_key_version,
+			sender_identity_pub_key: None,
+		};
+		let decrypted = self
+			.entity_facade
+			.decrypt_and_map(&type_model, parsed_entity, resolved)?;
+		self.instance_mapper
+			.parse_entity::<T>(decrypted)
+			.map_err(|e| ApiCallError::internal_with_err(e, "Failed to map decrypted blob entity"))
 	}
 
 	#[allow(dead_code)] // will be used but rustc can't see it in some configurations right now

--- a/tuta-sdk/rust/sdk/src/lib.rs
+++ b/tuta-sdk/rust/sdk/src/lib.rs
@@ -578,10 +578,18 @@ impl LoggedInSdk {
 	/// Generates a new interface to operate on mail entities
 	#[must_use]
 	pub fn mail_facade(&self) -> MailFacade {
+		let key_loader = self
+			.crypto_entity_client
+			.get_crypto_facade()
+			.get_key_loader_facade()
+			.clone();
 		MailFacade::new(
 			self.crypto_entity_client.clone(),
 			self.user_facade.clone(),
 			self.service_executor.clone(),
+			self.blob_facade.clone(),
+			key_loader,
+			self.json_serializer.clone(),
 		)
 	}
 
@@ -729,4 +737,5 @@ mod tests {
 		let parsed_mail = create_test_entity_dict::<Mail>();
 		let _ = sdk.serialize_mail(parsed_mail);
 	}
+
 }

--- a/tuta-sdk/rust/sdk/src/mail_facade.rs
+++ b/tuta-sdk/rust/sdk/src/mail_facade.rs
@@ -1,14 +1,20 @@
+use crate::blobs::blob_facade::BlobFacade;
 #[cfg_attr(test, mockall_double::double)]
 use crate::crypto_entity_client::CryptoEntityClient;
 use crate::element_value::ParsedEntity;
 use crate::entities::generated::sys::{Group, GroupInfo};
 use crate::entities::generated::tutanota::{
-	Mail, MailBox, MailSet, MailboxGroupRoot, SimpleMoveMailPostIn, UnreadMailStatePostIn,
+	Mail, MailBox, MailDetails, MailDetailsBlob, MailSet, MailboxGroupRoot, SimpleMoveMailPostIn,
+	UnreadMailStatePostIn,
 };
 use crate::entities::Entity;
 use crate::folder_system::{FolderSystem, MailSetKind};
 use crate::groups::GroupType;
 use crate::id::id_tuple::IdTupleGenerated;
+use crate::json_element::RawEntity;
+use crate::json_serializer::JsonSerializer;
+#[cfg_attr(test, mockall_double::double)]
+use crate::key_loader_facade::KeyLoaderFacade;
 use crate::rest_error::HttpError;
 use crate::services::generated::tutanota::{SimpleMoveMailService, UnreadMailStateService};
 #[cfg_attr(test, mockall_double::double)]
@@ -25,6 +31,9 @@ pub struct MailFacade {
 	crypto_entity_client: Arc<CryptoEntityClient>,
 	user_facade: Arc<UserFacade>,
 	service_executor: Arc<ResolvingServiceExecutor>,
+	blob_facade: Arc<BlobFacade>,
+	key_loader_facade: Arc<KeyLoaderFacade>,
+	json_serializer: Arc<JsonSerializer>,
 }
 
 impl MailFacade {
@@ -32,11 +41,17 @@ impl MailFacade {
 		crypto_entity_client: Arc<CryptoEntityClient>,
 		user_facade: Arc<UserFacade>,
 		service_executor: Arc<ResolvingServiceExecutor>,
+		blob_facade: Arc<BlobFacade>,
+		key_loader_facade: Arc<KeyLoaderFacade>,
+		json_serializer: Arc<JsonSerializer>,
 	) -> Self {
 		MailFacade {
 			crypto_entity_client,
 			user_facade,
 			service_executor,
+			blob_facade,
+			key_loader_facade,
+			json_serializer,
 		}
 	}
 }
@@ -86,6 +101,73 @@ impl MailFacade {
 
 	pub fn get_crypto_entity_client(&self) -> Arc<CryptoEntityClient> {
 		self.crypto_entity_client.clone()
+	}
+
+	/// Load and decrypt the `MailDetails` for the given `Mail`.
+	///
+	/// Blob elements don't carry their own `_ownerEncSessionKey`, so the session
+	/// key is resolved from the parent `Mail` — mirroring TS
+	/// `MailFacade.loadMailDetailsBlob()` + `keyProviderFromInstance()`.
+	pub async fn load_mail_details_blob(
+		&self,
+		mail: &Mail,
+	) -> Result<MailDetails, ApiCallError> {
+		if mail.mailDetailsDraft.is_some() {
+			return Err(ApiCallError::internal(
+				"not supported, must be mail details blob".to_owned(),
+			));
+		}
+		let details_id = mail
+			.mailDetails
+			.as_ref()
+			.ok_or_else(|| ApiCallError::internal("Mail has no mailDetails ID".to_owned()))?;
+		let list_id = &details_id.list_id;
+		let element_id = &details_id.element_id;
+
+		let owner_enc_sk = mail
+			._ownerEncSessionKey
+			.as_ref()
+			.ok_or_else(|| ApiCallError::internal("Mail missing _ownerEncSessionKey".to_owned()))?;
+		let owner_group = mail
+			._ownerGroup
+			.as_ref()
+			.ok_or_else(|| ApiCallError::internal("Mail missing _ownerGroup".to_owned()))?;
+		let owner_key_version = mail._ownerKeyVersion.unwrap_or(0).unsigned_abs();
+
+		let group_key = self
+			.key_loader_facade
+			.load_sym_group_key(owner_group, owner_key_version, None)
+			.await
+			.map_err(|e| {
+				ApiCallError::internal(format!("Failed to load group key: {e}"))
+			})?;
+		let session_key = group_key.decrypt_aes_key(owner_enc_sk).map_err(|e| {
+			ApiCallError::internal(format!("Failed to decrypt session key: {e}"))
+		})?;
+
+		let type_ref = MailDetailsBlob::type_ref();
+
+		let body = self
+			.blob_facade
+			.load_blob_element(&type_ref, list_id, element_id, list_id)
+			.await?;
+
+		let raw_entities: Vec<RawEntity> =
+			serde_json::from_slice(&body).map_err(|e| {
+				ApiCallError::internal(format!("Failed to parse blob response: {e}"))
+			})?;
+		let raw = raw_entities.into_iter().next().ok_or_else(|| {
+			ApiCallError::internal("Empty blob response".to_owned())
+		})?;
+		let parsed = self.json_serializer.parse(&type_ref, raw)?;
+
+		let blob: MailDetailsBlob = self.crypto_entity_client.decrypt_with_owner_key(
+			parsed,
+			&session_key,
+			owner_enc_sk.clone(),
+			owner_key_version,
+		)?;
+		Ok(blob.details)
 	}
 
 	/// Invoke the SimpleMoveMail service to move mail(s) to the first folder of a given folder
@@ -233,19 +315,55 @@ fn get_enabled_mail_addresses_for_group_info(group_info: &GroupInfo) -> Vec<Stri
 #[cfg(test)]
 mod tests {
 	use super::UnreadMailStatePostIn;
+	use crate::bindings::file_client::MockFileClient;
+	use crate::bindings::rest_client::MockRestClient;
+	use crate::blobs::blob_access_token_facade::MockBlobAccessTokenFacade;
+	use crate::blobs::blob_facade::BlobFacade;
 	use crate::crypto_entity_client::MockCryptoEntityClient;
 	use crate::entities::generated::tutanota::{MoveMailPostOut, SimpleMoveMailPostIn};
 	use crate::folder_system::MailSetKind;
+	use crate::instance_mapper::InstanceMapper;
+	use crate::json_serializer::JsonSerializer;
+	use crate::key_loader_facade::MockKeyLoaderFacade;
 	use crate::mail_facade::MailFacade;
 	use crate::services::generated::tutanota::SimpleMoveMailService;
 	use crate::services::generated::tutanota::UnreadMailStateService;
 	use crate::services::service_executor::MockResolvingServiceExecutor;
+	use crate::type_model_provider::TypeModelProvider;
 	use crate::user_facade::MockUserFacade;
 	use crate::util::test_utils::create_test_entity;
 	use crate::GeneratedId;
+	use crate::HeadersProvider;
 	use crate::IdTupleGenerated;
+	use crypto_primitives::randomizer_facade::RandomizerFacade;
+	use crypto_primitives::randomizer_facade::test_util::DeterministicRng;
 	use mockall::predicate::{always, eq};
 	use std::sync::Arc;
+
+	fn make_test_facade(executor: MockResolvingServiceExecutor) -> MailFacade {
+		let type_model_provider = Arc::new(TypeModelProvider::new_test(
+			Arc::new(MockRestClient::new()),
+			Arc::new(MockFileClient::new()),
+			"http://localhost:9000".to_string(),
+		));
+		let blob_facade = Arc::new(BlobFacade::new(
+			MockBlobAccessTokenFacade::default(),
+			Arc::new(MockRestClient::new()),
+			RandomizerFacade::from_core(DeterministicRng(42)),
+			Arc::new(HeadersProvider { access_token: None }),
+			Arc::new(InstanceMapper::new(type_model_provider.clone())),
+			Arc::new(JsonSerializer::new(type_model_provider.clone())),
+			type_model_provider.clone(),
+		));
+		MailFacade::new(
+			Arc::new(MockCryptoEntityClient::default()),
+			Arc::new(MockUserFacade::default()),
+			Arc::new(executor),
+			blob_facade,
+			Arc::new(MockKeyLoaderFacade::default()),
+			Arc::new(JsonSerializer::new(type_model_provider.clone())),
+		)
+	}
 
 	#[tokio::test]
 	async fn mark_mail_split() {
@@ -273,11 +391,7 @@ mod tests {
 				.with(eq(second_invocation), always())
 				.returning(|_, _| Ok(()));
 
-			let facade = MailFacade::new(
-				Arc::new(MockCryptoEntityClient::default()),
-				Arc::new(MockUserFacade::default()),
-				Arc::new(executor),
-			);
+			let facade = make_test_facade(executor);
 			facade
 				.set_unread_status_for_mails(mails, unread)
 				.await
@@ -309,11 +423,7 @@ mod tests {
 				.with(eq(invocation), always())
 				.returning(|_, _| Ok(()));
 
-			let facade = MailFacade::new(
-				Arc::new(MockCryptoEntityClient::default()),
-				Arc::new(MockUserFacade::default()),
-				Arc::new(executor),
-			);
+			let facade = make_test_facade(executor);
 			facade
 				.set_unread_status_for_mails(mails, unread)
 				.await
@@ -337,11 +447,7 @@ mod tests {
 				.expect_post::<UnreadMailStateService>()
 				.with(eq(invocation), always())
 				.returning(|_, _| Ok(()));
-			let facade = MailFacade::new(
-				Arc::new(MockCryptoEntityClient::default()),
-				Arc::new(MockUserFacade::default()),
-				Arc::new(executor),
-			);
+			let facade = make_test_facade(executor);
 			facade
 				.set_unread_status_for_mails(mails, unread)
 				.await
@@ -386,11 +492,7 @@ mod tests {
 				})
 			});
 
-		let facade = MailFacade::new(
-			Arc::new(MockCryptoEntityClient::default()),
-			Arc::new(MockUserFacade::default()),
-			Arc::new(executor),
-		);
+		let facade = make_test_facade(executor);
 		facade.trash_mails(mails).await.unwrap();
 	}
 
@@ -417,11 +519,7 @@ mod tests {
 					..create_test_entity()
 				})
 			});
-		let facade = MailFacade::new(
-			Arc::new(MockCryptoEntityClient::default()),
-			Arc::new(MockUserFacade::default()),
-			Arc::new(executor),
-		);
+		let facade = make_test_facade(executor);
 		facade.trash_mails(mails).await.unwrap();
 	}
 
@@ -443,11 +541,7 @@ mod tests {
 					..create_test_entity()
 				})
 			});
-		let facade = MailFacade::new(
-			Arc::new(MockCryptoEntityClient::default()),
-			Arc::new(MockUserFacade::default()),
-			Arc::new(executor),
-		);
+		let facade = make_test_facade(executor);
 		facade.trash_mails(mails).await.unwrap();
 	}
 


### PR DESCRIPTION
Add support for loading and decrypting blob elements (e.g. `MailDetailsBlob`) in the Rust SDK, mirroring the TypeScript implementation.

### Changes

- **`BlobFacade.load_blob_element()`** — loads a blob element from blob storage servers with server failover (`tryServers` equivalent) and automatic retry on 403 with token eviction (`doBlobRequestWithRetry` equivalent)
- **`BlobAccessTokenCache`** — split into separate read/write caches; add `BlobReadArchiveTokenKey` for archive-level read tokens
- **`BlobAccessTokenFacade`** — add `request_read_token_archive()` and `evict_archive_token()`
- **`CryptoEntityClient.decrypt_with_owner_key()`** — decrypt a parsed entity using a pre-resolved session key from a parent entity (for blob elements that inherit their session key)
- **`MailFacade.load_mail_details_blob()`** — resolves the session key from the parent `Mail` entity and loads + decrypts the `MailDetailsBlob`, returning `MailDetails`

### Tests

- `load_blob_element_success` — verifies URL construction, query params, and successful response
- `load_blob_element_retries_on_403` — verifies token eviction and retry with fresh token
- `load_blob_element_returns_server_error_without_retry` — verifies non-403 errors are not retried
- Existing `MailFacade` tests refactored with `make_test_facade()` helper to accommodate new dependencies