### PR TITLE
[desktop] fix click-to-update notification on Linux, close #10844

### DIFF
--- a/src/applications/common/desktop/notifications/DesktopNotifier.ts
+++ b/src/applications/common/desktop/notifications/DesktopNotifier.ts
@@ -10,6 +10,11 @@ import { defer, DeferredObject, getFromMap, isEmpty, LazyLoaded, noOp } from "@t
 export class DesktopNotifier {
 	private readonly initPromise: DeferredObject<void> = defer()
 	private readonly notificationDismissersPerUser: Map<string, Dismisser[]> = new Map()
+	// Retains dismissers for one-shot notifications until the user clicks
+	// one. Without this the JS-side electron.Notification can be collected
+	// before the click event fires, which on Linux/GTK intermittently kills
+	// the click handler (issue #10844).
+	private readonly oneShotDismissers: Set<Dismisser> = new Set()
 
 	constructor(
 		private readonly tray: DesktopTray,
@@ -48,11 +53,29 @@ export class DesktopNotifier {
 			throw new Error("Notifications are not supported")
 		}
 
-		const onClick = props.onClick ?? noOp
+		const userOnClick = props.onClick ?? noOp
 
 		await this.initPromise.promise
 
-		factory.makeNotification(params, onClick)
+		// Retain the dismisser so the underlying electron.Notification cannot
+		// be collected before the click event fires. When the click lands we
+		// run the user handler, then dismiss the OS notification through the
+		// retained closure and release the reference so the set stays bounded.
+		let dismisser: Dismisser | undefined
+		const onClick = () => {
+			try {
+				userOnClick()
+			} finally {
+				if (dismisser !== undefined) {
+					this.oneShotDismissers.delete(dismisser)
+					const toDismiss = dismisser
+					dismisser = undefined
+					toDismiss()
+				}
+			}
+		}
+		dismisser = factory.makeNotification(params, onClick)
+		this.oneShotDismissers.add(dismisser)
 	}
 
 	/**

--- a/test/tests/desktop/notifications/DesktopNotifierTest.ts
+++ b/test/tests/desktop/notifications/DesktopNotifierTest.ts
@@ -153,4 +153,50 @@ o.spec("DesktopNotifier", function () {
 		await notifier.onNotificationClick("1234")
 		verify(factory.processNotification("1234"))
 	})
+
+	o.test("showOneShot retains the notification and closes it when the user clicks (issue #10844)", async function () {
+		const notifier = new DesktopNotifier(desktopTray, notificationFactoryLazy)
+		await notifier.start(0)
+
+		let onClickInvoked = false
+		await notifier.showOneShot({
+			title: "Update available",
+			body: "Click to update",
+			onClick: () => {
+				onClickInvoked = true
+			},
+		})
+
+		o.check(createdNotifications.length).equals(1)
+		const created = createdNotifications[0]
+
+		created.click()
+
+		o.check(onClickInvoked).equals(true)
+		// Before the fix, showOneShot dropped the dismisser returned by the
+		// factory, so the underlying electron.Notification was eligible for
+		// GC immediately and was never closed via the dismisser. Retaining
+		// the dismisser and invoking it on click is what keeps the JS-side
+		// notification alive on Linux/GTK long enough for the click to land.
+		verify(created.close(), { times: 1 })
+	})
+
+	o.test("showOneShot retains dismissers independently for concurrent notifications (issue #10844)", async function () {
+		const notifier = new DesktopNotifier(desktopTray, notificationFactoryLazy)
+		await notifier.start(0)
+
+		let clicks = 0
+		await notifier.showOneShot({ title: "T1", onClick: () => clicks++ })
+		await notifier.showOneShot({ title: "T2", onClick: () => clicks++ })
+		await notifier.showOneShot({ title: "T3", onClick: () => clicks++ })
+
+		o.check(createdNotifications.length).equals(3)
+
+		for (const n of createdNotifications) n.click()
+
+		o.check(clicks).equals(3)
+		for (const n of createdNotifications) {
+			verify(n.close(), { times: 1 })
+		}
+	})
 })


### PR DESCRIPTION
## Summary

Fixes #10844. On Linux/GTK the "Click to update" notification's click handler would intermittently stop working. @charlag described it on the issue as "sometimes works, sometimes not, slightly infuriating". The user can still update via Settings > Desktop, but clicking the notification toast is supposed to trigger the update and it does so on macOS and Windows only.

## Root cause

`DesktopNotifier.showOneShot` was discarding the `Dismisser` returned by `factory.makeNotification(...)`. The closure that retains the `electron.Notification` reference was therefore eligible for garbage collection as soon as `showOneShot` returned. The GTK notification backend on Linux does not strongly retain the JS-side wrapper across the asynchronous click round-trip, so when V8 happened to collect between `show()` and the user click, the click event was dropped silently. The macOS Cocoa bridge and the Windows Toast binding both retain the wrapper through their native objects, which is why the bug surfaces on Linux only.

The fact that `showCountedUserNotification` in the same file already retains its dismisser via `notificationDismissersPerUser` (so badge-counted notifications never lost their click handler) is what made the asymmetry obvious.

## Fix

Mirror the retention pattern used by `showCountedUserNotification`:

- Add a `private readonly oneShotDismissers: Set<Dismisser>` member on `DesktopNotifier`.
- Wrap the user-supplied `onClick` so that after it runs, the dismisser is released from the set and invoked, which closes the OS notification and drops the reference.

The wrapped click handler uses `try { userOnClick() } finally { cleanup }` so a throwing user handler cannot leak the retention.

## Tests

`test/tests/desktop/notifications/DesktopNotifierTest.ts` gains two cases:

1. After `showOneShot`, simulating a click invokes the user handler and dismisses the notification through the retained closure (`close()` called once via the dismisser).
2. Three concurrent `showOneShot` calls each retain their own dismisser and dismiss independently on click.

Both cases fail against the current `master` and pass with the fix applied. The existing four `DesktopNotifierTest` cases continue to pass unmodified.

## Validation

- Unit test surface for `DesktopNotifier` runs green with the fix.
- The fix is retention-only and platform-agnostic. macOS and Windows behavior is unchanged because the OS bindings on those platforms were already retaining the wrapper themselves. On Linux the previously missing retention is now provided.
- `npx eslint` clean on both touched files. `npx prettier --check` clean on both touched files.

## Notes on the retention set

The new retention `Set` releases entries on user click. If the OS auto-dismisses a notification without a click (timeout, user dismisses via the X button), the dismisser stays in the set until the app exits. This is a bounded leak. One closure per one-shot notification, and one-shots in Tutanota are limited to update-available and update-error events, so the upper bound over an app session is in the low double digits. Extending the factory `Dismisser` contract to surface OS-side close events would let us clean these up too, but that is an API change and was kept out of this PR to preserve the surgical scope.