### PR TITLE
Fix cannot save draft when last missed event batch contains no updates

### DIFF
--- a/src/applications/calendar-app/calendarLocator.ts
+++ b/src/applications/calendar-app/calendarLocator.ts
@@ -637,7 +637,7 @@ class CalendarLocator implements CommonLocator {
 		// Should be called elsewhere later e.g. in CommonLocator
 		this.logins.init()
 		this.progressTracker = new ProgressTracker()
-		this.eventController = new EventController(calendarLocator.logins, this.progressTracker)
+		this.eventController = new EventController(calendarLocator.logins)
 		this.syncTracker = new SyncTracker()
 		this.search = new CalendarSearchModel(() => this.calendarEventsRepository())
 		this.entityClient = new EntityClient(restInterface, this.clientModelInfo)

--- a/src/applications/common/api/main/EventController.ts
+++ b/src/applications/common/api/main/EventController.ts
@@ -1,10 +1,8 @@
-import { identity, Nullable } from "@tutao/utils"
+import { identity } from "@tutao/utils"
 import type { LoginController } from "./LoginController"
 import stream from "mithril/stream"
 import Stream from "mithril/stream"
 import { assertMainOrNode } from "@tutao/app-env"
-import { ProgressTracker } from "./ProgressTracker"
-import { ProgressMonitorId } from "../../../../platform-kit/network/ProgressMonitorInterface"
 import { EntityEventsListener, EntityUpdateData } from "../../../../platform-kit/instance-pipeline/utils/EntityUpdateUtils"
 import { OperationStatusUpdate, WebsocketCounterData } from "@tutao/entities/sys"
 
@@ -21,10 +19,7 @@ export class EventController {
 	private entityListeners: Set<EntityEventsListener> = new Set()
 	private readonly operationListeners: Set<OperationStatusUpdateListener> = new Set()
 
-	constructor(
-		private readonly logins: LoginController,
-		private readonly progressTracker: ProgressTracker,
-	) {}
+	constructor(private readonly logins: LoginController) {}
 
 	addEntityListener(listener: EntityEventsListener) {
 		if (this.entityListeners.has(listener)) {
@@ -54,12 +49,7 @@ export class EventController {
 		return this.countersStream.map(identity)
 	}
 
-	async onEntityUpdateReceived(
-		entityUpdates: readonly EntityUpdateData[],
-		eventOwnerGroupId: Id,
-		progressMonitorId: Nullable<ProgressMonitorId>,
-		isInitialSyncDone: boolean,
-	): Promise<void> {
+	async onEntityUpdateReceived(entityUpdates: readonly EntityUpdateData[], eventOwnerGroupId: Id, isInitialSyncDone: boolean): Promise<void> {
 		if (this.logins.isUserLoggedIn()) {
 			// the UserController must be notified first as other event receivers depend on it to be up-to-date
 			await this.logins.getUserController().entityEventsReceived(entityUpdates, eventOwnerGroupId)
@@ -70,10 +60,6 @@ export class EventController {
 
 			for (const listener of listenersByPriorities) {
 				await listener.onEntityUpdatesReceived(entityUpdates, eventOwnerGroupId, isInitialSyncDone)
-			}
-
-			if (progressMonitorId !== null && !(await this.progressTracker.getMonitor(progressMonitorId)?.isDone())) {
-				await this.progressTracker.workDoneForMonitor(progressMonitorId, 1)
 			}
 		}
 	}

--- a/src/applications/common/api/worker/EventBusEventCoordinator.ts
+++ b/src/applications/common/api/worker/EventBusEventCoordinator.ts
@@ -43,16 +43,10 @@ export class EventBusEventCoordinator implements EventBusListener {
 		private readonly syncTracker: SyncTracker,
 	) {}
 
-	async onEntityEventsReceived(
-		events: readonly EntityUpdateData[],
-		batchId: Id,
-		groupId: Id,
-		progressMonitorId: Nullable<ProgressMonitorId>,
-		isInitialSyncDone: boolean,
-	): Promise<void> {
+	async onEntityEventsReceived(events: readonly EntityUpdateData[], batchId: Id, groupId: Id, isInitialSyncDone: boolean): Promise<void> {
 		await this.entityEventsReceived(events)
 		await (await this.mailFacade?.())?.entityEventsReceived(events)
-		await this.eventController.onEntityUpdateReceived(events, groupId, progressMonitorId, isInitialSyncDone)
+		await this.eventController.onEntityUpdateReceived(events, groupId, isInitialSyncDone)
 		// Call the indexer in this last step because now the processed event is stored and the indexer has a separate event queue that
 		// shall not receive the event twice.
 		if (!isTest() && !isAdminClient()) {

--- a/src/applications/drive-app/driveLocator.ts
+++ b/src/applications/drive-app/driveLocator.ts
@@ -568,7 +568,7 @@ class DriveLocator implements CommonLocator {
 		// Should be called elsewhere later e.g. in CommonLocator
 		this.logins.init()
 		this.progressTracker = new ProgressTracker()
-		this.eventController = new EventController(driveLocator.logins, this.progressTracker)
+		this.eventController = new EventController(driveLocator.logins)
 		this.syncTracker = new SyncTracker()
 		this.search = new DriveSearchModelStub()
 		this.entityClient = new EntityClient(restInterface, this.clientModelInfo)

--- a/src/applications/mail-app/mailLocator.ts
+++ b/src/applications/mail-app/mailLocator.ts
@@ -850,7 +850,7 @@ class MailLocator implements CommonLocator {
 		// Should be called elsewhere later e.g. in CommonLocator
 		this.logins.init()
 		this.progressTracker = new ProgressTracker()
-		this.eventController = new EventController(mailLocator.logins, this.progressTracker)
+		this.eventController = new EventController(mailLocator.logins)
 		this.syncTracker = new SyncTracker()
 		this.search = new SearchModel(this.searchFacade, () => this.calendarEventsRepository())
 		this.entityClient = new EntityClient(restInterface, this.clientModelInfo)

--- a/src/platform-kit/network/EventBusClient.ts
+++ b/src/platform-kit/network/EventBusClient.ts
@@ -11,11 +11,11 @@ import {
 	TooManyRequestsError,
 } from "@tutao/rest-client/error"
 import { type AppName, AttributeModel, hasError, isSameTypeRef, timestampToGeneratedId, TypeRef } from "../meta"
-import { assertNotNull, DateProvider, delay, identity, lazyAsync, Nullable, ofClass, promiseMap, randomIntFromInterval } from "@tutao/utils"
+import { assertNotNull, DateProvider, delay, identity, isNotEmpty, lazyAsync, Nullable, ofClass, promiseMap, randomIntFromInterval } from "@tutao/utils"
 import { EntityAdapter, InstancePipeline, LoggedInUserProvider, SessionKeyResolver, TypeModelResolver } from "@tutao/instance-pipeline"
 import { CloseEventBusOption, ConnectMode, WsConnectionState } from "./Constants.js"
 import { SessionKeyNotFoundError } from "@tutao/crypto/error"
-import { ProgressMonitorId, ProgressMonitorInterface } from "./ProgressMonitorInterface.js"
+import { ProgressMonitorInterface } from "./ProgressMonitorInterface.js"
 import { WebsocketConnectivityListener } from "./WebsocketConnectivityListener.js"
 import { LastProcessedEventBatchProvider } from "./LastProcessedEventBatchProvider.js"
 import { filterIndexMemberships } from "./GroupUtils.js"
@@ -78,13 +78,7 @@ const enum MessageType {
 export interface EventBusListener {
 	onCounterChanged(counter: WebsocketCounterData): unknown
 
-	onEntityEventsReceived(
-		events: readonly EntityUpdateData[],
-		batchId: Id,
-		groupId: Id,
-		progressMonitorId: Nullable<ProgressMonitorId>,
-		isInitialSyncDone: boolean,
-	): Promise<void>
+	onEntityEventsReceived(events: readonly EntityUpdateData[], batchId: Id, groupId: Id, isInitialSyncDone: boolean): Promise<void>
 
 	/**
 	 * @param markers only phishing (not spam) markers will be sent as event bus updates
@@ -343,13 +337,7 @@ export class EventBusClient {
 				if (!this.isInitialSyncDone) {
 					this.lastMissedBatchId = batchId
 				}
-				// if the updates were not added to the queue, since the array is empty because it was optimized away,
-				// we need to complete the work for the batch here, since the processEventBatch function
-				// (and therefore the EventController) will not be called for this particular batch.
-				const wasAdded = this.eventQueue.add(batchId, groupId, updates, this.isInitialSyncDone)
-				if (!wasAdded && !(await this.progressMonitor?.isDone())) {
-					await this.progressMonitor?.workDone(1)
-				}
+				this.eventQueue.add(batchId, groupId, updates, this.isInitialSyncDone)
 				break
 			}
 			case MessageType.UnreadCounterUpdate: {
@@ -680,17 +668,16 @@ export class EventBusClient {
 	private async processEventBatch(batch: QueuedBatch): Promise<void> {
 		try {
 			if (this.isTerminated()) return
+
 			const filteredEvents = await this.cache.entityEventsReceived(batch.events, batch.batchId, batch.groupId)
-			if (!this.isTerminated()) {
-				const progressMonitorId = (await this.progressMonitor?.progressMonitorId) ?? null
-				await this.listener.onEntityEventsReceived(
-					filteredEvents,
-					batch.batchId,
-					batch.groupId,
-					progressMonitorId,
-					assertNotNull(batch.isInitialSyncDone),
-				)
+			if (!this.isTerminated() && isNotEmpty(filteredEvents)) {
+				await this.listener.onEntityEventsReceived(filteredEvents, batch.batchId, batch.groupId, assertNotNull(batch.isInitialSyncDone))
 			}
+
+			if (!(await this.progressMonitor?.isDone())) {
+				await this.progressMonitor?.workDone(1)
+			}
+
 			// call syncDone listener right after the last missed batch is processed
 			if (batch.batchId === this.lastMissedBatchId) {
 				this.listener.onSyncDone()
@@ -709,11 +696,11 @@ export class EventBusClient {
 				})
 				this.serviceUnavailableRetry = retryPromise
 				return retryPromise
-			} else {
-				if (!isExpectedErrorForSynchronization(e)) {
-					console.log("EVENT", "error", e)
-					throw e
-				}
+			}
+
+			if (!isExpectedErrorForSynchronization(e)) {
+				console.log("EVENT", "error", e)
+				throw e
 			}
 		}
 	}
@@ -734,5 +721,9 @@ export class EventBusClient {
 				.concat(user.userGroup)
 				.map((membership) => membership.group)
 		}
+	}
+
+	async waitForEmptyQueue(): Promise<void> {
+		await this.eventQueue.waitForEmptyQueue()
 	}
 }

--- a/src/platform-kit/network/EventQueue.ts
+++ b/src/platform-kit/network/EventQueue.ts
@@ -1,7 +1,6 @@
 import { ConnectionError, ServiceUnavailableError } from "@tutao/rest-client/error"
 import { purgeSyncMetrics, syncMetrics } from "@tutao/utils"
 import { EntityUpdateData, getLogStringForEntityEvent } from "../instance-pipeline/utils/EntityUpdateUtils"
-import { ProgressMonitorInterface } from "./ProgressMonitorInterface"
 
 export type QueuedBatch = {
 	events: readonly EntityUpdateData[]
@@ -19,7 +18,6 @@ export class EventQueue {
 	public readonly eventQueue: Array<WritableQueuedBatch>
 	private processingBatch: QueuedBatch | null
 	private paused: boolean
-	private progressMonitor: ProgressMonitorInterface | null
 	private emptyQueueEventTarget: EventTarget
 
 	/**
@@ -33,7 +31,6 @@ export class EventQueue {
 		this.eventQueue = []
 		this.processingBatch = null
 		this.paused = false
-		this.progressMonitor = null
 		this.emptyQueueEventTarget = new EventTarget()
 	}
 
@@ -43,15 +40,7 @@ export class EventQueue {
 		}
 	}
 
-	setProgressMonitor(progressMonitor: ProgressMonitorInterface) {
-		this.progressMonitor?.completed() // make sure any old monitor does not have pending work
-		this.progressMonitor = progressMonitor
-	}
-
-	/**
-	 * @return whether the batch was added (not optimized away)
-	 */
-	add(batchId: Id, groupId: Id, newEvents: ReadonlyArray<EntityUpdateData>, isInitialSyncDone: boolean): boolean {
+	add(batchId: Id, groupId: Id, newEvents: ReadonlyArray<EntityUpdateData>, isInitialSyncDone: boolean): void {
 		const newBatch: WritableQueuedBatch = {
 			events: [],
 			groupId,
@@ -60,14 +49,10 @@ export class EventQueue {
 		}
 
 		newBatch.events.push(...newEvents)
-
-		if (newBatch.events.length !== 0) {
-			this.eventQueue.push(newBatch)
-		}
+		this.eventQueue.push(newBatch)
 
 		// ensures that events are processed when not **paused**
 		this.start()
-		return newBatch.events.length > 0
 	}
 
 	start() {
@@ -95,7 +80,6 @@ export class EventQueue {
 			this.queueAction(next)
 				.then(() => {
 					this.eventQueue.shift()
-					this.progressMonitor?.workDone(1)
 					this.processingBatch = null
 
 					// do this *before* processNext() is called
@@ -158,9 +142,5 @@ export class EventQueue {
 	/** @private visibleForTesting */
 	get __processingBatch(): QueuedBatch | null {
 		return this.processingBatch
-	}
-
-	getProgressMonitor() {
-		return this.progressMonitor
 	}
 }

--- a/test/tests/api/worker/EventBusClientTest.ts
+++ b/test/tests/api/worker/EventBusClientTest.ts
@@ -35,7 +35,7 @@ export const noPatchesAndInstance: Pick<EntityUpdateData, "instance" | "patches"
 	patches: null,
 	blobInstance: null,
 }
-o.spec("EventBusClientTest", function () {
+o.spec("EventBusClient", function () {
 	let ebc: EventBusClient
 	let cacheMock: DefaultEntityRestCache
 	let userMock: UserFacade
@@ -132,7 +132,7 @@ o.spec("EventBusClientTest", function () {
 			]
 		})
 
-		o("initial connect: when the cache is clean it initializes cache with GENERATED_MIN_ID", async function () {
+		o.test("initial connect: when the cache is clean it initializes cache with GENERATED_MIN_ID", async function () {
 			when(lastProcessedEventBatchStorageFacade.getLastEntityEventBatchForGroup(mailGroupId)).thenResolve(null)
 			when(cacheMock.timeSinceLastSyncMs()).thenResolve(null)
 
@@ -147,7 +147,7 @@ o.spec("EventBusClientTest", function () {
 			)
 		})
 
-		o("reconnect: when the cache is out of sync with the server, the cache is purged", async function () {
+		o.test("reconnect: when the cache is out of sync with the server, the cache is purged", async function () {
 			when(lastProcessedEventBatchStorageFacade.getLastEntityEventBatchForGroup(mailGroupId)).thenResolve("lastBatchId")
 			// Make initial connection to simulate reconnect (populate lastEntityEventIds
 			await ebc.connect(ConnectMode.Initial)
@@ -164,7 +164,7 @@ o.spec("EventBusClientTest", function () {
 			verify(listenerMock.onError(matchers.isA(OutOfSyncError)))
 		})
 
-		o("initial connect: when the cache is out of sync with the server, the cache is purged", async function () {
+		o.test("initial connect: when the cache is out of sync with the server, the cache is purged", async function () {
 			when(lastProcessedEventBatchStorageFacade.getLastEntityEventBatchForGroup(mailGroupId)).thenResolve("lastBatchId")
 			when(cacheMock.isOutOfSync()).thenResolve(true)
 
@@ -176,7 +176,7 @@ o.spec("EventBusClientTest", function () {
 		})
 	})
 
-	o("parallel received event batches are passed sequentially to the entity rest cache", async function () {
+	o.test("parallel received event batches are passed sequentially to the entity rest cache", async function () {
 		o.timeout(20000)
 		await ebc.connect(ConnectMode.Initial)
 		await socket.onopen?.(new Event("open"))
@@ -219,7 +219,7 @@ o.spec("EventBusClientTest", function () {
 		verify(cacheMock.entityEventsReceived(matchers.anything(), matchers.anything(), matchers.anything()), { times: 2 })
 	})
 
-	o("on counter update it send message to the main thread", async function () {
+	o.test("on counter update it send message to the main thread", async function () {
 		const counterUpdate = createCounterData({ mailGroupId: "group1", counterValue: 4, counterId: "list1" })
 
 		await ebc.connect(ConnectMode.Initial)
@@ -233,10 +233,10 @@ o.spec("EventBusClientTest", function () {
 		const updateCaptor = matchers.captor()
 		verify(listenerMock.onCounterChanged(updateCaptor.capture()))
 
-		o(updateCaptor.values!.map(removeOriginals)).deepEquals([counterUpdate])
+		o.check(updateCaptor.values!.map(removeOriginals)).deepEquals([counterUpdate])
 	})
 
-	o("verify new hash is set when entity updates are processed", async function () {
+	o.test("verify new hash is set when entity updates are processed", async function () {
 		await ebc.connect(ConnectMode.Initial)
 		await socket.onmessage?.({
 			data: await createEntityMessage(
@@ -252,11 +252,11 @@ o.spec("EventBusClientTest", function () {
 
 		await ebc.messageQueue
 
-		o(typeModelResolver.getServerApplicationTypesModelHash()).equals("newHash")
+		o.check(typeModelResolver.getServerApplicationTypesModelHash()).equals("newHash")
 	})
 
 	o.spec("sleep detection", function () {
-		o("on connect it starts", async function () {
+		o.test("on connect it starts", async function () {
 			verify(sleepDetector.start(matchers.anything()), { times: 0 })
 
 			await ebc.connect(ConnectMode.Initial)
@@ -265,7 +265,7 @@ o.spec("EventBusClientTest", function () {
 			verify(sleepDetector.start(matchers.anything()), { times: 1 })
 		})
 
-		o("on disconnect it stops", async function () {
+		o.test("on disconnect it stops", async function () {
 			await ebc.connect(ConnectMode.Initial)
 			await socket.onopen?.(new Event("open"))
 
@@ -273,7 +273,7 @@ o.spec("EventBusClientTest", function () {
 			verify(sleepDetector.stop())
 		})
 
-		o("on sleep it reconnects", async function () {
+		o.test("on sleep it reconnects", async function () {
 			let passedCb: Thunk
 			when(sleepDetector.start(matchers.anything())).thenDo((cb: Thunk) => (passedCb = cb))
 			const firstSocket = socket

--- a/test/tests/api/worker/EventBusClientTest.ts
+++ b/test/tests/api/worker/EventBusClientTest.ts
@@ -2,14 +2,13 @@ import o from "@tutao/otest"
 import { EventBusClient, EventBusListener } from "../../../../src/platform-kit/network/EventBusClient.js"
 import { OperationType, timestampToGeneratedId } from "../../../../src/platform-kit/meta"
 import { DefaultEntityRestCache } from "../../../../src/applications/common/api/worker/rest/DefaultEntityRestCache.js"
-import { OutOfSyncError } from "../../../../src/platform-kit/app-env/OutOfSyncError.js"
-import { matchers, object, verify, when } from "testdouble"
+import { OutOfSyncError, ProgrammingError } from "../../../../src/platform-kit/app-env"
+import { func, matchers, object, verify, when } from "testdouble"
 import { SleepDetector } from "../../../../src/applications/common/api/worker/utils/SleepDetector.js"
 import { UserFacade } from "../../../../src/platform-kit/base/facades/UserFacade"
 import { clientInitializedTypeModelResolver, createTestEntity, instancePipelineFromTypeModelResolver, removeOriginals } from "../../TestUtils.js"
 import { InstancePipeline, TypeModelResolver } from "../../../../src/platform-kit/instance-pipeline"
 import { CryptoFacade } from "../../../../src/platform-kit/base/crypto/CryptoFacade"
-import { ProgrammingError } from "../../../../src/platform-kit/app-env"
 import { Thunk } from "../../../../src/platform-kit/utils"
 import { ConnectMode, WsConnectionState } from "../../../../src/platform-kit/network/Constants"
 import { MailTypeRef } from "@tutao/entities/tutanota"
@@ -27,8 +26,9 @@ import {
 } from "@tutao/entities/sys"
 import { WebsocketConnectivityListener } from "../../../../src/platform-kit/network/WebsocketConnectivityListener"
 import { LastProcessedEventBatchProvider } from "../../../../src/platform-kit/network/LastProcessedEventBatchProvider"
-import { EntityUpdateData } from "../../../../src/platform-kit/instance-pipeline/utils/EntityUpdateUtils"
+import { EntityUpdateData, entityUpdateToUpdateData } from "../../../../src/platform-kit/instance-pipeline/utils/EntityUpdateUtils"
 import { GroupType } from "../../../../src/entities/sys/Utils"
+import { ProgressMonitorInterface } from "../../../../src/platform-kit/network/ProgressMonitorInterface"
 
 export const noPatchesAndInstance: Pick<EntityUpdateData, "instance" | "patches" | "blobInstance"> = {
 	instance: null,
@@ -49,6 +49,7 @@ o.spec("EventBusClientTest", function () {
 	let cryptoFacadeMock: CryptoFacade
 	let connectivityListenerMock: WebsocketConnectivityListener
 	let lastProcessedEventBatchStorageFacade: LastProcessedEventBatchProvider
+	let createProgressMonitor: (totalWork: number) => ProgressMonitorInterface
 	let now = Date.UTC(2026, 3, 25)
 
 	function initEventBus() {
@@ -73,7 +74,7 @@ o.spec("EventBusClientTest", function () {
 			cryptoFacadeMock,
 			() => Promise.resolve(lastProcessedEventBatchStorageFacade),
 			serverDateProvider,
-			object(),
+			createProgressMonitor,
 		)
 	}
 
@@ -94,27 +95,7 @@ o.spec("EventBusClientTest", function () {
 	o.beforeEach(async function () {
 		listenerMock = object()
 		lastProcessedEventBatchStorageFacade = object()
-		cacheMock = object({
-			async entityEventsReceived(events): Promise<ReadonlyArray<EntityUpdateData>> {
-				return events.slice()
-			},
-			async getLastEntityEventBatchForGroup(_groupId: Id): Promise<Id | null> {
-				return null
-			},
-			async recordSyncTime(): Promise<void> {
-				return
-			},
-			async timeSinceLastSyncMs(): Promise<number | null> {
-				return null
-			},
-			async purgeStorage(): Promise<void> {},
-			async putLastEntityEventBatchForGroup(_groupId: Id, _batchId: Id): Promise<void> {
-				return
-			},
-			async isOutOfSync(): Promise<boolean> {
-				return false
-			},
-		} as Partial<DefaultEntityRestCache> as DefaultEntityRestCache)
+		cacheMock = object()
 
 		user = createTestEntity(UserTypeRef, {
 			userGroup: createTestEntity(GroupMembershipTypeRef, {
@@ -135,6 +116,7 @@ o.spec("EventBusClientTest", function () {
 		instancePipeline = instancePipelineFromTypeModelResolver(typeModelResolver)
 		cryptoFacadeMock = object()
 		connectivityListenerMock = object()
+		createProgressMonitor = func<(totalWork: number) => ProgressMonitorInterface>()
 		initEventBus()
 	})
 
@@ -199,14 +181,26 @@ o.spec("EventBusClientTest", function () {
 		await ebc.connect(ConnectMode.Initial)
 		await socket.onopen?.(new Event("open"))
 
-		const messageData1 = await createEntityMessage(1)
-		const messageData2 = await createEntityMessage(2)
+		const messageData1 = await createEntityMessage(
+			createEntityData({
+				eventBatchId: "1",
+				eventBatchOwner: "ownerId",
+				application: "tutanota",
+				typeId: String(MailTypeRef.typeId),
+			}),
+		)
+		const messageData2 = await createEntityMessage(
+			createEntityData({
+				eventBatchId: "2",
+				eventBatchOwner: "ownerId",
+				application: "tutanota",
+				typeId: String(MailTypeRef.typeId),
+			}),
+		)
 
 		const filteredEvents: EntityUpdateData[] = []
 		when(cacheMock.entityEventsReceived(matchers.anything(), matchers.anything(), matchers.anything())).thenResolve(filteredEvents)
-		when(
-			listenerMock.onEntityEventsReceived(matchers.anything(), matchers.anything(), matchers.anything(), matchers.anything(), matchers.anything()),
-		).thenResolve()
+		when(listenerMock.onEntityEventsReceived(matchers.anything(), matchers.anything(), matchers.anything(), matchers.anything())).thenResolve()
 
 		// call twice as if it was received in parallel
 		const p1 = socket.onmessage?.({
@@ -245,7 +239,15 @@ o.spec("EventBusClientTest", function () {
 	o("verify new hash is set when entity updates are processed", async function () {
 		await ebc.connect(ConnectMode.Initial)
 		await socket.onmessage?.({
-			data: await createEntityMessage(1, "newHash"),
+			data: await createEntityMessage(
+				createEntityData({
+					eventBatchId: "1",
+					eventBatchOwner: "ownerId",
+					application: "tutanota",
+					typeId: String(MailTypeRef.typeId),
+					applicationTypesHash: "newHash",
+				}),
+			),
 		} as MessageEvent<string>)
 
 		await ebc.messageQueue
@@ -293,22 +295,199 @@ o.spec("EventBusClientTest", function () {
 		})
 	})
 
-	async function createEntityMessage(eventBatchId: number, applicationTypesHash: string = "hash"): Promise<string> {
-		const event: WebsocketEntityData = createTestEntity(WebsocketEntityDataTypeRef, {
-			eventBatchId: String(eventBatchId),
-			eventBatchOwner: "ownerId",
+	o.spec("all event batches are processed", function () {
+		const mailGroupId = "mailGroupId"
+		let progressMonitor: ProgressMonitorInterface
+
+		o.beforeEach(function () {
+			user.memberships = [
+				createTestEntity(GroupMembershipTypeRef, {
+					groupType: GroupType.Mail,
+					group: mailGroupId,
+				}),
+			]
+			when(lastProcessedEventBatchStorageFacade.getLastEntityEventBatchForGroup(mailGroupId)).thenResolve("lastBatchId")
+
+			progressMonitor = object()
+			when(progressMonitor.isDone()).thenResolve(false)
+			when(createProgressMonitor(matchers.anything())).thenReturn(progressMonitor)
+		})
+
+		o.test("event batch with entity update of a known type is processed", async function () {
+			const eventBatchId = "1"
+			const batchEvents = [
+				await entityUpdateToUpdateData(
+					createTestEntity(EntityUpdateTypeRef, {
+						application: MailTypeRef.app,
+						typeId: String(MailTypeRef.typeId),
+						operation: OperationType.UPDATE,
+					}),
+				),
+			]
+			when(cacheMock.entityEventsReceived(matchers.anything(), eventBatchId, mailGroupId)).thenResolve(batchEvents)
+
+			await ebc.connect(ConnectMode.Initial)
+			await socket.onopen?.(new Event("open"))
+
+			await socket.onmessage?.({
+				data: "initialSyncWorkEstimate;1",
+			} as MessageEvent)
+			await ebc.messageQueue
+
+			const entityData = createEntityData({
+				eventBatchId,
+				application: "tutanota",
+				typeId: String(MailTypeRef.typeId),
+				eventBatchOwner: mailGroupId,
+			})
+			await socket.onmessage?.({
+				data: await createEntityMessage(entityData),
+			} as MessageEvent)
+			await ebc.messageQueue
+			verify(listenerMock.onSyncDone(), { times: 0 })
+
+			await ebc.waitForEmptyQueue()
+			verify(listenerMock.onEntityEventsReceived(batchEvents, eventBatchId, mailGroupId, matchers.anything()))
+			verify(progressMonitor.workDone(1), { times: 1 })
+			verify(listenerMock.onSyncDone())
+		})
+
+		o.test("event batch with entity update of an unknown type is processed", async function () {
+			const eventBatchId = "1"
+			when(cacheMock.entityEventsReceived(matchers.anything(), eventBatchId, mailGroupId)).thenResolve([])
+
+			await ebc.connect(ConnectMode.Initial)
+			await socket.onopen?.(new Event("open"))
+
+			await socket.onmessage?.({
+				data: "initialSyncWorkEstimate;1",
+			} as MessageEvent)
+			await ebc.messageQueue
+
+			const entityData = createEntityData({ eventBatchId, application: "unknown", typeId: "1", eventBatchOwner: mailGroupId })
+			await socket.onmessage?.({
+				data: await createEntityMessage(entityData),
+			} as MessageEvent)
+			await ebc.messageQueue
+			verify(listenerMock.onSyncDone(), { times: 0 })
+
+			await ebc.waitForEmptyQueue()
+			verify(listenerMock.onEntityEventsReceived(matchers.anything(), matchers.anything(), matchers.anything(), matchers.anything()), { times: 0 })
+			verify(progressMonitor.workDone(1), { times: 1 })
+			verify(listenerMock.onSyncDone())
+		})
+
+		o.test("event batch with empty entity updates is processed", async function () {
+			const eventBatchId = "1"
+			when(cacheMock.entityEventsReceived(matchers.anything(), eventBatchId, mailGroupId)).thenResolve([])
+
+			await ebc.connect(ConnectMode.Initial)
+			await socket.onopen?.(new Event("open"))
+
+			await socket.onmessage?.({
+				data: "initialSyncWorkEstimate;1",
+			} as MessageEvent)
+			await ebc.messageQueue
+
+			const entityData = createTestEntity(WebsocketEntityDataTypeRef, {
+				eventBatchId,
+				eventBatchOwner: mailGroupId,
+				entityUpdates: [],
+				applicationTypesHash: "hash",
+			})
+			await socket.onmessage?.({
+				data: await createEntityMessage(entityData),
+			} as MessageEvent)
+			await ebc.messageQueue
+			verify(listenerMock.onSyncDone(), { times: 0 })
+
+			await ebc.waitForEmptyQueue()
+			verify(listenerMock.onEntityEventsReceived(matchers.anything(), matchers.anything(), matchers.anything(), matchers.anything()), { times: 0 })
+			verify(progressMonitor.workDone(1), { times: 1 })
+			verify(listenerMock.onSyncDone())
+		})
+	})
+
+	o.spec("handle InitialSyncWorkEstimate message", function () {
+		const mailGroupId = "mailGroupId"
+		let progressMonitor: ProgressMonitorInterface
+
+		o.beforeEach(function () {
+			user.memberships = [
+				createTestEntity(GroupMembershipTypeRef, {
+					groupType: GroupType.Mail,
+					group: mailGroupId,
+				}),
+			]
+			when(lastProcessedEventBatchStorageFacade.getLastEntityEventBatchForGroup(mailGroupId)).thenResolve("lastBatchId")
+
+			progressMonitor = object()
+			when(createProgressMonitor(matchers.anything())).thenReturn(progressMonitor)
+		})
+
+		o.test("handle first InitialSyncWorkEstimate message", async function () {
+			const totalWorkCaptor = matchers.captor()
+			when(createProgressMonitor(totalWorkCaptor.capture())).thenReturn(progressMonitor)
+			const workDoneCaptor = matchers.captor()
+			when(progressMonitor.workDone(workDoneCaptor.capture())).thenResolve()
+
+			await ebc.connect(ConnectMode.Initial)
+			await socket.onopen?.(new Event("open"))
+
+			await socket.onmessage?.({
+				data: "initialSyncWorkEstimate;10",
+			} as MessageEvent)
+			await ebc.messageQueue
+
+			// newWorkEstimate (10) + artificialWorkEstimate (25) + initialWorkDone (25)
+			o.check(totalWorkCaptor.value).equals(10 + 25 + 25)
+			// initialWorkDone is finished directly after creating progressMonitor
+			o.check(workDoneCaptor.value).equals(25)
+		})
+
+		o.test("handle subsequent InitialSyncWorkEstimate message", async function () {
+			when(createProgressMonitor(matchers.anything())).thenReturn(progressMonitor)
+			when(progressMonitor.workDone(matchers.anything())).thenResolve()
+
+			await ebc.connect(ConnectMode.Initial)
+			await socket.onopen?.(new Event("open"))
+
+			await socket.onmessage?.({
+				data: "initialSyncWorkEstimate;1",
+			} as MessageEvent)
+			await ebc.messageQueue
+
+			progressMonitor.totalWork = 1230
+			const updateTotalWorkCaptor = matchers.captor()
+			when(progressMonitor.updateTotalWork(updateTotalWorkCaptor.capture())).thenResolve()
+
+			await socket.onmessage?.({
+				data: "initialSyncWorkEstimate;5",
+			} as MessageEvent)
+			await ebc.messageQueue
+
+			o.check(updateTotalWorkCaptor.value).equals(1230 + 5)
+		})
+	})
+
+	type EntityMessageParams = { eventBatchId: string; eventBatchOwner: string; application: string; typeId: string; applicationTypesHash?: string }
+
+	function createEntityData({ eventBatchId, eventBatchOwner, application, typeId, applicationTypesHash = "hash" }: EntityMessageParams): WebsocketEntityData {
+		return createTestEntity(WebsocketEntityDataTypeRef, {
+			eventBatchId,
+			eventBatchOwner,
 			entityUpdates: [
 				createTestEntity(EntityUpdateTypeRef, {
-					_id: "eventBatchId",
-					application: "tutanota",
-					typeId: MailTypeRef.typeId.toString(),
-					instanceListId: "listId1",
-					instanceId: "id1",
+					application,
+					typeId,
 					operation: OperationType.UPDATE,
 				}),
 			],
-			applicationTypesHash: applicationTypesHash,
+			applicationTypesHash,
 		})
+	}
+
+	async function createEntityMessage(event: WebsocketEntityData): Promise<string> {
 		const instanceAsData = await instancePipeline.mapAndEncrypt(event._type, event, null)
 		return "entityUpdate;" + JSON.stringify(instanceAsData)
 	}

--- a/test/tests/api/worker/EventBusEventCoordinatorTest.ts
+++ b/test/tests/api/worker/EventBusEventCoordinatorTest.ts
@@ -200,11 +200,11 @@ o.spec("EventBusEventCoordinatorTest", () => {
 			},
 		]
 
-		await eventBusEventCoordinator.onEntityEventsReceived(updates, "batchId", "groupId", null, false)
+		await eventBusEventCoordinator.onEntityEventsReceived(updates, "batchId", "groupId", false)
 
 		verify(userFacade.updateUser(user))
 		verify(cacheManagementFacade.tryUpdatingUserGroupKey())
-		verify(eventController.onEntityUpdateReceived(updates, "groupId", null, false))
+		verify(eventController.onEntityUpdateReceived(updates, "groupId", false))
 		verify(mailFacade.entityEventsReceived(updates))
 	})
 
@@ -219,11 +219,11 @@ o.spec("EventBusEventCoordinatorTest", () => {
 			},
 		]
 
-		await eventBusEventCoordinator.onEntityEventsReceived(updates, "batchId", "groupId", null, false)
+		await eventBusEventCoordinator.onEntityEventsReceived(updates, "batchId", "groupId", false)
 
 		verify(userFacade.updateUser(user))
 		verify(cacheManagementFacade.tryUpdatingUserGroupKey(), { times: 0 })
-		verify(eventController.onEntityUpdateReceived(updates, "groupId", null, false))
+		verify(eventController.onEntityUpdateReceived(updates, "groupId", false))
 		verify(mailFacade.entityEventsReceived(updates))
 	})
 
@@ -242,12 +242,12 @@ o.spec("EventBusEventCoordinatorTest", () => {
 			},
 		]
 
-		await eventBusEventCoordinator.onEntityEventsReceived(updates, "batchId", "groupId", null, false)
+		await eventBusEventCoordinator.onEntityEventsReceived(updates, "batchId", "groupId", false)
 
 		verify(keyRotationFacadeMock.updateGroupMembershipsInOneList([[instanceListId, instanceId]]))
 		verify(userFacade.updateUser(user), { times: 0 })
 		verify(cacheManagementFacade.tryUpdatingUserGroupKey(), { times: 0 })
-		verify(eventController.onEntityUpdateReceived(updates, "groupId", null, false))
+		verify(eventController.onEntityUpdateReceived(updates, "groupId", false))
 		verify(mailFacade.entityEventsReceived(updates))
 	})
 })


### PR DESCRIPTION
This issue occurs because when saving draft we wait for initial sync to be done, but because:
- sync is only marked as done when the last event batch is processed,
- entity updates of unknown types are filtered out,
- and event batches with empty entity updates are not added to the event queue and therefore not processed,
when the last missed event batch either has no events or contains only events unknown to the client, initial sync is never marked as done.

Close #10884

Co-authored-by: abp <abp@tutao.de>
Co-authored-by: wrd <wrd@tutao.de>
Co-authored-by: paw <paw-hub@users.noreply.github.com>