### PR TITLE
Add MicrotaskBouncer

### DIFF
--- a/src/applications/mail-app/workerUtils/index/IndexedDbMailIndexerBackend.ts
+++ b/src/applications/mail-app/workerUtils/index/IndexedDbMailIndexerBackend.ts
@@ -17,6 +17,7 @@ import { GroupTimestamps, MailIndexerBackend, MailWithDetailsAndAttachments } fr
 import { ProgrammingError } from "../../../../platform-kit/app-env"
 import { ClientTypeModelResolver } from "../../../../platform-kit/instance-pipeline"
 import { File, Mail, MailDetails, MailTypeRef } from "@tutao/entities/tutanota"
+import { MicrotaskBouncer } from "../../../../platform-kit/utils/PromiseUtils"
 
 export class IndexedDbMailIndexerBackend implements MailIndexerBackend {
 	constructor(
@@ -31,10 +32,14 @@ export class IndexedDbMailIndexerBackend implements MailIndexerBackend {
 
 	async indexMails(dataPerGroup: GroupTimestamps, mailsWithDetails: readonly MailWithDetailsAndAttachments[]): Promise<void> {
 		const indexUpdate = this.createIndexUpdate()
+		const microtaskBouncer = new MicrotaskBouncer()
+
 		for (const element of mailsWithDetails) {
+			await microtaskBouncer.bounce()
 			const keyToIndexEntries = await this.createMailIndexEntries(element.mail, element.mailDetails, element.attachments)
 			await this.core.encryptSearchIndexEntries(element.mail._id, assertNotNull(element.mail._ownerGroup), keyToIndexEntries, indexUpdate)
 		}
+
 		await this.core.writeIndexUpdateWithIndexTimestamps(
 			Array.from(dataPerGroup).map(([id, timestamp]) => ({
 				groupId: id,

--- a/src/platform-kit/utils/PromiseUtils.ts
+++ b/src/platform-kit/utils/PromiseUtils.ts
@@ -10,6 +10,70 @@ export function delay(ms: number): Promise<void> {
 }
 
 /**
+ * Forces long-running microtasks to yield to the queued macrotasks after some time.
+ *
+ * We need to do this, because the task queue will stall if the microtask queue never clears.
+ *
+ * For example, if a Promise queues other promises that immediately resolve (and add more immediately resolving/resolved
+ * promises - this can be recursively or in a long-running loop), it will just keep adding tasks to the end.
+ *
+ * If the macrotask queue is stalled, other events (websocket, sleep detection, user events, etc.) won't be handled.
+ *
+ * This class works by forcing microtasks that await {@link MicrotaskBouncer#bounce} to wait for a new macrotask once
+ * the maximum allotted time is reached.
+ *
+ * See https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
+ */
+export class MicrotaskBouncer {
+	private evictTimestamp: number | null = null
+
+	// Next macrotask that the microtasks are allowed to run in.
+	private nextMacrotaskPromise: Promise<void> | null = null
+
+	/**
+	 * Create a new bouncer
+	 * @param maxTimeMillis maximum time in milliseconds; this should be a small number (i.e. 100 ms)
+	 * @param dateProvider the current time in milliseconds
+	 */
+	constructor(
+		private readonly maxTimeMillis: number = 100,
+		private readonly dateProvider: () => number = () => Date.now(),
+	) {}
+
+	/**
+	 * If the time slice is over, return a promise that yields to any queued macrotask(s).
+	 */
+	bounce(): Promise<void> {
+		const now = this.dateProvider()
+
+		if (this.evictTimestamp == null) {
+			this.evictTimestamp = now + this.maxTimeMillis
+		} else if (now > this.evictTimestamp) {
+			if (this.nextMacrotaskPromise == null) {
+				// this enqueues a macrotask, forcing anything resolving this to wait until this macrotask is handled
+				// rather than create a new microtask
+				this.nextMacrotaskPromise = new Promise((resolve) => {
+					// no delay = resolve on the next event cycle
+					//
+					// (this will be put at the *end* of the task queue, after all currently scheduled macrotasks)
+					setTimeout(resolve)
+				}).then(() => {
+					// this will only happen once our new macrotask is reached (thus this is safe from race conditions
+					// even if we go beyond our timestamp)
+					this.evictTimestamp = null
+					this.nextMacrotaskPromise = null
+				})
+			}
+
+			// this will make all microtasks using this bouncer converge on this promise
+			return this.nextMacrotaskPromise
+		}
+
+		return Promise.resolve()
+	}
+}
+
+/**
  * Pass to Promise.then to perform an action while forwarding on the result
  * @param action
  */

--- a/test/tests/utils/PromiseUtilTest.ts
+++ b/test/tests/utils/PromiseUtilTest.ts
@@ -1,6 +1,7 @@
 import o, { verify } from "@tutao/otest"
 import { defer, delay, promiseFilter, promiseMap } from "../../../src/platform-kit/utils"
 import { func, matchers, when } from "testdouble"
+import { MicrotaskBouncer } from "../../../src/platform-kit/utils/PromiseUtils"
 
 function mockDeferMapper() {
 	const mapper = func<(el: any, idx: number) => Promise<any>>((n) => n.promise)
@@ -120,6 +121,81 @@ o.spec("PromiseUtils", function () {
 			await delay(1)
 			verify(mapper(matchers.anything(), matchers.anything()), { times: 4 })
 			o(await resultP).deepEquals([1, 4])
+		})
+	})
+
+	o.spec("MicrotaskBouncer", () => {
+		o.test("awaiting bounce yields to queued macro task when the time slice is over", async () => {
+			let isMacrotaskProcessed = false
+			setTimeout(() => {
+				isMacrotaskProcessed = true
+			}, 0)
+
+			let currentDate = 0
+			const microtaskBouncer = new MicrotaskBouncer(2, () => currentDate)
+
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isMacrotaskProcessed).equals(false)
+
+			currentDate = 1
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isMacrotaskProcessed).equals(false)
+
+			currentDate = 2
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isMacrotaskProcessed).equals(false)
+
+			currentDate = 3
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isMacrotaskProcessed).equals(true)
+		})
+
+		o.test("eviction timestamp resets after yielding", async () => {
+			let isFirstMacrotaskProcessed = false
+			setTimeout(() => {
+				isFirstMacrotaskProcessed = true
+			}, 0)
+
+			let currentDate = 0
+			const microtaskBouncer = new MicrotaskBouncer(2, () => currentDate)
+
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isFirstMacrotaskProcessed).equals(false)
+
+			currentDate = 3
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isFirstMacrotaskProcessed).equals(true)
+
+			let isSecondMacrotaskProcessed = false
+			setTimeout(() => {
+				isSecondMacrotaskProcessed = true
+			}, 0)
+
+			currentDate = 4
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isSecondMacrotaskProcessed).equals(false)
+
+			currentDate = 5
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isSecondMacrotaskProcessed).equals(false)
+
+			currentDate = 6
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isSecondMacrotaskProcessed).equals(false)
+
+			currentDate = 7
+			await microtaskBouncer.bounce()
+			await Promise.resolve()
+			o.check(isSecondMacrotaskProcessed).equals(true)
 		})
 	})
 })

--- a/test/tests/utils/PromiseUtilTest.ts
+++ b/test/tests/utils/PromiseUtilTest.ts
@@ -9,16 +9,16 @@ function mockDeferMapper() {
 	return mapper
 }
 
-o.spec("PromiseUtils", function () {
-	o.spec("promiseMap Array<T>", function () {
-		o("empty", async function () {
-			o(await promiseMap([], (n) => n + 1)).deepEquals([])
+o.spec("PromiseUtils", () => {
+	o.spec("promiseMap Array<T>", () => {
+		o.test("empty", async () => {
+			o.check(await promiseMap([], (n) => n + 1)).deepEquals([])
 		})
-		o("non-empty", async function () {
-			o(await promiseMap([1, 2, 3], (n) => n + 1)).deepEquals([2, 3, 4])
+		o.test("non-empty", async () => {
+			o.check(await promiseMap([1, 2, 3], (n) => n + 1)).deepEquals([2, 3, 4])
 		})
 
-		o("parallel", async function () {
+		o.test("parallel", async () => {
 			const defer1 = defer<void>()
 			const defer2 = defer<void>()
 			const defer3 = defer<void>()
@@ -40,7 +40,7 @@ o.spec("PromiseUtils", function () {
 			verify(mapper(matchers.anything(), matchers.anything()), { times: 3 })
 		})
 
-		o("async in order", async function () {
+		o.test("async in order", async () => {
 			const defer1 = defer()
 			const defer2 = defer()
 			const mapper = mockDeferMapper()
@@ -52,9 +52,9 @@ o.spec("PromiseUtils", function () {
 			verify(mapper(matchers.anything(), matchers.anything()), { times: 2 })
 			defer2.resolve(2)
 			await Promise.resolve()
-			o(await resultPromise).deepEquals([1, 2])
+			o.check(await resultPromise).deepEquals([1, 2])
 		})
-		o("stops on rejection", async function () {
+		o.test("stops on rejection", async () => {
 			const defer1 = defer()
 			const defer2 = defer()
 			const mapper = mockDeferMapper()
@@ -62,40 +62,40 @@ o.spec("PromiseUtils", function () {
 			await Promise.resolve()
 			verify(mapper(matchers.anything(), matchers.anything()), { times: 1 })
 			defer1.reject(new Error("test"))
-			await o(() => resultPromise).asyncThrows(Error)
+			await o.check(() => resultPromise).asyncThrows(Error)
 			verify(mapper(matchers.anything(), matchers.anything()), { times: 1 })
 		})
-		o("stops on exception", async function () {
+		o.test("stops on exception", async () => {
 			const mapper = func<(number: number, idx: number) => Promise<number>>()
 			when(mapper(matchers.anything(), matchers.anything()), { ignoreExtraArgs: true }).thenDo(() => {
 				throw new Error("test")
 			})
-			await o(() => promiseMap([1, 2], mapper)).asyncThrows(Error)
+			await o.check(() => promiseMap([1, 2], mapper)).asyncThrows(Error)
 			// we would test that the mapper is called here but testdouble is not supporting that and are being very stubborn about it
 			//https://github.com/testdouble/testdouble.js/issues/412
 		})
 	})
-	o.spec("promiseFilter", function () {
+	o.spec("promiseFilter", () => {
 		async function isEven(n) {
 			return n % 2 === 0
 		}
 
-		o("sync", async function () {
+		o.test("sync", async () => {
 			const arr = [1, 2, 3, 4]
 			const result = await promiseFilter(arr, isEven)
-			o(result).deepEquals([2, 4])
+			o.check(result).deepEquals([2, 4])
 		})
-		o("async", async function () {
+		o.test("async", async () => {
 			const arr = [1, 2, 3, 4]
 			const result = await promiseFilter(arr, (n) => Promise.resolve(isEven(n)))
-			o(result).deepEquals([2, 4])
+			o.check(result).deepEquals([2, 4])
 		})
-		o("index", async function () {
+		o.test("index", async () => {
 			const arr = [1, 2, 3, 4]
 			const result = await promiseFilter(arr, (_, i) => Promise.resolve(isEven(i)))
-			o(result).deepEquals([1, 3])
+			o.check(result).deepEquals([1, 3])
 		})
-		o("no concurrency", async function () {
+		o.test("no concurrency", async () => {
 			// One deferred per each item we want to check
 			const arr = [1, 2, 3, 4]
 			const deferred = [defer<boolean>(), defer<boolean>(), defer<boolean>(), defer<boolean>()]
@@ -120,7 +120,7 @@ o.spec("PromiseUtils", function () {
 			deferred[3].resolve(true)
 			await delay(1)
 			verify(mapper(matchers.anything(), matchers.anything()), { times: 4 })
-			o(await resultP).deepEquals([1, 4])
+			o.check(await resultP).deepEquals([1, 4])
 		})
 	})
 


### PR DESCRIPTION
Microtasks created from promises will block the task queue if the microtask queue never empties. This can occur if we have a long-running loop that continuously creates and resolves promises.

MicrotaskBouncer forces microtasks to yield to the task queue after some time.

We want to use this for mail indexing on web, first, as this issue affects this significantly.

Close #10973