### PR TITLE
fix(desktop): set explicit autoSelectFamilyAttemptTimeout on the net agent

### DIFF
--- a/src/applications/common/desktop/net/NetAgent.ts
+++ b/src/applications/common/desktop/net/NetAgent.ts
@@ -11,9 +11,11 @@ export type FetchImpl = (target: string | URL, init?: UndiciRequestInit) => Prom
 const SOCKET_IDLE_TIMEOUT_MS = 5 * 60 * 1000 + 1000
 /** Timeout between reading data. */
 const READ_TIMEOUT_MS = 20_000
+/** Per-address-family attempt timeout; raised above Node's 250ms default to survive slow IPv4 paths when IPv6 is unreachable. */
+const AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS = 2_000
 
 // We do not enable HTTP2 yet because it is still experimental (and buggy).
-const agent = new Agent({
+export const desktopAgentOptions = {
 	connections: 3,
 	keepAliveTimeout: SOCKET_IDLE_TIMEOUT_MS,
 	bodyTimeout: READ_TIMEOUT_MS,
@@ -21,7 +23,10 @@ const agent = new Agent({
 	connectTimeout: READ_TIMEOUT_MS,
 	// this is needed to address issues in some cases where IPv6 does not really work
 	autoSelectFamily: true,
-})
+	autoSelectFamilyAttemptTimeout: AUTO_SELECT_FAMILY_ATTEMPT_TIMEOUT_MS,
+}
+
+const agent = new Agent(desktopAgentOptions)
 
 export const customFetch: FetchImpl = async (target: string | URL, init?: UndiciRequestInit): Promise<UndiciResponse> => {
 	if (init?.body != null) {

--- a/test/tests/Suite.ts
+++ b/test/tests/Suite.ts
@@ -304,6 +304,7 @@ async function setupSuite({ integration }: { integration?: boolean }) {
 		await import("./desktop/files/TempFsTest.js")
 		await import("./desktop/integration/DesktopIntegratorTest.js")
 		await import("./desktop/integration/WindowsRegistryFacadeTest.js")
+		await import("./desktop/net/NetAgentTest.js")
 		await import("./desktop/net/ProtocolProxyTest.js")
 		await import("./desktop/sse/DesktopAlarmSchedulerTest.js")
 		await import("./desktop/sse/DesktopAlarmStorageTest.js")

--- a/test/tests/desktop/net/NetAgentTest.ts
+++ b/test/tests/desktop/net/NetAgentTest.ts
@@ -1,0 +1,11 @@
+import o from "@tutao/otest"
+import { desktopAgentOptions } from "../../../../src/applications/common/desktop/net/NetAgent.js"
+
+o.spec("NetAgent", function () {
+	o("sets an explicit autoSelectFamilyAttemptTimeout when autoSelectFamily is enabled", function () {
+		if (desktopAgentOptions.autoSelectFamily) {
+			o(typeof desktopAgentOptions.autoSelectFamilyAttemptTimeout).equals("number")
+			o(desktopAgentOptions.autoSelectFamilyAttemptTimeout > 250).equals(true)
+		}
+	})
+})


### PR DESCRIPTION
## Summary
The shared Undici agent enables `autoSelectFamily` but omits `autoSelectFamilyAttemptTimeout`, leaving Node at its 250ms default.

On high-latency paths where IPv4 handshakes take longer than 250ms and public IPv6 is unreachable (e.g. ULA-only networks), the IPv6 attempt returns ENETUNREACH immediately, and Undici throws AggregateError, even though IPv4 would have completed within the configured connectTimeout.

This PR sets autoSelectFamilyAttemptTimeout to 2 seconds, and adds a test that asserts an explicit timeout above 250 ms is always configured alongside
autoSelectFamily.

## Validation
Tested on Fedora Linux and MacOS.

### Scenario
- IPv4-only WAN connectivity
- Local IPv6 ULA enabled
- No public IPv6 route
- Dual-stack DNS responses
- IPv4 handshake approximately 300–340 ms

### Before

- Requests consistently failed after approximately 250 ms.
- Desktop client was unable to complete REST requests.

### After

- Requests complete successfully over IPv4.
- Existing dual-stack behaviour remains unchanged.

Fixes #9536, #8214, #8635