### PR TITLE
Show orphaned custom folders

### DIFF
--- a/src/applications/common/api/common/mail/FolderSystem.ts
+++ b/src/applications/common/api/common/mail/FolderSystem.ts
@@ -1,4 +1,4 @@
-import { groupBy } from "@tutao/utils"
+import { assertNotNull, groupBy } from "@tutao/utils"
 import { elementIdPart, getElementId, isSameId } from "@tutao/meta"
 import { Mail, MailSet } from "@tutao/entities/tutanota"
 import { MailSetKind, SystemFolderType } from "../../../../../entities/tutanota/Utils"
@@ -13,27 +13,37 @@ export interface IndentedFolder {
 export class FolderSystem {
 	readonly systemSubtrees: ReadonlyArray<FolderSubtree>
 	readonly customSubtrees: ReadonlyArray<FolderSubtree>
+	readonly orphanSubtrees: ReadonlyArray<FolderSubtree>
 	readonly importedMailSet: Readonly<MailSet | null>
 
 	constructor(mailSets: readonly MailSet[]) {
-		const mailsetByParent = groupBy(mailSets, (mailSet) => (mailSet.parentFolder ? elementIdPart(mailSet.parentFolder) : null))
+		const mailSetByParent = groupBy(mailSets, (mailSet) => (mailSet.parentFolder ? elementIdPart(mailSet.parentFolder) : null))
+		const existingMailSets = new Set(mailSets.map(getElementId))
 		const systemMailSets: MailSet[] = []
 		const topLevelCustomFolders: MailSet[] = []
+		const topLevelOrphanFolders: MailSet[] = []
 
 		for (const mailSet of mailSets) {
 			if (isVisibleSystemMailSet(mailSet)) {
 				systemMailSets.push(mailSet)
-			} else if (mailSet.folderType === MailSetKind.CUSTOM && isTopLevelMailSet(mailSet)) {
-				topLevelCustomFolders.push(mailSet)
+			} else if (mailSet.folderType === MailSetKind.CUSTOM) {
+				if (isTopLevelMailSet(mailSet)) {
+					topLevelCustomFolders.push(mailSet)
+				} else if (!existingMailSets.has(elementIdPart(assertNotNull(mailSet.parentFolder)))) {
+					topLevelOrphanFolders.push(mailSet)
+				}
 			}
 		}
 
 		this.importedMailSet = mailSets.find((f) => f.folderType === MailSetKind.IMPORTED) || null
-		this.systemSubtrees = systemMailSets.sort(compareSystem).map((f) => this.makeSubtree(mailsetByParent, f, compareCustom))
-		this.customSubtrees = topLevelCustomFolders.sort(compareCustom).map((f) => this.makeSubtree(mailsetByParent, f, compareCustom))
+		this.systemSubtrees = systemMailSets.sort(compareSystem).map((f) => this.makeSubtree(mailSetByParent, f, compareCustom))
+		this.customSubtrees = topLevelCustomFolders.sort(compareCustom).map((f) => this.makeSubtree(mailSetByParent, f, compareCustom))
+		this.orphanSubtrees = topLevelOrphanFolders.sort(compareCustom).map((f) => this.makeSubtree(mailSetByParent, f, compareCustom))
 	}
 
 	getIndentedList(excludeFolder: MailSet | null = null): IndentedFolder[] {
+		// orphanSubtrees are excluded from indentedList because they're only shown so the user can decide whether to
+		// delete or move them to the system/custom subtrees.
 		return [...this.getIndentedFolderList(this.systemSubtrees, excludeFolder), ...this.getIndentedFolderList(this.customSubtrees, excludeFolder)]
 	}
 
@@ -43,7 +53,10 @@ export class FolderSystem {
 	}
 
 	getFolderById(folderId: Id): MailSet | null {
-		const subtree = this.getFolderByIdInSubtrees(this.systemSubtrees, folderId) ?? this.getFolderByIdInSubtrees(this.customSubtrees, folderId)
+		const subtree =
+			this.getFolderByIdInSubtrees(this.systemSubtrees, folderId) ??
+			this.getFolderByIdInSubtrees(this.customSubtrees, folderId) ??
+			this.getFolderByIdInSubtrees(this.orphanSubtrees, folderId)
 		return subtree?.folder ?? null
 	}
 
@@ -64,7 +77,7 @@ export class FolderSystem {
 	 */
 	getCustomFoldersOfParent(parent: IdTuple | null): MailSet[] {
 		if (parent) {
-			const parentFolder = this.getFolderByIdInSubtrees([...this.customSubtrees, ...this.systemSubtrees], elementIdPart(parent))
+			const parentFolder = this.getFolderByIdInSubtrees([...this.orphanSubtrees, ...this.customSubtrees, ...this.systemSubtrees], elementIdPart(parent))
 			return parentFolder ? parentFolder.children.map((child) => child.folder) : []
 		} else {
 			return this.customSubtrees.map((subtree) => subtree.folder)
@@ -72,7 +85,7 @@ export class FolderSystem {
 	}
 
 	getDescendantFoldersOfParent(parent: IdTuple): IndentedFolder[] {
-		const parentFolder = this.getFolderByIdInSubtrees([...this.customSubtrees, ...this.systemSubtrees], elementIdPart(parent))
+		const parentFolder = this.getFolderByIdInSubtrees([...this.orphanSubtrees, ...this.customSubtrees, ...this.systemSubtrees], elementIdPart(parent))
 		if (parentFolder) {
 			return this.getIndentedFolderList([parentFolder]).slice(1)
 		} else {
@@ -82,7 +95,12 @@ export class FolderSystem {
 
 	/** returns all parents of the folder, including the folder itself */
 	getPathToFolder(folderId: IdTuple): MailSet[] {
-		return this.getPathToFolderInSubtrees(this.systemSubtrees, folderId) ?? this.getPathToFolderInSubtrees(this.customSubtrees, folderId) ?? []
+		return (
+			this.getPathToFolderInSubtrees(this.systemSubtrees, folderId) ??
+			this.getPathToFolderInSubtrees(this.customSubtrees, folderId) ??
+			this.getPathToFolderInSubtrees(this.orphanSubtrees, folderId) ??
+			[]
+		)
 	}
 
 	checkFolderForAncestor(folder: MailSet, potentialAncestorId: IdTuple): boolean {

--- a/src/applications/mail-app/mail/view/MailFoldersView.ts
+++ b/src/applications/mail-app/mail/view/MailFoldersView.ts
@@ -7,7 +7,7 @@ import { FolderSubtree, FolderSystem } from "../../../common/api/common/mail/Fol
 import { isSelectedPrefix, NavButtonAttrs, NavButtonColor } from "../../../../ui/base/NavButton.js"
 import { MAIL_PREFIX } from "../../../../ui/utils/RouteChange.js"
 import { MailFolderRow } from "./MailFolderRow.js"
-import { last, Thunk } from "../../../../platform-kit/utils"
+import { isNotEmpty, last, noOp, Thunk } from "../../../../platform-kit/utils"
 import { attachDropdown, DropdownButtonAttrs } from "../../../../ui/base/Dropdown.js"
 import { Icons } from "../../../../ui/base/icons/Icons.js"
 import { ButtonColor } from "../../../../ui/base/Button.js"
@@ -42,6 +42,12 @@ export interface MailFolderViewAttrs {
 
 type Counters = Record<string, number>
 
+const enum FolderSystemKind {
+	System,
+	Custom,
+	Orphan,
+}
+
 /** Displays a tree of all mailSets. */
 export class MailFoldersView implements Component<MailFolderViewAttrs> {
 	// Contains the id of the visible row
@@ -54,6 +60,7 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 		// Important: this array is keyed so each item must have a key and `null` cannot be in the array
 		// So instead we push or not push into array
 		const customSystems = folders?.customSubtrees ?? []
+		const orphanSystems = folders?.orphanSubtrees ?? []
 		const systemSystems = folders?.systemSubtrees ?? []
 		const children: Children = []
 		const selectedFolder = folders
@@ -62,12 +69,14 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 			.find((f) => isSelectedPrefix(MAIL_PREFIX + "/" + getElementId(f)))
 		const path = folders && selectedFolder ? folders.getPathToFolder(selectedFolder._id) : []
 		const isInternalUser = locator.logins.isInternalUserLoggedIn()
-		const systemChildren = folders && this.renderFolderTree(systemSystems, groupCounters, folders, attrs, path, isInternalUser)
+		const systemChildren = folders && this.renderFolderTree(systemSystems, FolderSystemKind.System, groupCounters, folders, attrs, path, isInternalUser)
 		if (systemChildren) {
 			children.push(...systemChildren.children)
 		}
 		if (isInternalUser) {
-			const customChildren = folders ? this.renderFolderTree(customSystems, groupCounters, folders, attrs, path, isInternalUser).children : []
+			const customChildren = folders
+				? this.renderFolderTree(customSystems, FolderSystemKind.Custom, groupCounters, folders, attrs, path, isInternalUser).children
+				: []
 			children.push(
 				m(
 					SidebarSection,
@@ -80,12 +89,31 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 				),
 			)
 			children.push(this.renderAddFolderButtonRow(attrs))
+
+			const orphanChildren = folders
+				? this.renderFolderTree(orphanSystems, FolderSystemKind.Orphan, groupCounters, folders, attrs, path, isInternalUser).children
+				: []
+			if (isNotEmpty(orphanChildren)) {
+				children.push(
+					m(
+						SidebarSection,
+						{
+							name: "failedToDeleteFolders_label",
+							button: !attrs.inEditMode ? this.renderEditFoldersButton(attrs) : null,
+							key: "orphanFolders", // we need to set a key because folder rows also have a key.
+						},
+						orphanChildren,
+					),
+				)
+			}
 		}
+
 		return children
 	}
 
 	private renderFolderTree(
 		subSystems: readonly FolderSubtree[],
+		subSystemsKind: FolderSystemKind,
 		groupCounters: Counters,
 		folders: FolderSystem,
 		attrs: MailFolderViewAttrs,
@@ -118,7 +146,7 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 				isSelectedPrefix: attrs.inEditMode ? false : MAIL_PREFIX + "/" + getElementId(system.folder),
 				colors: NavButtonColor.Nav,
 				click: () => attrs.onFolderClick(system.folder),
-				dropHandler: (dropData) => attrs.onFolderDrop(dropData, system.folder),
+				dropHandler: subSystemsKind === FolderSystemKind.Orphan ? noOp : (dropData) => attrs.onFolderDrop(dropData, system.folder),
 				disableHoverBackground: true,
 				disabled: attrs.inEditMode,
 				dragStartHandler: isNestableMailSet(system.folder)
@@ -141,12 +169,12 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 			const summedCount = !currentExpansionState && hasChildren ? this.getTotalFolderCounter(groupCounters, system) : groupCounters[counterId]
 			const childResult =
 				hasChildren && currentExpansionState
-					? this.renderFolderTree(system.children, groupCounters, folders, attrs, path, isInternalUser, indentationLevel + 1)
+					? this.renderFolderTree(system.children, subSystemsKind, groupCounters, folders, attrs, path, isInternalUser, indentationLevel + 1)
 					: { children: null, numRows: 0 }
 			const isRightButtonVisible = this.visibleRow === id
 			const rightButton =
 				isInternalUser && (isEditableMailSet(system.folder) || canHaveDescendents(system.folder)) && (isRightButtonVisible || attrs.inEditMode)
-					? this.createFolderMoreButton(system.folder, folders, attrs, () => {
+					? this.createFolderMoreButton(system.folder, subSystemsKind, folders, attrs, () => {
 							this.visibleRow = null
 						})
 					: null
@@ -225,7 +253,13 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 		return (counters[counterId] ?? 0) + system.children.reduce((acc, child) => acc + this.getTotalFolderCounter(counters, child), 0)
 	}
 
-	private createFolderMoreButton(folder: MailSet, folders: FolderSystem, attrs: MailFolderViewAttrs, onClose: Thunk): IconButtonAttrs {
+	private createFolderMoreButton(
+		folder: MailSet,
+		folderSystemKind: FolderSystemKind,
+		folders: FolderSystem,
+		attrs: MailFolderViewAttrs,
+		onClose: Thunk,
+	): IconButtonAttrs {
 		return attachDropdown({
 			mainButtonAttrs: {
 				title: "more_label",
@@ -246,8 +280,8 @@ export class MailFoldersView implements Component<MailFolderViewAttrs> {
 			},
 			childAttrs: async () => {
 				return folder.folderType === MailSetKind.CUSTOM
-					? // cannot add new folder to custom folder in spam or trash folder
-						isSpamOrTrashFolder(folders, folder)
+					? // cannot add new folder to custom folder in spam, trash, or orphan folder tree
+						folderSystemKind === FolderSystemKind.Orphan || isSpamOrTrashFolder(folders, folder)
 						? [this.editButtonAttrs(attrs, folders, folder), this.deleteButtonAttrs(attrs, folder)]
 						: [this.editButtonAttrs(attrs, folders, folder), this.addButtonAttrs(attrs, folder), this.deleteButtonAttrs(attrs, folder)]
 					: [this.addButtonAttrs(attrs, folder)]

--- a/test/tests/mail/model/FolderSystemTest.ts
+++ b/test/tests/mail/model/FolderSystemTest.ts
@@ -33,10 +33,47 @@ o.spec("FolderSystem", function () {
 		parentFolder: customSubfolder._id,
 		name: "A",
 	})
+	const orphanFolder = createTestEntity(MailSetTypeRef, {
+		_id: [listId, "orphan"],
+		folderType: MailSetKind.CUSTOM,
+		parentFolder: [listId, "deletedParent"],
+		name: "Orphan",
+	})
+	const subOrphanFolder1 = createTestEntity(MailSetTypeRef, {
+		_id: [listId, "subOrphan1"],
+		folderType: MailSetKind.CUSTOM,
+		parentFolder: orphanFolder._id,
+		name: "Sub-Orphan 1",
+	})
+	const subOrphanFolder2 = createTestEntity(MailSetTypeRef, {
+		_id: [listId, "subOrphan2"],
+		folderType: MailSetKind.CUSTOM,
+		parentFolder: orphanFolder._id,
+		name: "Sub-Orphan 2",
+	})
+	const subSubOrphanFolder = createTestEntity(MailSetTypeRef, {
+		_id: [listId, "subSubOrphan"],
+		folderType: MailSetKind.CUSTOM,
+		parentFolder: subOrphanFolder2._id,
+		name: "Sub-Sub-Orphan",
+	})
 
 	const mail = createTestEntity(MailTypeRef, { _id: ["mailListId", "inbox"], sets: [customSubfolder._id] })
+	const mailInOrphanFolder = createTestEntity(MailTypeRef, { _id: ["mailListId", "orphanMail"], sets: [orphanFolder._id] })
+	const mailInSubOrphanFolder = createTestEntity(MailTypeRef, { _id: ["mailListId", "subOrphanMail"], sets: [subOrphanFolder1._id] })
 
-	const allFolders = [archive, inbox, customFolder, customSubfolder, customSubSubfolder, customSubSubfolderAnother]
+	const allFolders = [
+		archive,
+		inbox,
+		customFolder,
+		customSubfolder,
+		customSubSubfolder,
+		customSubSubfolderAnother,
+		orphanFolder,
+		subOrphanFolder1,
+		subOrphanFolder2,
+		subSubOrphanFolder,
+	]
 
 	o("correctly builds the subtrees", function () {
 		const system = new FolderSystem(allFolders)
@@ -59,6 +96,21 @@ o.spec("FolderSystem", function () {
 				],
 			},
 		])("custom subtrees")
+		o(system.orphanSubtrees).deepEquals([
+			{
+				folder: orphanFolder,
+				children: [
+					{
+						folder: subOrphanFolder1,
+						children: [],
+					},
+					{
+						folder: subOrphanFolder2,
+						children: [{ folder: subSubOrphanFolder, children: [] }],
+					},
+				],
+			},
+		])("orphan subtrees")
 	})
 
 	o("indented list sorts mailSets correctly on the same level", function () {
@@ -120,6 +172,8 @@ o.spec("FolderSystem", function () {
 		const system = new FolderSystem(allFolders)
 
 		o(system.getFolderById(getElementId(archive))).deepEquals(archive)
+		o(system.getFolderById(getElementId(orphanFolder))).deepEquals(orphanFolder)
+		o(system.getFolderById(getElementId(subSubOrphanFolder))).deepEquals(subSubOrphanFolder)
 	})
 
 	o("getFolderById not there returns null", function () {
@@ -131,17 +185,21 @@ o.spec("FolderSystem", function () {
 	o("getFolderByMail", function () {
 		const system = new FolderSystem(allFolders)
 		o(system.getFolderByMail(mail)).equals(customSubfolder)
+		o(system.getFolderByMail(mailInOrphanFolder)).equals(orphanFolder)
+		o(system.getFolderByMail(mailInSubOrphanFolder)).equals(subOrphanFolder1)
 	})
 
 	o("getCustomFoldersOfParent", function () {
 		const system = new FolderSystem(allFolders)
 
 		o(system.getCustomFoldersOfParent(customSubfolder._id)).deepEquals([customSubSubfolderAnother, customSubSubfolder])
+		o(system.getCustomFoldersOfParent(orphanFolder._id)).deepEquals([subOrphanFolder1, subOrphanFolder2])
 	})
 
 	o("getPathToFolder", function () {
 		const system = new FolderSystem(allFolders)
 
 		o(system.getPathToFolder(customSubSubfolder._id)).deepEquals([customFolder, customSubfolder, customSubSubfolder])
+		o(system.getPathToFolder(subSubOrphanFolder._id)).deepEquals([orphanFolder, subOrphanFolder2, subSubOrphanFolder])
 	})
 })

--- a/test/tests/mail/model/FolderSystemTest.ts
+++ b/test/tests/mail/model/FolderSystemTest.ts
@@ -75,14 +75,14 @@ o.spec("FolderSystem", function () {
 		subSubOrphanFolder,
 	]
 
-	o("correctly builds the subtrees", function () {
+	o.test("correctly builds the subtrees", function () {
 		const system = new FolderSystem(allFolders)
 
-		o(system.systemSubtrees).deepEquals([
+		o.check(system.systemSubtrees).deepEquals([
 			{ folder: inbox, children: [] },
 			{ folder: archive, children: [] },
 		])("system subtrees")
-		o(system.customSubtrees).deepEquals([
+		o.check(system.customSubtrees).deepEquals([
 			{
 				folder: customFolder,
 				children: [
@@ -96,7 +96,7 @@ o.spec("FolderSystem", function () {
 				],
 			},
 		])("custom subtrees")
-		o(system.orphanSubtrees).deepEquals([
+		o.check(system.orphanSubtrees).deepEquals([
 			{
 				folder: orphanFolder,
 				children: [
@@ -113,10 +113,10 @@ o.spec("FolderSystem", function () {
 		])("orphan subtrees")
 	})
 
-	o("indented list sorts mailSets correctly on the same level", function () {
+	o.test("indented list sorts mailSets correctly on the same level", function () {
 		const system = new FolderSystem(allFolders)
 
-		o(system.getIndentedList()).deepEquals([
+		o.check(system.getIndentedList()).deepEquals([
 			{ level: 0, folder: inbox },
 			{ level: 0, folder: archive },
 			{ level: 0, folder: customFolder },
@@ -126,7 +126,7 @@ o.spec("FolderSystem", function () {
 		])
 	})
 
-	o("indented list sorts stepsiblings correctly", function () {
+	o.test("indented list sorts stepsiblings correctly", function () {
 		const customFolderAnother = createTestEntity(MailSetTypeRef, {
 			_id: [listId, "customAnother"],
 			folderType: MailSetKind.CUSTOM,
@@ -141,7 +141,7 @@ o.spec("FolderSystem", function () {
 
 		const system = new FolderSystem([...allFolders, customFolderAnother, customFolderAnotherSub])
 
-		o(system.getIndentedList()).deepEquals([
+		o.check(system.getIndentedList()).deepEquals([
 			{ level: 0, folder: inbox },
 			{ level: 0, folder: archive },
 			{ level: 0, folder: customFolderAnother },
@@ -153,53 +153,53 @@ o.spec("FolderSystem", function () {
 		])
 	})
 
-	o("indented list will not return folder or descendants of given folder", function () {
+	o.test("indented list will not return folder or descendants of given folder", function () {
 		const system = new FolderSystem(allFolders)
-		o(system.getIndentedList(customSubfolder)).deepEquals([
+		o.check(system.getIndentedList(customSubfolder)).deepEquals([
 			{ level: 0, folder: inbox },
 			{ level: 0, folder: archive },
 			{ level: 0, folder: customFolder },
 		])
 	})
 
-	o("getSystemFolderByType", function () {
+	o.test("getSystemFolderByType", function () {
 		const system = new FolderSystem(allFolders)
 
-		o(system.getSystemFolderByType(MailSetKind.ARCHIVE)).deepEquals(archive)
+		o.check(system.getSystemFolderByType(MailSetKind.ARCHIVE)).deepEquals(archive)
 	})
 
-	o("getFolderById", function () {
+	o.test("getFolderById", function () {
 		const system = new FolderSystem(allFolders)
 
-		o(system.getFolderById(getElementId(archive))).deepEquals(archive)
-		o(system.getFolderById(getElementId(orphanFolder))).deepEquals(orphanFolder)
-		o(system.getFolderById(getElementId(subSubOrphanFolder))).deepEquals(subSubOrphanFolder)
+		o.check(system.getFolderById(getElementId(archive))).deepEquals(archive)
+		o.check(system.getFolderById(getElementId(orphanFolder))).deepEquals(orphanFolder)
+		o.check(system.getFolderById(getElementId(subSubOrphanFolder))).deepEquals(subSubOrphanFolder)
 	})
 
-	o("getFolderById not there returns null", function () {
+	o.test("getFolderById not there returns null", function () {
 		const system = new FolderSystem(allFolders)
 
-		o(system.getFolderById("randomId")).equals(null)
+		o.check(system.getFolderById("randomId")).equals(null)
 	})
 
-	o("getFolderByMail", function () {
+	o.test("getFolderByMail", function () {
 		const system = new FolderSystem(allFolders)
-		o(system.getFolderByMail(mail)).equals(customSubfolder)
-		o(system.getFolderByMail(mailInOrphanFolder)).equals(orphanFolder)
-		o(system.getFolderByMail(mailInSubOrphanFolder)).equals(subOrphanFolder1)
+		o.check(system.getFolderByMail(mail)).equals(customSubfolder)
+		o.check(system.getFolderByMail(mailInOrphanFolder)).equals(orphanFolder)
+		o.check(system.getFolderByMail(mailInSubOrphanFolder)).equals(subOrphanFolder1)
 	})
 
-	o("getCustomFoldersOfParent", function () {
+	o.test("getCustomFoldersOfParent", function () {
 		const system = new FolderSystem(allFolders)
 
-		o(system.getCustomFoldersOfParent(customSubfolder._id)).deepEquals([customSubSubfolderAnother, customSubSubfolder])
-		o(system.getCustomFoldersOfParent(orphanFolder._id)).deepEquals([subOrphanFolder1, subOrphanFolder2])
+		o.check(system.getCustomFoldersOfParent(customSubfolder._id)).deepEquals([customSubSubfolderAnother, customSubSubfolder])
+		o.check(system.getCustomFoldersOfParent(orphanFolder._id)).deepEquals([subOrphanFolder1, subOrphanFolder2])
 	})
 
-	o("getPathToFolder", function () {
+	o.test("getPathToFolder", function () {
 		const system = new FolderSystem(allFolders)
 
-		o(system.getPathToFolder(customSubSubfolder._id)).deepEquals([customFolder, customSubfolder, customSubSubfolder])
-		o(system.getPathToFolder(subSubOrphanFolder._id)).deepEquals([orphanFolder, subOrphanFolder2, subSubOrphanFolder])
+		o.check(system.getPathToFolder(customSubSubfolder._id)).deepEquals([customFolder, customSubfolder, customSubSubfolder])
+		o.check(system.getPathToFolder(subSubOrphanFolder._id)).deepEquals([orphanFolder, subOrphanFolder2, subSubOrphanFolder])
 	})
 })


### PR DESCRIPTION
This reverts commit dff7ab50e6b0a6b26c2bca2e9e434121158a1f55 to re-add "Failed-to-delete folders" section after it was rolled back in the hopes of fixing an issue with old folders not showing.

The change can be safely re-added, since we now know old folders not showing was not caused by this change.

Close #11081