### PR TITLE
Drive: make context menu target / reset active selection

### DIFF
--- a/src/applications/drive-app/drive/view/DriveFolderContent.ts
+++ b/src/applications/drive-app/drive/view/DriveFolderContent.ts
@@ -39,6 +39,7 @@ export interface DriveFolderContentAttrs {
 	listState: ListState<FolderItem>
 	selectionEvents: DriveFolderSelectionEvents
 	onDropInto: (f: FolderItem, event: DragEvent) => unknown
+	onEntryContextMenu: (f: FolderItem, event: MouseEvent) => unknown
 	clipboard: DriveClipboard | null
 }
 
@@ -88,7 +89,7 @@ export class DriveFolderContent implements Component<DriveFolderContentAttrs> {
 	private focusedOnMoreActions: boolean = false
 
 	view({
-		attrs: { selection, sortOrder, onSort, fileActions, selectionEvents, listState, clipboard, onDropInto },
+		attrs: { selection, sortOrder, onSort, fileActions, selectionEvents, listState, clipboard, onDropInto, onEntryContextMenu },
 	}: Vnode<DriveFolderContentAttrs>): Children {
 		return m(
 			"div.flex.col.overflow-hidden.column-gap-12",
@@ -198,6 +199,7 @@ export class DriveFolderContent implements Component<DriveFolderContentAttrs> {
 										}
 									},
 									onDropInto,
+									onContextMenu: onEntryContextMenu,
 								} satisfies DriveFolderContentEntryAttrs & CommonAttributes<DriveFolderContentEntryAttrs, DriveFolderContentEntry>),
 							),
 						),

--- a/src/applications/drive-app/drive/view/DriveFolderContentEntry.ts
+++ b/src/applications/drive-app/drive/view/DriveFolderContentEntry.ts
@@ -4,12 +4,11 @@ import { Icon, IconSize } from "../../../../ui/base/Icon"
 import { Icons } from "../../../../ui/base/icons/Icons"
 import { assertNotNull, filterInt } from "../../../../platform-kit/utils"
 import { IconButton, IconButtonAttrs } from "../../../../ui/base/IconButton"
-import { attachDropdown, DomRectReadOnlyPolyfilled, Dropdown } from "../../../../ui/base/Dropdown"
+import { attachDropdown } from "../../../../ui/base/Dropdown"
 import { theme } from "../../../../ui/theme"
-import { modal } from "../../../../ui/base/Modal"
 import { FolderItem } from "./DriveUtils"
 import { TabIndex } from "../../../../platform-kit/app-env"
-import { getContextActions, isDraggingDriveItems } from "./DriveGuiUtils"
+import { getFileContextActions, isDraggingDriveItems } from "./DriveGuiUtils"
 import { getDisplayType, getFileIcon, getItemIconFill } from "../model/DriveMimeUtils"
 
 export interface FileActions {
@@ -38,6 +37,7 @@ export interface DriveFolderContentEntryAttrs {
 	onDropInto: (f: FolderItem, event: DragEvent) => unknown
 	onDragEnd: () => unknown
 	isCut: boolean
+	onContextMenu: (f: FolderItem, event: MouseEvent) => unknown
 	onDomUpdated?: (dom: HTMLElement, moreActionsDom: HTMLElement) => unknown
 }
 
@@ -62,8 +62,9 @@ export class DriveFolderContentEntry implements Component<DriveFolderContentEntr
 			onDragStart,
 			onDragEnd,
 			onDropInto,
+			onContextMenu,
 			isCut,
-			fileActions: { onCopy, onCut, onTrash, onRestore, onOpenItem, onRename, onStartMove, onDelete, onDownload },
+			fileActions,
 		},
 	}: Vnode<DriveFolderContentEntryAttrs>): Children {
 		const updatedDate = item.type === "file" ? item.file.updatedDate : item.folder.updatedDate
@@ -120,18 +121,13 @@ export class DriveFolderContentEntry implements Component<DriveFolderContentEntr
 							onSingleSelection(item)
 						}
 					} else if (event.detail === 2) {
-						onOpenItem(item)
+						fileActions.onOpenItem(item)
 					}
 				},
 				oncontextmenu: (e: MouseEvent) => {
+					onContextMenu(item, e)
 					e.preventDefault()
 					e.stopPropagation()
-					const dropdown = new Dropdown(
-						() => getContextActions(item, onRename, onCopy, onCut, onRestore, onTrash, onStartMove, onDelete, onDownload),
-						300,
-					)
-					dropdown.setOrigin(new DomRectReadOnlyPolyfilled(e.clientX, e.clientY, 0, 0))
-					modal.displayUnique(dropdown, false)
 				},
 			},
 			[
@@ -182,7 +178,7 @@ export class DriveFolderContentEntry implements Component<DriveFolderContentEntr
 									// is focused programmatically
 									tabindex: TabIndex.Programmatic,
 								},
-								childAttrs: async () => getContextActions(item, onRename, onCopy, onCut, onRestore, onTrash, onStartMove, onDelete, onDownload),
+								childAttrs: async () => getFileContextActions(item, fileActions),
 							}),
 							oncreate: (vnode: VnodeDOM<IconButtonAttrs, _NoLifecycle<IconButton>>) => {
 								this.moreButtonDom = vnode.dom as HTMLElement

--- a/src/applications/drive-app/drive/view/DriveFolderContentMobile.ts
+++ b/src/applications/drive-app/drive/view/DriveFolderContentMobile.ts
@@ -10,7 +10,7 @@ import { IconButton } from "../../../../ui/base/IconButton"
 import { attachDropdown } from "../../../../ui/base/Dropdown"
 import { formatDateTime, formatStorageSize } from "../../../../ui/utils/Formatter"
 import { FileActions } from "./DriveFolderContentEntry"
-import { getContextActions } from "./DriveGuiUtils"
+import { getFileContextActions } from "./DriveGuiUtils"
 import { DriveFolderSelectionEvents } from "./DriveFolderContent"
 import { getDisplayType, getFileIcon, getItemIconFill } from "../model/DriveMimeUtils"
 import { assertNotNull, filterInt } from "@tutao/utils"
@@ -121,9 +121,8 @@ class DriveFolderItemRow implements ViewHolder<FolderItem> {
 								title: "more_label",
 							},
 							childAttrs: async () => {
-								const { onCopy, onCut, onDelete, onDownload, onRename, onRestore, onStartMove, onTrash } = this.fileActions()
 								if (this.item) {
-									return getContextActions(this.item, onRename, onCopy, onCut, onRestore, onTrash, onStartMove, onDelete, onDownload)
+									return getFileContextActions(this.item, this.fileActions())
 								} else {
 									return []
 								}

--- a/src/applications/drive-app/drive/view/DriveFolderView.ts
+++ b/src/applications/drive-app/drive/view/DriveFolderView.ts
@@ -11,8 +11,8 @@ import { theme } from "../../../../ui/theme"
 import { IconMessageBox } from "../../../../ui/base/ColumnEmptyMessageBox"
 import { LayerType } from "../../../../ui/base/RootView"
 import { Icon, IconSize } from "../../../../ui/base/Icon"
-import { DomRectReadOnlyPolyfilled, Dropdown } from "../../../../ui/base/Dropdown"
-import { isMobileDriveLayout, newItemActions, parseDragItems } from "./DriveGuiUtils"
+import { DomRectReadOnlyPolyfilled, Dropdown, DropdownChildAttrs } from "../../../../ui/base/Dropdown"
+import { getFileContextActions, getSelectionContextActions, isMobileDriveLayout, newItemActions, parseDragItems } from "./DriveGuiUtils"
 import { modal } from "../../../../ui/base/Modal"
 import { DropType } from "../../../../ui/base/GuiUtils"
 import { FileActions } from "./DriveFolderContentEntry"
@@ -120,6 +120,8 @@ export class DriveFolderView implements Component<DriveFolderViewAttrs> {
 						const dropdown = new Dropdown(() => newItemActions({ onUploadFiles, onCreateFolder, onUploadFolders, onPaste }), 300)
 						dropdown.setOrigin(new DomRectReadOnlyPolyfilled(e.clientX, e.clientY, 0, 0))
 						modal.displayUnique(dropdown, false)
+
+						selectionEvents.onSelectNone()
 					}
 				},
 				onclick: (e: MouseEvent) => {
@@ -149,9 +151,37 @@ export class DriveFolderView implements Component<DriveFolderViewAttrs> {
 						listState,
 						selectionEvents,
 						clipboard,
+						onEntryContextMenu: (f, e) =>
+							this.onEntryContextMenu(f, e, selection, selectionEvents, selectedItemsActions, fileActions, listState.selectedItems.has(f)),
 					} satisfies DriveFolderContentAttrs),
 		)
 	}
+
+	private onEntryContextMenu(
+		item: FolderItem,
+		e: MouseEvent,
+		selection: SelectionState,
+		selectionEvents: DriveFolderSelectionEvents,
+		selectedItemsActions: DriveSelectedItemsActions,
+		fileActions: FileActions,
+		isItemSelected: boolean,
+	) {
+		let contextActions: DropdownChildAttrs[]
+
+		if (isItemSelected && selection.type === "multiselect") {
+			contextActions = getSelectionContextActions(selectedItemsActions)
+		} else {
+			selectionEvents.onSingleSelection(item)
+
+			// Nothing is selected, open the context menu for the item that received the event.
+			contextActions = getFileContextActions(item, fileActions)
+		}
+
+		const dropdown = new Dropdown(() => contextActions, 300)
+		dropdown.setOrigin(new DomRectReadOnlyPolyfilled(e.clientX, e.clientY, 0, 0))
+		modal.displayUnique(dropdown, false)
+	}
+
 	private renderEmptyView(folder: DriveFolder | null): Children {
 		return m(
 			"",

--- a/src/applications/drive-app/drive/view/DriveGuiUtils.ts
+++ b/src/applications/drive-app/drive/view/DriveGuiUtils.ts
@@ -10,6 +10,8 @@ import { DriveFolder } from "@tutao/entities/drive"
 import { getFileBaseNameAndExtensions } from "../../../../ui/utils/FileUtils"
 import { isBrowser, isDesktop } from "@tutao/app-env"
 import { isNotNull } from "@tutao/utils"
+import { FileActions } from "./DriveFolderContentEntry"
+import { DriveSelectedItemsActions } from "./DriveFolderNav"
 
 export function newItemActions({
 	onUploadFiles,
@@ -143,17 +145,11 @@ export function driveFolderName(folder: DriveFolder): Translation {
 			return lang.makeTranslation(`${folder.name}`, folder.name)
 	}
 }
-export function getContextActions(
-	item: FileFolderItem | FolderFolderItem,
-	onRename: (f: FolderItem) => unknown,
-	onCopy: (f: FolderItem) => unknown,
-	onCut: (f: FolderItem) => unknown,
-	onRestore: (f: FolderItem) => unknown,
-	onTrash: (f: FolderItem) => unknown,
-	onStartMove: (f: FolderItem) => unknown,
-	onDelete: (f: FolderItem) => unknown,
-	onDownload: (f: FolderItem) => unknown,
-): DropdownChildAttrs[] {
+
+// NOTE: Keep the order roughly in sync with getSelectionContextActions.
+export function getFileContextActions(item: FileFolderItem | FolderFolderItem, fileActions: FileActions): DropdownChildAttrs[] {
+	const { onRename, onCopy, onCut, onRestore, onTrash, onStartMove, onDelete, onDownload } = fileActions
+
 	const itemInTrash = (item.type === "file" && item.file.originalParent != null) || (item.type === "folder" && item.folder.originalParent != null)
 
 	// Caution: when adding actions, make sure they match the order in the action bar.
@@ -223,6 +219,85 @@ export function getContextActions(
 			},
 		)
 	}
+	return actions
+}
+
+// NOTE: Keep the order roughly in sync with getFileContextActions.
+export function getSelectionContextActions(selectionActions: DriveSelectedItemsActions): DropdownChildAttrs[] {
+	const { onCopy, onCut, onDelete, onDownload, onMove, onPaste, onRestore, onTrash } = selectionActions
+
+	const actions: DropdownChildAttrs[] = []
+
+	if (onDownload) {
+		actions.push({
+			label: "download_action",
+			icon: Icons.DownloadFilled,
+			click: () => {
+				onDownload()
+			},
+		})
+	}
+
+	if (onCopy) {
+		actions.push({
+			label: "copy_action",
+			icon: Icons.CopyFilled,
+			click: () => {
+				onCopy()
+			},
+		})
+	}
+
+	if (onCut) {
+		actions.push({
+			label: "cut_action",
+			icon: Icons.ScissorsFilled,
+			click: () => {
+				onCut()
+			},
+		})
+	}
+
+	if (onMove) {
+		actions.push({
+			label: "move_action",
+			icon: Icons.Move,
+			click: () => {
+				onMove()
+			},
+		})
+	}
+
+	if (onTrash) {
+		actions.push({
+			label: "trash_action",
+			icon: Icons.TrashFilled,
+			click: () => {
+				onTrash()
+			},
+		})
+	}
+
+	if (onRestore) {
+		actions.push({
+			label: "restoreFromTrash_action",
+			icon: Icons.ArrowBackFilled,
+			click: () => {
+				onRestore()
+			},
+		})
+	}
+
+	if (onDelete) {
+		actions.push({
+			label: "delete_action",
+			icon: Icons.TrashCrossFilled,
+			click: () => {
+				onDelete()
+			},
+		})
+	}
+
 	return actions
 }
 


### PR DESCRIPTION
Ensures that:

- right-clicking on a group of selected files shows a context menu
  targeting all these files, not just the file under the cursor
- right-clicking on a non-selected file clears the current selection
  (if there is one) and opens a file-specific context menu
- right-clicking on empty space clears the selection (like left-click)

tuta#3693