### PR TITLE
fix user key rotation of admin user

### DIFF
--- a/src/platform-kit/base/base-crypto/KeyRotationFacade.ts
+++ b/src/platform-kit/base/base-crypto/KeyRotationFacade.ts
@@ -56,7 +56,6 @@ import {
 	createKeyPair,
 	createMembershipPutIn,
 	createPubEncKeyData,
-	createPublicKeySignature,
 	createRecoverCodeData,
 	createUserGroupKeyRotationData,
 	createUserGroupKeyRotationPostIn,
@@ -90,8 +89,9 @@ import {
 } from "@tutao/entities/sys"
 import { AccountType, GroupType } from "../../../entities/sys/Utils"
 import { assertEnumValue, elementIdPart, getElementId, isSameId, isSameTypeRef, listIdPart } from "@tutao/meta"
-import { asPublicKeyIdentifier, PublicKeySignatureType } from "./Constants"
+import { asPublicKeyIdentifier } from "./Constants"
 import { GroupInvitationPostData, InternalRecipientKeyData, InternalRecipientKeyDataTypeRef } from "@tutao/entities/tutanota"
+import { toEncryptedKeyPair } from "./EncryptedKeyPair"
 
 assertWorkerOrNode()
 
@@ -1051,7 +1051,10 @@ export class KeyRotationFacade {
 		)
 
 		// decrypt his private distribution key
-		const adminGroupDistKeyPair = this.cryptoWrapper.decryptKeyPair(adminGroupKeyDistributionKeyPairKey, userGroupKeyRotation.adminDistKeyPair)
+		const adminGroupDistKeyPair = this.cryptoWrapper.decryptKeyPair(
+			adminGroupKeyDistributionKeyPairKey,
+			toEncryptedKeyPair(userGroupKeyRotation.adminDistKeyPair),
+		)
 		//decrypt new symmetric admin group key
 		const senderIdentifier = {
 			identifier: assertNotNull(distEncAdminGroupSymKey.senderIdentifier),

--- a/src/platform-kit/crypto/instance-pipeline-crypto/KeyEncryption.ts
+++ b/src/platform-kit/crypto/instance-pipeline-crypto/KeyEncryption.ts
@@ -12,6 +12,7 @@ import { SYMMETRIC_CIPHER_FACADE } from "./SymmetricCipherFacade.js"
 import { ProgrammingError } from "@tutao/app-env"
 
 export abstract class EncryptedKeyPairs {
+	#brand: undefined // make sure the type system understands that this is not the regular KeyPair type
 	constructor() {} // public readonly pubKyberKey: null | Uint8Array, // public readonly pubEccKey: null | Uint8Array,
 }
 

--- a/test/tests/network/crypto/facades/KeyRotationFacadeTest.ts
+++ b/test/tests/network/crypto/facades/KeyRotationFacadeTest.ts
@@ -109,6 +109,7 @@ import { ServiceExecutor } from "../../../../../src/platform-kit/network/Service
 import { AccountType, GroupType } from "../../../../../src/entities/sys/Utils"
 import { EncryptedPqKeyPairs } from "../../../../../src/platform-kit/crypto/instance-pipeline-crypto/KeyEncryption"
 import { CryptoWrapper } from "../../../../../src/platform-kit/crypto/instance-pipeline-crypto/CryptoWrapper"
+import { toEncryptedKeyPair } from "../../../../../src/platform-kit/base/base-crypto/EncryptedKeyPair"
 
 const { anything } = matchers
 const PQ_SAFE_BITARRAY_KEY_LENGTH = getKeyLengthInBytes(AesKeyLength.Aes256) / 4
@@ -410,7 +411,7 @@ function prepareMultiAdminUserKeyRotation(
 
 	when(mocks.keyLoaderFacade.getCurrentSymGroupKey(adminGroupId)).thenResolve(CURRENT_ADMIN_GROUP_KEY)
 
-	when(mocks.cryptoWrapper.decryptKeyPair(adminGroupDistributionKeyPairKey, encryptedAdminDistKeyPair as EncryptedPqKeyPairs)).thenReturn(adminDistPqKeyPair)
+	when(mocks.cryptoWrapper.decryptKeyPair(adminGroupDistributionKeyPairKey, toEncryptedKeyPair(encryptedAdminDistKeyPair))).thenReturn(adminDistPqKeyPair)
 	when(mocks.asymmetricCryptoFacade.decryptSymKeyWithKeyPairAndAuthenticate(adminDistPqKeyPair, distEncAdminGroupSymKey, anything())).thenResolve({
 		decryptedAesKey: NEW_ADMIN_GROUP_KEY.object,
 	})


### PR DESCRIPTION
the instanceof check in decryptKeyPar does not work because we pass a KeyPair and not EncryptedKeyPairs this should be detected by the type system, so we add a branding to the type

we fix the bug by converting the KeyPair in KeyRotationFacade

#tuta3715