### PR TITLE
[ios] Fix infinite recursion when encoding null in SQL

### DIFF
--- a/app-ios/TutanotaSharedFramework/Sql/TaggedSqlValue.swift
+++ b/app-ios/TutanotaSharedFramework/Sql/TaggedSqlValue.swift
@@ -23,7 +23,7 @@ public enum SqlType: String {
 		switch self {
 		case .null:
 			try container.encode(SqlType.null.rawValue, forKey: .type)
-			try container.encode(self, forKey: .value)
+			try container.encodeNil(forKey: .value)
 		case .number(let value):
 			try container.encode(SqlType.number.rawValue, forKey: .type)
 			try container.encode(value, forKey: .value)


### PR DESCRIPTION
This was caused by passing the instance we're encoding into encode(), which will therefore call encode on the instance again and again until the stack runs out.

We were probably never encoding null before, hence it was never caught until we introduced an offline migration that has a nullable value.

Instead we can just call encodeNil to basically encode no value.

Closes #11170