### PR TITLE
Fix `searched until date` in quickSearch

### DIFF
--- a/src/applications/mail-app/search/SearchBarOverlay.ts
+++ b/src/applications/mail-app/search/SearchBarOverlay.ts
@@ -20,6 +20,7 @@ import { renderSearchInOurApps } from "./view/SearchView"
 import { isTutaTeamMail } from "../../common/mailFunctionality/SharedMailUtils"
 import { companyTeamLabel } from "../../../platform-kit/app-env/boot/ClientConstants"
 import { formatEventDuration } from "../../calendar-app/calendar/gui/DateTimeTextFormatterUtils"
+import { isNonBlockingSearchAvailable } from "./model/SearchUtils"
 
 type SearchBarOverlayAttrs = {
 	state: SearchBarState
@@ -105,7 +106,9 @@ export class SearchBarOverlay implements Component<SearchBarOverlayAttrs> {
 		}
 
 		if (showMoreAction.indexTimestamp > FULL_INDEXED_TIMESTAMP && !indexInfo) {
-			indexInfo = lang.get("searchedUntil_msg") + " " + formatDate(new Date(showMoreAction.indexTimestamp))
+			indexInfo = isNonBlockingSearchAvailable()
+				? lang.get("searchedUntil_msg") + " " + formatDate(new Date(showMoreAction.indexTimestamp))
+				: lang.get("notAllMailsSearchable_msg")
 		}
 
 		return indexInfo


### PR DESCRIPTION
show `searched until date` only in webview and in app while indexing 
show `not all emails are searchable` message

Close #11179