### PR TITLE
Show partial search result when offline db is partially indexed

### DIFF
--- a/src/applications/mail-app/search/model/SearchModel.ts
+++ b/src/applications/mail-app/search/model/SearchModel.ts
@@ -8,7 +8,15 @@ import { assertNonNull, assertNotNull, incrementMonth, lazyAsync, ofClass, token
 import { ProgressTracker } from "../../../common/api/main/ProgressTracker.js"
 import { CalendarEventsRepository } from "../../../common/calendar/date/CalendarEventsRepository.js"
 import { SearchFacade } from "../../workerUtils/index/SearchFacade"
-import { areResultsForTheSameQuery, hasMoreResults, isSameSearchRestriction, isSameSearchRestrictionWithRangeExtended, searchQueryEquals } from "./SearchUtils"
+import {
+	areResultsForTheSameQuery,
+	hasMoreResults,
+	isIncompleteMailResult,
+	isNonBlockingSearchAvailable,
+	isSameSearchRestriction,
+	isSameSearchRestrictionWithRangeExtended,
+	searchQueryEquals,
+} from "./SearchUtils"
 import { getMailIndexTimestampForSearch } from "../../../common/api/common/utils/IndexUtils"
 import { ProgressMonitorInterface } from "../../../../platform-kit/network/ProgressMonitorInterface"
 import { CalendarEvent, CalendarEventTypeRef, ContactTypeRef, MailTypeRef } from "@tutao/entities/tutanota"
@@ -76,14 +84,19 @@ export class SearchModel {
 			end: this.lastQuery?.restriction?.end,
 		}
 
-		if (this.lastQuery && searchQueryEquals(searchQuery, this.lastQuery)) {
+		const result = this.result()
+		if (
+			this.lastQuery &&
+			searchQueryEquals(searchQuery, this.lastQuery) &&
+			// we search again for same query, if current result is for mail and index was extended since result was created
+			!(result && isIncompleteMailResult(result, this.indexState().currentMailIndexTimestamp))
+		) {
 			return this.lastSearchPromise
 		}
 
 		this.lastQuery = searchQuery
 		const { query, restriction, minSuggestionCount, maxResults } = searchQuery
 		this.lastQueryString(query)
-		let result = this.result()
 
 		if (result && !isSameTypeRef(restriction.type, result.restriction.type)) {
 			// reset the result in case only the search type has changed
@@ -280,28 +293,15 @@ export class SearchModel {
 			this.result(calendarResult)
 			this.lastSearchPromise = Promise.resolve(calendarResult)
 		} else if (isSameTypeRef(MailTypeRef, restriction.type)) {
-			// we set search end when null to be able to tell when the same search is extended
-			const indexState = this.indexState()
-
-			const aimedTimestamp = indexState.aimedMailIndexTimestamp
-			const currentTimestamp = indexState.currentMailIndexTimestamp
-
-			if (restriction.end == null) {
-				restriction.end = getMailIndexTimestampForSearch(aimedTimestamp)
+			if (isNonBlockingSearchAvailable() && restriction.end == null) {
+				// we set search end when null to be able to tell when the same search is extended
+				const indexState = this.indexState()
+				restriction.end = getMailIndexTimestampForSearch(indexState.aimedMailIndexTimestamp)
 			}
 
-			// We modify the query because we need SearchFacade to not give us mails older than the current
-			// timestamp, as the offline cleaner may not have purged all emails yet.
-			//
-			// We can only be certain about mails up to currentTimestamp.
-			const truncatedRestriction = { ...restriction, end: Math.max(currentTimestamp, restriction.end) }
-
 			this.lastSearchPromise = this._searchFacade
-				.search(query, truncatedRestriction, minSuggestionCount, maxResults ?? undefined)
+				.search(query, restriction, minSuggestionCount, maxResults ?? undefined)
 				.then((result) => {
-					// we put back in the original restriction as we want the user's query to be put in here, not the
-					// modified request
-					result.restriction = restriction
 					this.result(result)
 					return result
 				})
@@ -338,6 +338,10 @@ export class SearchModel {
 	 * @param extensionEnd timestamp to which current result should be extended
 	 */
 	async extendCurrentResult(extensionEnd: number): Promise<void> {
+		if (!isNonBlockingSearchAvailable()) {
+			throw new ProgrammingError("Tried to extend search result but non-blocking search isn't available")
+		}
+
 		await this.lastSearchPromise
 		await this.lastSearchExtensionPromise
 

--- a/src/applications/mail-app/search/model/SearchUtils.ts
+++ b/src/applications/mail-app/search/model/SearchUtils.ts
@@ -385,6 +385,21 @@ export function hasMoreResults(searchResult: SearchResult): boolean {
 }
 
 /**
+ * @return true for mail result where search range goes beyond indexed range, and indexed range was extended since
+ * the search result was created
+ */
+export function isIncompleteMailResult(searchResult: SearchResult, currentIndexTimestamp: number): boolean {
+	if (
+		!isSameTypeRef(MailTypeRef, searchResult.restriction.type) ||
+		(searchResult.restriction.end != null && searchResult.restriction.end >= searchResult.currentIndexTimestamp)
+	) {
+		return false
+	}
+
+	return searchResult.currentIndexTimestamp > currentIndexTimestamp
+}
+
+/**
  * @return true if non-blocking search is used on the current client
  */
 export function isNonBlockingSearchAvailable(): boolean {

--- a/src/applications/mail-app/search/view/SearchListView.ts
+++ b/src/applications/mail-app/search/view/SearchListView.ts
@@ -48,6 +48,8 @@ export interface SearchListViewAttrs {
 	indexStateStream: Stream<SearchIndexStateInfo>
 	currentStartDate: Date | null
 	extendSearchResult: (extendDate: Date | null) => unknown
+	isIncompleteMailList: boolean
+	searchAndRecreateMailList: () => unknown
 }
 
 export class SearchListView implements Component<SearchListViewAttrs> {
@@ -168,6 +170,20 @@ export class SearchListView implements Component<SearchListViewAttrs> {
 				},
 				this.renderShowMoreButton(extendToDate),
 			)
+		} else if (
+			attrs.listModel.state.loadingStatus === ListLoadingState.Done &&
+			attrs.indexStateStream().currentMailIndexTimestamp === FULL_INDEXED_TIMESTAMP &&
+			attrs.isIncompleteMailList
+		) {
+			innerChildren = m(
+				"",
+				{
+					onclick: () => {
+						attrs.searchAndRecreateMailList()
+					},
+				},
+				this.renderReloadListButton(),
+			)
 		} else {
 			return null
 		}
@@ -185,6 +201,13 @@ export class SearchListView implements Component<SearchListViewAttrs> {
 			},
 			innerChildren,
 		)
+	}
+
+	private renderReloadListButton(): Children {
+		return [
+			m(".flex-center.content-accent-fg.b", lang.getTranslationText("reloadList_action")),
+			m(".bottom.small", lang.getTranslationText("moreEmailsAvailable_msg")),
+		]
 	}
 
 	private renderShowMoreButton(searchUntilDate: Date | null): Children {

--- a/src/applications/mail-app/search/view/SearchView.ts
+++ b/src/applications/mail-app/search/view/SearchView.ts
@@ -269,6 +269,10 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 							void showNotAvailableForFreeDialog(UpgradePromptType.EXTEND_MAIL_SEARCH_RANGE)
 						}
 					},
+					isIncompleteMailList: this.searchViewModel.isIncompleteMailList(),
+					searchAndRecreateMailList: () => {
+						this.searchViewModel.searchAgainAndRecreateList()
+					},
 				} satisfies SearchListViewAttrs),
 			),
 		])

--- a/src/applications/mail-app/search/view/SearchViewModel.ts
+++ b/src/applications/mail-app/search/view/SearchViewModel.ts
@@ -53,6 +53,7 @@ import {
 	getRestriction,
 	getSearchUrl,
 	hasMoreResults,
+	isIncompleteMailResult,
 	isNonBlockingSearchAvailable,
 	isSameSearchRestriction,
 	searchCategoryForRestriction,
@@ -307,24 +308,12 @@ export class SearchViewModel {
 		if (searchQuery == null) {
 			// no search query at all yet
 			listModel.updateLoadingStatus(ListLoadingState.Done)
-		} else if (this.search.isSameSearchWithExtendedRange(searchQuery, restriction)) {
+		} else if (isNonBlockingSearchAvailable() && this.search.isSameSearchWithExtendedRange(searchQuery, restriction)) {
 			if (restriction.end != null) {
 				this.search.extendCurrentResult(restriction.end).catch(() => listModel.updateLoadingStatus(ListLoadingState.ConnectionLost))
 			}
 		} else if (this.search.isNewSearch(searchQuery, restriction)) {
-			listModel.updateLoadingStatus(ListLoadingState.Loading)
-			this.search
-				.search(
-					{
-						query: searchQuery,
-						restriction,
-						minSuggestionCount: 0,
-						maxResults,
-					},
-					this.progressTracker,
-				)
-				.then(() => listModel.updateLoadingStatus(ListLoadingState.Idle))
-				.catch(() => listModel.updateLoadingStatus(ListLoadingState.ConnectionLost))
+			this.performNewSearch(listModel, searchQuery, restriction, maxResults)
 		}
 
 		if (isSameTypeRef(restriction.type, ContactTypeRef)) {
@@ -368,6 +357,27 @@ export class SearchViewModel {
 				}
 			}
 		}
+	}
+
+	private performNewSearch(
+		listModel: ListElementListModel<SearchResultListEntry>,
+		searchQuery: string,
+		restriction: SearchRestriction,
+		maxResults: number | null,
+	) {
+		listModel.updateLoadingStatus(ListLoadingState.Loading)
+		this.search
+			.search(
+				{
+					query: searchQuery,
+					restriction,
+					minSuggestionCount: 0,
+					maxResults,
+				},
+				this.progressTracker,
+			)
+			.then(() => listModel.updateLoadingStatus(ListLoadingState.Idle))
+			.catch(() => listModel.updateLoadingStatus(ListLoadingState.ConnectionLost))
 	}
 
 	private extractCalendarListIds(listIds: string[]): readonly [string, string] | string | null {
@@ -478,7 +488,9 @@ export class SearchViewModel {
 				this.listModel.updateLoadingStatus(ListLoadingState.Idle)
 			}
 
-			// the current search result will be extended as the range extends
+			// for non-blocking search, the current search result will be extended as the range extends.
+			// for full-archive-download search, once indexing is done, the list will reload automatically if empty and
+			// by user action if not.
 			void this.indexerFacade.extendMailIndex(targetStartDate?.getTime() ?? FULL_INDEXED_TIMESTAMP)
 		} else if (!isSameDay) {
 			this.searchAgain()
@@ -934,26 +946,35 @@ export class SearchViewModel {
 	}
 
 	private onMailIndexStateChanged(newState: SearchIndexStateInfo): void {
-		if (
-			isNonBlockingSearchAvailable() &&
-			isSameTypeRef(MailTypeRef, this.searchedType) &&
-			newState.progress === 0 &&
-			newState.error == null &&
-			newState.currentMailIndexTimestamp !== FULL_INDEXED_TIMESTAMP &&
-			(this._startDate == null || this._startDate.getTime() < newState.currentMailIndexTimestamp)
-		) {
-			// Indexing was cancelled and _startDate is outside the index range
-			const newStartTimestamp =
-				newState.currentMailIndexTimestamp === NOTHING_INDEXED_TIMESTAMP ? getEndOfDay(new Date()) : newState.currentMailIndexTimestamp
-			this._startDate = new Date(newStartTimestamp)
+		if (!isSameTypeRef(MailTypeRef, this.searchedType)) {
+			return
 		}
 
+		const isIndexingDoneOrCanceled = newState.progress === 0 && newState.error == null
 		const currentResult = this.search.result()
-		const isCurrentResultComplete = currentResult == null || (this._startDate != null && this._startDate.getTime() > currentResult.currentIndexTimestamp)
 
-		// only extend result when index is extended and result isn't already complete
-		if (!isCurrentResultComplete && currentResult.currentIndexTimestamp > newState.currentMailIndexTimestamp) {
-			void this.search.extendCurrentResult(newState.currentMailIndexTimestamp)
+		if (isNonBlockingSearchAvailable()) {
+			if (
+				isIndexingDoneOrCanceled &&
+				newState.currentMailIndexTimestamp !== FULL_INDEXED_TIMESTAMP &&
+				(this._startDate == null || this._startDate.getTime() < newState.currentMailIndexTimestamp)
+			) {
+				// Indexing was cancelled and _startDate is outside the index range
+				const newStartTimestamp =
+					newState.currentMailIndexTimestamp === NOTHING_INDEXED_TIMESTAMP ? getEndOfDay(new Date()) : newState.currentMailIndexTimestamp
+				this._startDate = new Date(newStartTimestamp)
+			}
+
+			const isCurrentResultComplete =
+				currentResult == null || (this._startDate != null && this._startDate.getTime() > currentResult.currentIndexTimestamp)
+
+			// only extend result when index is extended and result isn't already complete
+			if (!isCurrentResultComplete && currentResult.currentIndexTimestamp > newState.currentMailIndexTimestamp) {
+				void this.search.extendCurrentResult(newState.currentMailIndexTimestamp)
+			}
+		} else if (isIndexingDoneOrCanceled && currentResult && isEmpty(currentResult.results) && !hasMoreResults(currentResult)) {
+			// Indexing is done or cancelled and list is empty, list will not be recreated
+			this.performNewSearch(this.listModel, currentResult.query, currentResult.restriction, SEARCH_PAGE_SIZE)
 		}
 	}
 
@@ -984,6 +1005,20 @@ export class SearchViewModel {
 		}
 
 		this.previousResult = newResult
+	}
+
+	isIncompleteMailList(): boolean {
+		const currentResult = this.search.result()
+		return currentResult != null && isIncompleteMailResult(currentResult, this.search.indexState().currentMailIndexTimestamp)
+	}
+
+	searchAgainAndRecreateList(): void {
+		const restriction = this.getRestriction()
+		const maxResults = isSameTypeRef(MailTypeRef, restriction.type) ? SEARCH_PAGE_SIZE : null
+		this.performNewSearch(this.listModel, this.currentQuery, restriction, maxResults)
+
+		// new result is handled in onSearchResultChanged. We set previousResult to null so list gets recreated
+		this.previousResult = null
 	}
 
 	private async loadSearchResults<T extends SearchableTypes>(

--- a/src/ui/translations/de.ts
+++ b/src/ui/translations/de.ts
@@ -2404,5 +2404,7 @@ export default {
 		"clearCacheConfirm_msg": "Are you sure you want to clear cache?",
 		"notAllMailsSearchable_msg": "Not all emails are searchable, but in German",
 		"reIndexLocalData_msg": "Suchindex neu erstellen. Dies ist hilfreich, falls einige E-Mails beim Suchen nicht gefunden werden.",
+		"reloadList_action": "RELOAD LIST",
+		"moreEmailsAvailable_msg": "More emails available"
 	}
 }

--- a/src/ui/translations/de_sie.ts
+++ b/src/ui/translations/de_sie.ts
@@ -2404,5 +2404,7 @@ export default {
 		"clearCacheConfirm_msg": "Are you sure you want to clear cache?",
 		"notAllMailsSearchable_msg": "Not all emails are searchable, but in German",
 		"reIndexLocalData_msg": "Suchindex neu erstellen. Dies ist hilfreich, falls einige E-Mails beim Suchen nicht gefunden werden.",
+		"reloadList_action": "RELOAD LIST",
+		"moreEmailsAvailable_msg": "More emails available"
 	}
 }

--- a/src/ui/translations/en.ts
+++ b/src/ui/translations/en.ts
@@ -2404,5 +2404,7 @@ export default {
 		"clearCacheConfirm_msg": "Clearing cache will refresh the app.",
 		"notAllMailsSearchable_msg": "Not all emails are searchable",
 		"reIndexLocalData_msg": "Re-index all emails. This may be useful if you are missing emails in search.",
+		"reloadList_action": "RELOAD LIST",
+		"moreEmailsAvailable_msg": "More emails available"
 	}
 }

--- a/src/ui/utils/TranslationKey.ts
+++ b/src/ui/utils/TranslationKey.ts
@@ -2403,3 +2403,5 @@ export type TranslationKeyType =
 	| "clearCache_msg"
 	| "clearCacheConfirm_msg"
 	| "notAllMailsSearchable_msg"
+	| "reloadList_action"
+	| "moreEmailsAvailable_msg"


### PR DESCRIPTION
- Prevent extending current search result when non-blocking search is unavailable
- Reload list automatically when indexing is done or canceled and the list is empty
- When list is not empty (showing partial search result), show  button at the end of the list to allow user to "Reload list" and show the full search result

Close #11196

Co-authored-by: bir <bir@tutao.de>