### PR TITLE
Fix attachments getting removed from reply

### DIFF
--- a/src/applications/mail-app/mail/editor/MailEditor.ts
+++ b/src/applications/mail-app/mail/editor/MailEditor.ts
@@ -262,8 +262,17 @@ export class MailEditor implements Component<MailEditorAttrs> {
 			null,
 		)
 
+		const startInlineAttachmentCleanup = debounce(50, () => {
+			cleanupInlineAttachments(
+				[this.editor.getDOM(), this.collapsedReply],
+				model.getAttachments(),
+				model.getRemovedInlineImages(),
+				model.getNonInlineAttachmentsCids(),
+			)
+		})
+
 		const onEditorChanged = () => {
-			cleanupInlineAttachments(this.editor.getDOM(), model.getAttachments(), model.getRemovedInlineImages(), model.getNonInlineAttachmentsCids())
+			startInlineAttachmentCleanup()
 			model.markAsChangedIfNecessary(true)
 			m.redraw()
 		}

--- a/src/applications/mail-app/mail/editor/MailEditorViewModel.ts
+++ b/src/applications/mail-app/mail/editor/MailEditorViewModel.ts
@@ -1,6 +1,6 @@
 import m from "mithril"
 import { SendMailModel } from "../../../common/mailFunctionality/SendMailModel.js"
-import { contains, debounce, findAllAndRemove, isNotNull, ofClass } from "@tutao/utils"
+import { assertNotNull, contains, findAllAndRemove, isEmpty, isNotNull, Nullable, ofClass } from "@tutao/utils"
 import { PermissionError } from "../../../common/api/common/error/PermissionError"
 import { Dialog } from "../../../../ui/base/Dialog"
 import { FileNotFoundError } from "../../../common/api/common/error/FileNotFoundError"
@@ -8,8 +8,8 @@ import { lang } from "../../../../ui/utils/LanguageViewModel"
 import { UserError } from "../../../common/api/main/UserError"
 import { showUserError } from "../../../common/misc/ErrorHandlerImpl"
 import { locator } from "../../../common/api/main/CommonLocator"
-import { FileChooserMultiMode, DownloadPostProcessing, showFileChooser } from "../../../common/file/FileController.js"
-import { Mode, ProgrammingError } from "@tutao/app-env"
+import { DownloadPostProcessing, FileChooserMultiMode, showFileChooser } from "../../../common/file/FileController.js"
+import { Mode } from "@tutao/app-env"
 import { AttachmentBubbleAttrs, AttachmentType } from "../../../../ui/AttachmentBubble.js"
 import { Attachment, FileReference } from "../../../../entities/tutanota/Utils"
 import { DataFile } from "../../../../entities/tutanota/MailBundle"
@@ -101,54 +101,74 @@ export function createAttachmentBubbleAttrs(
 	}))
 }
 
-export const cleanupInlineAttachments: (arg0: HTMLElement, arg2: Array<Attachment>, arg3: Array<Attachment>, arg4: Set<string>) => void = debounce(
-	50,
-	(domElement: HTMLElement, attachments: Array<Attachment>, removedInlineImages: Array<Attachment>, nonInlineAttachmentsCids: Set<string>) => {
-		// Previously we replied on subtree option of MutationObserver to receive info when nested child is removed.
-		// It works but it doesn't work if the parent of the nested child is removed, we would have to go over each mutation
-		// and check each descendant and if it's an image with CID or not.
-		// It's easier and faster to just go over each inline image that we know about. It's more bookkeeping but it's easier
-		// code which touches less dome.
-		//
-		// Alternative would be observe the parent of each inline image but that's more complexity and we need to take care of
-		// new (just inserted) inline images and also assign listener there.
-		// Doing this check instead of relying on mutations also helps with the case when node is removed but inserted again
-		// briefly, e.g. if some text is inserted before/after the element, Squire would put it into another diff and this
-		// means removal + insertion.
-		if (domElement) {
-			const elementsToRemove: Attachment[] = []
-			const imagesInDocument = domElement.querySelectorAll("img[cid]")
-			const imageCids: string[] = []
+/**
+ * Cleanup inline attachments that are no longer present in the editor.
+ *
+ * This also handles re-adding attachments in case an inline attachment is deleted and restored via undo.
+ *
+ * @param editorElements contains all elements that can contain attachments (the editor dom and any collapsable elements)
+ * @param attachments all attachments (must be non-readonly in case we remove or re-add attachments)
+ * @param removedInlineImages all attachments removed through this function (in case we undo)
+ * @param nonInlineAttachmentsCids cids of all attachments that aren't inline and shouldn't be touched by this function
+ */
+export function cleanupInlineAttachments(
+	editorElements: readonly Nullable<HTMLElement>[],
+	attachments: Attachment[],
+	removedInlineImages: Attachment[],
+	nonInlineAttachmentsCids: ReadonlySet<string>,
+) {
+	// Previously we replied on subtree option of MutationObserver to receive info when nested child is removed.
+	// It works but it doesn't work if the parent of the nested child is removed, we would have to go over each mutation
+	// and check each descendant and if it's an image with CID or not.
+	// It's easier and faster to just go over each inline image that we know about. It's more bookkeeping but it's easier
+	// code which touches less dome.
+	//
+	// Alternative would be observe the parent of each inline image but that's more complexity and we need to take care of
+	// new (just inserted) inline images and also assign listener there.
+	// Doing this check instead of relying on mutations also helps with the case when node is removed but inserted again
+	// briefly, e.g. if some text is inserted before/after the element, Squire would put it into another diff and this
+	// means removal + insertion.
+	const allEditorElements = editorElements.filter(isNotNull)
+	if (isEmpty(allEditorElements)) {
+		return
+	}
 
-			for (let i = 0; i < imagesInDocument.length; i++) {
-				const cid = imagesInDocument[i].getAttribute("cid")
-				if (cid) {
-					imageCids.push(cid)
-
-					// We try to find if image was previously removed and is now being added back in (undo to bring back a removed image)
-					const attachmentIndex = removedInlineImages.findIndex((a) => a.cid === cid)
-					if (attachmentIndex !== -1) {
-						const removedAttachment = removedInlineImages.splice(attachmentIndex, 1)[0]
-						attachments.push(removedAttachment)
-						m.redraw()
-					}
-				}
-			}
-
-			for (const attachment of attachments) {
-				// if the attachment has a cid then it is an inline image
-				if (attachment.cid && !imageCids.includes(attachment.cid) && !nonInlineAttachmentsCids.has(attachment.cid)) {
-					elementsToRemove.push(attachment)
-					removedInlineImages.push(attachment)
-				}
-			}
-
-			if (findAllAndRemove(attachments, (attachment) => elementsToRemove.includes(attachment))) {
-				m.redraw()
-			}
+	const imageCidsPerElement = allEditorElements.map((dom) => {
+		const imagesWithCids: NodeListOf<Element> = dom.querySelectorAll("img[cid]")
+		const list = []
+		for (let i = 0; i < imagesWithCids.length; i++) {
+			list.push(assertNotNull(imagesWithCids[i].getAttribute("cid")))
 		}
-	},
-)
+		return list
+	})
+
+	// in case an element in editorElements is part of another element in editorElements, a Set lets us dedupe and access at O(1)
+	// (don't worry: we consider an inline attachment as still existing if its cid is in *at least* one)
+	const imageCids: Set<string> = new Set(imageCidsPerElement.flat())
+	const elementsToRemove: Attachment[] = []
+
+	for (const cid of imageCids) {
+		// We try to find if image was previously removed and is now being added back in (undo to bring back a removed image)
+		const attachmentIndex = removedInlineImages.findIndex((a) => a.cid === cid)
+		if (attachmentIndex !== -1) {
+			const removedAttachment = removedInlineImages.splice(attachmentIndex, 1)[0]
+			attachments.push(removedAttachment)
+			m.redraw()
+		}
+	}
+
+	for (const attachment of attachments) {
+		// if the attachment has a cid then it is an inline image
+		if (attachment.cid && !imageCids.has(attachment.cid) && !nonInlineAttachmentsCids.has(attachment.cid)) {
+			elementsToRemove.push(attachment)
+			removedInlineImages.push(attachment)
+		}
+	}
+
+	if (findAllAndRemove(attachments, (attachment) => elementsToRemove.includes(attachment))) {
+		m.redraw()
+	}
+}
 
 export function getConfidentialStateMessage(isConfidential: boolean): string {
 	return isConfidential ? lang.get("confidentialStatus_msg") : lang.get("nonConfidentialStatus_msg")


### PR DESCRIPTION
Basically, cleanupInlineAttachments needs to know about all elements
with inline attachments. This means not just the editor dom but also the
reply element.

This also does some state cleanup by making debounce occur on the
MailEditor rather than on the function, itself.

Closes https://github.com/tutao/tutanota/issues/11127