### PR TITLE
Fix GitHub issue template descriptions for Android and iOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/03-android-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03-android-bug.yml
@@ -1,5 +1,5 @@
 name: Bug Report (Android app)
-description: File a bug report for the issue with the desktop app
+description: File a bug report for the issue with the Android app
 labels: ["bug", "android"]
 type: bug
 body:

--- a/.github/ISSUE_TEMPLATE/04-ios-bug.yml
+++ b/.github/ISSUE_TEMPLATE/04-ios-bug.yml
@@ -1,5 +1,5 @@
 name: Bug Report (iOS app)
-description: File a bug report for the issue with the desktop app
+description: File a bug report for the issue with the iOS app
 labels: ["bug", "ios"]
 type: bug
 body:


### PR DESCRIPTION
Fix copy/paste error inherited from the desktop app:

<img width="673" height="453" alt="image" src="https://github.com/user-attachments/assets/ce1a37d7-d836-4ef8-9f4b-0cc6047e27b3" />

