### PR TITLE
Use throttledRoute for more things

### DIFF
--- a/src/applications/common/misc/NavShortcuts.ts
+++ b/src/applications/common/misc/NavShortcuts.ts
@@ -1,7 +1,7 @@
 import { keyManager } from "../../../ui/utils/KeyManager.js"
 import { FeatureType, Keys } from "../../../platform-kit/app-env"
 import m from "mithril"
-import { CALENDAR_PREFIX, CONTACTS_PREFIX, DRIVE_PREFIX, LogoutUrl, MAIL_PREFIX, SETTINGS_PREFIX } from "../../../ui/utils/RouteChange.js"
+import { CALENDAR_PREFIX, CONTACTS_PREFIX, DRIVE_PREFIX, LogoutUrl, MAIL_PREFIX, SETTINGS_PREFIX, throttleRoute } from "../../../ui/utils/RouteChange.js"
 import { showQuickActionBar } from "./quickactions/QuickActionBar"
 import { LoginController } from "../api/main/LoginController"
 import { QuickActionsModel } from "./quickactions/QuickActionsModel"
@@ -13,36 +13,38 @@ export function setupNavShortcuts({ quickActionsModel, logins }: { quickActionsM
 		return logins.isInternalUserLoggedIn() && logins.getUserController().sessionType !== SessionType.Temporary
 	}
 
+	const routeTo = throttleRoute()
+
 	keyManager.registerShortcuts([
 		{
 			key: Keys.M,
 			enabled: () => hasInAppNavigation(),
-			exec: () => m.route.set(MAIL_PREFIX),
+			exec: () => routeTo(MAIL_PREFIX),
 			help: "mailView_action",
 		},
 		{
 			key: Keys.C,
 			enabled: () => hasInAppNavigation() && !logins.isEnabled(FeatureType.DisableContacts),
-			exec: () => m.route.set(CONTACTS_PREFIX),
+			exec: () => routeTo(CONTACTS_PREFIX),
 			help: "contactView_action",
 		},
 		{
 			key: Keys.O,
 			enabled: () => hasInAppNavigation(),
-			exec: () => m.route.set(CALENDAR_PREFIX),
+			exec: () => routeTo(CALENDAR_PREFIX),
 			help: "calendarView_action",
 		},
 
 		{
 			key: Keys.P,
 			enabled: () => hasInAppNavigation() && isDriveEnabled(logins),
-			exec: () => m.route.set(DRIVE_PREFIX),
+			exec: () => routeTo(DRIVE_PREFIX),
 			help: "driveView_action",
 		},
 		{
 			key: Keys.S,
 			enabled: () => hasInAppNavigation(),
-			exec: () => m.route.set(SETTINGS_PREFIX),
+			exec: () => routeTo(SETTINGS_PREFIX),
 			help: "settingsView_action",
 		},
 		{

--- a/src/applications/mail-app/search/view/SearchView.ts
+++ b/src/applications/mail-app/search/view/SearchView.ts
@@ -107,7 +107,7 @@ import { showUserError } from "../../../common/misc/ErrorHandlerImpl"
 import { MoveMode } from "../../mail/model/MailModel"
 import { MailViewerViewModel } from "../../mail/view/MailViewerViewModel"
 import { Card } from "../../../../ui/base/Card"
-import { CALENDAR_PREFIX, CONTACTS_PREFIX, MAIL_PREFIX } from "../../../../ui/utils/RouteChange"
+import { CALENDAR_PREFIX, CONTACTS_PREFIX, MAIL_PREFIX, throttleRoute } from "../../../../ui/utils/RouteChange"
 import { FilterChip } from "../../../../ui/base/FilterChip"
 import { formatDate } from "../../../../ui/utils/Formatter"
 import { AllIcons } from "../../../../ui/base/Icon"
@@ -140,6 +140,7 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 	private readonly contactModel: ContactModel
 	private readonly startOfTheWeekOffset: number
 	private readonly undoModel: UndoModel
+	private readonly routeTo = throttleRoute()
 
 	private getSanitizedPreviewData: (event: CalendarEvent) => LazyLoaded<CalendarEventPreviewViewModel> = memoized((event: CalendarEvent) =>
 		new LazyLoaded(async () => {
@@ -538,11 +539,11 @@ export class SearchView extends BaseTopLevelView implements TopLevelView<SearchV
 							icon: Icons.ChevronLeft,
 							click: () => {
 								if (isSameTypeRef(this.searchViewModel.searchedType, MailTypeRef)) {
-									m.route.set(MAIL_PREFIX)
+									this.routeTo(MAIL_PREFIX)
 								} else if (isSameTypeRef(this.searchViewModel.searchedType, ContactTypeRef)) {
-									m.route.set(CONTACTS_PREFIX)
+									this.routeTo(CONTACTS_PREFIX)
 								} else if (isSameTypeRef(this.searchViewModel.searchedType, CalendarEventTypeRef)) {
-									m.route.set(CALENDAR_PREFIX)
+									this.routeTo(CALENDAR_PREFIX)
 								}
 							},
 						}),

--- a/src/ui/base/NavButton.ts
+++ b/src/ui/base/NavButton.ts
@@ -13,6 +13,7 @@ import { assertMainOrNode, isDesktop, Keys } from "../../platform-kit/app-env"
 import { isKeyPressed } from "../utils/KeyManager"
 import { DragEnterHandler, DragStartHandler, DropData, DropHandler, DropType } from "./GuiUtils"
 import { fileListToArray } from "../utils/FileUtils.js"
+import { throttleRoute } from "../utils/RouteChange"
 
 assertMainOrNode()
 export type NavButtonAttrs = {
@@ -45,6 +46,7 @@ export class NavButton implements Component<NavButtonAttrs> {
 	private _domButton!: HTMLElement
 	private _draggedOver: boolean
 	private _dropCounter: number // we also get drag enter/leave events from subelements, so we need to count to know when the drag leaves this button
+	private readonly routeTo = throttleRoute()
 
 	constructor() {
 		this._draggedOver = false
@@ -203,7 +205,7 @@ export class NavButton implements Component<NavButtonAttrs> {
 
 	click(event: Event, a: NavButtonAttrs, dom: HTMLElement) {
 		if (!this._isExternalUrl(a.href)) {
-			m.route.set(this._getUrl(a.href))
+			this.routeTo(this._getUrl(a.href))
 
 			if (a.click != null) {
 				a.click(event, dom)

--- a/src/ui/utils/RouteChange.ts
+++ b/src/ui/utils/RouteChange.ts
@@ -4,7 +4,7 @@ import { lazyMemoized } from "../../platform-kit/utils"
 
 assertMainOrNodeBoot()
 
-export type RouteSetFn = (path: string, args: Record<string, any>) => void
+export type RouteSetFn = (path: string, args?: Record<string, any>) => void
 
 /** return a replacement for m.route.set that replaces the last history
  * state for reroutes that happen quickly enough instead of adding a
@@ -16,7 +16,7 @@ export const throttleRoute = lazyMemoized((): RouteSetFn => {
 	let lastUrl: string | null = null
 	let lastArgs: Record<string, any> = {}
 	let lastRoute = m.route.get()
-	return function (url: string, args: Record<string, any>) {
+	return function (url: string, args: Record<string, any> = {}) {
 		// someone might have called m.route.set() without us, so if the route changed, we need to
 		// call m.route.set() in any case.
 		if (m.route.get() === lastRoute && url === lastUrl && shallowCompare(lastArgs, args)) return


### PR DESCRIPTION
If you call m.route.set directly and it leads to a redirect (that eventually calls throttledRoute), it may fail to actually do the redirect, resulting in the current route being in a broken state.

This commit makes it so we use throttledRoute whenever we go to the Mail section of the app. We were already doing this before through quick actions, and nothing seems to blow up when doing that.

Read the commit message for a longer explanation.