### PR TITLE
Improve setupMultiple retry policy

### DIFF
--- a/src/platform-kit/instance-pipeline/CryptoMapper.ts
+++ b/src/platform-kit/instance-pipeline/CryptoMapper.ts
@@ -466,7 +466,11 @@ export class EncryptedParsedInstance implements DeepEquals {
 
 	public getAttributeByNameOrNull(attributeName: AttributeName): Nullable<EncryptedParsedValue> {
 		const attrId = AttributeModel.getAttributeId(this.typeModel, attributeName)
-		return isNotNull(attrId) ? assertNotNull(this.parsedInstance.get(attrId), `Attribute ${attributeName} not found in instance`) : null
+		if (isNotNull(attrId)) {
+			const value = this.parsedInstance.get(attrId)
+			return assertNotNull(value, `Attribute ${attributeName} not found in instance`)
+		}
+		return null
 	}
 	public getAttributeByName(name: AttributeName): EncryptedParsedValue {
 		return assertNotNull(this.getAttributeByNameOrNull(name))

--- a/src/platform-kit/meta/EntityUtils.ts
+++ b/src/platform-kit/meta/EntityUtils.ts
@@ -71,6 +71,9 @@ export const LOAD_MULTIPLE_LIMIT = 100
 export const POST_MULTIPLE_LIMIT = 100
 export const DELETE_MULTIPLE_LIMIT = 100
 
+/** Number of entities required to fallback into single post request at setupMultiple retry */
+export const POST_MULTIPLE_INDIVIDUAL_POST_FALLBACK_THRESHOLD = POST_MULTIPLE_LIMIT / 5
+
 type OptionalEntity<T extends Entity> = T & {
 	_id?: T extends AggregatedEntity
 		? Id

--- a/src/platform-kit/network/EntityRestClient.ts
+++ b/src/platform-kit/network/EntityRestClient.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_REST_CLIENT_OPTIONS, type RestClient } from "@tutao/rest-client"
 import { HttpMethod, MediaType, RestTextBody } from "../rest-client/types"
-import { ClientTypeModel, expandId, LOAD_MULTIPLE_LIMIT, POST_MULTIPLE_LIMIT, Type, TypeRef } from "../meta"
+import { ClientTypeModel, expandId, LOAD_MULTIPLE_LIMIT, POST_MULTIPLE_INDIVIDUAL_POST_FALLBACK_THRESHOLD, POST_MULTIPLE_LIMIT, Type, TypeRef } from "../meta"
 import { SessionKeyNotFoundError } from "@tutao/crypto/error"
 import { assertNotNull, Category, downcast, isNotEmpty, lazy, Mapper, Nullable, ofClass, promiseMap, splitInChunks, syncMetrics } from "@tutao/utils"
 import { assertWorkerOrNode, ProgrammingError } from "@tutao/app-env"
@@ -71,7 +71,7 @@ export interface EntityMigrator {
 /**
  * Result object returned after attempting to post multiple entities.
  */
-type PostMultipleResult<T extends PersistentEntity> = {
+type PostMultipleHandlerResult<T extends PersistentEntity> = {
 	createdIds: Id[]
 	errors?: Error[]
 	failedInstances?: T[]
@@ -449,7 +449,7 @@ export class EntityRestClient implements EntityRestInterface {
 	 *
 	 * @param listId
 	 * @param instances
-	 * @returns {Promise<PostMultipleResult<T>>} An object containing successfully created IDs, errors, and failed instances.
+	 * @returns {Promise<PostMultipleHandlerResult<T>>} An object containing successfully created IDs, errors, and failed instances.
 	 * @throws {ConnectionError} If an offline error is encountered during the process.
 	 * @throws {SetupMultipleError} If any other unrecoverable errors occur during setup.
 	 */
@@ -467,109 +467,12 @@ export class EntityRestClient implements EntityRestInterface {
 			if (listId) throw new Error("List id must not be defined for ETs")
 		}
 
-		/**
-		 * Recursively posts a chunk of entities with retry logic.
-		 * @template T - The type of the entity being processed.
-		 * @param {T[]} instanceChunk - An array of entity instances to be posted in this batch.
-		 */
-		const postMultipleWithRetry = async (instanceChunk: T[]): Promise<PostMultipleResult<T>> => {
-			console.log(this.TAG, "postMultipleWithRetry", `\nEntities in the chunk: ${instanceChunk.length}\nFirst entities Id: ${instanceChunk[0]._id}`)
-
-			try {
-				const outgoingServerJsons = await promiseMap(instanceChunk, async (instance) => {
-					instance._ownerEncSessionKey = undefined /** {@link setup} method will re-assign a session key */
-					const sk = await this._crypto.setNewOwnerEncSessionKey(clientTypeModel, instance, null)
-					const encEntity = await this.instancePipeline.mapAndEncryptToParsedInstance(downcast<TypeRef<Entity>>(instance._type), instance, sk)
-					return this.instancePipeline.typeMapper.makeServerJson(encEntity)
-				})
-
-				// informs the server that this is a POST_MULTIPLE request
-				const queryParams = {
-					count: String(instanceChunk.length),
-				}
-
-				const persistencePostReturn = await this.restClient.request(path, HttpMethod.POST, {
-					...DEFAULT_REST_CLIENT_OPTIONS,
-					queryParams,
-					headers,
-					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(outgoingServerJsons)),
-					responseType: MediaType.Json,
-				})
-
-				const untypedPersistencePostReturn = IncomingServerJson.expectMultipleInstance(persistencePostReturn, persistencePostReturnTypeModel)
-
-				return {
-					createdIds: await this.parseSetupMultiple(untypedPersistencePostReturn),
-				}
-			} catch (e) {
-				if (e instanceof PayloadTooLargeError) {
-					console.warn(
-						this.TAG,
-						'setupMultiple failed with "Payload too large".',
-						`\nEntities in the failed chunk: ${instanceChunk.length}`,
-						`\nFirst entities Id: ${instanceChunk[0]._id}`,
-						`\nOriginal error: ${e}`,
-					)
-
-					const createdIds: Id[] = []
-					const errors: Error[] = []
-					const failedInstances: T[] = []
-
-					// Fallback to individual requests if chunk size is small enough
-					const FALLBACK_THRESHOLD = POST_MULTIPLE_LIMIT / 5
-					if (instanceChunk.length <= FALLBACK_THRESHOLD) {
-						console.log(this.TAG, `Retrying with individual entity post request fallback.\nEntities left: ${instanceChunk.length}`)
-
-						const individualResults = await Promise.allSettled(
-							instanceChunk.map(async (instance) => {
-								instance._ownerEncSessionKey = undefined
-								return assertNotNull(await this.setup(listId, instance, null, null))
-							}),
-						)
-
-						for (const [index, result] of individualResults.entries()) {
-							if (result.status === "fulfilled") {
-								createdIds.push(result.value)
-							} else {
-								const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason))
-								console.error("Error on individual entity setup", err)
-								errors.push(err)
-								failedInstances.push(instanceChunk[index])
-							}
-						}
-
-						return { createdIds, errors, failedInstances }
-					}
-
-					// Otherwise, split chunk in half and retry recursively
-					const smallerChunks = splitInChunks(instanceChunk.length / 2, instanceChunk)
-					for (const smallerChunk of smallerChunks) {
-						console.log(this.TAG, `Retrying with smaller chunk. \nFirst entity Id of new chunk: ${smallerChunk[0]._id}`)
-						const retryAttempt = await postMultipleWithRetry(smallerChunk)
-						createdIds.push(...retryAttempt.createdIds)
-						if (retryAttempt.errors && retryAttempt.failedInstances) {
-							errors.push(...retryAttempt.errors)
-							failedInstances.push(...retryAttempt.failedInstances)
-						}
-					}
-
-					return {
-						createdIds,
-						errors,
-						failedInstances,
-					}
-				} else {
-					return {
-						createdIds: [],
-						errors: [e],
-						failedInstances: instanceChunk,
-					}
-				}
-			}
-		}
-
 		const instanceChunks = splitInChunks(POST_MULTIPLE_LIMIT, instances)
-		const mapResult = await promiseMap(instanceChunks, postMultipleWithRetry)
+		console.time("Posting multiple with retry")
+		const mapResult = await promiseMap(instanceChunks, (chunk) =>
+			this.postMultipleHandlerWithRetry(listId!, chunk, path, headers, persistencePostReturnTypeModel, clientTypeModel),
+		)
+		console.time("Posting multiple with retry")
 
 		const createdIds = mapResult.flatMap((res) => res.createdIds)
 		const errors = mapResult.flatMap((res) => res.errors ?? [])
@@ -584,6 +487,158 @@ export class EntityRestClient implements EntityRestInterface {
 			throw new SetupMultipleError<T>("Setup multiple entities failed", errors, failedInstances)
 		} else {
 			return createdIds
+		}
+	}
+
+	/**
+	 * Recursively posts a chunk of entities with retry logic.
+	 *
+	 * @template T - The type of the entity being processed.
+	 *
+	 * @param listId
+	 * @param {T[]} instanceChunk - An array of entity instances to be posted in this batch.
+	 * @param path
+	 * @param headers
+	 * @param persistencePostReturnTypeModel
+	 * @param clientTypeModel
+	 */
+	private async postMultipleHandlerWithRetry<T extends PersistentEntity>(
+		listId: Id,
+		instanceChunk: T[],
+		path: string,
+		headers: Dict,
+		persistencePostReturnTypeModel: ServerTypeModel,
+		clientTypeModel: ClientTypeModel,
+	): Promise<PostMultipleHandlerResult<T>> {
+		console.log(this.TAG, "postMultipleHandlerWithRetry", `\nEntities in the chunk: ${instanceChunk.length}\nFirst entities Id: ${instanceChunk[0]._id}`)
+
+		try {
+			const outgoingServerJsons = await promiseMap(instanceChunk, async (instance) => {
+				instance._ownerEncSessionKey = undefined
+				const sk = await this._crypto.setNewOwnerEncSessionKey(clientTypeModel, instance, null)
+				const encEntity = await this.instancePipeline.mapAndEncryptToParsedInstance(downcast<TypeRef<Entity>>(instance._type), instance, sk)
+				return this.instancePipeline.typeMapper.makeServerJson(encEntity)
+			})
+
+			// informs the server that this is a POST_MULTIPLE request
+			const queryParams = {
+				count: String(instanceChunk.length),
+			}
+
+			const persistencePostReturn = await this.restClient.request(path, HttpMethod.POST, {
+				...DEFAULT_REST_CLIENT_OPTIONS,
+				queryParams,
+				headers,
+				body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(outgoingServerJsons)),
+				responseType: MediaType.Json,
+			})
+
+			const untypedPersistencePostReturn = IncomingServerJson.expectMultipleInstance(persistencePostReturn, persistencePostReturnTypeModel)
+			const createdIds = await this.parseSetupMultiple(untypedPersistencePostReturn)
+
+			console.log(
+				this.TAG,
+				"postMultipleHandlerWithRetry",
+				`Successfully retried chunk ${instanceChunk[0]._id} resulting in ${createdIds.length} created entities`,
+			)
+
+			return {
+				createdIds,
+			}
+		} catch (e) {
+			if (e instanceof PayloadTooLargeError) {
+				return await this.handlePayloadTooLargeForSetupMultiple(
+					instanceChunk,
+					e,
+					listId,
+					path,
+					headers,
+					persistencePostReturnTypeModel,
+					clientTypeModel,
+				)
+			} else {
+				// Unknown error without a proper handling
+				console.error(this.TAG, "postMultipleHandlerWithRetry", `Unknown error when retrying chunk ${instanceChunk[0]._id}`)
+				return {
+					createdIds: [],
+					errors: [e],
+					failedInstances: instanceChunk,
+				}
+			}
+		}
+	}
+
+	private async handlePayloadTooLargeForSetupMultiple<T extends PersistentEntity>(
+		instanceChunk: T[],
+		e: PayloadTooLargeError,
+		listId: string,
+		path: string,
+		headers: Dict,
+		persistencePostReturnTypeModel: ServerTypeModel,
+		clientTypeModel: ClientTypeModel,
+	) {
+		console.warn(
+			this.TAG,
+			'setupMultiple failed with "Payload too large".',
+			`\nEntities in the failed chunk: ${instanceChunk.length}`,
+			`\nFirst entities Id: ${instanceChunk[0]._id}`,
+			`\nOriginal error: ${e}`,
+		)
+
+		const createdIds: Id[] = []
+		const errors: Error[] = []
+		const failedInstances: T[] = []
+
+		// Fallback to individual requests if chunk size is small enough
+		if (instanceChunk.length <= POST_MULTIPLE_INDIVIDUAL_POST_FALLBACK_THRESHOLD) {
+			console.log(this.TAG, `Retrying with individual entity post request fallback.\nEntities left: ${instanceChunk.length}`)
+
+			const individualResults = await Promise.allSettled(
+				instanceChunk.map(async (instance) => {
+					// {@link setup} method will re-assign a session key and make a single post request to persist the provided entity
+					instance._ownerEncSessionKey = undefined
+					const createdEntityId = await this.setup(listId, instance, null, null)
+					return assertNotNull(createdEntityId)
+				}),
+			)
+
+			for (const [index, result] of individualResults.entries()) {
+				if (result.status === "fulfilled") {
+					createdIds.push(result.value)
+				} else {
+					const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason))
+					console.error("Error on individual entity setup", err)
+					errors.push(err)
+					failedInstances.push(instanceChunk[index])
+				}
+			}
+
+			return { createdIds, errors, failedInstances }
+		}
+
+		// Otherwise, split chunk in half and retry recursively
+		const smallerChunks = splitInChunks(Math.floor(instanceChunk.length / 2), instanceChunk)
+		const results = await Promise.allSettled(
+			smallerChunks.map((chunk) => {
+				console.log(this.TAG, `Retrying with smaller chunk. \nFirst entity Id of new chunk: ${chunk[0]._id}`)
+				return this.postMultipleHandlerWithRetry(listId, chunk, path, headers, persistencePostReturnTypeModel, clientTypeModel)
+			}),
+		)
+		for (const retryResult of results) {
+			if (retryResult.status === "fulfilled") {
+				createdIds.push(...retryResult.value.createdIds)
+
+				if (retryResult.value.errors) {
+					errors.push(...retryResult.value.errors)
+					failedInstances.push(...(retryResult.value.failedInstances ?? []))
+				}
+			}
+		}
+
+		return {
+			createdIds,
+			errors,
+			failedInstances,
 		}
 	}
 

--- a/src/platform-kit/network/EntityRestClient.ts
+++ b/src/platform-kit/network/EntityRestClient.ts
@@ -69,6 +69,15 @@ export interface EntityMigrator {
 }
 
 /**
+ * Result object returned after attempting to post multiple entities.
+ */
+type PostMultipleResult<T extends PersistentEntity> = {
+	createdIds: Id[]
+	errors?: Error[]
+	failedInstances?: T[]
+}
+
+/**
  * Retrieves the instances from the backend (db) and converts them to entities.
  *
  * Part of this process is
@@ -78,6 +87,8 @@ export interface EntityMigrator {
  *
  */
 export class EntityRestClient implements EntityRestInterface {
+	private readonly TAG = "[EntityRestClient]"
+
 	get _crypto(): CryptoNetworkHelper {
 		return this.lazyCrypto()
 	}
@@ -424,19 +435,30 @@ export class EntityRestClient implements EntityRestInterface {
 		const persistencePostReturnTypeModel = await this.typeModelResolver.resolveServerTypeReference(PersistenceResourcePostReturnTypeRef)
 		const postReturnJson = IncomingServerJson.expectSingleInstance(persistencePostReturn, persistencePostReturnTypeModel)
 		const parsedPersistencePostReturn = await this.instancePipeline.typeMapper.parseServerJson(postReturnJson)
-		return parsedPersistencePostReturn.getAttributeByNameOrNull("generatedId")?.asId() ?? null
+		const attributeByNameOrNull = parsedPersistencePostReturn.getAttributeByNameOrNull("generatedId")
+		return attributeByNameOrNull?.asId() ?? null
 	}
 
+	/**
+	 * Recursively posts a chunk of entities with retry logic.
+	 *
+	 * If a payload is too large, it splits the chunk in half and retries.
+	 * If the chunk size drops below the fallback threshold, it switches to individual entity requests.
+	 *
+	 * @template T - The type of the entity being processed.
+	 *
+	 * @param listId
+	 * @param instances
+	 * @returns {Promise<PostMultipleResult<T>>} An object containing successfully created IDs, errors, and failed instances.
+	 * @throws {ConnectionError} If an offline error is encountered during the process.
+	 * @throws {SetupMultipleError} If any other unrecoverable errors occur during setup.
+	 */
 	async setupMultiple<T extends PersistentEntity>(listId: Id | null, instances: Array<T>): Promise<Array<Id>> {
-		const count = instances.length
-
-		if (count < 1) {
+		if (instances.length < 1) {
 			return []
 		}
 
-		const instanceChunks = splitInChunks(POST_MULTIPLE_LIMIT, instances)
-		const typeRef = instances[0]._type
-		const { clientTypeModel, path, headers } = await this._validateAndPrepareRestRequest(typeRef, listId, null, null, null, null, null)
+		const { clientTypeModel, path, headers } = await this._validateAndPrepareRestRequest(instances[0]._type, listId, null, null, null, null, null)
 		const persistencePostReturnTypeModel = await this.typeModelResolver.resolveServerTypeReference(PersistenceResourcePostReturnTypeRef)
 
 		if (clientTypeModel.type === Type.ListElement) {
@@ -445,19 +467,27 @@ export class EntityRestClient implements EntityRestInterface {
 			if (listId) throw new Error("List id must not be defined for ETs")
 		}
 
-		const errors: Error[] = []
-		const failedInstances: T[] = []
-		const idChunks: Array<Array<Id>> = await promiseMap(instanceChunks, async (instanceChunk) => {
+		/**
+		 * Recursively posts a chunk of entities with retry logic.
+		 * @template T - The type of the entity being processed.
+		 * @param {T[]} instanceChunk - An array of entity instances to be posted in this batch.
+		 */
+		const postMultipleWithRetry = async (instanceChunk: T[]): Promise<PostMultipleResult<T>> => {
+			console.log(this.TAG, "postMultipleWithRetry", `\nEntities in the chunk: ${instanceChunk.length}\nFirst entities Id: ${instanceChunk[0]._id}`)
+
 			try {
 				const outgoingServerJsons = await promiseMap(instanceChunk, async (instance) => {
+					instance._ownerEncSessionKey = undefined /** {@link setup} method will re-assign a session key */
 					const sk = await this._crypto.setNewOwnerEncSessionKey(clientTypeModel, instance, null)
 					const encEntity = await this.instancePipeline.mapAndEncryptToParsedInstance(downcast<TypeRef<Entity>>(instance._type), instance, sk)
 					return this.instancePipeline.typeMapper.makeServerJson(encEntity)
 				})
+
 				// informs the server that this is a POST_MULTIPLE request
 				const queryParams = {
 					count: String(instanceChunk.length),
 				}
+
 				const persistencePostReturn = await this.restClient.request(path, HttpMethod.POST, {
 					...DEFAULT_REST_CLIENT_OPTIONS,
 					queryParams,
@@ -465,36 +495,95 @@ export class EntityRestClient implements EntityRestInterface {
 					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(outgoingServerJsons)),
 					responseType: MediaType.Json,
 				})
+
 				const untypedPersistencePostReturn = IncomingServerJson.expectMultipleInstance(persistencePostReturn, persistencePostReturnTypeModel)
-				return await this.parseSetupMultiple(untypedPersistencePostReturn)
+
+				return {
+					createdIds: await this.parseSetupMultiple(untypedPersistencePostReturn),
+				}
 			} catch (e) {
 				if (e instanceof PayloadTooLargeError) {
-					// If we try to post too many large instances then we get PayloadTooLarge
-					// So we fall back to posting single instances
-					const returnedIds = await promiseMap(instanceChunk, async (instance) => {
-						try {
-							return await this.setup(listId, instance, null, null)
-						} catch (e) {
-							errors.push(e)
-							failedInstances.push(instance)
+					console.warn(
+						this.TAG,
+						'setupMultiple failed with "Payload too large".',
+						`\nEntities in the failed chunk: ${instanceChunk.length}`,
+						`\nFirst entities Id: ${instanceChunk[0]._id}`,
+						`\nOriginal error: ${e}`,
+					)
+
+					const createdIds: Id[] = []
+					const errors: Error[] = []
+					const failedInstances: T[] = []
+
+					// Fallback to individual requests if chunk size is small enough
+					const FALLBACK_THRESHOLD = POST_MULTIPLE_LIMIT / 5
+					if (instanceChunk.length <= FALLBACK_THRESHOLD) {
+						console.log(this.TAG, `Retrying with individual entity post request fallback.\nEntities left: ${instanceChunk.length}`)
+
+						const individualResults = await Promise.allSettled(
+							instanceChunk.map(async (instance) => {
+								instance._ownerEncSessionKey = undefined
+								return assertNotNull(await this.setup(listId, instance, null, null))
+							}),
+						)
+
+						for (const [index, result] of individualResults.entries()) {
+							if (result.status === "fulfilled") {
+								createdIds.push(result.value)
+							} else {
+								const err = result.reason instanceof Error ? result.reason : new Error(String(result.reason))
+								console.error("Error on individual entity setup", err)
+								errors.push(err)
+								failedInstances.push(instanceChunk[index])
+							}
 						}
-					})
-					return returnedIds.filter(Boolean) as Id[]
+
+						return { createdIds, errors, failedInstances }
+					}
+
+					// Otherwise, split chunk in half and retry recursively
+					const smallerChunks = splitInChunks(instanceChunk.length / 2, instanceChunk)
+					for (const smallerChunk of smallerChunks) {
+						console.log(this.TAG, `Retrying with smaller chunk. \nFirst entity Id of new chunk: ${smallerChunk[0]._id}`)
+						const retryAttempt = await postMultipleWithRetry(smallerChunk)
+						createdIds.push(...retryAttempt.createdIds)
+						if (retryAttempt.errors && retryAttempt.failedInstances) {
+							errors.push(...retryAttempt.errors)
+							failedInstances.push(...retryAttempt.failedInstances)
+						}
+					}
+
+					return {
+						createdIds,
+						errors,
+						failedInstances,
+					}
 				} else {
-					errors.push(e)
-					failedInstances.push(...instanceChunk)
-					return [] as Id[]
+					return {
+						createdIds: [],
+						errors: [e],
+						failedInstances: instanceChunk,
+					}
 				}
 			}
-		})
+		}
 
-		if (errors.length) {
+		const instanceChunks = splitInChunks(POST_MULTIPLE_LIMIT, instances)
+		const mapResult = await promiseMap(instanceChunks, postMultipleWithRetry)
+
+		const createdIds = mapResult.flatMap((res) => res.createdIds)
+		const errors = mapResult.flatMap((res) => res.errors ?? [])
+		const failedInstances = mapResult.flatMap((res) => res.failedInstances ?? [])
+
+		console.log(this.TAG, "setupMultiple results:", `\nSuccessful entities: ${createdIds.length}`, `\nTotal errors: ${errors.length}`)
+
+		if (errors?.length) {
 			if (errors.some(isOfflineError)) {
 				throw new ConnectionError("Setup multiple entities failed")
 			}
 			throw new SetupMultipleError<T>("Setup multiple entities failed", errors, failedInstances)
 		} else {
-			return idChunks.flat()
+			return createdIds
 		}
 	}
 

--- a/test/tests/network/EntityRestClientTest.ts
+++ b/test/tests/network/EntityRestClientTest.ts
@@ -1035,6 +1035,19 @@ o.spec("EntityRestClient", function () {
 	})
 
 	o.spec("Setup multiple", function () {
+		function mockSetupMultipleSuccessCall(version, untypedGroupMembers: Array<OutgoingServerJson>, untypedPersistentPostReturn: Array<OutgoingServerJson>) {
+			when(
+				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
+					...DEFAULT_REST_CLIENT_OPTIONS,
+					headers: { ...authHeader, v: String(version) },
+					queryParams: { count: untypedGroupMembers.length.toString() },
+					responseType: MediaType.Json,
+					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedGroupMembers)),
+				}),
+				{ times: 1 },
+			).thenResolve(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedPersistentPostReturn))
+		}
+
 		o("Less than 100 entities created should result in a single rest request", async function () {
 			const newGroupMembers = groupMembers(1)
 			const { version } = await typeModelResolver.resolveClientTypeReference(GroupMemberTypeRef)
@@ -1050,16 +1063,7 @@ o.spec("EntityRestClient", function () {
 			})
 			const untypedPersistentPostReturn = await instancePipeline.mapAndEncrypt(PersistenceResourcePostReturnTypeRef, persistentPostReturn, null)
 
-			when(
-				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
-					...DEFAULT_REST_CLIENT_OPTIONS,
-					headers: { ...authHeader, v: String(version) },
-					queryParams: { count: "1" },
-					responseType: MediaType.Json,
-					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedGroupMembers)),
-				}),
-				{ times: 1 },
-			).thenResolve(OutgoingServerJson.getJsonRepresentationOfMultiple([untypedPersistentPostReturn]))
+			mockSetupMultipleSuccessCall(version, untypedGroupMembers, [untypedPersistentPostReturn])
 
 			const result = await entityRestClient.setupMultiple("listId", newGroupMembers)
 
@@ -1082,16 +1086,7 @@ o.spec("EntityRestClient", function () {
 				return await instancePipeline.mapAndEncrypt(PersistenceResourcePostReturnTypeRef, instance, null)
 			})
 
-			when(
-				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
-					...DEFAULT_REST_CLIENT_OPTIONS,
-					headers: { ...authHeader, v: String(version) },
-					queryParams: { count: "100" },
-					responseType: MediaType.Json,
-					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedGroupMembers)),
-				}),
-				{ times: 1 },
-			).thenResolve(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedPostReturns))
+			mockSetupMultipleSuccessCall(version, untypedGroupMembers, untypedPostReturns)
 
 			const result = await entityRestClient.setupMultiple("listId", newGroupMembers)
 			o(result).deepEquals(resultIds)
@@ -1113,27 +1108,8 @@ o.spec("EntityRestClient", function () {
 				return await instancePipeline.mapAndEncrypt(PersistenceResourcePostReturnTypeRef, instance, null)
 			})
 
-			when(
-				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
-					...DEFAULT_REST_CLIENT_OPTIONS,
-					headers: { ...authHeader, v: String(version) },
-					queryParams: { count: "100" },
-					responseType: MediaType.Json,
-					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedGroupMembers.slice(0, 100))),
-				}),
-				{ times: 1 },
-			).thenResolve(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedPostReturns.slice(0, 100)))
-
-			when(
-				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
-					...DEFAULT_REST_CLIENT_OPTIONS,
-					headers: { ...authHeader, v: String(version) },
-					queryParams: { count: "1" },
-					responseType: MediaType.Json,
-					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedGroupMembers.slice(100))),
-				}),
-				{ times: 1 },
-			).thenResolve(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedPostReturns.slice(100)))
+			mockSetupMultipleSuccessCall(version, untypedGroupMembers.slice(0, 100), untypedPostReturns.slice(0, 100))
+			mockSetupMultipleSuccessCall(version, untypedGroupMembers.slice(100), untypedPostReturns.slice(100))
 
 			const result = await entityRestClient.setupMultiple("listId", newGroupMembers)
 			o(result).deepEquals(resultIds)
@@ -1181,7 +1157,7 @@ o.spec("EntityRestClient", function () {
 			o(result.errors.every((e) => e instanceof restError.BadRequestError)).equals(true)
 		})
 
-		o("Post multiple: When a PayloadTooLarge error occurs individual instances are posted", async function () {
+		o("Post multiple: When PayloadTooLarge occurs at or below threshold, it falls back to individual requests", async function () {
 			const listId = "listId"
 			const instances = groupMembers(3)
 			const idArray = ["0", null, "2"] // GET fails for id 1
@@ -1216,6 +1192,79 @@ o.spec("EntityRestClient", function () {
 			o(result.errors.length).equals(1)
 			o(result.errors[0] instanceof restError.InternalServerError).equals(true)
 			o(result.failedInstances).deepEquals([instances[1]])
+		})
+
+		o("Post multiple: When PayloadTooLarge occurs above threshold, it splits and retries recursively", async function () {
+			const listId = "listId"
+			// 50 entities is > single post request fallback threshold (20), but < POST_MULTIPLE_LIMIT (100)
+			const originalChunkSize = 50
+			const instances = groupMembers(originalChunkSize)
+
+			const resultIds = countFrom(0, originalChunkSize).map(String)
+			const untypedPostReturns = await promiseMap(resultIds, async (id) => {
+				const instance = createTestEntity(PersistenceResourcePostReturnTypeRef, {
+					generatedId: id,
+					permissionListId: "permissionListId",
+				})
+				return await instancePipeline.mapAndEncrypt(PersistenceResourcePostReturnTypeRef, instance, null)
+			})
+
+			const { version } = await typeModelResolver.resolveClientTypeReference(GroupMemberTypeRef)
+			const untypedGroupMembers = await promiseMap(instances, async (group) => {
+				return instancePipeline.mapAndEncrypt(GroupMemberTypeRef, group, null)
+			})
+
+			// First bulk call throws PayloadTooLargeError, forcing a split into 25 and 25
+			const firstSplitChunkSize = untypedGroupMembers.length / 2
+			when(
+				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
+					...DEFAULT_REST_CLIENT_OPTIONS,
+					headers: { ...authHeader, v: String(version) },
+					queryParams: { count: untypedGroupMembers.length.toString() },
+					responseType: MediaType.Json,
+					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(untypedGroupMembers)),
+				}),
+				{ times: 1 },
+			).thenReject(new restError.PayloadTooLargeError("too large"))
+
+			// First chunk of the retry succeeds
+			const firstRetryChunkEntities = untypedGroupMembers.slice(0, untypedGroupMembers.length / 2)
+			const firstRetryChunkUntypedPersistentPostReturn = untypedPostReturns.slice(0, untypedPostReturns.length / 2)
+			mockSetupMultipleSuccessCall(version, firstRetryChunkEntities, firstRetryChunkUntypedPersistentPostReturn)
+
+			// Second chunk fails, forcing another split
+			const secondRetryChunkEntities = untypedGroupMembers.slice(untypedGroupMembers.length / 2, untypedGroupMembers.length)
+			const secondRetryChunkUntypedPersistentPostReturn = untypedPostReturns.slice(untypedPostReturns.length / 2, untypedPostReturns.length)
+			when(
+				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
+					...DEFAULT_REST_CLIENT_OPTIONS,
+					headers: { ...authHeader, v: String(version) },
+					queryParams: { count: firstSplitChunkSize.toString() },
+					responseType: MediaType.Json,
+					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(secondRetryChunkEntities)),
+				}),
+				{ times: 1 },
+			).thenReject(new restError.PayloadTooLargeError("retry too large"))
+
+			// Second split happens for the second half of the original list
+			mockSetupMultipleSuccessCall(
+				version,
+				secondRetryChunkEntities.slice(0, secondRetryChunkEntities.length / 2),
+				secondRetryChunkUntypedPersistentPostReturn.slice(0, secondRetryChunkUntypedPersistentPostReturn.length / 2),
+			)
+			mockSetupMultipleSuccessCall(
+				version,
+				secondRetryChunkEntities.slice(secondRetryChunkEntities.length / 2, secondRetryChunkEntities.length),
+				secondRetryChunkUntypedPersistentPostReturn.slice(
+					secondRetryChunkUntypedPersistentPostReturn.length / 2,
+					secondRetryChunkUntypedPersistentPostReturn.length,
+				),
+			)
+
+			const result = await entityRestClient.setupMultiple(listId, instances)
+
+			verify(restClient.request(anything(), anything(), anything()), { ignoreExtraArgs: true, times: 5 })
+			o(result.sort((a, b) => Number.parseInt(a) - Number.parseInt(b))).deepEquals(resultIds)
 		})
 	})
 

--- a/test/tests/network/EntityRestClientTest.ts
+++ b/test/tests/network/EntityRestClientTest.ts
@@ -1214,8 +1214,7 @@ o.spec("EntityRestClient", function () {
 				return instancePipeline.mapAndEncrypt(GroupMemberTypeRef, group, null)
 			})
 
-			// First bulk call throws PayloadTooLargeError, forcing a split into 25 and 25
-			const firstSplitChunkSize = untypedGroupMembers.length / 2
+			// First bulk call throws PayloadTooLargeError, forcing a split, Math.floor(chunkSize / 2), into two chunks of 25
 			when(
 				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
 					...DEFAULT_REST_CLIENT_OPTIONS,
@@ -1227,43 +1226,44 @@ o.spec("EntityRestClient", function () {
 				{ times: 1 },
 			).thenReject(new restError.PayloadTooLargeError("too large"))
 
-			// First chunk of the retry succeeds
 			const firstRetryChunkEntities = untypedGroupMembers.slice(0, untypedGroupMembers.length / 2)
 			const firstRetryChunkUntypedPersistentPostReturn = untypedPostReturns.slice(0, untypedPostReturns.length / 2)
+
+			// First chunk of the retry succeeds
 			mockSetupMultipleSuccessCall(version, firstRetryChunkEntities, firstRetryChunkUntypedPersistentPostReturn)
 
-			// Second chunk fails, forcing another split
 			const secondRetryChunkEntities = untypedGroupMembers.slice(untypedGroupMembers.length / 2, untypedGroupMembers.length)
 			const secondRetryChunkUntypedPersistentPostReturn = untypedPostReturns.slice(untypedPostReturns.length / 2, untypedPostReturns.length)
+
+			// Second chunk fails, forcing another split
 			when(
 				restClient.request(`/rest/sys/groupmember/listId`, HttpMethod.POST, {
 					...DEFAULT_REST_CLIENT_OPTIONS,
 					headers: { ...authHeader, v: String(version) },
-					queryParams: { count: firstSplitChunkSize.toString() },
+					queryParams: { count: secondRetryChunkEntities.length.toString() },
 					responseType: MediaType.Json,
 					body: new RestTextBody(OutgoingServerJson.getJsonRepresentationOfMultiple(secondRetryChunkEntities)),
 				}),
 				{ times: 1 },
-			).thenReject(new restError.PayloadTooLargeError("retry too large"))
+			).thenReject(new restError.PayloadTooLargeError("second chunk retry too large"))
 
-			// Second split happens for the second half of the original list
+			// Second split happens for the second half of the original list, creating 3 chunks = 12, 12, 1
+			const newChunkSize = Math.floor(secondRetryChunkEntities.length / 2) // floor(25/2) = 12
 			mockSetupMultipleSuccessCall(
 				version,
-				secondRetryChunkEntities.slice(0, secondRetryChunkEntities.length / 2),
-				secondRetryChunkUntypedPersistentPostReturn.slice(0, secondRetryChunkUntypedPersistentPostReturn.length / 2),
+				secondRetryChunkEntities.slice(0, newChunkSize),
+				secondRetryChunkUntypedPersistentPostReturn.slice(0, newChunkSize),
 			)
 			mockSetupMultipleSuccessCall(
 				version,
-				secondRetryChunkEntities.slice(secondRetryChunkEntities.length / 2, secondRetryChunkEntities.length),
-				secondRetryChunkUntypedPersistentPostReturn.slice(
-					secondRetryChunkUntypedPersistentPostReturn.length / 2,
-					secondRetryChunkUntypedPersistentPostReturn.length,
-				),
+				secondRetryChunkEntities.slice(newChunkSize, secondRetryChunkEntities.length - 1),
+				secondRetryChunkUntypedPersistentPostReturn.slice(newChunkSize, secondRetryChunkUntypedPersistentPostReturn.length - 1),
 			)
+			mockSetupMultipleSuccessCall(version, secondRetryChunkEntities.slice(-1), secondRetryChunkUntypedPersistentPostReturn.slice(-1))
 
 			const result = await entityRestClient.setupMultiple(listId, instances)
 
-			verify(restClient.request(anything(), anything(), anything()), { ignoreExtraArgs: true, times: 5 })
+			verify(restClient.request(anything(), anything(), anything()), { ignoreExtraArgs: true, times: 6 })
 			o(result.sort((a, b) => Number.parseInt(a) - Number.parseInt(b))).deepEquals(resultIds)
 		})
 	})


### PR DESCRIPTION
This commit changes the retry policy of EntityRestClient.setupMultiple in case of PayloadTooLarge errors.
The new approach is to recursively reduce the chunk size in half and retry.
If at some point this error happens to a payload with not many entities we still fallback to individual post requests.

Closes #11246