### PR TITLE
[Desktop] Fix missed missed notifications

### DIFF
--- a/src/app-kit/native-bridge/common/EncryptedMissedNotification.ts
+++ b/src/app-kit/native-bridge/common/EncryptedMissedNotification.ts
@@ -1,27 +1,9 @@
 import { Nullable } from "@tutao/utils"
-import { createNotificationSessionKey, NotificationSessionKey } from "@tutao/entities/sys"
 
 import { EncryptedParsedInstance } from "@tutao/instance-pipeline"
 
 export class EncryptedMissedNotification {
 	constructor(public readonly notification: EncryptedParsedInstance) {}
-
-	getNotificationSessionKeys(): Array<NotificationSessionKey> {
-		const alarmNotifications = this.notification.getAttributeByName("alarmNotifications").asNestedObjList()
-		for (const alarmNotification of alarmNotifications) {
-			// all alarm notifications share the same keys (see CalendarFacade#encryptNotificationKeyForDevices)
-			const notificationSessionKeys = alarmNotification.getAttributeByName("notificationSessionKeys").asNestedObjList()
-			if (notificationSessionKeys.length > 0) {
-				return notificationSessionKeys.map((nsk) => {
-					return createNotificationSessionKey({
-						pushIdentifier: nsk.getAttributeByName("pushIdentifier").asIdTupleList()[0],
-						pushIdentifierSessionEncSessionKey: nsk.getAttributeByName("pushIdentifierSessionEncSessionKey").asByteArray(),
-					})
-				})
-			}
-		}
-		return []
-	}
 
 	get lastProcessedNotificationId(): Nullable<Id> {
 		return this.notification.getAttributeByNameOrNull("lastProcessedNotificationId")?.getNullWhenNull()?.asId() ?? null

--- a/src/applications/common/desktop/sse/TutaSseFacade.ts
+++ b/src/applications/common/desktop/sse/TutaSseFacade.ts
@@ -168,25 +168,25 @@ export class TutaSseFacade implements SseEventHandler {
 			const alarmIdentifier = encryptedAlarmNotification.getAlarmId()
 			const operation = downcast<OperationType>(encryptedAlarmNotification.getOperation())
 			if (operation === OperationType.CREATE) {
-				while (true) {
-					const sk = await this.alarmStorage.getNotificationSessionKey(encryptedMissedNotification.getNotificationSessionKeys())
-					if (!sk) {
-						// none of the NotificationSessionKeys in the AlarmNotification worked.
-						// this is indicative of a serious problem with the stored keys.
-						// therefore, we should invalidate the sseInfo and throw away
-						// our pushEncSessionKeys.
-						throw new CryptoError("could not find session key to decrypt alarm notification")
-					}
-					const alarmNotification = await this.nativeInstancePipeline.decryptAndMapEncryptedInstance<AlarmNotification>(
-						alarmNotificationUntyped,
-						assertNotNull(sk).sessionKey,
-					)
-					if (hasError(alarmNotification)) {
-						// some property of the AlarmNotification couldn't be decrypted with the selected key
-						// throw away the key that caused the error and try the next one
-						await this.alarmStorage.removePushIdentifierKey(elementIdPart(sk.notificationSessionKey.pushIdentifier))
-						continue
-					}
+				const sk = await this.alarmStorage.getNotificationSessionKey(encryptedAlarmNotification.getNotificationSessionKeys())
+				if (!sk) {
+					// none of the NotificationSessionKeys in the AlarmNotification worked.
+					// this is indicative of a serious problem with the stored keys.
+					// therefore, we should invalidate the sseInfo and throw away
+					// our pushEncSessionKeys.
+					throw new CryptoError("could not find session key to decrypt alarm notification")
+				}
+				const alarmNotification = await this.nativeInstancePipeline.decryptAndMapEncryptedInstance<AlarmNotification>(
+					alarmNotificationUntyped,
+					assertNotNull(sk).sessionKey,
+				)
+				if (hasError(alarmNotification)) {
+					// some property of the AlarmNotification couldn't be decrypted with the selected key
+					// throw away the key that caused the error and try the next one
+					await this.alarmStorage.removePushIdentifierKey(elementIdPart(sk.notificationSessionKey.pushIdentifier))
+					// TODO do we really want to throw now? Or first decrypt all notifications that we can?
+					throw new CryptoError("could not find session key to decrypt alarm notification")
+				} else {
 					return await this.alarmScheduler.handleCreateAlarm(alarmNotification)
 				}
 			} else if (operation === OperationType.DELETE) {


### PR DESCRIPTION
Missed notifications are a virtual type, bundling the contents of multiple notifications, each of which have their own session key. This means that not all alarm notifications in one missed notification have the same session key. The session key is available for each alarm notification, and that is where we should look for it, instead of getting the first we find on the missed notification.