### PR TITLE
[desktop] Fix high-latency address racing and bounded SSE recovery

### DIFF
--- a/src/applications/common/desktop/DesktopMain.ts
+++ b/src/applications/common/desktop/DesktopMain.ts
@@ -97,6 +97,9 @@ import { CertificateProvider } from "./CertificateProvider"
 mp()
 
 dns.setDefaultResultOrder("ipv4first")
+// Node's 250 ms default can abort viable connections on high-latency or lossy routes.
+// Apply the larger timeout to every Node network client used by the desktop app.
+net.setDefaultAutoSelectFamilyAttemptTimeout(20_000)
 
 setupAssetProtocol(electron)
 

--- a/src/applications/common/desktop/net/DesktopNetworkClient.ts
+++ b/src/applications/common/desktop/net/DesktopNetworkClient.ts
@@ -1,11 +1,66 @@
 import http from "node:http"
 import https from "node:https"
+import net from "node:net"
+import tls from "node:tls"
+import type { Duplex } from "node:stream"
 import { ConnectionError } from "@tutao/rest-client/error"
 import { log } from "../DesktopLog.js"
 import type { ReadStream } from "node:fs"
 import { newPromise } from "@tutao/utils"
+import { connectWithHappyEyeballs } from "./HappyEyeballsConnector.js"
 
 const TAG = "[DesktopNetworkClient]"
+
+class HappyEyeballsHttpsAgent extends https.Agent {
+	constructor() {
+		// Preserve https.globalAgent's pooling policy. Its five-second socket
+		// timeout is deliberately omitted so the connector owns establishment's
+		// single 20-second deadline.
+		super({ keepAlive: true, scheduling: "lifo" })
+	}
+
+	override createConnection(options: https.RequestOptions, callback?: (error: Error | null, stream: Duplex) => void): Duplex | null | undefined {
+		const hostname = options.hostname ?? options.host
+		if (callback == null || hostname == null || options.socketPath != null) {
+			return super.createConnection(options, callback)
+		}
+		// Node omits the stream when reporting an asynchronous connection error,
+		// although @types/node declares the callback's stream as always present.
+		const finishConnection = callback as (error: Error | null, stream?: Duplex) => void
+
+		const port = Number(options.port ?? 443)
+		const servername = options.servername ?? (net.isIP(hostname) === 0 ? hostname : undefined)
+		void connectWithHappyEyeballs({
+			hostname,
+			port,
+			family: options.family,
+			localAddress: options.localAddress,
+			readyEvent: "secureConnect",
+			createConnection: (candidate) => {
+				const socket = super.createConnection({
+					...options,
+					host: candidate.address,
+					hostname: candidate.address,
+					family: candidate.family,
+					servername,
+				})
+				if (!(socket instanceof tls.TLSSocket)) {
+					socket?.destroy()
+					throw new TypeError("HTTPS agent did not create a TLS socket")
+				}
+				socket.setNoDelay(true)
+				return socket
+			},
+		}).then(
+			(socket) => finishConnection(null, socket),
+			(error) => finishConnection(error),
+		)
+
+		return undefined
+	}
+}
+
+const httpsAgent = new HappyEyeballsHttpsAgent()
 
 /**
  * Manually re-doing http$requestOptions because built-in definition is crap.
@@ -29,7 +84,13 @@ export type ClientRequestOptions = {
 
 export class DesktopNetworkClient {
 	request(url: URL, opts: ClientRequestOptions): http.ClientRequest {
-		return this.getModule(url).request(url, opts)
+		if (url.protocol === "https:") {
+			return https.request(url, { ...opts, agent: httpsAgent })
+		} else {
+			// Production SSE and POST endpoints use HTTPS. Preserve Node's default
+			// behavior for the plain-HTTP path instead of broadening this adapter.
+			return http.request(url, opts)
+		}
 	}
 
 	/**
@@ -67,13 +128,5 @@ export class DesktopNetworkClient {
 				req.end()
 			}
 		})
-	}
-
-	private getModule(url: URL): typeof import("http") | typeof import("https") {
-		if (url.protocol === "https:") {
-			return https
-		} else {
-			return http
-		}
 	}
 }

--- a/src/applications/common/desktop/net/HappyEyeballsConnector.ts
+++ b/src/applications/common/desktop/net/HappyEyeballsConnector.ts
@@ -1,0 +1,265 @@
+import dns from "node:dns"
+import net from "node:net"
+import os from "node:os"
+
+export const CONNECTION_ATTEMPT_DELAY_MS = 1_000
+export const CONNECTION_TIMEOUT_MS = 20_000
+const IP_FAMILY_HINT_CACHE_MS = 5 * 60 * 1_000
+
+type IpFamily = 4 | 6
+
+let cachedIpFamilyHint: { family: IpFamily; expiresAt: number } | null = null
+
+export type ConnectionCandidate = {
+	address: string
+	family: IpFamily
+}
+
+export type HappyEyeballsOptions<T extends net.Socket> = {
+	hostname: string
+	port: number
+	family?: number
+	localAddress?: string
+	readyEvent: "connect" | "secureConnect"
+	createConnection: (candidate: ConnectionCandidate) => T
+}
+
+/**
+ * Staggers connection attempts while keeping previous attempts alive. The first
+ * socket to complete the requested handshake wins and all other sockets are
+ * closed. DNS resolution and all connection attempts share one overall timeout.
+ */
+export function connectWithHappyEyeballs<T extends net.Socket>(options: HappyEyeballsOptions<T>): Promise<T> {
+	return new Promise((resolve, reject) => {
+		let candidates: ReadonlyArray<ConnectionCandidate> = []
+		let nextCandidateIndex = 0
+		let nextAttemptTimer: NodeJS.Timeout | null = null
+		let settled = false
+		const activeSockets = new Set<T>()
+		const connectionErrors: Array<Error> = []
+
+		const overallTimeout = setTimeout(() => {
+			const error = new Error(`Connection to ${options.hostname}:${options.port} timed out after ${CONNECTION_TIMEOUT_MS} ms`)
+			;(error as NodeJS.ErrnoException).code = "ETIMEDOUT"
+			finishWithError(error)
+		}, CONNECTION_TIMEOUT_MS)
+
+		function clearNextAttemptTimer() {
+			if (nextAttemptTimer != null) {
+				clearTimeout(nextAttemptTimer)
+				nextAttemptTimer = null
+			}
+		}
+
+		function closeActiveSockets(winner?: T) {
+			for (const socket of activeSockets) {
+				if (socket !== winner) socket.destroy()
+			}
+			activeSockets.clear()
+		}
+
+		function finishWithSocket(socket: T) {
+			if (settled) {
+				socket.destroy()
+				return
+			}
+			settled = true
+			clearTimeout(overallTimeout)
+			clearNextAttemptTimer()
+			closeActiveSockets(socket)
+			resolve(socket)
+		}
+
+		function finishWithError(error: Error) {
+			if (settled) return
+			settled = true
+			clearTimeout(overallTimeout)
+			clearNextAttemptTimer()
+			closeActiveSockets()
+			reject(error)
+		}
+
+		function finishWhenExhausted() {
+			if (nextCandidateIndex < candidates.length || activeSockets.size > 0) return
+			finishWithError(new AggregateError(connectionErrors, `Could not connect to ${options.hostname}:${options.port}`))
+		}
+
+		function startNextConnection() {
+			if (settled) return
+			clearNextAttemptTimer()
+
+			let attempt: { candidate: ConnectionCandidate; socket: T } | null = null
+			while (attempt == null) {
+				const candidate = candidates[nextCandidateIndex]
+				if (candidate == null) {
+					finishWhenExhausted()
+					return
+				}
+				nextCandidateIndex += 1
+
+				try {
+					attempt = { candidate, socket: options.createConnection(candidate) }
+				} catch (error) {
+					connectionErrors.push(asError(error))
+				}
+			}
+			const { candidate, socket } = attempt
+
+			activeSockets.add(socket)
+			let attemptFinished = false
+			const cleanupAttemptListeners = () => {
+				socket.removeListener(options.readyEvent, onConnected)
+				socket.removeListener("error", onError)
+				socket.removeListener("close", onClose)
+			}
+
+			const onConnected = () => {
+				if (attemptFinished) return
+				attemptFinished = true
+				cleanupAttemptListeners()
+				activeSockets.delete(socket)
+				finishWithSocket(socket)
+			}
+
+			const onError = (error: Error) => {
+				if (attemptFinished) return
+				attemptFinished = true
+				cleanupAttemptListeners()
+				activeSockets.delete(socket)
+				if (settled) return
+				socket.destroy()
+				connectionErrors.push(error)
+				if (nextCandidateIndex < candidates.length) {
+					startNextConnection()
+				} else {
+					finishWhenExhausted()
+				}
+			}
+
+			const onClose = () => {
+				if (attemptFinished) return
+				const error = new Error(`Connection to ${candidate.address}:${options.port} closed before completing the handshake`)
+				;(error as NodeJS.ErrnoException).code = "ECONNRESET"
+				onError(error)
+			}
+
+			socket.once(options.readyEvent, onConnected)
+			socket.once("error", onError)
+			socket.once("close", onClose)
+
+			// One second gives the preferred route a head start without imposing
+			// Node's short per-address cutoff; previous attempts remain active.
+			if (nextCandidateIndex < candidates.length) {
+				nextAttemptTimer = setTimeout(startNextConnection, CONNECTION_ATTEMPT_DELAY_MS)
+			}
+		}
+
+		resolveConnectionCandidates(options.hostname, options.family, options.localAddress).then(
+			(resolvedCandidates) => {
+				if (settled) return
+				candidates = resolvedCandidates
+				if (candidates.length === 0) {
+					const error = new Error(`No usable addresses found for ${options.hostname}`)
+					;(error as NodeJS.ErrnoException).code = "ENOTFOUND"
+					finishWithError(error)
+					return
+				}
+				startNextConnection()
+			},
+			(error) => finishWithError(asError(error)),
+		)
+	})
+}
+
+async function resolveConnectionCandidates(hostname: string, requestedFamily?: number, localAddress?: string): Promise<Array<ConnectionCandidate>> {
+	const hostnameFamily = net.isIP(hostname)
+	const localAddressFamily = localAddress == null ? 0 : net.isIP(localAddress)
+	const explicitFamily = asIpFamily(requestedFamily)
+	const sourceFamily = asIpFamily(localAddressFamily)
+	if (explicitFamily != null && sourceFamily != null && explicitFamily !== sourceFamily) return []
+	const requiredFamily = explicitFamily ?? sourceFamily
+
+	if (hostnameFamily !== 0) {
+		const family = hostnameFamily as IpFamily
+		return requiredFamily == null || requiredFamily === family ? [{ address: hostname, family }] : []
+	}
+
+	const lookupResults = await dns.promises.lookup(hostname, { all: true })
+	const uniqueCandidates: Array<ConnectionCandidate> = []
+	const seen = new Set<string>()
+	for (const result of lookupResults) {
+		const family = asIpFamily(result.family)
+		if (family == null || (requiredFamily != null && family !== requiredFamily)) continue
+		const key = `${family}:${result.address}`
+		if (!seen.has(key)) {
+			seen.add(key)
+			uniqueCandidates.push({ address: result.address, family })
+		}
+	}
+
+	return interleaveCandidates(uniqueCandidates, getPreferredIpFamily())
+}
+
+/**
+ * Uses configured interface addresses as an ordering hint. IPv4 remains the
+ * default unless there is a usable IPv6 address and no usable IPv4 address.
+ * Both families are still attempted regardless of this preference.
+ */
+export function determinePreferredIpFamily(networkInterfaces = os.networkInterfaces()): IpFamily {
+	let hasIpv4Hint = false
+	let hasIpv6Hint = false
+
+	for (const addresses of Object.values(networkInterfaces)) {
+		for (const address of addresses ?? []) {
+			if (address.internal || isLinkLocalAddress(address.address, address.family)) continue
+			if (address.family === "IPv4") hasIpv4Hint = true
+			if (address.family === "IPv6") hasIpv6Hint = true
+		}
+	}
+
+	return !hasIpv4Hint && hasIpv6Hint ? 6 : 4
+}
+
+function getPreferredIpFamily(): IpFamily {
+	const now = Date.now()
+	if (cachedIpFamilyHint == null || cachedIpFamilyHint.expiresAt <= now) {
+		cachedIpFamilyHint = {
+			family: determinePreferredIpFamily(),
+			expiresAt: now + IP_FAMILY_HINT_CACHE_MS,
+		}
+	}
+	return cachedIpFamilyHint.family
+}
+
+function isLinkLocalAddress(address: string, family: string): boolean {
+	if (family === "IPv4") return address.startsWith("169.254.")
+	if (family !== "IPv6") return false
+	const firstHextet = Number.parseInt(address.split(":", 1)[0], 16)
+	return firstHextet >= 0xfe80 && firstHextet <= 0xfebf
+}
+
+function interleaveCandidates(candidates: ReadonlyArray<ConnectionCandidate>, preferredFamily: IpFamily): Array<ConnectionCandidate> {
+	const ipv4Candidates = candidates.filter((candidate) => candidate.family === 4)
+	const ipv6Candidates = candidates.filter((candidate) => candidate.family === 6)
+	const interleaved: Array<ConnectionCandidate> = []
+	const length = Math.max(ipv4Candidates.length, ipv6Candidates.length)
+	const preferredCandidates = preferredFamily === 4 ? ipv4Candidates : ipv6Candidates
+	const fallbackCandidates = preferredFamily === 4 ? ipv6Candidates : ipv4Candidates
+
+	for (let index = 0; index < length; index += 1) {
+		const preferredCandidate = preferredCandidates[index]
+		const fallbackCandidate = fallbackCandidates[index]
+		if (preferredCandidate != null) interleaved.push(preferredCandidate)
+		if (fallbackCandidate != null) interleaved.push(fallbackCandidate)
+	}
+
+	return interleaved
+}
+
+function asIpFamily(family: number | undefined): IpFamily | null {
+	return family === 4 || family === 6 ? family : null
+}
+
+function asError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error))
+}

--- a/src/applications/common/desktop/net/NetAgent.ts
+++ b/src/applications/common/desktop/net/NetAgent.ts
@@ -1,5 +1,8 @@
 import type { HeadersInit, RequestInit, Response } from "undici"
-import { Agent, fetch as undiciFetch, Headers } from "undici"
+import { Agent, buildConnector, fetch as undiciFetch, Headers, setGlobalDispatcher } from "undici"
+import net from "node:net"
+import tls from "node:tls"
+import { CONNECTION_TIMEOUT_MS, connectWithHappyEyeballs } from "./HappyEyeballsConnector.js"
 
 export type UndiciResponse = Response
 export type UndiciRequestInit = RequestInit
@@ -11,6 +14,59 @@ export type FetchImpl = (target: string | URL, init?: UndiciRequestInit) => Prom
 const SOCKET_IDLE_TIMEOUT_MS = 5 * 60 * 1000 + 1000
 /** Timeout between reading data. */
 const READ_TIMEOUT_MS = 20_000
+const MAX_CACHED_TLS_SESSIONS = 100
+
+const defaultConnector = buildConnector({ allowH2: false, timeout: CONNECTION_TIMEOUT_MS })
+const tlsSessions = new Map<string, Buffer>()
+
+const happyEyeballsConnector: NonNullable<Agent.Options["connect"]> = (options, callback) => {
+	if (options.socketPath != null) {
+		callback(new Error("Unix socket connections are not supported by the desktop network agent"), null)
+		return
+	}
+	if (options.httpSocket != null || (options.protocol !== "http:" && options.protocol !== "https:")) {
+		defaultConnector(options, callback)
+		return
+	}
+
+	const secure = options.protocol === "https:"
+	const port = Number(options.port || (secure ? 443 : 80))
+	const servername = options.servername ?? (net.isIP(options.hostname) === 0 ? options.hostname : undefined)
+	const sessionKey = `${servername ?? options.hostname}:${port}`
+
+	void connectWithHappyEyeballs({
+		hostname: options.hostname,
+		port,
+		localAddress: options.localAddress ?? undefined,
+		readyEvent: secure ? "secureConnect" : "connect",
+		createConnection: (candidate) => {
+			const tcpSocket = net.connect({
+				host: candidate.address,
+				port,
+				family: candidate.family,
+				localAddress: options.localAddress ?? undefined,
+			})
+			const socket = secure
+				? tls.connect({
+						socket: tcpSocket,
+						servername,
+						ALPNProtocols: ["http/1.1"],
+						session: tlsSessions.get(sessionKey),
+					})
+				: tcpSocket
+
+			socket.setKeepAlive(true, 60_000)
+			socket.setNoDelay(true)
+			if (socket instanceof tls.TLSSocket) {
+				socket.on("session", (session) => cacheTlsSession(sessionKey, session))
+			}
+			return socket
+		},
+	}).then(
+		(socket) => callback(null, socket),
+		(error) => callback(error, null),
+	)
+}
 
 // We do not enable HTTP2 yet because it is still experimental (and buggy).
 const agent = new Agent({
@@ -18,20 +74,20 @@ const agent = new Agent({
 	keepAliveTimeout: SOCKET_IDLE_TIMEOUT_MS,
 	bodyTimeout: READ_TIMEOUT_MS,
 	headersTimeout: READ_TIMEOUT_MS,
-	connectTimeout: READ_TIMEOUT_MS,
-	// this is needed to address issues in some cases where IPv6 does not really work
-	autoSelectFamily: true,
+	connect: happyEyeballsConnector,
 })
+
+// Node's built-in fetch uses Undici's global dispatcher. Install the same
+// bounded agent used by customFetch so every main-process fetch follows the
+// same connection race and per-origin connection limit.
+setGlobalDispatcher(agent)
 
 export const customFetch: FetchImpl = async (target: string | URL, init?: UndiciRequestInit): Promise<UndiciResponse> => {
 	if (init?.body != null) {
 		// undici throws an error if this is not taken care of.
 		init.duplex = "half"
 	}
-	return await undiciFetch(target, {
-		...(init ?? {}),
-		dispatcher: agent,
-	})
+	return await undiciFetch(target, init)
 }
 
 /**
@@ -57,4 +113,13 @@ export function convertHeaders(headers: globalThis.Headers): UndiciHeadersInit {
  */
 export function toGlobalResponse(response: FetchResult): globalThis.Response {
 	return response as unknown as globalThis.Response
+}
+
+function cacheTlsSession(key: string, session: Buffer) {
+	tlsSessions.delete(key)
+	tlsSessions.set(key, session)
+	if (tlsSessions.size > MAX_CACHED_TLS_SESSIONS) {
+		const oldestKey = tlsSessions.keys().next().value
+		if (oldestKey != null) tlsSessions.delete(oldestKey)
+	}
 }

--- a/src/applications/common/desktop/sse/SseClient.ts
+++ b/src/applications/common/desktop/sse/SseClient.ts
@@ -1,11 +1,13 @@
 import http from "node:http"
 import type { DesktopNetworkClient } from "../net/DesktopNetworkClient"
 import { makeTaggedLogger } from "../DesktopLog"
-import { Scheduler } from "../../api/common/utils/Scheduler.js"
+import type { ScheduledTimeoutId, Scheduler } from "../../api/common/utils/Scheduler.js"
 import { ProgrammingError } from "../../../../platform-kit/app-env"
 
 import { newPromise } from "../../../../platform-kit/utils"
 import { reverse } from "../../misc/EnumUtils"
+import { ConnectionError } from "@tutao/rest-client/error"
+import { CONNECTION_TIMEOUT_MS } from "../net/HappyEyeballsConnector.js"
 
 const log = makeTaggedLogger("[SSE]")
 
@@ -13,9 +15,9 @@ const log = makeTaggedLogger("[SSE]")
  * Provides computed delays for SSE (in ms)
  */
 export interface SseDelay {
-	reconnectDelay(attempt: number): number
+	connectionFailureDelay(attempt: number): number
 
-	initialConnectionDelay(): number
+	connectionLostDelay(): number
 }
 
 export interface SseEventHandler {
@@ -54,8 +56,14 @@ export enum ConnectionState {
  */
 type State =
 	| { state: ConnectionState.disconnected }
-	| { state: ConnectionState.connecting; options: SseConnectOptions; attempt: number; connection: http.ClientRequest }
-	| { state: ConnectionState.delayedReconnect; options: SseConnectOptions; attempt: number; timeout: NodeJS.Timeout }
+	| {
+			state: ConnectionState.connecting
+			options: SseConnectOptions
+			attempt: number
+			connection: http.ClientRequest
+			establishmentTimeout: ScheduledTimeoutId
+	  }
+	| { state: ConnectionState.delayedReconnect; options: SseConnectOptions; attempt: number; timeout: ScheduledTimeoutId }
 	| {
 			state: ConnectionState.connected
 			options: SseConnectOptions
@@ -133,6 +141,20 @@ export class SseClient {
 			},
 			method: "GET",
 		})
+		const reconnectAfterRequestFailure = (error: Error) => {
+			const state = this.state
+			if (state.state !== ConnectionState.connecting || state.connection !== connection) return false
+			log.error("error:", error.message)
+			this.scheduler.unscheduleTimeout(state.establishmentTimeout)
+			this.exponentialBackoffReconnect()
+			return true
+		}
+		const establishmentTimeout = this.scheduler.scheduleAfter(() => {
+			const error = new ConnectionError(`SSE connection timed out after ${CONNECTION_TIMEOUT_MS} ms`)
+			if (reconnectAfterRequestFailure(error)) connection.destroy(error)
+		}, CONNECTION_TIMEOUT_MS)
+		this.state = { state: ConnectionState.connecting, connection, establishmentTimeout, attempt, options }
+
 		connection
 			.on("socket", (s) => {
 				// We add this listener purely as a workaround for some problem with net module.
@@ -142,6 +164,12 @@ export class SseClient {
 				s.on("lookup", () => log.debug("lookup"))
 			})
 			.on("response", async (res) => {
+				const state = this.state
+				if (state.state !== ConnectionState.connecting || state.connection !== connection) {
+					res.destroy()
+					return
+				}
+				this.scheduler.unscheduleTimeout(state.establishmentTimeout)
 				log.debug("established SSE connection with code", res.statusCode)
 				this.state = { state: ConnectionState.connected, connection, options, receivedHeartbeat: false }
 				this.resetHeartbeatListener()
@@ -173,24 +201,19 @@ export class SseClient {
 					.on("close", () => {
 						log.debug("response closed")
 						// This event is fired also when we close the connection manually. In this case we do not want to reconnect.
-						if (this.state.state !== ConnectionState.disconnected) this.delayedReconnect()
+						if (this.state.state === ConnectionState.connected && this.state.connection === connection) this.delayedReconnect()
 					})
 					.on("error", (e) => {
 						log.error("response error:", e)
 						// This event is fired also when we close the connection manually. In this case we do not want to reconnect.
-						if (this.state.state !== ConnectionState.disconnected) this.delayedReconnect()
+						if (this.state.state === ConnectionState.connected && this.state.connection === connection) this.delayedReconnect()
 					})
 			})
 			.on("information", () => log.debug("information"))
 			.on("connect", () => log.debug("connect:"))
-			.on("error", (e) => {
-				log.error("error:", e.message)
-				if (this.state.state === ConnectionState.connecting) {
-					this.exponentialBackoffReconnect()
-				}
-			})
+			.on("error", reconnectAfterRequestFailure)
+			.on("close", () => reconnectAfterRequestFailure(new ConnectionError("SSE connection closed before receiving a response")))
 			.end()
-		this.state = { state: ConnectionState.connecting, connection, attempt, options }
 	}
 
 	async disconnect() {
@@ -202,11 +225,12 @@ export class SseClient {
 				break
 			case ConnectionState.connected:
 			case ConnectionState.connecting:
+				if (state.state === ConnectionState.connecting) this.scheduler.unscheduleTimeout(state.establishmentTimeout)
+				// Mark the connection as intentionally closed before destroy() emits
+				// error/close events, otherwise those handlers can schedule a retry.
+				this.state = { state: ConnectionState.disconnected }
 				return newPromise<void>((resolve) => {
-					state.connection.once("close", () => {
-						this.state = { state: ConnectionState.disconnected }
-						resolve()
-					})
+					state.connection.once("close", resolve)
 					state.connection.destroy()
 				})
 		}
@@ -227,7 +251,7 @@ export class SseClient {
 			throw new ProgrammingError("Invalid state: not connecting")
 		}
 		log.debug("Scheduling exponential reconnect")
-		const timeout = this.scheduler.scheduleAfter(() => this.retryConnect(), this.delay.reconnectDelay(this.state.attempt))
+		const timeout = this.scheduler.scheduleAfter(() => this.retryConnect(), this.delay.connectionFailureDelay(this.state.attempt))
 		this.state = {
 			state: ConnectionState.delayedReconnect,
 			attempt: this.state.attempt + 1,
@@ -241,8 +265,8 @@ export class SseClient {
 			throw new ProgrammingError("Invalid state: not connected")
 		}
 		log.debug("Scheduling delayed reconnect")
-		const timeout = this.scheduler.scheduleAfter(() => this.retryConnect(), this.delay.initialConnectionDelay())
-		this.state = { state: ConnectionState.delayedReconnect, attempt: 0, options: this.state.options, timeout }
+		const timeout = this.scheduler.scheduleAfter(() => this.retryConnect(), this.delay.connectionLostDelay())
+		this.state = { state: ConnectionState.delayedReconnect, attempt: 1, options: this.state.options, timeout }
 	}
 
 	private async retryConnect() {

--- a/src/applications/common/desktop/sse/reconnectDelay.ts
+++ b/src/applications/common/desktop/sse/reconnectDelay.ts
@@ -1,14 +1,24 @@
-import { SseDelay } from "./SseClient.js"
+import type { SseDelay } from "./SseClient.js"
+import { CONNECTION_TIMEOUT_MS } from "../net/HappyEyeballsConnector.js"
+import { randomInt } from "node:crypto"
 
-const INITIAL_SSE_CONNECT_TIMEOUT_SEC = 60
-const MAX_SSE_CONNECT_TIMEOUT_SEC = 2400
+const MAX_SSE_RECONNECT_INTERVAL_MS = 120_000
+type RandomInt = (minimum: number, maximum: number) => number
 
 export class DesktopSseDelay implements SseDelay {
-	initialConnectionDelay(): number {
-		return INITIAL_SSE_CONNECT_TIMEOUT_SEC * 1000
+	constructor(private readonly randomInteger: RandomInt = randomInt) {}
+
+	connectionLostDelay(): number {
+		return this.withEqualJitter(CONNECTION_TIMEOUT_MS)
 	}
 
-	reconnectDelay(attempt: number): number {
-		return Math.min(INITIAL_SSE_CONNECT_TIMEOUT_SEC * Math.pow(2, attempt), MAX_SSE_CONNECT_TIMEOUT_SEC) * 1000
+	connectionFailureDelay(attempt: number): number {
+		const interval = Math.min(CONNECTION_TIMEOUT_MS * Math.pow(2, Math.max(0, attempt - 1)), MAX_SSE_RECONNECT_INTERVAL_MS)
+		return this.withEqualJitter(interval)
+	}
+
+	private withEqualJitter(maximum: number): number {
+		const minimum = Math.ceil(maximum / 2)
+		return this.randomInteger(minimum, maximum + 1)
 	}
 }

--- a/test/tests/Suite.ts
+++ b/test/tests/Suite.ts
@@ -346,6 +346,7 @@ async function setupSuite({ integration }: { integration?: boolean }) {
 		await import("./desktop/files/TempFsTest.js")
 		await import("./desktop/integration/DesktopIntegratorTest.js")
 		await import("./desktop/integration/WindowsRegistryFacadeTest.js")
+		await import("./desktop/net/HappyEyeballsConnectorTest.js")
 		await import("./desktop/net/ProtocolProxyTest.js")
 		await import("./desktop/sse/DesktopAlarmSchedulerTest.js")
 		await import("./desktop/sse/DesktopAlarmStorageTest.js")

--- a/test/tests/desktop/net/HappyEyeballsConnectorTest.ts
+++ b/test/tests/desktop/net/HappyEyeballsConnectorTest.ts
@@ -1,0 +1,309 @@
+import o, { assertThrows, mockAttribute, unmockAttribute } from "@tutao/otest"
+import dns from "node:dns"
+import net from "node:net"
+import os from "node:os"
+import {
+	CONNECTION_ATTEMPT_DELAY_MS,
+	CONNECTION_TIMEOUT_MS,
+	connectWithHappyEyeballs,
+	determinePreferredIpFamily,
+} from "../../../../src/applications/common/desktop/net/HappyEyeballsConnector.js"
+import type { ConnectionCandidate, HappyEyeballsOptions } from "../../../../src/applications/common/desktop/net/HappyEyeballsConnector.js"
+
+o.spec("HappyEyeballsConnector", () => {
+	let timers: TimerMock
+	let lookupResults: Promise<Array<{ address: string; family: number }>>
+	let lookupCalls: number
+	let mocks: Array<Record<string, unknown>>
+
+	o.beforeEach(() => {
+		timers = new TimerMock()
+		lookupResults = Promise.resolve([
+			{ address: "192.0.2.1", family: 4 },
+			{ address: "2001:db8::1", family: 6 },
+		])
+		lookupCalls = 0
+		mocks = [
+			mockAttribute(globalThis, globalThis.setTimeout, timers.setTimeout),
+			mockAttribute(globalThis, globalThis.clearTimeout, timers.clearTimeout),
+			mockAttribute(dns.promises, dns.promises.lookup, async () => {
+				lookupCalls += 1
+				return await lookupResults
+			}),
+			mockAttribute(os, os.networkInterfaces, () => dualStackInterfaces),
+		]
+	})
+
+	o.afterEach(() => {
+		for (const mock of mocks.reverse()) unmockAttribute(mock)
+	})
+
+	o.test("interleaves families and keeps previous attempts active", async () => {
+		lookupResults = Promise.resolve([
+			{ address: "2001:db8::1", family: 6 },
+			{ address: "192.0.2.1", family: 4 },
+			{ address: "192.0.2.1", family: 4 },
+			{ address: "2001:db8::2", family: 6 },
+			{ address: "192.0.2.2", family: 4 },
+		])
+		const attempts: Array<ConnectionAttempt> = []
+		const result = connect((candidate) => addAttempt(attempts, candidate))
+
+		await flushPromises()
+		o(attempts.map(({ candidate }) => candidate)).deepEquals([{ address: "192.0.2.1", family: 4 }])
+		let resolved = false
+		void result.then(() => {
+			resolved = true
+		})
+		attempts[0].socket.emit("connect")
+		await flushPromises()
+		o(resolved).equals(false)
+
+		timers.runNext(CONNECTION_ATTEMPT_DELAY_MS)
+		o(attempts.map(({ candidate }) => candidate)).deepEquals([
+			{ address: "192.0.2.1", family: 4 },
+			{ address: "2001:db8::1", family: 6 },
+		])
+		o(attempts[0].socket.destroyCalls).equals(0)
+
+		timers.runNext(CONNECTION_ATTEMPT_DELAY_MS)
+		timers.runNext(CONNECTION_ATTEMPT_DELAY_MS)
+		o(attempts.map(({ candidate }) => candidate)).deepEquals([
+			{ address: "192.0.2.1", family: 4 },
+			{ address: "2001:db8::1", family: 6 },
+			{ address: "192.0.2.2", family: 4 },
+			{ address: "2001:db8::2", family: 6 },
+		])
+
+		attempts[3].socket.emit("secureConnect")
+		o(await result).equals(attempts[3].socket)
+		o(attempts.slice(0, 3).map(({ socket }) => socket.destroyCalls)).deepEquals([1, 1, 1])
+		o(attempts[3].socket.destroyCalls).equals(0)
+	})
+
+	o.test("starts the next address immediately after a hard error", async () => {
+		const attempts: Array<ConnectionAttempt> = []
+		const result = connect((candidate) => addAttempt(attempts, candidate))
+		await flushPromises()
+
+		const firstError = new Error("first failed")
+		attempts[0].socket.emit("error", firstError)
+		o(attempts.length).equals(2)
+		o(attempts[0].socket.destroyCalls).equals(1)
+
+		const secondError = new Error("second failed")
+		attempts[1].socket.emit("error", secondError)
+		const error = await assertThrows(AggregateError, () => result)
+		o(error.errors).deepEquals([firstError, secondError])
+	})
+
+	o.test("waits for active attempts after every address has started", async () => {
+		const attempts: Array<ConnectionAttempt> = []
+		const result = connect((candidate) => addAttempt(attempts, candidate))
+		await flushPromises()
+		timers.runNext(CONNECTION_ATTEMPT_DELAY_MS)
+
+		const secondError = new Error("second failed")
+		attempts[1].socket.emit("error", secondError)
+		o(attempts[0].socket.destroyCalls).equals(0)
+
+		const firstError = new Error("first failed")
+		attempts[0].socket.emit("error", firstError)
+		const error = await assertThrows(AggregateError, () => result)
+		o(error.errors).deepEquals([secondError, firstError])
+	})
+
+	o.test("advances past synchronous connection errors without recursion", async () => {
+		const attempts: Array<ConnectionAttempt> = []
+		const syncError = new Error("synchronous failure")
+		const result = connect((candidate) => {
+			if (candidate.family === 4) throw syncError
+			return addAttempt(attempts, candidate)
+		})
+
+		await flushPromises()
+		o(attempts.map(({ candidate }) => candidate)).deepEquals([{ address: "2001:db8::1", family: 6 }])
+		attempts[0].socket.emit("error", new Error("IPv6 failed"))
+		const error = await assertThrows(AggregateError, () => result)
+		o(error.errors[0]).equals(syncError)
+	})
+
+	o.test("uses the requested family and the local address family", async () => {
+		const familyAttempts: Array<ConnectionAttempt> = []
+		const familyResult = connect((candidate) => addAttempt(familyAttempts, candidate), { family: 6 })
+		await flushPromises()
+		o(familyAttempts.map(({ candidate }) => candidate)).deepEquals([{ address: "2001:db8::1", family: 6 }])
+		familyAttempts[0].socket.emit("secureConnect")
+		await familyResult
+
+		const localAddressAttempts: Array<ConnectionAttempt> = []
+		const localAddressResult = connect((candidate) => addAttempt(localAddressAttempts, candidate), { localAddress: "192.0.2.10" })
+		await flushPromises()
+		o(localAddressAttempts.map(({ candidate }) => candidate)).deepEquals([{ address: "192.0.2.1", family: 4 }])
+		localAddressAttempts[0].socket.emit("secureConnect")
+		await localAddressResult
+	})
+
+	o.test("rejects conflicting requested and local address families", async () => {
+		const result = assertThrows(Error, () =>
+			connect(() => new SocketStub(), {
+				family: 4,
+				localAddress: "2001:db8::10",
+			}),
+		)
+
+		await flushPromises()
+		const error = (await result) as NodeJS.ErrnoException
+		o(error.code).equals("ENOTFOUND")
+		o(lookupCalls).equals(0)
+	})
+
+	o.test("destroys active sockets at the overall deadline", async () => {
+		const attempts: Array<ConnectionAttempt> = []
+		const result = assertThrows(Error, () => connect((candidate) => addAttempt(attempts, candidate)))
+		await flushPromises()
+
+		timers.runNext(CONNECTION_TIMEOUT_MS)
+		const error = (await result) as NodeJS.ErrnoException
+		o(error.code).equals("ETIMEDOUT")
+		o(attempts[0].socket.destroyCalls).equals(1)
+	})
+
+	o.test("applies the overall deadline while DNS is pending", async () => {
+		let resolveLookup: (addresses: Array<{ address: string; family: number }>) => void
+		lookupResults = new Promise((resolve) => {
+			resolveLookup = resolve
+		})
+		const attempts: Array<ConnectionAttempt> = []
+		const result = assertThrows(Error, () => connect((candidate) => addAttempt(attempts, candidate)))
+
+		timers.runNext(CONNECTION_TIMEOUT_MS)
+		const error = (await result) as NodeJS.ErrnoException
+		o(error.code).equals("ETIMEDOUT")
+		resolveLookup!([{ address: "192.0.2.1", family: 4 }])
+		await flushPromises()
+		o(attempts).deepEquals([])
+	})
+
+	o.test("treats a close before the handshake as a connection error", async () => {
+		lookupResults = Promise.resolve([{ address: "192.0.2.1", family: 4 }])
+		const attempts: Array<ConnectionAttempt> = []
+		const result = assertThrows(AggregateError, () => connect((candidate) => addAttempt(attempts, candidate)))
+		await flushPromises()
+
+		attempts[0].socket.emit("close")
+		const error = await result
+		o((error.errors[0] as NodeJS.ErrnoException).code).equals("ECONNRESET")
+	})
+
+	o.test("uses interface addresses only as an ordering hint", () => {
+		o(determinePreferredIpFamily(dualStackInterfaces)).equals(4)
+		o(determinePreferredIpFamily(ipv6OnlyInterfaces)).equals(6)
+		o(determinePreferredIpFamily(linkLocalOnlyInterfaces)).equals(4)
+	})
+
+	function connect(
+		createConnection: (candidate: ConnectionCandidate) => SocketStub,
+		overrides: Partial<HappyEyeballsOptions<SocketStub>> = {},
+	): Promise<SocketStub> {
+		return connectWithHappyEyeballs({
+			hostname: "example.com",
+			port: 443,
+			readyEvent: "secureConnect",
+			createConnection,
+			...overrides,
+		})
+	}
+})
+
+type ConnectionAttempt = {
+	candidate: ConnectionCandidate
+	socket: SocketStub
+}
+
+function addAttempt(attempts: Array<ConnectionAttempt>, candidate: ConnectionCandidate): SocketStub {
+	const socket = new SocketStub()
+	attempts.push({ candidate, socket })
+	return socket
+}
+
+class SocketStub extends net.Socket {
+	destroyCalls = 0
+
+	override destroy(): this {
+		this.destroyCalls += 1
+		this.emit("close")
+		return this
+	}
+}
+
+class TimerMock {
+	private nextId = 1
+	private readonly scheduled = new Map<number, { callback: () => void; delay: number }>()
+
+	readonly setTimeout = (callback: () => void, delay: number): NodeJS.Timeout => {
+		const id = this.nextId++
+		this.scheduled.set(id, { callback, delay })
+		return id as unknown as NodeJS.Timeout
+	}
+
+	readonly clearTimeout = (timeout: NodeJS.Timeout | number | undefined): void => {
+		this.scheduled.delete(timeout as number)
+	}
+
+	runNext(delay: number): void {
+		const entry = Array.from(this.scheduled.entries()).find(([, timer]) => timer.delay === delay)
+		if (entry == null) throw new Error(`No timer scheduled after ${delay} ms`)
+		this.scheduled.delete(entry[0])
+		entry[1].callback()
+	}
+}
+
+async function flushPromises(): Promise<void> {
+	await Promise.resolve()
+	await Promise.resolve()
+}
+
+const dualStackInterfaces: ReturnType<typeof os.networkInterfaces> = {
+	eth0: [
+		{ address: "192.0.2.10", netmask: "255.255.255.0", family: "IPv4", mac: "00:00:00:00:00:00", internal: false, cidr: "192.0.2.10/24" },
+		{
+			address: "2001:db8::10",
+			netmask: "ffff:ffff:ffff:ffff::",
+			family: "IPv6",
+			mac: "00:00:00:00:00:00",
+			internal: false,
+			cidr: "2001:db8::10/64",
+			scopeid: 0,
+		},
+	],
+}
+
+const ipv6OnlyInterfaces: ReturnType<typeof os.networkInterfaces> = {
+	eth0: [
+		{
+			address: "fd00::10",
+			netmask: "ffff:ffff:ffff:ffff::",
+			family: "IPv6",
+			mac: "00:00:00:00:00:00",
+			internal: false,
+			cidr: "fd00::10/64",
+			scopeid: 0,
+		},
+	],
+}
+
+const linkLocalOnlyInterfaces: ReturnType<typeof os.networkInterfaces> = {
+	eth0: [
+		{ address: "169.254.1.1", netmask: "255.255.0.0", family: "IPv4", mac: "00:00:00:00:00:00", internal: false, cidr: "169.254.1.1/16" },
+		{
+			address: "fe80::1",
+			netmask: "ffff:ffff:ffff:ffff::",
+			family: "IPv6",
+			mac: "00:00:00:00:00:00",
+			internal: false,
+			cidr: "fe80::1/64",
+			scopeid: 2,
+		},
+	],
+}

--- a/test/tests/desktop/sse/SseClientTest.ts
+++ b/test/tests/desktop/sse/SseClientTest.ts
@@ -1,11 +1,14 @@
 import o, { verify } from "@tutao/otest"
-import { SseClient, SseConnectOptions, SseDelay, SseEventHandler } from "../../../../src/applications/common/desktop/sse/SseClient.js"
-import { ClientRequestOptions, DesktopNetworkClient } from "../../../../src/applications/common/desktop/net/DesktopNetworkClient.js"
+import { SseClient } from "../../../../src/applications/common/desktop/sse/SseClient.js"
+import type { SseConnectOptions, SseDelay, SseEventHandler } from "../../../../src/applications/common/desktop/sse/SseClient.js"
+import type { ClientRequestOptions, DesktopNetworkClient } from "../../../../src/applications/common/desktop/net/DesktopNetworkClient.js"
 import { matchers, object, when } from "testdouble"
 import http from "node:http"
 import { assertNotNull, defer, getFirstOrThrow } from "../../../../src/platform-kit/utils"
 import { SchedulerMock } from "../../TestUtils.js"
 import * as restError from "../../../../src/platform-kit/rest-client/error"
+import { CONNECTION_TIMEOUT_MS } from "../../../../src/applications/common/desktop/net/HappyEyeballsConnector.js"
+import { DesktopSseDelay } from "../../../../src/applications/common/desktop/sse/reconnectDelay.js"
 
 o.spec("SseClient", function () {
 	const defaultOptions: SseConnectOptions = Object.freeze({
@@ -24,6 +27,8 @@ o.spec("SseClient", function () {
 		delay = object()
 		listener = object()
 		scheduler = new SchedulerMock()
+		when(delay.connectionFailureDelay(matchers.anything())).thenReturn(10)
+		when(delay.connectionLostDelay()).thenReturn(CONNECTION_TIMEOUT_MS)
 
 		sseClient = new SseClient(net as unknown as DesktopNetworkClient, delay, scheduler)
 
@@ -109,7 +114,7 @@ o.spec("SseClient", function () {
 	o.spec("reconnect", () => {
 		o.test("reconnects if response is closed", async () => {
 			const response = new ResponseStub()
-			when(delay.initialConnectionDelay()).thenReturn(10)
+			when(delay.connectionLostDelay()).thenReturn(10)
 
 			await sseClient.connect(defaultOptions)
 
@@ -131,7 +136,7 @@ o.spec("SseClient", function () {
 
 			const request = await net.waitForRequest()
 			await request.sendResponse(response)
-			when(delay.initialConnectionDelay()).thenReturn(10)
+			when(delay.connectionLostDelay()).thenReturn(10)
 
 			net.prepareForAnotherRequest()
 			response.sendError(new Error("test"))
@@ -144,7 +149,7 @@ o.spec("SseClient", function () {
 
 	o.spec("failing to connect", () => {
 		o.test("on failing to connect the first time it reschedules with attempts=1", async () => {
-			when(delay.reconnectDelay(1)).thenReturn(1)
+			when(delay.connectionFailureDelay(1)).thenReturn(1)
 			await sseClient.connect(defaultOptions)
 
 			const request = await net.waitForRequest()
@@ -155,8 +160,8 @@ o.spec("SseClient", function () {
 		})
 
 		o.test("on failing to connect the second time it reschedules with attempts=2", async () => {
-			when(delay.reconnectDelay(1)).thenReturn(1)
-			when(delay.reconnectDelay(2)).thenReturn(2)
+			when(delay.connectionFailureDelay(1)).thenReturn(1)
+			when(delay.connectionFailureDelay(2)).thenReturn(2)
 			await sseClient.connect(defaultOptions)
 
 			const request1 = await net.waitForRequest()
@@ -169,6 +174,82 @@ o.spec("SseClient", function () {
 			await request2.sendError(new Error("error2"))
 			scheduler.getThunkAfter(2)()
 			await net.waitForRequest()
+		})
+
+		o.test("waits for the failure delay after the establishment deadline", async () => {
+			await sseClient.connect(defaultOptions)
+
+			const request = await net.waitForRequest()
+			net.prepareForAnotherRequest()
+			const establishmentTimeoutThunk = scheduler.getThunkAfter(CONNECTION_TIMEOUT_MS)
+			establishmentTimeoutThunk()
+
+			o(request.state).equals("destroyed")
+			o(net.requests.length).equals(1)
+			scheduler.getThunkAfter(10)()
+			await net.waitForRequest()
+		})
+
+		o.test("schedules the full failure delay after a slow failure", async () => {
+			when(delay.connectionFailureDelay(1)).thenReturn(5_000)
+			await sseClient.connect(defaultOptions)
+
+			const request = await net.waitForRequest()
+			await request.sendError(new Error("error"))
+
+			o(scheduler.scheduledAfter.has(5_000)).equals(true)
+			o(scheduler.scheduledAt.size).equals(0)
+			verify(delay.connectionFailureDelay(1), { times: 1 })
+		})
+
+		o.test("reconnects if the request closes before receiving a response", async () => {
+			await sseClient.connect(defaultOptions)
+
+			const request = await net.waitForRequest()
+			net.prepareForAnotherRequest()
+			request.close()
+
+			o(net.requests.length).equals(1)
+			scheduler.getThunkAfter(10)()
+			await net.waitForRequest()
+		})
+
+		o.test("schedules only one retry for duplicate request failure events", async () => {
+			await sseClient.connect(defaultOptions)
+
+			const request = await net.waitForRequest()
+			await request.sendError(new Error("error"))
+			request.close()
+
+			verify(delay.connectionFailureDelay(1), { times: 1 })
+			o(scheduler.alarmId).equals(2)
+		})
+
+		o.test("destroys a response from a stale request", async () => {
+			await sseClient.connect(defaultOptions)
+
+			const firstRequest = await net.waitForRequest()
+			await firstRequest.sendError(new Error("error"))
+			net.prepareForAnotherRequest()
+			scheduler.getThunkAfter(10)()
+			await net.waitForRequest()
+
+			const staleResponse = new ResponseStub()
+			await firstRequest.sendResponse(staleResponse)
+			o(staleResponse.state).equals("destroyed")
+		})
+
+		o.test("cancels the establishment deadline after receiving a response", async () => {
+			await sseClient.connect(defaultOptions)
+			const establishmentTimeout = assertNotNull(scheduler.scheduledAfter.get(CONNECTION_TIMEOUT_MS)).id
+			const establishmentTimeoutThunk = scheduler.getThunkAfter(CONNECTION_TIMEOUT_MS)
+
+			const request = await net.waitForRequest()
+			await request.sendResponse(new ResponseStub())
+			establishmentTimeoutThunk()
+
+			o(scheduler.cancelledAt.has(establishmentTimeout)).equals(true)
+			o(request.state).equals("created")
 		})
 	})
 
@@ -231,7 +312,7 @@ o.spec("SseClient", function () {
 			await request.sendError(new Error("test"))
 
 			await sseClient.disconnect()
-			o(scheduler.cancelledAt.size).equals(1)
+			o(scheduler.cancelledAt.size).equals(2)
 		})
 
 		o.test("should disconnect and use new options if connect() is called while connected", async () => {
@@ -261,6 +342,38 @@ o.spec("SseClient", function () {
 				method: "GET",
 			})
 		})
+	})
+})
+
+o.spec("DesktopSseDelay", () => {
+	o.test("uses crypto-compatible equal-jitter bounds with 20, 40, 80 and 120 second ceilings", () => {
+		const requestedBounds: Array<[number, number]> = []
+		const minimumDelay = new DesktopSseDelay((minimum, maximum) => {
+			requestedBounds.push([minimum, maximum])
+			return minimum
+		})
+		const maximumDelay = new DesktopSseDelay((_minimum, maximum) => maximum - 1)
+
+		o(minimumDelay.connectionLostDelay()).equals(10_000)
+		o(maximumDelay.connectionLostDelay()).equals(20_000)
+		o(minimumDelay.connectionFailureDelay(1)).equals(10_000)
+		o(maximumDelay.connectionFailureDelay(1)).equals(20_000)
+		o(minimumDelay.connectionFailureDelay(2)).equals(20_000)
+		o(maximumDelay.connectionFailureDelay(2)).equals(40_000)
+		o(minimumDelay.connectionFailureDelay(3)).equals(40_000)
+		o(maximumDelay.connectionFailureDelay(3)).equals(80_000)
+		o(minimumDelay.connectionFailureDelay(4)).equals(60_000)
+		o(maximumDelay.connectionFailureDelay(4)).equals(120_000)
+		o(minimumDelay.connectionFailureDelay(10)).equals(60_000)
+		o(maximumDelay.connectionFailureDelay(10)).equals(120_000)
+		o(requestedBounds).deepEquals([
+			[10_000, 20_001],
+			[10_000, 20_001],
+			[20_000, 40_001],
+			[40_000, 80_001],
+			[60_000, 120_001],
+			[60_000, 120_001],
+		])
 	})
 })
 
@@ -313,6 +426,10 @@ class RequestStub implements Partial<http.ClientRequest> {
 		await this.eventListeners.get("error")!(error)
 	}
 
+	close() {
+		this.eventListeners.get("close")?.()
+	}
+
 	waitForDestroy() {
 		return this.destroyedDefer.promise
 	}
@@ -338,6 +455,7 @@ class RequestStub implements Partial<http.ClientRequest> {
 
 class ResponseStub implements Partial<http.IncomingMessage> {
 	statusCode: number = 200
+	state: "created" | "destroyed" = "created"
 	eventListeners = new Map<string, (...args: any[]) => unknown>()
 
 	on(event, listener) {
@@ -359,5 +477,10 @@ class ResponseStub implements Partial<http.IncomingMessage> {
 
 	sendError(e: Error) {
 		this.eventListeners.get("error")?.()
+	}
+
+	destroy() {
+		this.state = "destroyed"
+		return this as unknown as http.IncomingMessage
 	}
 }


### PR DESCRIPTION
## Summary and user impact

**For more than two years, Tuta Desktop has rejected viable connections on affected high-latency routes. The failure has been publicly documented since [#6641](https://github.com/tutao/tutanota/issues/6641) in March 2024, and this audit identifies 23 matching or plausible GitHub issues.**

VPN and overlay topologies appear in both directions: some expose the defect, while others restore connectivity by changing the route.

Among reporters with usable public Git commit time zones, 14 were outside Europe and three were in Europe — approximately 5:1. Commit offsets indicate the configured clock when a commit was made, not residence.

Tuta Desktop has failed for me for years on high-latency routes, approximately half the time. The web client usually remained usable on the same connection. With this series, connection establishment is immediate and reliable on the same route. I have never seen Tuta Desktop connect this quickly.

Two defects cause the failures:

1. Node destroys a viable address attempt after 250 ms before trying the next address.
2. If that failure reaches the initial desktop SSE request, the released client waits 120 seconds before retrying. Subsequent failures wait 4, 8, 16, 32, then 40 minutes. An establishment request without a response or error can remain stuck forever.

The commits add a 20-second fallback for direct Node consumers, parallel TLS-aware address racing for native desktop HTTP traffic, and bounded jittered SSE recovery.

On 2026-08-27, seven direct HTTP/1.1 connections from my current network to `app.tuta.com` had a median TCP connection time of 262 ms after DNS and a median `secureConnect` time of 798 ms after DNS. All seven succeeded, consistent with a viable high-latency route rather than a server outage.

A separate server-side TLS issue adds one RTT to new connections. `app.tuta.com` rejects the default Electron/Node client's initial X25519 key share and requests P-256. In ten alternating-order pairs using the installed Electron runtime, preferring `prime256v1:X25519` reduced the median time to `secureConnect` from 769 to 533 ms; the median paired saving was 241 ms. This PR does not change TLS group policy; the issue is tracked separately as **#11405**.

I have added Tuta TLS handshakes to my network monitoring and may follow up if further server-side problems appear.

## Connection failure

[RFC 8305 section 5](https://www.rfc-editor.org/rfc/rfc8305.html#section-5) defines 250 ms as a **Connection Attempt Delay**. Starting a new attempt must not cancel earlier attempts; several attempts may remain active.

Node's `autoSelectFamily` uses 250 ms as `autoSelectFamilyAttemptTimeout` for every address except the last. It closes the earlier socket when the timer expires. Node therefore does not implement the required parallel behavior:

- [nodejs/node#48145 — Implement parallel Happy Eyeballs as described in RFC 8305](https://github.com/nodejs/node/issues/48145)
- [nodejs/node#54359 — Happy eyeballs implementation times out prematurely](https://github.com/nodejs/node/issues/54359)

Tuta sets `dns.setDefaultResultOrder("ipv4first")`. On affected routes, Node starts a viable high-latency IPv4 address, destroys it after approximately 250 ms, then tries an unreachable IPv6 address as the final candidate.

```text
DNS:            IPv4 viable, >250 ms       IPv6 unreachable

Current Node:
  t+0 ms        start IPv4
  t+250 ms      destroy IPv4
                start IPv6
                IPv6 fails
                AggregateError [ETIMEDOUT]

Fixed:
  t+0 ms        start preferred address
  t+1 s         start next address if required; keep earlier attempts active
                advance immediately after hard errors
                first valid TLS secureConnect wins
                20-second overall deadline
```

The matching issues show 250–655 ms desktop failures, 249–521 ms IPv4 RTT, unreachable IPv6, and working browsers or curl.

## History

| Change | Result |
| --- | --- |
| Native desktop networking, discussed in #4504 | Desktop and browser traffic use different network stacks. |
| Node 18 DNS-order regression, #5294/#5295 | Tuta preferred IPv4. A slow viable IPv4 address later became Node's first non-final candidate. |
| Automatic family selection, #6641 | Address-family fallback was enabled, but retained Node's 250 ms cutoff. |
| Original desktop SSE implementation, 2019 | A randomized in-flight watchdog bounded silent establishment requests. |
| SSE rewrite, 2024, #6927 | Retry constants became fixed post-error delays. The establishment watchdog was removed. Retries reached 40 minutes. |

## Coverage and invariants

| Path | Behavior |
| --- | --- |
| Undici agent | Races addresses for `ProtocolProxy`, HTTP/HTTPS, file requests, and missed-notification downloads. |
| Main-process global `fetch` | Uses the same race and per-origin connection limit, including external-calendar fetches. |
| `DesktopNetworkClient` HTTPS agent | Races native POST and SSE connections. |
| ImapFlow and direct Node `net`/`tls` | Uses the 20-second global fallback. |

- HTTPS succeeds at `secureConnect`. The original hostname remains the SNI and certificate-verification name.
- Local interfaces affect order only. Both address families remain eligible.
- Late and losing sockets are destroyed. Failed attempts are retained in one `AggregateError`.
- SSE request close before response is a connection failure.
- SSE watchdogs are cancelled on response and disconnect.
- Duplicate and stale SSE request/response events cannot change the active connection.

Issue [#7720](https://github.com/tutao/tutanota/issues/7720) records the old 2, 4, 8, 16, 32, then 40-minute sequence. The new maximum cooldown is two minutes. Equal jitter prevents synchronized retry waves during outages.

## Exact commit messages

### [desktop] Raise fallback address attempt timeout

Commit [`3d9b664df276545e930bcb6aa9fca812223fcf6f`](https://github.com/ArminShupuk/tutanota/commit/3d9b664df276545e930bcb6aa9fca812223fcf6f)

The Node version bundled with Electron gives family-autoselection connection attempts only 250 ms. This can abort viable connections on high-latency or lossy routes before they complete.

Raise the global attempt timeout to 20 seconds as a safety net for direct Node net/tls consumers, particularly ImapFlow, and for connection paths that do not use the desktop HTTP connectors.

Desktop HTTP traffic receives a parallel connection-racing implementation in the following commit, avoiding the serial delays this larger fallback could otherwise introduce.

### [desktop] Race address connection attempts

Commit [`bba7b3c2d917fcc3692d77d390bfaeafc52e24d2`](https://github.com/ArminShupuk/tutanota/commit/bba7b3c2d917fcc3692d77d390bfaeafc52e24d2)

Node’s family-autoselection implementation does not yet retain previous attempts while starting another one. It closes each attempt when its short per-address timer expires, which can reject viable high-latency routes. Parallel RFC 8305 behavior and premature attempt timeouts are tracked upstream:

https://github.com/nodejs/node/issues/48145
https://github.com/nodejs/node/issues/54359

The larger global timeout from the previous commit prevents premature failure for fallback consumers, but using it serially for application traffic could make a broken address expensive.

Add a shared connector that keeps attempts active, starts another address after one second, advances immediately on hard errors, and uses a 20-second overall deadline. For HTTPS, TLS secureConnect determines the winner rather than the first TCP connection.

Use interface addresses only as an ordering hint: prefer IPv4 when both families appear available, prefer IPv6 when only usable IPv6 is visible, and never remove either family from the race.

Wire the connector into Undici, Node’s global fetch dispatcher, and the native HTTPS agent used by SSE and POST requests. Installing the Undici agent globally deliberately gives every main-process fetch the same connection race and per-origin connection limit.

### [desktop] Restore bounded SSE retries

Commit [`14fdb42f63668886357321f1b7bf4d6cd2c4ffa2`](https://github.com/ArminShupuk/tutanota/commit/14fdb42f63668886357321f1b7bf4d6cd2c4ffa2)

The original 2019 desktop SSE implementation scheduled a randomized watchdog while each request was still in flight, initially up to 120 seconds and exponentially capped at 40 minutes:
https://github.com/tutao/tutanota/commit/a3651c2454a4b1f17a8d7c91abc4888ac8a3f1c0

The 2024 SSE rewrite retained those constants but turned them into fixed post-error delays:
https://github.com/tutao/tutanota/pull/6927

That changed recovery in two ways: a failed initial request waited 120 seconds before retrying, eventually reaching 40 minutes, while a request that emitted neither a response nor an error had no watchdog and could remain connecting forever.

Give each SSE establishment attempt the same 20-second deadline as the desktop connector. After a failure, use Node crypto.randomInt to sample an equal-jitter cooldown with 20, 40, 80, and 120-second ceilings. Established connection loss uses the initial 10-to-20-second range.

Starting the cooldown after failure is important: measuring it from attempt start allowed the 20-second watchdog to consume the first jitter window and synchronize clients on an immediate retry. Post-failure jitter keeps blackholed endpoints spread as well as fast failures, while the two-minute cap keeps recovery bounded.

Cancel the watchdog on a response or explicit disconnect, handle request close before response, and ignore stale request and response events.

## Scope

Changed: native desktop Node HTTP/HTTPS, direct Node address-family dialing through the global fallback, and native desktop SSE establishment/retry.

Unchanged:

- Chromium renderer WebSocket reconnect behavior;
- Chromium online/offline event detection;
- mobile or WebView networking;
- the Electron updater's networking path;
- server availability, DDoS mitigation, IP blocking, or DNS-provider filtering;
- local keychain, safe-storage, or SQLite/offline-database errors;
- the renderer's ordinary 10–20-second REST timeout policy;
- generic REST retry semantics;
- the native SSE heartbeat watchdog design;
- immediate recovery from an OS online/resume event.

## GitHub issue audit

### Methodology

Audit date: 2026-08-27. Source: authenticated GitHub API.

- 10,887 issue/PR records were downloaded; 3,971 pull requests were excluded, leaving **6,916 issues**.
- **11,265 comments** on those issues were indexed together with every title and body.
- The first broad lexical pass produced 422 candidates across 48 issue/comment phrase searches.
- **90 commit-derived searches** covered exact Node errors, 250–561 ms timings, IPv4/IPv6 and VPN topology, browser/mobile success on the same route, SSE retry messages, stuck establishment, notification/restart recovery, high latency, 4G/hotspot/satellite wording, sleep, and hibernation.
- Category-specific phrases were searched across the 255 comments in these 23 issues.
- These searches found one additional issue: #10410.

### Inclusion rules

An issue is included only when all of these are true:

1. A specific report or comment concerns the official desktop client. A mixed thread qualifies only for the matching report, not automatically for every participant.
2. The failed operation can use a path changed by one of these commits: native desktop HTTP/HTTPS, a direct Node address-family dial, or native desktop SSE establishment/retry.
3. Public evidence does not establish another cause such as keychain/SQLite failure, renderer WebSocket state, a service-wide outage, IP/DNS blocking, bad proxy configuration, or a distinct 10–20-second renderer/request timeout.

Classification:

- **Category 1 — sure/direct:** exact matching stack/timing plus viable-route evidence, or native SSE logs directly showing the changed retry behavior.
- **Category 2 — specific clue, logs missing:** at least one commit-specific discriminator, but not enough evidence to prove the full mechanism.
- **Category 3 — default networking error that could fit:** the relevant desktop symptom with no established competing cause, but no diagnostic discriminator.

VPN/proxy use does not determine category. It may cause failure, restore connectivity by changing the route, or make no difference.

### Category 1 — sure or directly evidenced

| Issue | State | Path | VPN/proxy evidence | Why it is here |
| --- | --- | --- | --- | --- |
| [#11402](https://github.com/tutao/tutanota/issues/11402) | Open | Address | Not stated | Exact `AggregateError [ETIMEDOUT]` / `internalConnectMultiple` stack; desktop fails within a few hundred milliseconds while web, curl, and system Node work. |
| [#9536](https://github.com/tutao/tutanota/issues/9536) | Open | Address | Mixed: Tailscale is present for one reporter; another used a local forwarder as a workaround | Exact stack, 257–304 ms failures, and measured IPv4 RTT of 296–311 ms. |
| [#8921](https://github.com/tutao/tutanota/issues/8921) | Open | Address | Yes: Tailscale mesh; no exit node | A viable IPv4 attempt is cancelled early and followed by unreachable IPv6; browser and curl work. The reporter also reproduces the Node/Undici failure independently. |
| [#8635](https://github.com/tutao/tutanota/issues/8635) | Open | Address | Yes for one affected reporter: WireGuard/OpenVPN behavior varies; others do not state it | Exact stack, 261/304 ms failures, IPv4 RTT of 436–521 ms, unreachable IPv6, and a working browser. |
| [#8488](https://github.com/tutao/tutanota/issues/8488) | Open | Address | Yes in a later affected report: Mullvad; enabling in-tunnel IPv6 changes the result | Exact stack, 359 ms failure, IPv4 RTT of 249–267 ms, unreachable IPv6, and a working browser. |
| [#8311](https://github.com/tutao/tutanota/issues/8311) | Open | Address, SSE | Mixed: VPN involved or used as a workaround for some; at least one reporter fails both ways | Repeated exact stacks at 252–315 ms while the browser works; the thread also records an SSE failure at approximately 251 ms followed by reconnect scheduling. Later comments may contain other causes. |
| [#8214](https://github.com/tutao/tutanota/issues/8214) | Closed | Address | Not stated | IPv4-only route with approximately 265 ms RTT and a 250+ ms cutoff; Firefox and phone work. It stopped reproducing when routing improved to approximately 35 ms. |
| [#7709](https://github.com/tutao/tutanota/issues/7709) | Open | Address | Mixed: two affected reporters explicitly use no VPN/Private Relay; another fails with and without Private Relay | A 2026 report in this mixed thread has a 290 ms failure, 255–363 ms IPv4 RTT, no IPv6 route, and working web/iOS clients. Other reports in the thread may have different causes. |
| [#6869](https://github.com/tutao/tutanota/issues/6869) | Closed | Address | Yes: explicitly tested with and without VPN; same failure | Desktop-only failure in 434 ms while a phone works on the same network; closed as a duplicate of #6641. |
| [#6669](https://github.com/tutao/tutanota/issues/6669) | Closed | Address | Yes in one matching report: WireGuard with IPv6 disabled; others do not state it | Matching reports in this mixed thread contain `internalConnectMultiple` / `ETIMEDOUT` and 273–655 ms failures. The security-key symptom elsewhere in the thread is separate. |
| [#6641](https://github.com/tutao/tutanota/issues/6641) | Closed | Address | Mixed: VPN can fix the route, fail to fix it, or be absent; several reports explicitly cover both states | Historical root thread with exact stacks and many 256–434 ms desktop failures while browsers work. It led to enabling automatic family selection but left the premature per-address cutoff. |
| [#7720](https://github.com/tutao/tutanota/issues/7720) | Open | SSE, Address | Not stated | Logs show the 2, 4, 8, 16, 32, then 40-minute SSE retry sequence and repeated approximately 250–350 ms dials. The retry defect is direct; the underlying dial error was not printed, so the address sub-cause is less certain. |
| [#11294](https://github.com/tutao/tutanota/issues/11294) | Open | SSE | Not stated; affected user is unnamed | An established SSE stream logs `read ETIMEDOUT`, waits exactly 60 seconds, then reconnects successfully. Its reported alarm-recursion bug is separate; a 264 ms `ProtocolProxy` failure alone does not prove the address race. |

### Category 2 — specific matching clue, but decisive logs are missing

| Issue | State | Path | VPN/proxy evidence | Matching clue and missing evidence |
| --- | --- | --- | --- | --- |
| [#11378](https://github.com/tutao/tutanota/issues/11378) | Open | Address, Recovery | Yes: VPN, type not stated | Desktop remains `Offline, Reconnecting...` until restart while the browser works; a maintainer suspects IPv6. Missing native logs, timings, and v4/v6 reachability results. |
| [#11286](https://github.com/tutao/tutanota/issues/11286) | Open | Recovery | Yes: app starts before the VPN tunnel is established | Delayed autostart consistently avoids the indefinite offline state. Strong recovery trigger, but no native/SSE logs show which connection fails or whether retry actually stops. |
| [#10410](https://github.com/tutao/tutanota/issues/10410) | Open | Address | Not stated; route is an unreliable 4G connection | Linux desktop fails for months while web and mobile work, although slowly. A maintainer links #9536 and requests an IPv6 test. Missing native logs, timings, and requested family results. |
| [#7077](https://github.com/tutao/tutanota/issues/7077) | Closed | Address | Not stated | The parent issue concerns safe storage. One comment independently shows the exact `internalConnectMultiple` stack and a 275 ms failure, but provides no RTT/family evidence that the cancelled address was viable. |
| [#5889](https://github.com/tutao/tutanota/issues/5889) | Open | Address | Yes: Tails/Tor route | Desktop fails after 312–378 ms while Tor Browser works, but the root error is omitted and proxy configuration remains a competing explanation. |
| [#1135](https://github.com/tutao/tutanota/issues/1135) | Closed | Address | Yes: local SOCKS proxy/Tor | A later comment in this Tor-proxy thread contains the exact stack and a 266 ms failure. There is no viable-address measurement, and proxy routing remains a confounder. |
| [#7124](https://github.com/tutao/tutanota/issues/7124) | Closed | Address | Yes: VPN is the workaround | Linux desktop cannot connect without a VPN, while the same PC and connection work on Windows and enabling the VPN fixes Linux. Useful route/topology evidence; no logs, timings, DNS results, or family tests. |

### Category 3 — default networking error that could fit

| Issue | State | Path | VPN/proxy evidence | Symptom and missing evidence |
| --- | --- | --- | --- | --- |
| [#10590](https://github.com/tutao/tutanota/issues/10590) | Open | Address, Recovery | No: affected reporters explicitly say no VPN/proxy | Multiple macOS users get the default “connection to the server was lost” failure or refusal to reconnect; web/iOS work. No public native logs, attempt timings, or address-family data. The #7709 cross-reference supplies no additional diagnostics. |
| [#8060](https://github.com/tutao/tutanota/issues/8060) | Closed | Address | Private Relay was tested by the reporter; the issue occurs with and without it | macOS desktop repeatedly claims the user is offline despite stable internet; restart/reinstall do not reliably help and the reporter finds the PWA more reliable. No logs or controlled browser/network comparison were completed. |
| [#7187](https://github.com/tutao/tutanota/issues/7187) | Closed | Address, Recovery | Not stated | macOS desktop logs in, decrypts data, then shows the default server-lost error after an update. No logs or alternate-client tests; it later recovered without a documented cause. |

Total: **23 unique issues** — 13 category 1, seven category 2, and three category 3.

## Reproduction

Use a dual-address setup where:

1. one address is viable, but connection establishment exceeds Node's 250 ms attempt window; and
2. the alternative address is unreachable or black-holed.

Before: Node destroys the viable attempt and returns `AggregateError [ETIMEDOUT]`.

After: the viable attempt remains active and completes within the 20-second deadline.

For HTTPS, delay TCP/TLS establishment rather than the application response. Node's 250 ms timer applies during connection establishment; the new connector accepts an HTTPS winner at `secureConnect`.

SSE cases:

- make an establishment request emit neither response nor error and verify that the 20-second watchdog destroys it and schedules exactly one jittered retry;
- close the request before response and verify bounded recovery;
- repeatedly fail fast and verify the 20/40/80/120-second equal-jitter ceilings;
- establish a stream, then close/error it and verify reset to the initial 10–20-second range;
- deliver events from a stale request/response and verify that they cannot replace or tear down the current connection.

## Suggested regression tests

I recommend adding automated Docker/container networking tests to the pre-release integration suite.

Release matrix:

- dual-stack DNS where one address is slow but viable;
- TCP and TLS establishment beyond 250 ms;
- unreachable and black-holed IPv4 and IPv6 addresses in either order;
- latency, jitter, and packet loss high enough to require retransmission;
- VPN, proxy, interface, DNS, and route transitions;
- startup before a VPN/network becomes available;
- SSE establishment that stalls, closes before response, or repeatedly errors;
- stale connection events and disconnect/reconnect races;
- established SSE loss followed by recovery;
- Chromium renderer networking and native Node networking tested separately.

Use Linux network namespaces, containers, `tc netem`, controlled DNS answers, and black-holed routes. Assert correctness and timing: the viable route succeeds, earlier attempts remain alive until a winner exists, dead alternatives do not impose a 20-second serial stall on application traffic, and SSE retry intervals remain bounded and jittered.

## Verification

- `HappyEyeballs` focused tests: **10 passing, 0 failing**
- `SseClient` focused tests: **22 passing, 0 failing**
- `npm run test:types`: clean
- ESLint on all changed paths: clean
- Prettier check on all changed paths: clean

- Address-race coverage: attempt interleaving and cleanup, hard errors, exhaustion, synchronous failures, family/local-address filtering, pending DNS timeout, close before TLS, and ordering.
- SSE coverage: request close before response, duplicate failures, stale responses, cooldown after slow failure, watchdog handling, and duplicate-schedule prevention.

## Credit and follow-up

This work took 11 hours 30 minutes across reproduction, implementation, verification, upstream analysis, and the GitHub issue audit.

If this is merged, please apply a service credit to my Tuta account and acknowledge me in the release notes as **Armin Šupuk** (`armin@supuk.ch`).

I am available to implement the proposed integration tests or audit Tuta's networking commercially.