### PR TITLE
Drive: fix search views showing drive in filter chip for free accounts

### DIFF
--- a/src/applications/calendar-app/calendar/search/view/CalendarSearchView.ts
+++ b/src/applications/calendar-app/calendar/search/view/CalendarSearchView.ts
@@ -253,7 +253,7 @@ export class CalendarSearchView extends BaseTopLevelView implements TopLevelView
 						},
 						icon: Icons.CalendarFilled,
 					},
-					!ClientDetector.get().isMailApp()
+					!ClientDetector.get().isMailApp() && this.searchViewModel.isDriveEnabled()
 						? {
 								label: "driveView_action",
 								click: () => {

--- a/src/applications/calendar-app/calendar/search/view/CalendarSearchViewModel.ts
+++ b/src/applications/calendar-app/calendar/search/view/CalendarSearchViewModel.ts
@@ -50,6 +50,7 @@ import { CalendarEventModel, CalendarEventModelFactory, CalendarOperation } from
 import { MailboxModel } from "../../../../common/mailFunctionality/MailboxModel"
 import { ListState } from "../../../../../ui/base/List"
 import { CalendarEventPreviewViewModel } from "../../gui/eventpopup/CalendarEventPreviewViewModel"
+import { isDriveEnabled } from "../../../../common/misc/DriveUtils"
 
 type EventPreviewData =
 	| {
@@ -145,6 +146,10 @@ export class CalendarSearchViewModel {
 	readonly init = onceAsync(async () => {
 		this.eventController.addEntityUpdatesListener(this.entityEventsListener)
 	})
+
+	isDriveEnabled(): boolean {
+		return isDriveEnabled(this.logins)
+	}
 
 	getStartOfTheWeekOffset(): number {
 		return getStartOfTheWeekOffsetForUser(this.logins.getUserController().userSettingsGroupRoot)

--- a/src/applications/mail-app/search/view/ContactSearchView.ts
+++ b/src/applications/mail-app/search/view/ContactSearchView.ts
@@ -261,7 +261,7 @@ export class ContactSearchView extends BaseTopLevelView implements TopLevelView<
 						},
 						icon: Icons.CalendarFilled,
 					},
-					!ClientDetector.get().isMailApp()
+					!ClientDetector.get().isMailApp() && this.searchViewModel.isDriveEnabled()
 						? {
 								label: "driveView_action",
 								click: () => {

--- a/src/applications/mail-app/search/view/ContactSearchViewModel.ts
+++ b/src/applications/mail-app/search/view/ContactSearchViewModel.ts
@@ -14,6 +14,7 @@ import Stream from "mithril/stream"
 import { NotFoundError } from "@tutao/rest-client/error"
 import { EntityClient } from "../../../../platform-kit/network/EntityClient"
 import { compareContacts } from "../../contacts/ContactUtils"
+import { isDriveEnabled } from "../../../common/misc/DriveUtils"
 
 export class ContactSearchViewModel {
 	#listModel: ListModel<Contact, Id> = emptyListModel()
@@ -35,6 +36,10 @@ export class ContactSearchViewModel {
 		private readonly search: ContactSearchModel,
 		private readonly updateUi: () => unknown,
 	) {}
+
+	isDriveEnabled(): boolean {
+		return isDriveEnabled(this.logins)
+	}
 
 	getUrlFromSearchCategory(category: SearchCategoryType) {
 		return getSearchUrl(this.currentQuery, createEmptyRestriction(category))

--- a/src/applications/mail-app/search/view/MailSearchView.ts
+++ b/src/applications/mail-app/search/view/MailSearchView.ts
@@ -936,7 +936,7 @@ export class MailSearchView extends BaseTopLevelView implements TopLevelView<Mai
 						},
 						icon: Icons.CalendarFilled,
 					},
-					!ClientDetector.get().isMailApp()
+					!ClientDetector.get().isMailApp() && this.searchViewModel.isDriveEnabled()
 						? {
 								label: "driveView_action",
 								click: () => {

--- a/src/applications/mail-app/search/view/MailSearchViewModel.ts
+++ b/src/applications/mail-app/search/view/MailSearchViewModel.ts
@@ -55,6 +55,7 @@ import {
 import { ListFetchResult, onlySingleSelection } from "../../../../ui/base/ListUtils"
 import { MailSearchModel } from "../model/MailSearchModel"
 import { ClientDetector } from "../../../../platform-kit/app-env/boot/ClientDetector"
+import { isDriveEnabled } from "../../../common/misc/DriveUtils"
 
 const SEARCH_PAGE_SIZE = 100
 export class MailSearchViewModel {
@@ -130,6 +131,10 @@ export class MailSearchViewModel {
 
 	isFreeAccount(): boolean {
 		return this.logins.getUserController().isFreeAccount()
+	}
+
+	isDriveEnabled(): boolean {
+		return isDriveEnabled(this.logins)
 	}
 
 	getSelectedMails(): readonly Mail[] {


### PR DESCRIPTION
In the search views, free users could also switch to drive search view even if drive was not enabled for them. This change stops users for whom drive is not enabled to do this.