### PR TITLE
Drive: increase replace-on-upload robustness

### DIFF
--- a/src/applications/common/desktop/files/DesktopFileFacade.ts
+++ b/src/applications/common/desktop/files/DesktopFileFacade.ts
@@ -30,6 +30,7 @@ import { OpenDialogOptions } from "electron"
 import { CommandExecutor } from "../CommandExecutor"
 import { createHash } from "node:crypto"
 import { fileUrlFromString } from "./fileUtils"
+import { ConnectionError } from "@tutao/rest-client/error"
 import { DataFile } from "../../../../entities/tutanota/Utils"
 
 const TAG = "[DesktopFileFacade]"
@@ -109,6 +110,8 @@ export class DesktopFileFacade implements FileFacade {
 			log.info(TAG, "Download finished", result.statusCode, result.suspensionTime)
 
 			return result
+		} catch (e) {
+			throw new ConnectionError(`Download failed ${e.name} ${e.message} ${e.stack}`)
 		} finally {
 			this.activeRequests.delete(fileId)
 		}
@@ -329,6 +332,8 @@ export class DesktopFileFacade implements FileFacade {
 				suspensionTime: getHttpHeader(response.headers, "suspension-time") ?? getHttpHeader(response.headers, "retry-after"),
 				responseBody,
 			}
+		} catch (e) {
+			throw new ConnectionError(`Upload failed ${e.name} ${e.message} ${e.stack}`)
 		} finally {
 			this.tfs.closeFileStream(fileStream)
 			this.activeRequests.delete(fileId)

--- a/src/applications/drive-app/drive/model/DriveModel.ts
+++ b/src/applications/drive-app/drive/model/DriveModel.ts
@@ -15,7 +15,6 @@ import {
 	OperationUpdate,
 	pickNewFileName,
 	RunningOperation,
-	toFolderItem,
 	walkTree,
 } from "../view/DriveUtils"
 import { DriveTransferController, DriveTransfers, DriveTransferState } from "../view/DriveTransferController"
@@ -199,9 +198,16 @@ export class DriveModel {
 					fileName = pickNewFileName(fileName, takenFileNames)
 				} else {
 					const itemToReplace = assertNotNull(
-						folderItems.files.find((item) => item.name === fileName) ?? folderItems.folders.find((item) => item.name === fileName),
+						folderItems.files.find((item) => item.name === fileName) ?? folderItems.folders.find((item) => item.name === fileName) ?? null,
 					)
-					await this.moveToTrash([folderItemToId(toFolderItem(itemToReplace, null))])
+
+					this.transferController.setCompletionListenerFor(file, async () => {
+						try {
+							await this.driveFacade.moveToTrash([itemToReplace._id], [])
+						} catch (e) {
+							console.log(`Couldn't automatically delete file ${JSON.stringify(itemToReplace._id)}`, e)
+						}
+					})
 				}
 				takenFileNames.add(fileName)
 
@@ -249,7 +255,7 @@ export class DriveModel {
 		this.transferController.flush()
 	}
 
-	async moveToTrash(items: readonly FolderItemId[]) {
+	async moveToTrash(items: readonly FolderItemId[]): Promise<void> {
 		const { fileIds, folderIds } = itemsIntoIds(items)
 		try {
 			await this.driveFacade.moveToTrash(fileIds, folderIds)

--- a/src/applications/drive-app/drive/view/DriveTransferController.ts
+++ b/src/applications/drive-app/drive/view/DriveTransferController.ts
@@ -65,6 +65,7 @@ export class DriveTransferController {
 	private queue: QueuedTransfer[] = []
 	private finishedTransfers: QueuedTransfer[] = []
 	private allTransfersDoneListener: (() => unknown) | null = null
+	private completionListeners: Map<WebFile | FileReference | DataFile, () => unknown> = new Map()
 
 	get state(): DriveTransfers {
 		const currentTransfers = this.queue.map(queuedTransferToState)
@@ -106,6 +107,14 @@ export class DriveTransferController {
 
 	setAllTransfersDoneListener(listener: () => unknown) {
 		this.allTransfersDoneListener = listener
+	}
+
+	setCompletionListenerFor(file: WebFile | FileReference | DataFile, listener: () => unknown) {
+		if (this.completionListeners.has(file)) {
+			throw new ProgrammingError("completion listener for this file already exists")
+		} else {
+			this.completionListeners.set(file, listener)
+		}
 	}
 
 	async upload(file: WebFile | FileReference | DataFile, filename: string, targetFolderId: IdTuple): Promise<void> {
@@ -257,6 +266,7 @@ export class DriveTransferController {
 		const activeTransfers = this.queue.filter((transfer) => transfer.state === "active" || transfer.state === "waiting")
 		this.queue.splice(0, this.queue.length, ...activeTransfers)
 		this.finishedTransfers.splice(0)
+		this.completionListeners.clear()
 	}
 
 	private finishUpload(fileId: FileId) {
@@ -315,9 +325,14 @@ export class DriveTransferController {
 	}
 
 	private finalizeTransfer(transferId: TransferId, newState: "finished" | "failed") {
-		const stateForThisFile = this.transferForId(transferId)
-		if (stateForThisFile) {
-			stateForThisFile.state = newState
+		const transfer = this.transferForId(transferId)
+		if (transfer) {
+			transfer.state = newState
+
+			if (transfer.state === "finished" && transfer.type === "upload" && this.completionListeners.has(transfer.file)) {
+				this.completionListeners.get(transfer.file)?.()
+				this.completionListeners.delete(transfer.file) // do not remove on failed, it might be retried later
+			}
 			// once all transfers are done move them to the finished, which are not used for progress
 			const allTransfersDone = this.checkAllTransfersDone()
 			if (allTransfersDone) {

--- a/test/tests/drive/DriveModelTest.ts
+++ b/test/tests/drive/DriveModelTest.ts
@@ -11,7 +11,7 @@ import { clientInitializedTypeModelResolver, createTestEntity, withOverriddenEnv
 import { FileFolderItem, FolderFolderItem, FolderItem, FolderItemId, toFolderItem } from "../../../src/applications/drive-app/drive/view/DriveUtils"
 import { elementIdPart, getElementId } from "../../../src/platform-kit/meta"
 import { EntityRestClientMock } from "../api/worker/rest/EntityRestClientMock"
-import { WebFile } from "../../../src/entities/tutanota/Utils"
+import { FileReference, WebFile } from "../../../src/entities/tutanota/Utils"
 import { WindowFacade } from "../../../src/applications/common/misc/WindowFacade"
 import { Mode } from "../../../src/platform-kit/app-env"
 
@@ -406,6 +406,17 @@ o.spec("DriveModel", function () {
 			]
 
 			when(driveFacade.getFolderContents(rootFolders.root._id)).thenResolve({ files: [], folders: existingFolders })
+			let completionListener: (file: WebFile | FileReference) => unknown
+			// Store the completion listener registered by DriveModel, so we can call it later from the mocked transfer controller
+			when(transferController.setCompletionListenerFor(matchers.anything(), matchers.anything())).thenDo(
+				(file: WebFile | FileReference, listener: (file: WebFile | FileReference) => unknown) => {
+					completionListener = listener
+				},
+			)
+			// Call the completion listener registered by DriveModel
+			when(transferController.upload(matchers.anything(), matchers.anything(), matchers.anything())).thenDo((file: WebFile | FileReference) => {
+				completionListener(file)
+			})
 			await driveModel.uploadFiles(webFiles, rootIds.root, async (_fileName: string, _fileCount: number) => {
 				return { choice: "replace", applyToAll: true }
 			})


### PR DESCRIPTION
Let's assume the user decided to replace an existing file during upload.

Before this change, the affected file would get deleted immediately and eventually the new one would appear after upload has completed. This could lead to a situation where the original file had been deleted but the upload failed, leaving the user without any version of this file in the current folder.

Now, the old file is only deleted after the new one had been successfully uploaded.

tuta#3911