### PR TITLE
Drive: fix exiting multiselect on mobile

### DIFF
--- a/src/applications/drive-app/drive/view/DriveView.ts
+++ b/src/applications/drive-app/drive/view/DriveView.ts
@@ -443,7 +443,7 @@ export class DriveView extends BaseTopLevelView implements TopLevelView<DriveVie
 				message: lang.getTranslation("itemsSelected_label", { "{number}": listState.selectedItems.size }),
 				selected: listState.selectedItems.size === listState.items.length,
 				selectAll: () => this.driveViewModel.toggleSelectAll(),
-				selectNone: () => this.driveViewModel.toggleSelectAll(),
+				selectNone: () => this.driveViewModel.selectionEvents.selectNone(),
 			})
 		} else {
 			const useBackButton = isNotEmpty(this.driveViewModel.parents)


### PR DESCRIPTION
The close button was hooked up to toggle the selection instead of clearing it. With no items selected, it would select everything instead of exiting multiselect.

tuta#3926